### PR TITLE
Support filenames with spaces in the blacklist option

### DIFF
--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -69,7 +69,7 @@ static void check_file_name(char *ptr, int lineno) {
 
 	int len = strlen(ptr);
 	// file globbing ('*') is allowed
-	if (strcspn(ptr, "\\&!?\"'<>%^(){}[];, ") != len) {
+	if (strcspn(ptr, "\\&!?\"'<>%^(){}[];,") != len) {
 		if (lineno == 0)
 			fprintf(stderr, "Error: \"%s\" is an invalid filename\n", ptr);
 		else

--- a/todo
+++ b/todo
@@ -1,3 +1,2 @@
 1. Deal with .purple directory. It holds the confiig files for pidgin
 
-2. Support filenames with spaces in blacklist option.


### PR DESCRIPTION
Filenames with spaces can now be blacklisted on the command line:

`firejail "--blacklist=My Documents"`

...or in a profile file:

`blacklist My Documents`
