### PR TITLE
Fix arguments passed to child process during execvp in --shell=none mode

### DIFF
--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -437,7 +437,7 @@ int sandbox(void* sandbox_arg) {
 
 		if (!arg_command)
 			printf("Child process initialized\n");
-		execvp(cfg.original_argv[cfg.original_program_index], &cfg.original_argv[cfg.original_program_index + 1]);
+		execvp(cfg.original_argv[cfg.original_program_index], &cfg.original_argv[cfg.original_program_index]);
 	}
 	//****************************************
 	// start the program using a shell


### PR DESCRIPTION
Without this patch, firejail handles arguments differently in `--shell=none` mode. For example, this is a normal command:

```
$ firejail --debug /bin/echo 1 2 3
...
Starting /bin/echo 1 2 3 
execvp argument 0: /bin/bash
execvp argument 1: -c
execvp argument 2: /bin/echo 1 2 3 
Child process initialized
1 2 3
```
But when you execute it with `--shell=none`, it drops the first argument, and only "2 3" is printed:
```
firejail --debug --shell=none /bin/echo 1 2 3
...
execvp argument 0: /bin/echo
execvp argument 1: 1
execvp argument 2: 2
execvp argument 3: 3
Child process initialized
2 3
```
This patch makes the `--shell=none` command work the same as a normal command:
```
firejail --debug --shell=none /bin/echo 1 2 3
...
execvp argument 0: /bin/echo
execvp argument 1: 1
execvp argument 2: 2
execvp argument 3: 3
Child process initialized
1 2 3
```
This does mean that existing scripts that use `--shell=none` will have to be changed.