### PR TITLE
Fixed Skype profile: was a copy of Steam profile

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -25,6 +25,7 @@ blacklist ${HOME}/.config/psi+
 blacklist ${HOME}/.retroshare
 blacklist ${HOME}/.weechat
 blacklist ${HOME}/.config/xchat
+blacklist ${HOME}/.Skype
 
 # Cryptocoins
 blacklist ${HOME}/.*coin

--- a/etc/skype.profile
+++ b/etc/skype.profile
@@ -1,6 +1,5 @@
 # Skype profile
-noblacklist ${HOME}/.steam
-noblacklist ${HOME}/.local/share/steam
+noblacklist ${HOME}/.Skype
 include /etc/firejail/disable-mgmt.inc
 include /etc/firejail/disable-secret.inc
 include /etc/firejail/disable-common.inc


### PR DESCRIPTION
It seems that default Skype profile, introduced in 4faa338ca738a0bf40d07b6d4b9b98f62a3cb34f, is and exact duplicate of Steam profile. Thus, Skype has access to Steam directories.
Besides, file containing Skype account credentials could be stolen and used to login from another machine.

Thus in this commit, I:
1) blacklisted ~/.Skype directory in `disable-common.inc`
2) revoked Skype access to Steam dirs, and granted it access to Skype dirs in `skype.profile`