### PR TITLE
Use configured libdir instead of $prefix/lib

### DIFF
--- a/src/firejail/Makefile.in
+++ b/src/firejail/Makefile.in
@@ -1,6 +1,9 @@
 all: firejail
 
-PREFIX=@prefix@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+
 VERSION=@PACKAGE_VERSION@
 NAME=@PACKAGE_NAME@
 HAVE_SECCOMP_H=@HAVE_SECCOMP_H@
@@ -13,7 +16,7 @@ H_FILE_LIST       = $(wildcard *.[h])
 C_FILE_LIST       = $(wildcard *.c)
 OBJS = $(C_FILE_LIST:.c=.o)
 BINOBJS =  $(foreach file, $(OBJS), $file)
-CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' -DPREFIX='"$(PREFIX)"' $(HAVE_SECCOMP) $(HAVE_SECCOMP_H) $(HAVE_CHROOT) $(HAVE_BIND) -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIE -pie -Wformat -Wformat-security
+CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' -DPREFIX='"$(prefix)"' -DLIBDIR='"$(libdir)"' $(HAVE_SECCOMP) $(HAVE_SECCOMP_H) $(HAVE_CHROOT) $(HAVE_BIND) -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIE -pie -Wformat -Wformat-security
 LDFLAGS += -pie -Wl,-z,relro -Wl,-z,now -lpthread
 
 %.o : %.c $(H_FILE_LIST)

--- a/src/firejail/bandwidth.c
+++ b/src/firejail/bandwidth.c
@@ -447,18 +447,18 @@ void bandwidth_pid(pid_t pid, const char *command, const char *dev, int down, in
 	cmd = NULL;
 	if (devname) {
 		if (strcmp(command, "set") == 0) {
-			if (asprintf(&cmd, "%s/lib/firejail/fshaper.sh --%s %s %d %d",
-				PREFIX, command, devname, down, up) == -1)
+			if (asprintf(&cmd, "%s/firejail/fshaper.sh --%s %s %d %d",
+				LIBDIR, command, devname, down, up) == -1)
 				errExit("asprintf");
 		}
 		else {
-			if (asprintf(&cmd, "%s/lib/firejail/fshaper.sh --%s %s", 
-				PREFIX, command, devname) == -1)
+			if (asprintf(&cmd, "%s/firejail/fshaper.sh --%s %s",
+				LIBDIR, command, devname) == -1)
 				errExit("asprintf");
 		}
 	}
 	else {
-		if (asprintf(&cmd, "%s/lib/firejail/fshaper.sh --%s", PREFIX, command) == -1)
+		if (asprintf(&cmd, "%s/firejail/fshaper.sh --%s", LIBDIR, command) == -1)
 			errExit("asprintf");
 	}
 	assert(cmd);

--- a/src/firejail/fs_trace.c
+++ b/src/firejail/fs_trace.c
@@ -58,7 +58,7 @@ void fs_trace(void) {
 	FILE *fp = fopen(preload, "w");
 	if (!fp)
 		errExit("fopen");
-	fprintf(fp, "%s/lib/firejail/libtrace.so\n", PREFIX);
+	fprintf(fp, "%s/firejail/libtrace.so\n", LIBDIR);
 	fclose(fp);
 	if (chown(preload, 0, 0) < 0)
 		errExit("chown");

--- a/src/firejail/output.c
+++ b/src/firejail/output.c
@@ -88,7 +88,7 @@ void check_output(int argc, char **argv) {
 			continue;
 		ptr += sprintf(ptr, "%s ", argv[i]);
 	}
-	sprintf(ptr, "| %s/lib/firejail/ftee %s", PREFIX, outfile);
+	sprintf(ptr, "| %s/firejail/ftee %s", LIBDIR, outfile);
 
 	// run command
 	char *a[4];


### PR DESCRIPTION
When a non-default libdir is used, firejail installs
some components in this directory, but the hardcoded
paths to ftee etc. still point to $prefix/lib.
Use the configured libdir path instead.