### PR TITLE
added new 0ad profile

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -162,7 +162,7 @@ realinstall:
 	install -c -m 0644 .etc/dnsmasq.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/palemoon.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/icedove.profile $(DESTDIR)/$(sysconfdir)/firejail/.
-	install -c -m 0644 .etc.0ad.profile $(DESTDIR)/$(sysconfdir)/firejail/.
+	install -c -m 0644 .etc/0ad.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	sh -c "if [ ! -f $(DESTDIR)/$(sysconfdir)/firejail/login.users ]; then install -c -m 0644 etc/login.users $(DESTDIR)/$(sysconfdir)/firejail/.; fi;"
 	sh -c "if [ ! -f $(DESTDIR)/$(sysconfdir)/firejail/firejail.config ]; then install -c -m 0644 etc/firejail.config $(DESTDIR)/$(sysconfdir)/firejail/.; fi;"
 	rm -fr .etc

--- a/Makefile.in
+++ b/Makefile.in
@@ -162,6 +162,7 @@ realinstall:
 	install -c -m 0644 .etc/dnsmasq.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/palemoon.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/icedove.profile $(DESTDIR)/$(sysconfdir)/firejail/.
+	install -c -m 0644 .etc.0ad.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	sh -c "if [ ! -f $(DESTDIR)/$(sysconfdir)/firejail/login.users ]; then install -c -m 0644 etc/login.users $(DESTDIR)/$(sysconfdir)/firejail/.; fi;"
 	sh -c "if [ ! -f $(DESTDIR)/$(sysconfdir)/firejail/firejail.config ]; then install -c -m 0644 etc/firejail.config $(DESTDIR)/$(sysconfdir)/firejail/.; fi;"
 	rm -fr .etc

--- a/etc/0ad.profile
+++ b/etc/0ad.profile
@@ -1,0 +1,34 @@
+# Firejail profile for 0ad.
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-programs.inc
+
+#May cause problems for online gamers if they use a password manager. Test first.
+include /etc/firejail/disable-passwdmgr.inc
+
+# Call these options
+caps.drop all
+seccomp
+protocol unix,inet,inet6,netlink
+netfilter
+tracelog
+noroot
+
+# Whitelists
+noblacklist ~/.cache/0ad
+mkdir ~/.cache
+mkdir ~/.cache/0ad
+whitelist ~/.cache/0ad
+
+noblacklist ~/.config/0ad
+mkdir ~/.config
+mkdir ~/.config/0ad
+whitelist ~/.config/0ad
+
+noblacklist ~/.local/share/0ad
+mkdir ~/.local
+mkdir ~/.local/share
+mkdir ~/.local/share/0ad
+whitelist ~/.local/share/0ad
+
+

--- a/etc/0ad.profile
+++ b/etc/0ad.profile
@@ -1,10 +1,8 @@
 # Firejail profile for 0ad.
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
-include /etc/firejail/disable-programs.inc
-
-#May cause problems for online gamers if they use a password manager. Test first.
 include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 # Call these options
 caps.drop all
@@ -30,5 +28,3 @@ mkdir ~/.local
 mkdir ~/.local/share
 mkdir ~/.local/share/0ad
 whitelist ~/.local/share/0ad
-
-

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -53,6 +53,7 @@ blacklist ${HOME}/.TelegramDesktop
 blacklist ${HOME}/.hedgewars
 blacklist ${HOME}/.steam
 blacklist ${HOME}/.config/wesnoth
+blacklist ${HOME}/.config/0ad
 
 # Cryptocoins
 blacklist ${HOME}/.*coin
@@ -81,6 +82,7 @@ blacklist ${HOME}/.cache/thunderbird
 blacklist ${HOME}/.cache/icedove
 blacklist ${HOME}/.cache/transmission
 blacklist ${HOME}/.cache/wesnoth
+blacklist ${HOME}/.cache/0ad
 
 # share
 blacklist ${HOME}/.local/share/epiphany
@@ -88,3 +90,4 @@ blacklist ${HOME}/.local/share/mupen64plus
 blacklist ${HOME}/.local/share/spotify
 blacklist ${HOME}/.local/share/steam
 blacklist ${HOME}/.local/share/wesnoth
+blacklsit ${HOME}/.local/share/0ad

--- a/platform/debian/conffiles
+++ b/platform/debian/conffiles
@@ -82,4 +82,5 @@
 /etc/firejail/dnsmasq.profile
 /etc/firejail/palemoon.profile
 /etc/firejail/icedove.profile
+/etc/firejail/0ad.profile
 


### PR DESCRIPTION
Profile for the game 0ad. 
I included `include /etc/firejail/disable-passwdmgr.inc` which *might* cause a problem if someone plays this game across a network and uses a password manager to store their password--don't know if this would actually be a problem or not since I've never played it online so I couldn't test it. Do you think that line should be left in or taken out?
I like blacklisting as much as possible! :)