### PR TITLE
Add compile-time option to restrict --net= to root only

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,9 @@ AC_ARG_ENABLE([network],
     AS_HELP_STRING([--disable-network], [disable network]))
 AS_IF([test "x$enable_network" != "xno"], [
 	HAVE_NETWORK="-DHAVE_NETWORK"
+	AS_IF([test "x$enable_network" = "xrestricted"], [
+	       HAVE_NETWORK="$HAVE_NETWORK -DHAVE_NETWORK_RESTRICTED"
+	])
 	AC_SUBST(HAVE_NETWORK)
 ])
 

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1090,6 +1090,12 @@ int main(int argc, char **argv) {
 				cfg.interface3.configured = 0;
 				continue;
 			}
+#ifdef HAVE_NETWORK_RESTRICTED
+			if (getuid() != 0) {
+				fprintf(stderr, "Error: only --net=none is allowed to non-root users\n");
+				exit(1);
+			}
+#endif
 			if (strcmp(argv[i] + 6, "lo") == 0) {
 				fprintf(stderr, "Error: cannot attach to lo device\n");
 				exit(1);


### PR DESCRIPTION
./configure --enable-network=restricted allows only `--net=none` to non-root users.

Other variants delegate too much power to non-root users and dangerous (it completely bypasses system-wide firewall and routing, it allows introducing arbitrary-chosen MAC and IP interfaces on LAN [disregarding DHCP policy], etc).

Root already had power to twiddle with anything, so no sense to restrain her, and `--net=none` looks safe enough (and still useful) for ordinary users (and permitted via `unshare -rn` anyway).

See #290