### PR TITLE
Allow firefox theming with non-global themes

### DIFF
--- a/etc/firefox.profile
+++ b/etc/firefox.profile
@@ -17,6 +17,7 @@ whitelist ~/.zotero
 whitelist ~/.lastpass
 whitelist ~/.gtkrc-2.0
 whitelist ~/.config/gtk-3.0
+whitelist ~/.themes/
 whitelist ~/.vimperatorrc
 whitelist ~/.vimperator
 whitelist ~/.pentadactylrc


### PR DESCRIPTION
User can have gtk themes installed locally. This directory is pretty safe to read, no private data there.