### PR TITLE
Rewrite globbing code to fix various minor issues

### DIFF
--- a/etc/disable-history.inc
+++ b/etc/disable-history.inc
@@ -1,10 +1,3 @@
 # History files in $HOME
 blacklist ${HOME}/.history
-blacklist ${HOME}/.bash_history
-blacklist ${HOME}/.zsh_history
-blacklist ${HOME}/.ksh_history
-blacklist ${HOME}/.sh_history
-blacklist ${HOME}/.nano_history
-blacklist ${HOME}/.python_history
-blacklist ${HOME}/.mysql_history
-blacklist ${HOME}/.pgsql_history
+blacklist ${HOME}/.*_history


### PR DESCRIPTION
* Plug a memory leak.
* Remove the short-circuit.  (This breaks when someone uses [] or ?
  patterns without using *.  I figure it's best to use the principle of
  least surprise and just let the system glob() implementation do what
  it does.)
* Stop sorting results.

I've also replaced a lot of disable-history.inc with a glob pattern.
Now it catches files like .sqlite_history and whatever the user runs
under rlwrap.