### PR TITLE
Allow alternative opera config path

### DIFF
--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -18,6 +18,7 @@ blacklist ${HOME}/.config/google-chrome-beta
 blacklist ${HOME}/.config/google-chrome-unstable
 blacklist ${HOME}/.config/opera
 blacklist ${HOME}/.config/opera-beta
+blacklist ${HOME}/.opera
 blacklist ~/.config/vivaldi
 blacklist ${HOME}/.filezilla
 blacklist ${HOME}/.config/filezilla

--- a/etc/opera.profile
+++ b/etc/opera.profile
@@ -1,6 +1,7 @@
 # Opera browser profile
 noblacklist ~/.config/opera
 noblacklist ~/.cache/opera
+noblacklist ~/.opera
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
@@ -14,6 +15,8 @@ whitelist ~/.config/opera
 mkdir ~/.cache
 mkdir ~/.cache/opera
 whitelist ~/.cache/opera
+mkdir ~/.opera
+whitelist ~/.opera
 mkdir ~/.pki
 whitelist ~/.pki
 include /etc/firejail/whitelist-common.inc


### PR DESCRIPTION
Petter Reinholdtsen reported in [1] that ~/.opera is used by older Opera versions, so this path should also be allowed.

[1] https://bugs.debian.org/819950