### PR TITLE
Make the sandbox process reap all children.

### DIFF
--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -134,7 +134,11 @@ static void monitor_application(pid_t app_pid) {
 		usleep(20000);
 
 		int status;
-		unsigned rv = waitpid(app_pid, &status, 0);
+		unsigned rv;
+		do {
+			rv = waitpid(-1, &status, 0);
+		}
+		while(rv != app_pid);
 		if (arg_debug)
 			printf("Sandbox monitor: waitpid %u retval %d status %d\n", app_pid, rv, status);
 


### PR DESCRIPTION
Quick patch for netblue30/firejail#256

Instead of running waitpid(app) in the sandbox, run waitpid(-1) in a loop and check the return value until the original app dies.

I'm not sure you should trust me to write C code, but this patch has been running my KMail for several minutes now without eating any kittens :)