### PR TITLE
Fix for systems that don't have CAP_SYSLOG

### DIFF
--- a/src/firejail/caps.c
+++ b/src/firejail/caps.c
@@ -289,10 +289,12 @@ int caps_default_filter(void) {
 	else if (arg_debug)
 		printf("Drop CAP_SYS_TTY_CONFIG\n");
 
+#ifdef CAP_SYSLOG
 	if (prctl(PR_CAPBSET_DROP, CAP_SYSLOG, 0, 0, 0) && arg_debug)
 		fprintf(stderr, "Warning: cannot drop CAP_SYSLOG");
 	else if (arg_debug)
 		printf("Drop CAP_SYSLOG\n");
+#endif
 
 	if (prctl(PR_CAPBSET_DROP, CAP_MKNOD, 0, 0, 0) && arg_debug)
 		fprintf(stderr, "Warning: cannot drop CAP_MKNOD");

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -48,7 +48,11 @@ void usage(void) {
 	printf("\t-c - execute command and exit.\n\n");
 	printf("\t--caps - enable default Linux capabilities filter. The filter disables\n");
 	printf("\t\tCAP_SYS_MODULE, CAP_SYS_RAWIO, CAP_SYS_BOOT, CAP_SYS_NICE,\n");
+#ifdef CAP_SYSLOG
 	printf("\t\tCAP_SYS_TTY_CONFIG, CAP_SYSLOG, CAP_MKNOD, CAP_SYS_ADMIN.\n\n");
+#else
+	printf("\t\tCAP_SYS_TTY_CONFIG, CAP_MKNOD, CAP_SYS_ADMIN.\n\n");
+#endif
 	printf("\t--caps.drop=all - drop all capabilities.\n\n");
 	printf("\t--caps.drop=capability,capability,capability - blacklist Linux\n");
 	printf("\t\tcapabilities filter.\n\n");


### PR DESCRIPTION
CAP_SYSLOG was retroactively split from CAP_SYSADMIN (Linux
kernel commit ce6ada35bdf710d16582cc4869c26722547e6f11). Existing
supported systems might not yet have this commit (eg RHEL 6.6) in
which case compilation fails.