### PR TITLE
Fixes for hexchat.profile

### DIFF
--- a/etc/hexchat.profile
+++ b/etc/hexchat.profile
@@ -1,6 +1,7 @@
 # HexChat instant messaging profile
 noblacklist ${HOME}/.config/hexchat
 noblacklist /usr/lib/python2*
+noblacklist /usr/lib/python3*
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc

--- a/etc/hexchat.profile
+++ b/etc/hexchat.profile
@@ -15,3 +15,4 @@ netfilter
 mkdir ~/.config
 mkdir ~/.config/hexchat
 whitelist ~/.config/hexchat
+include /etc/firejail/whitelist-common.inc


### PR DESCRIPTION
HexChat uses python3 under Arch Linux, so this is required for it to launch.
Also, links can't be clicked on since whitelist-common.inc isn't currently included (launching default browser requires mime types, otherwise it falls back to launching "perl" and fails).