### PR TITLE
Implement the expand_home util function

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -263,6 +263,7 @@ void check_private_dir(void);
 void update_map(char *mapping, char *map_file);
 void wait_for_other(int fd);
 void notify_other(int fd);
+char *expand_home(const char *path, const char* homedir);
 
 // fs_var.c
 void fs_var_log(void);	// mounting /var/log

--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -291,17 +291,8 @@ void fs_blacklist(const char *homedir) {
 		}
 
 		// replace home macro in blacklist array
-		char *new_name = NULL;
-		if (strncmp(ptr, "${HOME}", 7) == 0) {
-			if (asprintf(&new_name, "%s%s", homedir, ptr + 7) == -1)
-				errExit("asprintf");
-			ptr = new_name;
-		}
-		else if (strncmp(ptr, "~/", 2) == 0) {
-			if (asprintf(&new_name, "%s%s", homedir, ptr + 1) == -1)
-				errExit("asprintf");
-			ptr = new_name;
-		}
+		char *new_name = expand_home(ptr, homedir);
+		ptr = new_name;
 
 		// expand path macro - look for the file in /bin, /usr/bin, /sbin and  /usr/sbin directories
 		if (strncmp(ptr, "${PATH}", 7) == 0) {

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -433,15 +433,7 @@ void profile_read(const char *fname, const char *skip1, const char *skip2) {
 			}
 			
 			// expand ${HOME}/ in front of the new profile file
-			char *newprofile2 = NULL;
-			if (strncmp(newprofile, "${HOME}", 7) == 0) {
-				if (asprintf(&newprofile2, "%s%s", cfg.homedir, newprofile + 7) == -1)
-					errExit("asprintf");
-			}				
-			else if (strncmp(newprofile, "~/", 2) == 0) {
-				if (asprintf(&newprofile2, "%s%s", cfg.homedir, newprofile + 1) == -1)
-					errExit("asprintf");
-			}				
+			char *newprofile2 = expand_home(newprofile, cfg.homedir);
 			
 			// recursivity
 			profile_read((newprofile2)? newprofile2:newprofile, newskip1, newskip2);

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -455,3 +455,30 @@ void notify_other(int fd) {
 	fflush(stream);
 	fclose(stream);
 }
+
+// This function takes a pathname supplied by the user and expands '~' and
+// '${HOME}' at the start, to refer to a path relative to the user's home
+// directory (supplied).
+// The return value is allocated using malloc and must be freed by the caller.
+// The function returns NULL if there are any errors.
+char *expand_home(const char *path, const char* homedir)
+{
+	assert(path);
+	assert(homedir);
+	
+	// Replace home macro
+	char *new_name = NULL;
+	if (strncmp(path, "${HOME}", 7) == 0) {
+		if (asprintf(&new_name, "%s%s", homedir, path + 7) == -1)
+			errExit("asprintf");
+		return new_name;
+	}
+	else if (strncmp(path, "~/", 2) == 0) {
+		if (asprintf(&new_name, "%s%s", homedir, path + 1) == -1)
+			errExit("asprintf");
+		return new_name;
+	}
+	
+	return strdup(path);
+}
+


### PR DESCRIPTION
Implemented a new function called `expand_home` in util.c, in order to help with issue #40 . The following now work, that didn't before:

`firejail --private-home=~/dir/file`
`firejail --private-home=${HOME}/dir/file`

As a nice side-effect, the following now also works (previously `--private` only supported `~` for homedir):

`firejail --private=${HOME}/dir`

Hopefully I haven't broken anything else but please give it a test!