### PR TITLE
Create a .gitignore file for firejail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+*.o
+*.so
+*~
+Makefile
+config.log
+config.status
+firejail-login.5
+firejail-profile.5
+firejail.1
+firemon.1
+src/firejail/firejail
+src/firemon/firemon
+src/ftee/ftee
+


### PR DESCRIPTION
If you build firejail and then type `git status`, it shows all the built files as untracked. I've created a `.gitignore` file so that `git status` is clean even after a build. This also allows you to use `git add --all` when you create new files, rather than having to add each file individually.