### PR TITLE
Forward exit code from child process

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1778,7 +1778,8 @@ int main(int argc, char **argv) {
 	signal (SIGTERM, my_handler);
 	
 	// wait for the child to finish
-	waitpid(child, NULL, 0);
+	int status = NULL;
+	waitpid(child, &status, 0);
 
 	// free globals
 #ifdef HAVE_SECCOMP
@@ -1799,7 +1800,13 @@ int main(int argc, char **argv) {
 		}
 	}
 
-	myexit(0);
+	if (WIFEXITED(status)){
+		myexit(WEXITSTATUS(status));
+	} else if (WIFSIGNALED(status)) {
+		myexit(WTERMSIG(status));
+	} else {
+		myexit(0);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
This PR reads the status code of the child process run inside the
sandbox and forwards it to the outer process. Which in turn makes that
result its own exiting status code.

This changes the behaviour of firejail in the sense that the following would prior give you the (misleading) status `0`:
```
$> firejail 'echo 1'
Parent pid 13488, child pid 13489
The new log directory is /proc/13489/root/var/log

Child process initialized
/bin/bash: echo 1: command not found

parent is shutting down, bye...
$> echo $?
127
```

Fixes #358.