### PR TITLE
Xapps

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -180,6 +180,9 @@ realinstall:
 	install -c -m 0644 .etc/quiterss.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/cyberfox.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/snap.profile $(DESTDIR)/$(sysconfdir)/firejail/.
+	install -c -m 0644 .etc/xplayer.profile $(DESTDIR)/$(sysconfdir)/firejail/.
+	install -c -m 0644 .etc/xreader.profile $(DESTDIR)/$(sysconfdir)/firejail/.
+	install -c -m 0644 .etc/xviewer.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	sh -c "if [ ! -f $(DESTDIR)/$(sysconfdir)/firejail/login.users ]; then install -c -m 0644 etc/login.users $(DESTDIR)/$(sysconfdir)/firejail/.; fi;"
 	sh -c "if [ ! -f $(DESTDIR)/$(sysconfdir)/firejail/firejail.config ]; then install -c -m 0644 etc/firejail.config $(DESTDIR)/$(sysconfdir)/firejail/.; fi;"
 	rm -fr .etc

--- a/README
+++ b/README
@@ -70,6 +70,7 @@ Fred-Barclay (https://github.com/Fred-Barclay)
 	- fixed disable-common.inc for mate-terminal
 	- blacklisted escape-happy terminals in disable-common.inc
 	- blacklisted g++
+	- added xplayer, xreader, and xviewer profiles
 Petter Reinholdtsen (pere@hungry.com)
 	- Opera profile patch
 n1trux (https://github.com/n1trux)

--- a/README.md
+++ b/README.md
@@ -283,6 +283,6 @@ $ man firejail-profile
 lxterminal, Epiphany, cherrytree, Polari, Vivaldi, Atril, qutebrowser, SlimJet, Battle for Wesnoth, Hedgewars, qTox,
 OpenSSH client, OpenBox window manager, Dillo, cmus, dnsmasq, PaleMoon, Icedove, abrowser, 0ad, netsurf,
 Warzone2100, okular, gwenview, Gpredict, Aweather, Stellarium, Google-Play-Music-Desktop-Player, quiterss,
-cyberfox, generic Ubuntu snap application profile
+cyberfox, generic Ubuntu snap application profile, xplayer, xreader, xviewer
 
 

--- a/RELNOTES
+++ b/RELNOTES
@@ -23,7 +23,8 @@ firejail (0.9.40-rc1) baseline; urgency=low
   * new profiles: PaleMoon, Icedove, abrowser, 0ad, netsurf, Warzone2100
   * new profiles: okular, gwenview, Google-Play-Music-Desktop-Player
   * new profiles: Aweather, Stellarium, gpredict, quiterss, cyberfox
-  * new profiles: generic Ubuntu snap application profile
+  * new profiles: generic Ubuntu snap application profile, xplayer
+  * new profiles: xreader, xplayer
   * generic.profile renamed default.profile
   * build rpm packages using "make rpms"
   * bugfixes

--- a/etc/atril.profile
+++ b/etc/atril.profile
@@ -1,5 +1,6 @@
 # Atril profile
 noblacklist ~/.config/atril
+noblacklist ~/.local/share
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
@@ -8,10 +9,6 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
-net none
 noroot
 tracelog
-
-mkdir ~/.config
-mkdir ~/.config/atril
-whitelist ~/.config/atril
+netfilter

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -12,17 +12,22 @@ blacklist ${HOME}/.config/uGet
 blacklist ${HOME}/.config/Gpredict
 blacklist ${HOME}/.config/aweather
 blacklist ${HOME}/.config/stellarium
-blacklist ~/.kde/share/apps/okular
-blacklist ~/.kde/share/config/okularrc
-blacklist ~/.kde/share/config/okularpartrc
-blacklist ~/.kde/share/apps/gwenview
-blacklist ~/.kde/share/config/gwenviewrc
+blacklist ${HOME}/.config/atril
+blacklist ${HOME}/.config/xreader
+blacklist ${HOME}/.config/xviewer
+blacklist ${HOME}/.kde/share/apps/okular
+blacklist ${HOME}/.kde/share/config/okularrc
+blacklist ${HOME}/.kde/share/config/okularpartrc
+blacklist ${HOME}/.kde/share/apps/gwenview
+blacklist ${HOME}/.kde/share/config/gwenviewrc
 
 # Media players
 blacklist ${HOME}/.config/cmus
 blacklist ${HOME}/.config/deadbeef
 blacklist ${HOME}/.config/spotify
 blacklist ${HOME}/.config/vlc
+blacklist ${HOME}/.config/totem
+blacklist ${HOME}/.config/xplayer
 
 # HTTP / FTP / Mail
 blacklist ${HOME}/.icedove
@@ -95,6 +100,7 @@ blacklist ${HOME}/.cache/transmission
 blacklist ${HOME}/.cache/wesnoth
 blacklist ${HOME}/.cache/0ad
 blacklist ${HOME}/.cache/8pecxstudios
+blacklist ${HOME}/.cache/xreader
 
 # share
 blacklist ${HOME}/.local/share/epiphany
@@ -103,3 +109,4 @@ blacklist ${HOME}/.local/share/spotify
 blacklist ${HOME}/.local/share/steam
 blacklist ${HOME}/.local/share/wesnoth
 blacklist ${HOME}/.local/share/0ad
+blacklist ${HOME}/.local/share/xplayer

--- a/etc/xplayer.profile
+++ b/etc/xplayer.profile
@@ -1,0 +1,15 @@
+# Xplayer profile
+noblacklist ~/.config/xplayer
+noblacklist ~/.local/share/xplayer
+
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-passwdmgr.inc
+
+caps.drop all
+seccomp
+protocol unix,inet,inet6
+noroot
+tracelog
+netfilter

--- a/etc/xreader.profile
+++ b/etc/xreader.profile
@@ -1,0 +1,16 @@
+# Xreader profile
+noblacklist ~/.config/xreader
+noblacklist ~/.cache/xreader
+noblacklist ~/.local/share
+
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-passwdmgr.inc
+
+caps.drop all
+seccomp
+protocol unix,inet,inet6
+noroot
+tracelog
+netfilter

--- a/etc/xviewer.profile
+++ b/etc/xviewer.profile
@@ -1,0 +1,13 @@
+noblacklist ~/.config/xviewer
+
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-passwdmgr.inc
+
+caps.drop all
+seccomp
+protocol unix,inet,inet6
+noroot
+tracelog
+netfilter

--- a/platform/debian/conffiles
+++ b/platform/debian/conffiles
@@ -94,3 +94,6 @@
 /etc/firejail/quiterss.profile
 /etc/firejail/cyberfox.profile
 /etc/firejail/snap.profile
+/etc/firejail/xplayer.profile
+/etc/firejail/xreader.profile
+/etc/firejail/xviewer.profile

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -60,6 +60,8 @@ Mathematica
 mathematica
 gwenview
 okular
+atril
+xreader
 
 # Media
 vlc
@@ -70,6 +72,8 @@ parole
 rhythmbox
 totem
 cmus
+xplayer
+xviewer
 
 # chat/messaging
 bitlbee


### PR DESCRIPTION
I noticed a somewhat serious bug with atril and firejail (atril wouldn't launch, if that counts as "serious" :laughing:) so this should patch that. I'm going to try and test deeper over the next few days and see if I can get a better profile, but I wanted to go ahead and get this patched ASAP.

I also added support for three of the four new Linux Mint xapps--xplayer, xreader, and xviewer (forked from totem, atril, and eog, respectively) and cleaned up a little in etc/disabled-programs.inc.

Hope this helps!
Fred

