### PR TITLE
whitelist keysnail config for firefox

### DIFF
--- a/etc/firefox.profile
+++ b/etc/firefox.profile
@@ -20,6 +20,7 @@ whitelist ~/.vimperatorrc
 whitelist ~/.vimperator
 whitelist ~/.pentadactylrc
 whitelist ~/.pentadactyl
+whitelist ~/.keysnail.js
 whitelist ~/.config/gnome-mplayer
 whitelist ~/.cache/gnome-mplayer/plugin
 include /etc/firejail/whitelist-common.inc


### PR DESCRIPTION
This whitelists [keysnail](https://github.com/mooz/keysnail/wiki)'s config (extension like vimperator and pentadactyl). This is the default place for the config.