### PR TITLE
add parole.profile

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -127,6 +127,7 @@ realinstall:
 	install -c -m 0644 .etc/weechat-curses.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/hexchat.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/rtorrent.profile $(DESTDIR)/$(sysconfdir)/firejail/.
+	install -c -m 0644 .etc/parole.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	bash -c "if [ ! -f $(DESTDIR)/$(sysconfdir)/firejail/login.users ]; then install -c -m 0644 etc/login.users $(DESTDIR)/$(sysconfdir)/firejail/.; fi;"
 	rm -fr .etc
 	# man pages

--- a/etc/parole.profile
+++ b/etc/parole.profile
@@ -1,0 +1,17 @@
+# Profile for Parole, the default XFCE4 media player
+include /etc/firejail/disable-mgmt.inc
+include /etc/firejail/disable-secret.inc
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
+private-etc passwd,group,fonts
+private-bin parole,dbus-launch
+blacklist ${HOME}/.pki/nssdb
+blacklist ${HOME}/.lastpass
+blacklist ${HOME}/.keepassx
+blacklist ${HOME}/.password-store
+caps.drop all
+seccomp
+protocol unix,inet,inet6
+netfilter
+noroot
+shell none

--- a/platform/debian/conffiles
+++ b/platform/debian/conffiles
@@ -53,3 +53,4 @@
 /etc/firejail/weechat-curses.profile
 /etc/firejail/hexchat.profile
 /etc/firejail/rtorrent.profile
+/etc/firejail/parole.profile


### PR DESCRIPTION
Why are those entries scattered around in some profiles? Shouldn't they go to some common profile like disable-secret.inc?
```
blacklist ${HOME}/.pki/nssdb
blacklist ${HOME}/.lastpass
blacklist ${HOME}/.keepassx
blacklist ${HOME}/.password-store
```