### PR TITLE
Add a profile for Spotify

### DIFF
--- a/etc/spotify.profile
+++ b/etc/spotify.profile
@@ -1,0 +1,19 @@
+# Spotify profile
+include /etc/firejail/disable-mgmt.inc
+include /etc/firejail/disable-secret.inc
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-history.inc
+
+# Whitelist the folders needed by Spotify - This is more restrictive 
+# than a blacklist though, but this is all spotify requires for 
+# streaming audio
+whitelist ${HOME}/.config/spotify
+whitelist ${HOME}/.local/share/spotify
+whitelist ${HOME}/.cache/spotify
+# Whitelist the pulseaudio config, to allow PulseAudio workaround (Issue #69)
+whitelist ${HOME}/.config/pulse
+
+caps.drop all
+seccomp
+netfilter
+noroot


### PR DESCRIPTION
This PR proposes a firejail profile for Spotify.

Since Spotify, when used for streaming, only requires access to a very small group of folders (config, local and cache for itself), I created the profile based around a whitelist. 

Finally, it allows access to the per-user pulseaudio config directory, in case anyone is using the [workaround for PulseAudio 7](https://github.com/netblue30/firejail/blob/master/README.md#pulseaudio-70)