### PR TITLE
Make the build reproducible

### DIFF
--- a/mkman.sh
+++ b/mkman.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 sed "s/VERSION/$1/g" $2 > $3
-MONTH=`date +%b`
+MONTH=`LC_ALL=C date -u --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%b`
 sed -i "s/MONTH/$MONTH/g" $3
-YEAR=`date +%Y`
+YEAR=`LC_ALL=C date -u --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y`
 sed -i "s/YEAR/$YEAR/g" $3

--- a/src/firejail/Makefile.in
+++ b/src/firejail/Makefile.in
@@ -14,8 +14,8 @@ HAVE_BIND=@HAVE_BIND@
 HAVE_FATAL_WARNINGS=@HAVE_FATAL_WARNINGS@
 
 
-H_FILE_LIST       = $(wildcard *.[h])
-C_FILE_LIST       = $(wildcard *.c)
+H_FILE_LIST       = $(sort $(wildcard *.[h]))
+C_FILE_LIST       = $(sort $(wildcard *.c))
 OBJS = $(C_FILE_LIST:.c=.o)
 BINOBJS =  $(foreach file, $(OBJS), $file)
 CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' -DPREFIX='"$(prefix)"'  -DSYSCONFDIR='"$(sysconfdir)/firejail"' -DLIBDIR='"$(libdir)"' $(HAVE_SECCOMP) $(HAVE_SECCOMP_H) $(HAVE_CHROOT) $(HAVE_BIND) -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIE -pie -Wformat -Wformat-security

--- a/src/firemon/Makefile.in
+++ b/src/firemon/Makefile.in
@@ -5,8 +5,8 @@ VERSION=@PACKAGE_VERSION@
 NAME=@PACKAGE_NAME@
 HAVE_FATAL_WARNINGS=@HAVE_FATAL_WARNINGS@
 
-H_FILE_LIST       = $(wildcard *.[h])
-C_FILE_LIST       = $(wildcard *.c)
+H_FILE_LIST       = $(sort $(wildcard *.[h]))
+C_FILE_LIST       = $(sort $(wildcard *.c))
 OBJS = $(C_FILE_LIST:.c=.o)
 BINOBJS =  $(foreach file, $(OBJS), $file)
 CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIE -pie -Wformat -Wformat-security

--- a/src/ftee/Makefile.in
+++ b/src/ftee/Makefile.in
@@ -5,8 +5,8 @@ VERSION=@PACKAGE_VERSION@
 NAME=@PACKAGE_NAME@
 HAVE_FATAL_WARNINGS=@HAVE_FATAL_WARNINGS@
 
-H_FILE_LIST       = $(wildcard *.[h])
-C_FILE_LIST       = $(wildcard *.c)
+H_FILE_LIST       = $(sort $(wildcard *.[h]))
+C_FILE_LIST       = $(sort $(wildcard *.c))
 OBJS = $(C_FILE_LIST:.c=.o)
 BINOBJS =  $(foreach file, $(OBJS), $file)
 CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' -DPREFIX='"$(PREFIX)"' -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIE -pie -Wformat -Wformat-security

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -3,8 +3,8 @@ VERSION=@PACKAGE_VERSION@
 NAME=@PACKAGE_NAME@
 HAVE_FATAL_WARNINGS=@HAVE_FATAL_WARNINGS@
 
-H_FILE_LIST       = $(wildcard *.[h])
-C_FILE_LIST       = $(wildcard *.c)
+H_FILE_LIST       = $(sort $(wildcard *.[h]))
+C_FILE_LIST       = $(sort $(wildcard *.c))
 OBJS = $(C_FILE_LIST:.c=.o)
 BINOBJS =  $(foreach file, $(OBJS), $file)
 CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIC -Wformat -Wformat-security

--- a/src/libtrace/Makefile.in
+++ b/src/libtrace/Makefile.in
@@ -3,8 +3,8 @@ VERSION=@PACKAGE_VERSION@
 NAME=@PACKAGE_NAME@
 HAVE_FATAL_WARNINGS=@HAVE_FATAL_WARNINGS@
 
-H_FILE_LIST       = $(wildcard *.[h])
-C_FILE_LIST       = $(wildcard *.c)
+H_FILE_LIST       = $(sort $(wildcard *.[h]))
+C_FILE_LIST       = $(sort $(wildcard *.c))
 OBJS = $(C_FILE_LIST:.c=.o)
 BINOBJS =  $(foreach file, $(OBJS), $file)
 CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIC -Wformat -Wformat-security

--- a/src/libtracelog/Makefile.in
+++ b/src/libtracelog/Makefile.in
@@ -3,8 +3,8 @@ VERSION=@PACKAGE_VERSION@
 NAME=@PACKAGE_NAME@
 HAVE_FATAL_WARNINGS=@HAVE_FATAL_WARNINGS@
 
-H_FILE_LIST       = $(wildcard *.[h])
-C_FILE_LIST       = $(wildcard *.c)
+H_FILE_LIST       = $(sort $(wildcard *.[h]))
+C_FILE_LIST       = $(sort $(wildcard *.c))
 OBJS = $(C_FILE_LIST:.c=.o)
 BINOBJS =  $(foreach file, $(OBJS), $file)
 CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIC -Wformat -Wformat-security


### PR DESCRIPTION
Firejail is currently not building reproducibly [1].
The order of object files is random while linking. This is easily fixed by sorting the filelists.

A timestamp from the current date is also embedded into manpages.
By making use of the SOURCE_DATE_EPOCH variable [2] (when available), the timestamp can
be set to a deterministic one.

[1]: https://reproducible.debian.net/rb-pkg/unstable/armhf/firejail.html
[2]: https://reproducible-builds.org/specs/source-date-epoch/