### PR TITLE
fs_etc: continue to copy files if one fails.

### DIFF
--- a/src/firejail/fs_etc.c
+++ b/src/firejail/fs_etc.c
@@ -96,7 +96,8 @@ static void duplicate(char *fname) {
 	if (arg_debug)
 		printf("%s\n", cmd);
 	if (system(cmd))
-		errExit("system cp -a --parents");
+		fprintf(stderr, "Warning (fs_etc): error copying file /etc/%s, skipping...\n", fname);
+
 	free(cmd);
 	
 	char *name;


### PR DESCRIPTION
Currently if one file fails when copying private-etc files the process stop and doesn't copy the other files. Also it doesn't log which file failed.

# Example:
```
private-etc localtime,foo,resolv.conf
```

# Before:
only copied `localtime`

## log
```
/run/firejail/mnt/cp: failed to restore the default file creation context: No such file or directory
```

# Now:
copy `localtime` and `resolv.conf`

## log:
```
Warning (fs_etc): error copying file /etc/foo, skipping...
```