### PR TITLE
Don't blacklist recently-used.xbel

### DIFF
--- a/etc/disable-secret.inc
+++ b/etc/disable-secret.inc
@@ -6,7 +6,6 @@ blacklist ${HOME}/kde4/share/apps/kwallet
 blacklist ${HOME}/kde/share/apps/kwallet
 blacklist ${HOME}/.netrc
 blacklist ${HOME}/.gnupg
-blacklist-nolog ${HOME}/.local/share/recently-used.xbel*
 blacklist ${HOME}/*.kdbx
 blacklist ${HOME}/*.kdb
 blacklist ${HOME}/*.key


### PR DESCRIPTION
Reasons:
* many modern GUI applications need this file
* it doesn't contain secret information (passwords, keys) but private information as is most other data in ~/