### PR TITLE
Fix potential null pointer dereference in netfilter

### DIFF
--- a/src/firejail/netfilter.c
+++ b/src/firejail/netfilter.c
@@ -67,9 +67,9 @@ void netfilter(const char *fname) {
 		}
 
 		filter = malloc(s.st_size + 1);	  // + '\0'
-		memset(filter, 0, s.st_size + 1);
 		if (!filter)
 			errExit("malloc");
+		memset(filter, 0, s.st_size + 1);
 
 		/* coverity[toctou] */
 		FILE *fp = fopen(fname, "r");


### PR DESCRIPTION
In netfilter.c, the memset call on line 70 is before the check for null pointer, so it could cause a null pointer dereference crash. The statement has been moved to after the null pointer check.