### PR TITLE
Support --enable-fatal-warnings in all Makefiles

### DIFF
--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -1,12 +1,13 @@
 PREFIX=@prefix@
 VERSION=@PACKAGE_VERSION@
 NAME=@PACKAGE_NAME@
+HAVE_FATAL_WARNINGS=@HAVE_FATAL_WARNINGS@
 
 H_FILE_LIST       = $(wildcard *.[h])
 C_FILE_LIST       = $(wildcard *.c)
 OBJS = $(C_FILE_LIST:.c=.o)
 BINOBJS =  $(foreach file, $(OBJS), $file)
-CFLAGS += -ggdb -O2 -DVERSION='"$(VERSION)"' -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIC -Wformat -Wformat-security
+CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIC -Wformat -Wformat-security
 LDFLAGS:=-pic -Wl,-z,relro -Wl,-z,now 
 
 all: $(OBJS)

--- a/src/libtrace/Makefile.in
+++ b/src/libtrace/Makefile.in
@@ -1,6 +1,7 @@
 PREFIX=@prefix@
 VERSION=@PACKAGE_VERSION@
 NAME=@PACKAGE_NAME@
+HAVE_FATAL_WARNINGS=@HAVE_FATAL_WARNINGS@
 
 H_FILE_LIST       = $(wildcard *.[h])
 C_FILE_LIST       = $(wildcard *.c)


### PR DESCRIPTION
Putting `--enable-fatal-warnings` in the `./configure` command is a great idea, thank you for that! As it means we can easily turn it on and off, I've made a patch to make it available in all the Makefiles.