### PR TITLE
added install-strip, make install now without strip.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -50,6 +50,80 @@ distclean: clean
 
 install: all
 	# firejail executable
+	mkdir -p $(DESTDIR)/$(PREFIX)/bin
+	install -c -m 0755 src/firejail/firejail $(DESTDIR)/$(PREFIX)/bin/.
+	chmod u+s $(DESTDIR)/$(PREFIX)/bin/firejail
+	# firemon executable
+	install -c -m 0755 src/firemon/firemon $(DESTDIR)/$(PREFIX)/bin/.
+	# libraries and plugins
+	mkdir -p $(DESTDIR)/$(PREFIX)/lib/firejail
+	install -c -m 0644 src/libtrace/libtrace.so $(DESTDIR)/$(PREFIX)/lib/firejail/.
+	install -c -m 0755 src/ftee/ftee $(DESTDIR)/$(PREFIX)/lib/firejail/.
+	install -c -m 0755 src/fshaper/fshaper.sh $(DESTDIR)/$(PREFIX)/lib/firejail/.
+	# documents
+	mkdir -p $(DESTDIR)/$(DOCDIR)
+	install -c -m 0644 COPYING $(DESTDIR)/$(DOCDIR)/.
+	install -c -m 0644 README $(DESTDIR)/$(DOCDIR)/.
+	install -c -m 0644 RELNOTES $(DESTDIR)/$(DOCDIR)/.
+	# etc files
+	mkdir -p $(DESTDIR)/etc/firejail
+	install -c -m 0644 etc/audacious.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/clementine.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/gnome-mplayer.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/rhythmbox.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/totem.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/firefox.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/icedove.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/iceweasel.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/midori.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/evince.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/chromium-browser.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/chromium.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/disable-mgmt.inc $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/disable-secret.inc $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/disable-common.inc $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/disable-history.inc $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/dropbox.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/opera.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/thunderbird.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/transmission-gtk.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/transmission-qt.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/vlc.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/deluge.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/qbittorrent.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/generic.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/pidgin.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/xchat.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/empathy.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/server.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/icecat.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/quassel.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/deadbeef.profile $(DESTDIR)/etc/firejail/.
+	install -c -m 0644 etc/filezilla.profile $(DESTDIR)/etc/firejail/.
+	bash -c "if [ ! -f /etc/firejail/login.users ]; then install -c -m 0644 etc/login.users $(DESTDIR)/etc/firejail/.; fi;"
+	# man pages
+	rm -f firejail.1.gz
+	gzip -9n firejail.1
+	rm -f firemon.1.gz
+	gzip -9n firemon.1
+	rm -f firejail-profile.5.gz
+	gzip -9n firejail-profile.5
+	rm -f firejail-login.5.gz
+	gzip -9n firejail-login.5
+	mkdir -p $(DESTDIR)/$(PREFIX)/share/man/man1
+	install -c -m 0644 firejail.1.gz $(DESTDIR)/$(PREFIX)/share/man/man1/.	
+	install -c -m 0644 firemon.1.gz $(DESTDIR)/$(PREFIX)/share/man/man1/.	
+	mkdir -p $(DESTDIR)/$(PREFIX)/share/man/man5
+	install -c -m 0644 firejail-profile.5.gz $(DESTDIR)/$(PREFIX)/share/man/man5/.	
+	install -c -m 0644 firejail-login.5.gz $(DESTDIR)/$(PREFIX)/share/man/man5/.	
+	rm -f firejail.1.gz firemon.1.gz firejail-profile.5.gz firejail-login.5.gz
+	# bash completion
+	mkdir -p $(DESTDIR)/$(PREFIX)/share/bash-completion/completions
+	install -c -m 0644 src/bash_completion/firejail.bash_completion $(DESTDIR)/$(PREFIX)/share/bash-completion/completions/firejail
+	install -c -m 0644 src/bash_completion/firemon.bash_completion $(DESTDIR)/$(PREFIX)/share/bash-completion/completions/firemon
+
+install-strip: all
+	# firejail executable
 	strip src/firejail/firejail
 	mkdir -p $(DESTDIR)/$(PREFIX)/bin
 	install -c -m 0755 src/firejail/firejail $(DESTDIR)/$(PREFIX)/bin/.


### PR DESCRIPTION
The default in autotools is not to strip executables when doing make install, but only when doing make install-strip. Not doing that confuses a lot of automated build systems like source based package managers or tools that build packages automatically. It would be very nice if you could pull this.