### PR TITLE
Include <sys/socket.h> for sa_family_t (RHEL 6.6)

### DIFF
--- a/src/include/libnetlink.h
+++ b/src/include/libnetlink.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <asm/types.h>
+#include <sys/socket.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <linux/if_link.h>


### PR DESCRIPTION
Seems this is a long-running dependency issue: http://comments.gmane.org/gmane.linux.network/203185

I have tested on Ubuntu 14.04 and RHEL 6.6 but this probably needs also testing on RH/CentOS 7 and a more recent Ubuntu/Debian before merge.
