### PR TITLE
Disallow access to kdbx files

### DIFF
--- a/etc/disable-secret.inc
+++ b/etc/disable-secret.inc
@@ -7,6 +7,7 @@ blacklist ${HOME}/kde/share/apps/kwallet
 blacklist ${HOME}/.netrc
 blacklist ${HOME}/.gnupg
 blacklist-nolog ${HOME}/.local/share/recently-used.xbel*
+blacklist ${HOME}/*.kdbx
 blacklist ${HOME}/*.kdb
 blacklist ${HOME}/*.key
 blacklist /etc/shadow


### PR DESCRIPTION
As of version 2.0, KeePassX now uses the `.kdbx` file extension instead of the already blacklisted `.kdb`.
See https://www.keepassx.org/news/2015/12/533 for more information.