### PR TITLE
Add '"' chars around every argument passed to bash

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1188,11 +1188,12 @@ int main(int argc, char **argv) {
 	}
 	else {
 		// calculate the length of the command
+		// TODO: escape the '"' characters, and possibly others like '\' and '!' if they can cause problems
 		int i;
 		int len = 0;
 		int argcnt = argc - prog_index;
 		for (i = 0; i < argcnt; i++)
-			len += strlen(argv[i + prog_index]) + 1; // + ' '
+			len += strlen(argv[i + prog_index]) + 3; // + ' ' + 2 '"'
 
 		// build the string
 		cfg.command_line = malloc(len + 1); // + '\0'
@@ -1200,7 +1201,7 @@ int main(int argc, char **argv) {
 			errExit("malloc");
 		char *ptr = cfg.command_line;
 		for (i = 0; i < argcnt; i++) {
-			sprintf(ptr, "%s ", argv[i + prog_index]);
+			sprintf(ptr, "\"%s\" ", argv[i + prog_index]);
 			ptr += strlen(ptr);
 		}
 	}


### PR DESCRIPTION
This seems to fix the problem with the spaces when a program is started through a shell (Bug #58).
Starting a program without using a shell is still working.

I haven't tested this thoroughly though, so I'm not sure if this causes any other problems.

---

However, spaces are not the only characters that can cause problems when starting a program through a shell.
If, for example, you open a file that contains `"` somewhere, it will probably fail.

So, to fully fix this, `"` characters will have to be escaped. Other characters, like `\` and `!` may also have to be escaped.
*Or* set "shell=none" as default, which would be even easier :smile: (but I suppose this is not the default for a reason).