### PR TITLE
remove duplicate include from uGet profile

### DIFF
--- a/etc/uget-gtk.profile
+++ b/etc/uget-gtk.profile
@@ -3,7 +3,6 @@ include /etc/firejail/disable-mgmt.inc
 include /etc/firejail/disable-secret.inc
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
-include /etc/firejail/whitelist-common.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6


### PR DESCRIPTION
Hey, thanks for the merge. I just saw you duplicated the whitelist include that was already in the profile, this deletes the first entry.