### PR TITLE
fix "clean/clear" typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ DESCRIPTION
        see DESKTOP INTEGRATION section in man 1 firejail.
 
 OPTIONS
-       --clear
-              Clear all firejail symbolic links
+       --clean
+              Remove all firejail symbolic links
 
        -?, --help
               Print options end exit.
@@ -164,7 +164,7 @@ OPTIONS
        /usr/local/bin/firefox
        /usr/local/bin/vlc
        [...]
-       $ sudo firecfg --clear
+       $ sudo firecfg --clean
        /usr/local/bin/firefox removed
        /usr/local/bin/vlc removed
        [...]

--- a/src/firecfg/main.c
+++ b/src/firecfg/main.c
@@ -49,7 +49,7 @@ static void usage(void) {
 	printf("   /usr/local/bin/firefox\n");
 	printf("   /usr/local/bin/vlc\n");
 	printf("   [...]\n");
-	printf("   $ sudo firecfg --clear\n");
+	printf("   $ sudo firecfg --clean\n");
 	printf("   /usr/local/bin/firefox removed\n");
 	printf("   /usr/local/bin/vlc removed\n");
 	printf("   [...]\n");

--- a/src/man/firecfg.txt
+++ b/src/man/firecfg.txt
@@ -48,7 +48,7 @@ $ firecfg --list
 .br
 [...]
 .br
-$ sudo firecfg --clear
+$ sudo firecfg --clean
 .br
 /usr/local/bin/firefox removed
 .br


### PR DESCRIPTION
Finish of the migration from "clear" to "clean" wording.