### PR TITLE
Fix warnings by clang-analyzer (scan-build)

### DIFF
--- a/src/firejail/fs_whitelist.c
+++ b/src/firejail/fs_whitelist.c
@@ -61,7 +61,7 @@ static void whitelist_path(ProfileEntry *entry) {
 	char *path = entry->data + 10;
 	assert(path);
 	const char *fname;
-	char *wfile;
+	char *wfile = NULL;
 	
 	if (entry->home_dir) {
 		fname = path + strlen(cfg.homedir);
@@ -86,7 +86,7 @@ static void whitelist_path(ProfileEntry *entry) {
 
 	// check if the file exists
 	struct stat s;
-	if (stat(wfile, &s) == 0) {
+	if (wfile && stat(wfile, &s) == 0) {
 		if (arg_debug)
 			printf("Whitelisting %s\n", path);
 	}

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -258,7 +258,7 @@ char *line_remove_spaces(const char *buf) {
 	}
 
 	// strip last blank character if any
-	if (*(ptr2 - 1) == ' ')
+	if (ptr2 > rv && *(ptr2 - 1) == ' ')
 		--ptr2;
 	*ptr2 = '\0';
 	//	if (arg_debug)

--- a/src/lib/libnetlink.c
+++ b/src/lib/libnetlink.c
@@ -626,7 +626,8 @@ printf("\tdata length: %d\n", alen);
 	rta = NLMSG_TAIL(n);
 	rta->rta_type = type;
 	rta->rta_len = len;
-	memcpy(RTA_DATA(rta), data, alen);
+	if (data)
+		memcpy(RTA_DATA(rta), data, alen);
 	n->nlmsg_len = NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len);
 	return 0;
 }


### PR DESCRIPTION
This fixes a few minor problems found by scan-build.