### PR TITLE
blacklist /usr/local/sbin

### DIFF
--- a/etc/disable-mgmt.inc
+++ b/etc/disable-mgmt.inc
@@ -1,6 +1,7 @@
 # system directories	
 blacklist /sbin
 blacklist /usr/sbin
+blacklist /usr/local/sbin
 
 # system management
 blacklist ${PATH}/umount


### PR DESCRIPTION
`/usr/local/sbin` might also contain administrative tools.