### PR TITLE
Fix #144

### DIFF
--- a/src/firejail/fs_whitelist.c
+++ b/src/firejail/fs_whitelist.c
@@ -387,6 +387,9 @@ void fs_whitelist(void) {
 			// if the link is already there, do not bother
 			struct stat s;
 			if (stat(entry->link, &s) != 0) {
+				// create the path if necessary
+				mkpath(entry->link, 0755);
+
 				int rv = symlink(entry->data + 10, entry->link);
 				if (rv)
 					fprintf(stderr, "Warning cannot create symbolic link %s\n", entry->link);


### PR DESCRIPTION
When whitelisting symlinks, ensure the parent directories exist.

This should fix it. At least for me it's working.
Please review the changes.