### PR TITLE
Epiphany: Fix settings being saved but not loaded

### DIFF
--- a/etc/epiphany.profile
+++ b/etc/epiphany.profile
@@ -12,6 +12,8 @@ whitelist ${HOME}/.local/share/epiphany
 mkdir ${HOME}/.config
 mkdir ${HOME}/.config/epiphany
 whitelist ${HOME}/.config/epiphany
+mkdir ${HOME}/.config/dconf
+whitelist ${HOME}/.config/dconf
 mkdir ${HOME}/.cache
 mkdir ${HOME}/.cache/epiphany
 whitelist ${HOME}/.cache/epiphany


### PR DESCRIPTION
For some reason, Epiphany was able to save the settings even without access to the `.config/dconf` directory, but it did not show them in the settings window.