### PR TITLE
Pale Moon profile && python blacklists

### DIFF
--- a/etc/disable-devel.inc
+++ b/etc/disable-devel.inc
@@ -34,3 +34,18 @@ blacklist /usr/lib/php*
 # Ruby
 blacklist /usr/bin/ruby
 blacklist /usr/lib/ruby
+
+# Python 2
+blacklist /usr/bin/python2*
+blacklist /usr/lib/python2*
+blacklist /usr/local/lib/python2*
+blacklist /usr/include/python2*
+blacklist /usr/share/python2* #If this exists (not on my machine).
+
+# Python 3
+blacklist /usr/bin/python3*
+blacklist /usr/lib/python3*
+blacklist /usr/local/lib/python3*
+blacklist /usr/share/python3*
+blacklist /usr/include/python3*
+

--- a/etc/palemoon.profile
+++ b/etc/palemoon.profile
@@ -1,0 +1,57 @@
+# Firejail profile for Pale Moon
+
+# Noblacklists
+noblacklist ~/.moonchild productions/pale moon
+noblacklist ~/.cache/moonchild productions/pale moon
+
+# Included profiles
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/whitelist-common.inc
+
+# Options
+caps.drop all
+seccomp
+protocol unix,inet,inet6,netlink
+netfilter
+tracelog
+noroot
+
+whitelist ${DOWNLOADS}
+mkdir ~/.moonchild productions
+whitelist ~/.moonchild productions
+mkdir ~/.cache
+mkdir ~/.cache/moonchild productions
+mkdir ~/.cache/moonchild productions/pale moon
+whitelist ~/.cache/moonchild productions/pale moon
+
+# These are uncommented in the Firefox profile. If you run into trouble you may
+# want to uncomment (some of) them.
+#whitelist ~/dwhelper
+#whitelist ~/.zotero
+#whitelist ~/.vimperatorrc
+#whitelist ~/.vimperator
+#whitelist ~/.pentadactylrc
+#whitelist ~/.pentadactyl
+#whitelist ~/.keysnail.js
+#whitelist ~/.config/gnome-mplayer
+#whitelist ~/.cache/gnome-mplayer/plugin
+#whitelist ~/.pki
+
+# For silverlight
+#whitelist ~/.wine-pipelight 
+#whitelist ~/.wine-pipelight64 
+#whitelist ~/.config/pipelight-widevine 
+#whitelist ~/.config/pipelight-silverlight5.1
+
+
+# lastpass, keepassx
+whitelist ~/.keepassx
+whitelist ~/.config/keepassx
+whitelist ~/keepassx.kdbx
+whitelist ~/.lastpass
+whitelist ~/.config/lastpass
+
+# experimental features
+#private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse


### PR DESCRIPTION
Hey netblue30! This should (hopefully) be working well now. I grabbed the firejail_0.9.40-rc1_1_amd64.deb from Sourceforge and replaced my usual 0.9.38 install from the debian testing repos--you've been pretty busy since my last attempt at a Pale Moon profile!

Re: https://github.com/netblue30/firejail/issues/343
`.mozilla` is still visible, but the only contents visible in it is the `extensions` subdirectory. The contents of `extensions` are not visible to Pale Moon so I feel pretty comfortable with this.
(Though I still would like to be able to blacklist `.mozilla` once and for all.) :-)

EDIT: just added python2 and python3 blacklists to etc/disable-devel. Would have made a separate pull request but apparently GitHub is smarter than I... :-)

