### PR TITLE
Update pidgin.profile

### DIFF
--- a/etc/pidgin.profile
+++ b/etc/pidgin.profile
@@ -1,4 +1,5 @@
 # Pidgin profile
+noblacklist ${HOME}/.purple
 include /etc/firejail/disable-mgmt.inc
 include /etc/firejail/disable-secret.inc
 include /etc/firejail/disable-common.inc


### PR DESCRIPTION
Pidgin's data directory is blacklisted in disable-common.inc, so it couldn't access it.