### PR TITLE
Support ~ in blacklist and profile includes

### DIFF
--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -297,6 +297,11 @@ void fs_blacklist(const char *homedir) {
 				errExit("asprintf");
 			ptr = new_name;
 		}
+		else if (strncmp(ptr, "~/", 2) == 0) {
+			if (asprintf(&new_name, "%s%s", homedir, ptr + 1) == -1)
+				errExit("asprintf");
+			ptr = new_name;
+		}
 
 		// expand path macro - look for the file in /bin, /usr/bin, /sbin and  /usr/sbin directories
 		if (strncmp(ptr, "${PATH}", 7) == 0) {

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -430,6 +430,10 @@ void profile_read(const char *fname, const char *skip1, const char *skip2) {
 				if (asprintf(&newprofile2, "%s%s", cfg.homedir, newprofile + 7) == -1)
 					errExit("asprintf");
 			}				
+			else if (strncmp(newprofile, "~/", 2) == 0) {
+				if (asprintf(&newprofile2, "%s%s", cfg.homedir, newprofile + 1) == -1)
+					errExit("asprintf");
+			}				
 			
 			// recursivity
 			profile_read((newprofile2)? newprofile2:newprofile, newskip1, newskip2);

--- a/todo
+++ b/todo
@@ -1,6 +1,3 @@
 1. Deal with .purple directory. It holds the confiig files for pidgin
 
-2. Support ~ in --blacklist filenames, maybe in some other options. Example
-$ firejail --blacklist=~/.ssh
-
-3. Support filenames with spaces in blacklist option.
+2. Support filenames with spaces in blacklist option.


### PR DESCRIPTION
The `~` character is now supported in the `--blacklist` option and in profile includes for specifying the home directory of the current user.