### PR TITLE
Adds support for tmpfs-based profiles (profile-sync-daemon)

### DIFF
--- a/etc/chromium.profile
+++ b/etc/chromium.profile
@@ -11,5 +11,6 @@ include /etc/firejail/disable-common.inc
 netfilter
 whitelist ${DOWNLOADS}
 whitelist ~/.config/chromium
+whitelist /tmp/home-chromium
 whitelist ~/.cache/chromium
 include /etc/firejail/whitelist-common.inc


### PR DESCRIPTION
Useful for the people using profile-sync-daemon with chromium, which moves the folder to /tmp and symlinks it to ~/.config/chromium

Can anything be done to keep chromium from using its atrocious blue theme though?