### PR TITLE
Added profiles for vivaldi

### DIFF
--- a/etc/vivaldi-beta.profile
+++ b/etc/vivaldi-beta.profile
@@ -1,0 +1,2 @@
+# Vivaldi Beta browser profile
+include /etc/firejail/vivaldi.profile

--- a/etc/vivaldi.profile
+++ b/etc/vivaldi.profile
@@ -1,0 +1,14 @@
+# Vivaldi browser profile
+noblacklist ${HOME}/.config/vivaldi
+include /etc/firejail/disable-mgmt.inc
+include /etc/firejail/disable-secret.inc
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
+
+netfilter
+whitelist ~/.config/vivaldi
+whitelist ${DOWNLOADS}
+whitelist ~/.cache/vivaldi
+include /etc/firejail/whitelist-common.inc
+
+


### PR DESCRIPTION
Hi netblue30. I've created two profiles for the vivaldi browser: etc/vivaldi.profile and etc/vivaldi-beta.profile. Since vivaldi is still in beta (and resides in /usr/bin/vivaldi-beta) I made vivaldi-beta.profile; however, it points back to vivaldi.profile in the same way that google-chrome-stable.profile points to google-chrome.profile.

I'm pretty new at GitHub so hopefully this is the correct way to go about this. I had to Google (well, DDG actually) to find instructions. :-) Let me know if this is okay! I've got a few other profiles I was thinking of committing if all goes well. 

Thanks,
Fred Barclay