### PR TITLE
Implement the --private-home option

### DIFF
--- a/src/firejail/arg-checking.txt
+++ b/src/firejail/arg-checking.txt
@@ -59,7 +59,7 @@ arg checking:
 	- check same owner
 	- unit test
 	
-9. --private.keep=filelist
+9. --private-home=filelist
 	- supported in profiles
 	- checking no ".."
 	- checking file found

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -282,9 +282,9 @@ void fs_private_dev(void);
 void fs_private(void);
 // private mode (--private=homedir)
 void fs_private_homedir(void);
-// private mode (--private.keep=list)
+// private mode (--private-home=list)
 void fs_private_home_list(void);
-// check directory linst specified by user (--private.keep option) - exit if it fails
+// check directory list specified by user (--private-home option) - exit if it fails
 void fs_check_home_list(void);
 // check new private home directory (--private= option) - exit if it fails
 void fs_check_private_dir(void);

--- a/src/firejail/fs_home.c
+++ b/src/firejail/fs_home.c
@@ -302,10 +302,10 @@ static void check_dir_or_file(const char *name) {
 	exit(1);
 }
 
-// check directory linst specified by user (--private.keep option) - exit if it fails
+// check directory list specified by user (--private-home option) - exit if it fails
 void fs_check_home_list(void) {
 	if (strstr(cfg.home_private_keep, "..")) {
-		fprintf(stderr, "Error: invalid private.keep list\n");
+		fprintf(stderr, "Error: invalid private-home list\n");
 		exit(1);
 	}
 	
@@ -385,7 +385,7 @@ static void duplicate(char *fname) {
 }
 
 
-// private mode (--private.keep=list):
+// private mode (--private-home=list):
 // 	mount homedir on top of /home/user,
 // 	tmpfs on top of  /root in nonroot mode,
 // 	tmpfs on top of /tmp in root mode,

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -677,7 +677,7 @@ int main(int argc, char **argv) {
 			arg_private = 1;
 		else if (strncmp(argv[i], "--private=", 10) == 0) {
 			if (cfg.home_private_keep) {
-				fprintf(stderr, "Error: a private list of files was already defined with --private.keep option.\n");
+				fprintf(stderr, "Error: a private list of files was already defined with --private-home option.\n");
 				exit(1);
 			}
 			
@@ -686,7 +686,8 @@ int main(int argc, char **argv) {
 			fs_check_private_dir();
 			arg_private = 1;
 		}
-		else if (strncmp(argv[i], "--private.keep=", 15) == 0) {
+		else if ((strncmp(argv[i], "--private.keep=", 15) == 0)
+		      || (strncmp(argv[i], "--private-home=", 15) == 0)) {
 			if (cfg.home_private) {
 				fprintf(stderr, "Error: a private home directory was already defined with --private option.\n");
 				exit(1);

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -228,7 +228,8 @@ int profile_check_line(char *ptr, int lineno) {
 	}
 
 	// private home list of files and directories
-	if (strncmp(ptr, "private.keep ", 13) == 0) {
+	if ((strncmp(ptr, "private.keep ", 13) == 0)
+	 || (strncmp(ptr, "private-home ", 13) == 0)) {
 		cfg.home_private_keep = ptr + 13;
 		fs_check_home_list();
 		arg_private = 1;

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -237,7 +237,7 @@ int sandbox(void* sandbox_arg) {
 	if (arg_private) {
 		if (cfg.home_private)	// --private=
 			fs_private_homedir();
-		else if (cfg.home_private_keep) // --private.keep=
+		else if (cfg.home_private_keep) // --private-home=
 			fs_private_home_list();
 		else // --private
 			fs_private();

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -148,7 +148,7 @@ void usage(void) {
 	printf("\t\tfilesystems. All modifications are discarded when the sandbox is\n");
 	printf("\t\tclosed.\n\n");
 	printf("\t--private=directory - use directory as user home.\n\n");
-	printf("\t--private.keep=file,directory - build a new user home in a temporary\n");
+	printf("\t--private-home=file,directory - build a new user home in a temporary\n");
 	printf("\t\tfilesystem, and copy the files and directories in the list in\n");
 	printf("\t\tthe new home. All modifications are discarded when the sandbox\n");
 	printf("\t\tis closed.\n\n");

--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -73,7 +73,7 @@ closed.
 \f\private directory
 Use directory as user home.
 .TP
-\f\private.keep file,directory
+\f\private-home file,directory
 Build a new user home in a temporary
 filesystem, and copy the files and directories in the list in the
 new home. All modifications are discarded when the sandbox is

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -639,7 +639,7 @@ Example:
 $ firejail \-\-private=/home/netblue/firefox-home firefox
 
 .TP
-\fB\-\-private.keep=file,directory
+\fB\-\-private-home=file,directory
 Build a new user home in a temporary
 filesystem, and copy the files and directories in the list in the
 new home. All modifications are discarded when the sandbox is
@@ -649,7 +649,7 @@ closed.
 .br
 Example:
 .br
-$ firejail \-\-private.keep=.mozilla firefox
+$ firejail \-\-private-home=.mozilla firefox
 .TP
 \fB\-\-private-dev
 Create a new /dev directory. Only null, full, zero, tty, pts, ptmx, random, urandom and shm devices are available.


### PR DESCRIPTION
This implements the enhancement in issue #15 - the `--private-home` option is another way of specifying `--private.keep`. The `--private.keep` option still works, but the documentation now only lists the `--private-home` option.