### PR TITLE
Fixing lintian warnings

### DIFF
--- a/RELNOTES
+++ b/RELNOTES
@@ -6,7 +6,7 @@ firejail (0.9.37) baseline; urgency=low
   * added KMail, Seamonkey profiles
   * --join command enhancement (--join-network, --join-filesystem)
   * symlink invocation
--- netblue30 <netblue30@yahoo.com>
+ -- netblue30 <netblue30@yahoo.com>  Tue,  5 Jan 2016 08:00:00 -0500
 
 firejail (0.9.36) baseline; urgency=low
   * added  unbound, dnscrypt-proxy, BitlBee, HexChat, WeeChat,

--- a/mkdeb.sh
+++ b/mkdeb.sh
@@ -36,6 +36,8 @@ cp platform/debian/copyright $INSTALL_DIR/usr/share/doc/firejail/.
 mkdir -p $DEBIAN_CTRL_DIR
 sed "s/FIREJAILVER/$2/g"  platform/debian/control > $DEBIAN_CTRL_DIR/control
 
+mkdir -p $INSTALL_DIR/usr/share/lintian/overrides/
+cp platform/debian/firejail.lintian-overrides $INSTALL_DIR/usr/share/lintian/overrides/firejail
 
 cp platform/debian/conffiles $DEBIAN_CTRL_DIR/.
 find $INSTALL_DIR  -type d | xargs chmod 755

--- a/platform/debian/firejail.lintian-overrides
+++ b/platform/debian/firejail.lintian-overrides
@@ -1,0 +1,2 @@
+# Firejail binary should be setuid
+firejail binary: setuid-binary usr/bin/firejail 4755 root/root


### PR DESCRIPTION
Lintian (debian package static analyzer) has been reporting two issues:
 * malformed changelof: added required info to RELNOTES based on commit date
 * setuid binary: added it to lintian-overrides