### PR TITLE
Separated thunderbird/icedove profiles

### DIFF
--- a/etc/icedove.profile
+++ b/etc/icedove.profile
@@ -1,3 +1,19 @@
-# Firejail profile for Mozilla Thunderbird (Icedove in Debian)
-include /etc/firejail/thunderbird.profile
+# Firejail profile for Mozilla Thunderbird (Icedove in Debian Stable)
+# Users have thunderbird set to open a browser by clicking a link in an email
+# We are not allowed to blacklist browser-specific directories
+
+noblacklist ~/.gnupg
+mkdir ~/.gnupg
+whitelist ~/.gnupg
+
+noblacklist ~/.icedove
+mkdir ~/.icedove
+whitelist ~/.icedove
+
+noblacklist ~/.cache/icedove
+mkdir ~/.cache
+mkdir ~/.cache/icedove
+whitelist ~/.cache/icedove
+
+include /etc/firejail/firefox.profile
 

--- a/etc/icedove.profile
+++ b/etc/icedove.profile
@@ -1,5 +1,5 @@
 # Firejail profile for Mozilla Thunderbird (Icedove in Debian Stable)
-# Users have thunderbird set to open a browser by clicking a link in an email
+# Users have icedove set to open a browser by clicking a link in an email
 # We are not allowed to blacklist browser-specific directories
 
 noblacklist ~/.gnupg

--- a/etc/thunderbird.profile
+++ b/etc/thunderbird.profile
@@ -1,14 +1,10 @@
-# Firejail profile for Mozilla Thunderbird (Icedove in Debian)
+# Firejail profile for Mozilla Thunderbird
 # Users have thunderbird set to open a browser by clicking a link in an email
 # We are not allowed to blacklist browser-specific directories
 
 noblacklist ~/.gnupg
 mkdir ~/.gnupg
 whitelist ~/.gnupg
-
-noblacklist ~/.icedove
-mkdir ~/.icedove
-whitelist ~/.icedove
 
 noblacklist ~/.thunderbird
 mkdir ~/.thunderbird
@@ -18,10 +14,6 @@ noblacklist ~/.cache/thunderbird
 mkdir ~/.cache
 mkdir ~/.cache/thunderbird
 whitelist ~/.cache/thunderbird
-
-noblacklist ~/.cache/icedove
-mkdir ~/.cache/icedove
-whitelist ~/.cache/icedove
 
 include /etc/firejail/firefox.profile
 


### PR DESCRIPTION
This makes it easier for the weirdos like me who use both Thunderbird and Icedove. :) TB can't see ID's profile; ID can't see TB's config. 