### PR TITLE
Revert "cmus.profile: use empty /etc"

### DIFF
--- a/etc/cmus.profile
+++ b/etc/cmus.profile
@@ -13,5 +13,5 @@ netfilter
 noroot
 
 private-bin cmus
-private-etc null
+private-etc group
 shell none


### PR DESCRIPTION
This reverts commit 471bba3242b01d91e6b1f52b9b12d2e88b5cf533.

Fucked up testing before, sorry.
Tried `--private-etc=null` on the CLI, while I had `--private-etc=group` in the profile and thought the CLI would override the profile, but it turns out it's complementary.