### PR TITLE
Clean up some fragile uses of strncmp.

### DIFF
--- a/src/firejail/caps.c
+++ b/src/firejail/caps.c
@@ -377,7 +377,7 @@ static uint64_t extract_caps(int pid) {
 	
 	char buf[MAXBUF];
 	while (fgets(buf, MAXBUF, fp)) {
-		if (strncmp(buf, "CapBnd:", 7) == 0) {
+		if (strncmp(buf, "CapBnd:\t", 8) == 0) {
 			char *ptr = buf + 8;
 			unsigned long long val;
 			sscanf(ptr, "%llx", &val);

--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -246,7 +246,7 @@ void fs_blacklist(const char *homedir) {
 		char *ptr;
 
 		// process blacklist command
-		if (strncmp(entry->data, "bind", 4) == 0)  {
+		if (strncmp(entry->data, "bind ", 5) == 0)  {
 			char *dname1 = entry->data + 5;
 			char *dname2 = split_comma(dname1);
 			if (dname2 == NULL) {
@@ -284,15 +284,15 @@ void fs_blacklist(const char *homedir) {
 		}
 
 		// process blacklist command
-		if (strncmp(entry->data, "blacklist", 9) == 0)  {
+		if (strncmp(entry->data, "blacklist ", 10) == 0)  {
 			ptr = entry->data + 10;
 			op = BLACKLIST_FILE;
 		}
-		else if (strncmp(entry->data, "read-only", 9) == 0) {
+		else if (strncmp(entry->data, "read-only ", 10) == 0) {
 			ptr = entry->data + 10;
 			op = MOUNT_READONLY;
 		}			
-		else if (strncmp(entry->data, "tmpfs", 5) == 0) {
+		else if (strncmp(entry->data, "tmpfs ", 6) == 0) {
 			ptr = entry->data + 6;
 			op = MOUNT_TMPFS;
 		}			


### PR DESCRIPTION
In some places the code compares the first n characters of a string and
then assumes a valid string starts from the n+2th character.  I didn't
find any places where this wasn't justifiable, but I think it's better
to stick to safer patterns, especially in SUID code.