### PR TITLE
man/firejail.txt: note you don't need --ip6= with SLAAC

### DIFF
--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -471,6 +471,8 @@ Example:
 .br
 $ firejail \-\-net=eth0 \-\-ip6=2001:0db8:0:f101::1/64 firefox
 
+Note: you don't need this option if you obtain your ip6 address from router via SLAAC (your ip6 address and default route will be configured by kernel automatically).
+
 .TP
 \fB\-\-iprange=address,address
 Assign an IP address in the provided range to the last network interface defined by a \-\-net option. A


### PR DESCRIPTION
If you obtain ipv6 connectivity from router via SLAAC/RA, IPv6 works without this option (and worked even before e669dbee639c4956430bc90345e1f05687c9d50a). Moreover, manual twiddling with IPv6 addresses/routes can do more harm than good in this configuration (e.g. when prefix is not static and changes midway due to ADSL reconnect, kernel handles this transparently, while with `--ip6=` option you are stick to (obsolete and non-working) address specified on firejail start).
Disclaimer: feel free to fix/polish wording/expand/etc, /me not a native speaker.