### PR TITLE
Replace get_link with realpath

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -251,7 +251,6 @@ void logmsg(const char *msg);
 void logargs(int argc, char **argv) ;
 void logerr(const char *msg);
 int copy_file(const char *srcname, const char *destname);
-char *get_link(const char *fname);
 int is_dir(const char *fname);
 int is_link(const char *fname);
 char *line_remove_spaces(const char *buf);

--- a/src/firejail/fs_dev.c
+++ b/src/firejail/fs_dev.c
@@ -127,30 +127,20 @@ void fs_dev_shm(void) {
 			errExit("mounting /dev/shm");
 	}
 	else {
-		char *lnk = get_link("/dev/shm");
+		char *lnk = realpath("/dev/shm", NULL);
 		if (lnk) {
-			// convert a link such as "../shm" into "/shm"
-			char *lnk2 = lnk;
-			int cnt = 0;
-			while (strncmp(lnk2, "../", 3) == 0) {
-				cnt++;
-				lnk2 = lnk2 + 3;
-			}
-			if (cnt != 0)
-				lnk2 = lnk + (cnt - 1) * 3 + 2;
-
-			if (!is_dir(lnk2)) {
+			if (!is_dir(lnk)) {
 				// create directory
-				if (mkdir(lnk2, S_IRWXU|S_IRWXG|S_IRWXO))
+				if (mkdir(lnk, S_IRWXU|S_IRWXG|S_IRWXO))
 					errExit("mkdir");
-				if (chown(lnk2, 0, 0))
+				if (chown(lnk, 0, 0))
 					errExit("chown");
-				if (chmod(lnk2, S_IRWXU|S_IRWXG|S_IRWXO))
+				if (chmod(lnk, S_IRWXU|S_IRWXG|S_IRWXO))
 					errExit("chmod");
 			}
 			if (arg_debug)
-				printf("Mounting tmpfs on %s on behalf of /dev/shm\n", lnk2);
-			if (mount("tmpfs", lnk2, "tmpfs", MS_NOSUID | MS_STRICTATIME | MS_REC,  "mode=777,gid=0") < 0)
+				printf("Mounting tmpfs on %s on behalf of /dev/shm\n", lnk);
+			if (mount("tmpfs", lnk, "tmpfs", MS_NOSUID | MS_STRICTATIME | MS_REC,  "mode=777,gid=0") < 0)
 				errExit("mounting /var/tmp");
 			free(lnk);
 		}

--- a/src/firejail/fs_var.c
+++ b/src/firejail/fs_var.c
@@ -240,7 +240,7 @@ void dbg_test_dir(const char *dir) {
 		if (is_dir(dir))
 			printf("%s is a directory\n", dir);
 		if (is_link(dir)) {
-			char *lnk = get_link(dir);
+			char *lnk = realpath(dir, NULL);
 			if (lnk) {
 				printf("%s is a symbolic link to %s\n", dir, lnk);
 				free(lnk);
@@ -259,30 +259,20 @@ void fs_var_lock(void) {
 			errExit("mounting /lock");
 	}
 	else {
-		char *lnk = get_link("/var/lock");
+		char *lnk = realpath("/var/lock", NULL);
 		if (lnk) {
-			// convert a link such as "../shm" into "/shm"
-			char *lnk2 = lnk;
-			int cnt = 0;
-			while (strncmp(lnk2, "../", 3) == 0) {
-				cnt++;
-				lnk2 = lnk2 + 3;
-			}
-			if (cnt != 0)
-				lnk2 = lnk + (cnt - 1) * 3 + 2;
-
-			if (!is_dir(lnk2)) {
+			if (!is_dir(lnk)) {
 				// create directory
-				if (mkdir(lnk2, S_IRWXU|S_IRWXG|S_IRWXO))
+				if (mkdir(lnk, S_IRWXU|S_IRWXG|S_IRWXO))
 					errExit("mkdir");
-				if (chown(lnk2, 0, 0))
+				if (chown(lnk, 0, 0))
 					errExit("chown");
-				if (chmod(lnk2, S_IRWXU|S_IRWXG|S_IRWXO))
+				if (chmod(lnk, S_IRWXU|S_IRWXG|S_IRWXO))
 					errExit("chmod");
 			}
 			if (arg_debug)
-				printf("Mounting tmpfs on %s on behalf of /var/lock\n", lnk2);
-			if (mount("tmpfs", lnk2, "tmpfs", MS_NOSUID | MS_STRICTATIME | MS_REC,  "mode=777,gid=0") < 0)
+				printf("Mounting tmpfs on %s on behalf of /var/lock\n", lnk);
+			if (mount("tmpfs", lnk, "tmpfs", MS_NOSUID | MS_STRICTATIME | MS_REC,  "mode=777,gid=0") < 0)
 				errExit("mounting /var/lock");
 			free(lnk);
 		}

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -172,30 +172,6 @@ int copy_file(const char *srcname, const char *destname) {
 	return 0;
 }
 
-
-char *get_link(const char *fname) {
-	assert(fname);
-	struct stat sb;
-	char *linkname;
-	ssize_t r;
-
-	if (lstat(fname, &sb) == -1)
-		return NULL;
-
-	linkname = malloc(sb.st_size + 1);
-	if (linkname == NULL)
-		return NULL;
-	memset(linkname, 0, sb.st_size + 1);
-
-	r = readlink(fname, linkname, sb.st_size + 1);
-	if (r < 0) {
-		free(linkname);
-		return NULL;
-	}
-	return linkname;
-}
-
-
 // return 1 if the file is a directory
 int is_dir(const char *fname) {
 	assert(fname);


### PR DESCRIPTION
Removed the `get_link` function in util.c and replace all calls to it with the `realpath` standard library function. This makes firejail handle all symlinks correctly.