### PR TITLE
changed typo in man file (namely --debug-blackilsts)

### DIFF
--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -243,7 +243,7 @@ Example:
 $ firejail \-\-debug firefox
 
 .TP
-\fB\-\-debug-blackilsts\fR
+\fB\-\-debug-blacklists\fR
 Debug blacklisting.
 .br
 


### PR DESCRIPTION
This fixes a typo in the man file. The option read --debug-blackilsts instead of --debug-blacklists.