### PR TITLE
Created Atril profile

### DIFF
--- a/etc/atril.profile
+++ b/etc/atril.profile
@@ -1,0 +1,7 @@
+# Atril profile
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/generic.profile
+blacklist ${HOME}/.wine
+
+tracelog
+


### PR DESCRIPTION
Atril is the default pdf viewer for the Mate DE.

I (mostly) forked the existing etc/evince.profile. I noticed that evice.profile and generic.profile were almost identical, so I told atril.profile to include generic.profile rather than have redundant code. I also added disable-devel.inc (which was already present in evince.profile) and blacklisted ~/.wine (also present in evince.profile).
"Netfilter" is in atril.profile due to the generic profile, while it is not present in the existing evince.profile, but I saw no reason to remove it from atril. 

Hope this isn't too confusing. :)

EDIT: one more thing. The sandbox profile for Atril (as for evince) is somewhat lax; I'll work on hardening it if you like. As it is, most of the directories/files in my /home are visible to the sandbox. 