### PR TITLE
Blacklisting ~/.local/share/kwalletd

### DIFF
--- a/etc/disable-secret.inc
+++ b/etc/disable-secret.inc
@@ -4,6 +4,7 @@ tmpfs ${HOME}/.gnome2_private
 blacklist ${HOME}/.gnome2/keyrings
 blacklist ${HOME}/kde4/share/apps/kwallet
 blacklist ${HOME}/kde/share/apps/kwallet
+blacklist ${HOME}/.local/share/kwalletd
 blacklist ${HOME}/.netrc
 blacklist ${HOME}/.gnupg
 blacklist ${HOME}/*.kdbx


### PR DESCRIPTION
(at least on Arch Linux) Kwallet saves encrypted passwords at `~/.local/share/kwalletd`.