### PR TITLE
HexChat/Atril profile fix

### DIFF
--- a/etc/atril.profile
+++ b/etc/atril.profile
@@ -1,4 +1,5 @@
 # Atril profile
+noblacklist ~/.config/atril
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
@@ -7,6 +8,10 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
-netfilter
+net none
 noroot
 tracelog
+
+mkdir ~/.config
+mkdir ~/.config/atril
+whitelist ~/.config/atril

--- a/etc/hexchat.profile
+++ b/etc/hexchat.profile
@@ -1,5 +1,6 @@
 # HexChat instant messaging profile
 noblacklist ${HOME}/.config/hexchat
+noblacklist /usr/lib/python2*
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
@@ -8,3 +9,8 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6
 noroot
+netfilter
+
+mkdir ~/.config
+mkdir ~/.config/hexchat
+whitelist ~/.config/hexchat


### PR DESCRIPTION
Hello netblue. I've started building firejail from this repo every day, so I found that my recent commit blacklisting python had broken hexchat (which apparently requires python libs). I've just fixed that with this commit. 

For Atril, I added the printing config directory, and changed `netfilter` to `net none.` I can't think of a good reason why a pdf viewer would need to go online. 

Cheers!