### PR TITLE
Compile with -W -Wall -Werror

### DIFF
--- a/src/firejail/Makefile.in
+++ b/src/firejail/Makefile.in
@@ -12,7 +12,7 @@ H_FILE_LIST       = $(wildcard *.[h])
 C_FILE_LIST       = $(wildcard *.c)
 OBJS = $(C_FILE_LIST:.c=.o)
 BINOBJS =  $(foreach file, $(OBJS), $file)
-CFLAGS += -ggdb -O2 -DVERSION='"$(VERSION)"' -DPREFIX='"$(PREFIX)"' $(HAVE_SECCOMP) $(HAVE_SECCOMP_H) $(HAVE_CHROOT) $(HAVE_BIND) -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIE -pie -Wformat -Wformat-security
+CFLAGS += -ggdb -W -Wall -Werror -O2 -DVERSION='"$(VERSION)"' -DPREFIX='"$(PREFIX)"' $(HAVE_SECCOMP) $(HAVE_SECCOMP_H) $(HAVE_CHROOT) $(HAVE_BIND) -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIE -pie -Wformat -Wformat-security
 LDFLAGS += -pie -Wl,-z,relro -Wl,-z,now -lpthread
 
 %.o : %.c $(H_FILE_LIST)

--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -199,7 +199,7 @@ static void globbing(OPERATION op, const char *fname, const char *emptydir, cons
 		glob_t globbuf;
 		globbuf.gl_offs = 0;
 		glob(fname, GLOB_DOOFFS, NULL, &globbuf);
-		int i;
+		unsigned int i;
 		for (i = 0; i < globbuf.gl_pathc; i++) {
 			assert(globbuf.gl_pathv[i]);
 			disable_file(op, globbuf.gl_pathv[i], emptydir, emptyfile);

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -175,7 +175,7 @@ static inline Bridge *last_bridge_configured(void) {
 static int read_pid(char *str, pid_t *pid) {
 	char *endptr;
 	errno = 0;
-	pid_t pidtmp = strtol(str, &endptr, 10);
+	long int pidtmp = strtol(str, &endptr, 10);
 	if ((errno == ERANGE && (pidtmp == LONG_MAX || pidtmp == LONG_MIN))
 		|| (errno != 0 && pidtmp == 0)) {
 		return 1;
@@ -183,7 +183,7 @@ static int read_pid(char *str, pid_t *pid) {
 	if (endptr == str) {
 		return 1;
 	}
-	*pid = pidtmp;
+	*pid = (pid_t)pidtmp;
 	return 0;
 }
 

--- a/src/firejail/netfilter.c
+++ b/src/firejail/netfilter.c
@@ -79,7 +79,7 @@ void netfilter(const char *fname) {
 		}
 
 		size_t sz = fread(filter, 1, s.st_size, fp);
-		if (sz != s.st_size) {
+		if ((off_t)sz != s.st_size) {
 			fprintf(stderr, "Error: cannot read network filter file\n");
 			exit(1);
 		}

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -69,7 +69,7 @@ static void check_file_name(char *ptr, int lineno) {
 
 	int len = strlen(ptr);
 	// file globbing ('*') is allowed
-	if (strcspn(ptr, "\\&!?\"'<>%^(){}[];,") != len) {
+	if (strcspn(ptr, "\\&!?\"'<>%^(){}[];,") != (size_t)len) {
 		if (lineno == 0)
 			fprintf(stderr, "Error: \"%s\" is an invalid filename\n", ptr);
 		else

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -130,6 +130,9 @@ static void chk_chroot(void) {
 }
 
 int sandbox(void* sandbox_arg) {
+	// Get rid of unused parameter warning
+	(void)sandbox_arg;
+
 	pid_t child_pid = getpid();
 	if (arg_debug)
 		printf("Initializing child process\n");	

--- a/src/firejail/seccomp.c
+++ b/src/firejail/seccomp.c
@@ -337,7 +337,7 @@ static void write_seccomp_file(void) {
 		printf("Save seccomp filter, size %lu bytes\n", sfilter_index * sizeof(struct sock_filter));
 	errno = 0;
 	ssize_t sz = write(fd, sfilter, sfilter_index * sizeof(struct sock_filter));
-	if (sz != (sfilter_index * sizeof(struct sock_filter))) {
+	if (sz != (ssize_t)(sfilter_index * sizeof(struct sock_filter))) {
 		fprintf(stderr, "Error: cannot save seccomp filter\n");
 		exit(1);
 	}

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -391,7 +391,8 @@ void extract_command_name(const char *str) {
 
 
 void update_map(char *mapping, char *map_file) {
-	int fd, j;
+	int fd;
+	size_t j;
 	size_t map_len;				  /* Length of 'mapping' */
 
 	/* Replace commas in mapping string with newlines */
@@ -407,7 +408,7 @@ void update_map(char *mapping, char *map_file) {
 		exit(EXIT_FAILURE);
 	}
 
-	if (write(fd, mapping, map_len) != map_len) {
+	if (write(fd, mapping, map_len) != (ssize_t)map_len) {
 		fprintf(stderr, "Error: cannot write to %s: %s\n", map_file, strerror(errno));
 		exit(EXIT_FAILURE);
 	}

--- a/src/firemon/Makefile.in
+++ b/src/firemon/Makefile.in
@@ -8,7 +8,7 @@ H_FILE_LIST       = $(wildcard *.[h])
 C_FILE_LIST       = $(wildcard *.c)
 OBJS = $(C_FILE_LIST:.c=.o)
 BINOBJS =  $(foreach file, $(OBJS), $file)
-CFLAGS += -ggdb -O2 -DVERSION='"$(VERSION)"' -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIE -pie -Wformat -Wformat-security
+CFLAGS += -ggdb -W -Wall -Werror -O2 -DVERSION='"$(VERSION)"' -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIE -pie -Wformat -Wformat-security
 LDFLAGS += -pie -Wl,-z,relro -Wl,-z,now 
 
 %.o : %.c $(H_FILE_LIST)

--- a/src/firemon/firemon.c
+++ b/src/firemon/firemon.c
@@ -40,6 +40,9 @@ static struct termios twait;	// no wait on key press
 static int terminal_set = 0;
 
 static void my_handler(int s){
+	// Remove unused parameter warning
+	(void)s;
+
 	if (terminal_set)
 		tcsetattr(0, TCSANOW, &tlocal);
 	exit(0); 

--- a/src/firemon/netstats.c
+++ b/src/firemon/netstats.c
@@ -195,7 +195,7 @@ void netstats(void) {
 		// start printing
 		firemon_clrscr();
 		char *header = get_header();
-		if (strlen(header) > col)
+		if (strlen(header) > (size_t)col)
 			header[col] = '\0';
 		printf("%s\n", header);
 		if (row > 0)

--- a/src/firemon/top.c
+++ b/src/firemon/top.c
@@ -42,7 +42,10 @@ static char *get_header(void) {
 // recursivity!!!
 static char *print_top(unsigned index, unsigned parent, unsigned *utime, unsigned *stime, unsigned itv, float *cpu, int *cnt) {
 	char *rv = NULL;
-	
+
+	// Remove unused parameter warning
+	(void)parent;
+
 	char procdir[20];
 	snprintf(procdir, 20, "/proc/%u", index);
 	struct stat s;
@@ -68,7 +71,7 @@ static char *print_top(unsigned index, unsigned parent, unsigned *utime, unsigne
 	
 	int i;
 	for (i = index + 1; i < max_pids; i++) {
-		if (pids[i].parent == index)
+		if (pids[i].parent == (pid_t)index)
 			print_top(i, index, utime, stime, itv, cpu, cnt);
 	}
 
@@ -213,7 +216,7 @@ void head_print(int col, int row) {
 		if (current >= row)
 			break;
 			
-		if (strlen(ptr->line) > col)
+		if (strlen(ptr->line) > (size_t)col)
 			ptr->line[col] = '\0';
 			
 		if (ptr->next == NULL || current == (row - 1)) {
@@ -264,7 +267,7 @@ void top(void) {
 		// start printing
 		firemon_clrscr();
 		char *header = get_header();
-		if (strlen(header) > col)
+		if (strlen(header) > (size_t)col)
 			header[col] = '\0';
 		printf("%s\n", header);
 		if (row > 0)

--- a/src/ftee/Makefile.in
+++ b/src/ftee/Makefile.in
@@ -8,7 +8,7 @@ H_FILE_LIST       = $(wildcard *.[h])
 C_FILE_LIST       = $(wildcard *.c)
 OBJS = $(C_FILE_LIST:.c=.o)
 BINOBJS =  $(foreach file, $(OBJS), $file)
-CFLAGS += -ggdb -O2 -DVERSION='"$(VERSION)"' -DPREFIX='"$(PREFIX)"' -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIE -pie -Wformat -Wformat-security
+CFLAGS += -ggdb -W -Wall -Werror -O2 -DVERSION='"$(VERSION)"' -DPREFIX='"$(PREFIX)"' -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIE -pie -Wformat -Wformat-security
 LDFLAGS += -pie -Wl,-z,relro -Wl,-z,now -lpthread
 
 %.o : %.c $(H_FILE_LIST)

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -6,7 +6,7 @@ H_FILE_LIST       = $(wildcard *.[h])
 C_FILE_LIST       = $(wildcard *.c)
 OBJS = $(C_FILE_LIST:.c=.o)
 BINOBJS =  $(foreach file, $(OBJS), $file)
-CFLAGS += -ggdb -O2 -DVERSION='"$(VERSION)"' -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIC -Wformat -Wformat-security
+CFLAGS += -ggdb -W -Wall -Werror -O2 -DVERSION='"$(VERSION)"' -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIC -Wformat -Wformat-security
 LDFLAGS:=-pic -Wl,-z,relro -Wl,-z,now 
 
 all: $(OBJS)

--- a/src/lib/libnetlink.c
+++ b/src/lib/libnetlink.c
@@ -363,7 +363,7 @@ int rtnl_talk(struct rtnl_handle *rtnl, struct nlmsghdr *n, pid_t peer,
 			fprintf(stderr, "sender address length == %d\n", msg.msg_namelen);
 			exit(1);
 		}
-		for (h = (struct nlmsghdr*)buf; status >= sizeof(*h); ) {
+		for (h = (struct nlmsghdr*)buf; status >= (int)sizeof(*h); ) {
 			int len = h->nlmsg_len;
 			int l = len - sizeof(*h);
 
@@ -376,7 +376,7 @@ int rtnl_talk(struct rtnl_handle *rtnl, struct nlmsghdr *n, pid_t peer,
 				exit(1);
 			}
 
-			if (nladdr.nl_pid != peer ||
+			if ((pid_t)(nladdr.nl_pid) != peer ||
 			    h->nlmsg_pid != rtnl->local.nl_pid ||
 			    h->nlmsg_seq != seq) {
 				/* Don't forget to skip that message. */
@@ -387,7 +387,7 @@ int rtnl_talk(struct rtnl_handle *rtnl, struct nlmsghdr *n, pid_t peer,
 
 			if (h->nlmsg_type == NLMSG_ERROR) {
 				struct nlmsgerr *err = (struct nlmsgerr*)NLMSG_DATA(h);
-				if (l < sizeof(struct nlmsgerr)) {
+				if (l < (int)sizeof(struct nlmsgerr)) {
 					fprintf(stderr, "ERROR truncated\n");
 				} else {
 					if (!err->error) {
@@ -465,7 +465,7 @@ int rtnl_listen(struct rtnl_handle *rtnl,
 			fprintf(stderr, "Sender address length == %d\n", msg.msg_namelen);
 			exit(1);
 		}
-		for (h = (struct nlmsghdr*)buf; status >= sizeof(*h); ) {
+		for (h = (struct nlmsghdr*)buf; status >= (int)sizeof(*h); ) {
 			int err;
 			int len = h->nlmsg_len;
 			int l = len - sizeof(*h);
@@ -528,7 +528,7 @@ int rtnl_from_file(FILE *rtnl, rtnl_filter_t handler,
 		len = h->nlmsg_len;
 		l = len - sizeof(*h);
 
-		if (l<0 || len>sizeof(buf)) {
+		if (l < 0 || len > (int)sizeof(buf)) {
 			fprintf(stderr, "!!!malformed message: len=%d @%lu\n",
 				len, ftell(rtnl));
 			return -1;
@@ -619,7 +619,7 @@ printf("\tdata length: %d\n", alen);
 	int len = RTA_LENGTH(alen);
 	struct rtattr *rta;
 
-	if (NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len) > maxlen) {
+	if ((int)(NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len)) > maxlen) {
 		fprintf(stderr, "addattr_l ERROR: message exceeded bound of %d\n",maxlen);
 		return -1;
 	}
@@ -673,7 +673,7 @@ else
 
 int addraw_l(struct nlmsghdr *n, int maxlen, const void *data, int len)
 {
-	if (NLMSG_ALIGN(n->nlmsg_len) + NLMSG_ALIGN(len) > maxlen) {
+	if ((int)(NLMSG_ALIGN(n->nlmsg_len) + NLMSG_ALIGN(len)) > maxlen) {
 		fprintf(stderr, "addraw_l ERROR: message exceeded bound of %d\n",maxlen);
 		return -1;
 	}
@@ -792,7 +792,7 @@ int parse_rtattr_byindex(struct rtattr *tb[], int max, struct rtattr *rta, int l
 int __parse_rtattr_nested_compat(struct rtattr *tb[], int max, struct rtattr *rta,
 			         int len)
 {
-	if (RTA_PAYLOAD(rta) < len)
+	if ((int)RTA_PAYLOAD(rta) < len)
 		return -1;
 	if (RTA_PAYLOAD(rta) >= RTA_ALIGN(len) + sizeof(struct rtattr)) {
 		rta = RTA_DATA(rta) + RTA_ALIGN(len);

--- a/src/lib/pid.c
+++ b/src/lib/pid.c
@@ -222,15 +222,18 @@ static void print_elem(unsigned index, int nowrap) {
 // recursivity!!!
 void pid_print_tree(unsigned index, unsigned parent, int nowrap) {
 	print_elem(index, nowrap);
+
+	// Remove unused parameter warning
+	(void)parent;
 	
-	int i;
-	for (i = index + 1; i < max_pids; i++) {
-		if (pids[i].parent == index)
+	unsigned i;
+	for (i = index + 1; i < (unsigned)max_pids; i++) {
+		if (pids[i].parent == (pid_t)index)
 			pid_print_tree(i, index, nowrap);
 	}
 
 	for (i = 0; i < index; i++) {
-		if (pids[i].parent == index)
+		if (pids[i].parent == (pid_t)index)
 			pid_print_tree(i, index, nowrap);
 	}
 }
@@ -245,6 +248,9 @@ void pid_store_cpu(unsigned index, unsigned parent, unsigned *utime, unsigned *s
 		*utime = 0;
 		*stime = 0;
 	}
+
+	// Remove unused parameter warning
+	(void)parent;
 	
 	unsigned utmp = 0;
 	unsigned stmp = 0;
@@ -252,9 +258,9 @@ void pid_store_cpu(unsigned index, unsigned parent, unsigned *utime, unsigned *s
 	*utime += utmp;
 	*stime += stmp;
 	
-	int i;
-	for (i = index + 1; i < max_pids; i++) {
-		if (pids[i].parent == index)
+	unsigned i;
+	for (i = index + 1; i < (unsigned)max_pids; i++) {
+		if (pids[i].parent == (pid_t)index)
 			pid_store_cpu(i, index, utime, stime);
 	}
 

--- a/src/libtrace/Makefile.in
+++ b/src/libtrace/Makefile.in
@@ -6,7 +6,7 @@ H_FILE_LIST       = $(wildcard *.[h])
 C_FILE_LIST       = $(wildcard *.c)
 OBJS = $(C_FILE_LIST:.c=.o)
 BINOBJS =  $(foreach file, $(OBJS), $file)
-CFLAGS += -ggdb -O2 -DVERSION='"$(VERSION)"' -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIC -Wformat -Wformat-security
+CFLAGS += -ggdb -W -Wall -Werror -O2 -DVERSION='"$(VERSION)"' -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIC -Wformat -Wformat-security
 LDFLAGS += -pie -Wl,-z,relro -Wl,-z,now 
 
 all: libtrace.so


### PR DESCRIPTION
Firejail now compiles with the `-W -Wall -Werror` option in `CFLAGS`. This option enables all warnings and turns them into errors, i.e. the compile stops if there are any warnings. I've removed all existing warnings so the code is now clean, and this means that in future the code will remain clean (as it's now impossible to introduce new warnings without breaking the build).