### PR TITLE
Make additional vimrc files; .xscreensaver file read only

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -108,7 +108,11 @@ read-only ${HOME}/.csh_files
 # Initialization files that allow arbitrary command execution
 read-only ${HOME}/.mailcap
 read-only ${HOME}/.exrc
+read-only ${HOME}/_exrc
 read-only ${HOME}/.vimrc
+read-only ${HOME}/_vimrc
+read-only ${HOME}/.gvimrc
+read-only ${HOME}/_gvimrc
 read-only ${HOME}/.vim
 read-only ${HOME}/.emacs
 read-only ${HOME}/.tmux.conf
@@ -116,6 +120,7 @@ read-only ${HOME}/.iscreenrc
 read-only ${HOME}/.muttrc
 read-only ${HOME}/.mutt/muttrc
 read-only ${HOME}/.xmonad
+read-only ${HOME}/.xscreensaver
 
 # The user ~/bin directory can override commands such as ls
 read-only ${HOME}/bin


### PR DESCRIPTION
Add .gvimrc and _ versions of other files used by vim when no dot-version available.
Add .xscreensaver that can be used for arbitrary command execution by setting "textProgram" (instead of default fortune) and screensaver that launches it.