### PR TITLE
Enable using the NO_NEW_PRIVS prctl(2) flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,13 @@ The following features can be enabled or disabled:
 
        x11    Enable or disable X11 sandboxing support, default enabled.
 
+       force-nonewprivs
+              Force use of theh NO_NEW_PRIVS prctl(2) flag.
+              This mitigates the possibility of a user abusing firejail's
+              features to trick a privileged (suid or file capabilities)
+              process into loading code or configuration that is partially
+              under their control.  Default disabled
+
        xephyr-screen
               Screen    size    for   --x11=xephyr,   default   800x600.   Run
               /usr/bin/xrandr for a full list of resolutions available on your

--- a/etc/firejail.config
+++ b/etc/firejail.config
@@ -30,6 +30,12 @@
 # Enable or disable X11 sandboxing support, default enabled.
 # x11 yes
 
+# Force use of nonewprivs.  This mitigates the possibility of
+# a user abusing firejail's features to trick a privileged (suid
+# or file capabilities) process into loading code or configuration
+# that is partially under their control.  Default disabled
+# force-nonewprivs no
+
 # Screen size for --x11=xephyr, default 800x600. Run /usr/bin/xrandr for
 # a full list of resolutions available on your specific setup.
 # xephyr-screen 640x480

--- a/src/firejail/checkcfg.c
+++ b/src/firejail/checkcfg.c
@@ -36,7 +36,9 @@ int checkcfg(int val) {
 		int i;
 		for (i = 0; i < CFG_MAX; i++)
 			cfg_val[i] = 1; // most of them are enabled by default
+
 		cfg_val[CFG_RESTRICTED_NETWORK] = 0; // disabled by default
+		cfg_val[CFG_FORCE_NONEWPRIVS  ] = 0; // disabled by default
 		
 		// open configuration file
 		char *fname;
@@ -103,6 +105,15 @@ int checkcfg(int val) {
 					cfg_val[CFG_CHROOT] = 1;
 				else if (strcmp(ptr + 7, "no") == 0)
 					cfg_val[CFG_CHROOT] = 0;
+				else
+					goto errout;
+			}
+			// nonewprivs
+			else if (strncmp(ptr, "force-nonewprivs ", 17) == 0) {
+				if (strcmp(ptr + 17, "yes") == 0)
+					cfg_val[CFG_SECCOMP] = 1;
+				else if (strcmp(ptr + 17, "no") == 0)
+					cfg_val[CFG_SECCOMP] = 0;
 				else
 					goto errout;
 			}

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -237,6 +237,7 @@ extern int arg_rlimit_nproc;	// rlimit nproc
 extern int arg_rlimit_fsize;	// rlimit fsize
 extern int arg_rlimit_sigpending;// rlimit sigpending
 extern int arg_nogroups;	// disable supplementary groups
+extern int arg_nonewprivs;	// set the NO_NEW_PRIVS prctl
 extern int arg_noroot;		// create a new user namespace and disable root user
 extern int arg_netfilter;	// enable netfilter
 extern int arg_netfilter6;	// enable netfilter6

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -566,7 +566,8 @@ void sandboxfs(int op, pid_t pid, const char *patqh);
 #define CFG_SECCOMP 5
 #define CFG_NETWORK 6
 #define CFG_RESTRICTED_NETWORK 7
-#define CFG_MAX 8 // this should always be the last entry
+#define CFG_FORCE_NONEWPRIVS 8
+#define CFG_MAX 9 // this should always be the last entry
 int checkcfg(int val);
 
 // fs_rdwr.c

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -77,6 +77,7 @@ int arg_rlimit_nproc = 0;			// rlimit nproc
 int arg_rlimit_fsize = 0;				// rlimit fsize
 int arg_rlimit_sigpending = 0;			// rlimit fsize
 int arg_nogroups = 0;				// disable supplementary groups
+int arg_nonewprivs = 0;			// set the NO_NEW_PRIVS prctl
 int arg_noroot = 0;				// create a new user namespace and disable root user
 int arg_netfilter;				// enable netfilter
 int arg_netfilter6;				// enable netfilter6
@@ -1367,6 +1368,9 @@ int main(int argc, char **argv) {
 			}
 		}
 #endif
+		else if (strcmp(argv[i], "--nonewprivs") == 0) {
+			arg_nonewprivs = 1;
+		}
 		else if (strncmp(argv[i], "--env=", 6) == 0)
 			env_store(argv[i] + 6);
 		else if (strncmp(argv[i], "--nosound", 9) == 0) {

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -131,6 +131,10 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 
 		return 0;
 	}
+	else if (strcmp(ptr, "nonewprivs") == 0) {
+		arg_nonewprivs = 1;
+		return 0;
+	}
 	else if (strcmp(ptr, "seccomp") == 0) {
 #ifdef HAVE_SECCOMP
 		if (checkcfg(CFG_SECCOMP))

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -750,11 +750,14 @@ int sandbox(void* sandbox_arg) {
 	//****************************************
 	// Set NO_NEW_PRIVS if desired
 	//****************************************
-	int no_new_privs = prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
-	if(no_new_privs != 0) {
-	  errExit("NO_NEW_PRIVS");
-	} else
-	  printf("No new privileges from this point on\n");
+	if (arg_nonewprivs) {
+		int no_new_privs = prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+
+		if(no_new_privs != 0)
+			errExit("NO_NEW_PRIVS");
+		else if (arg_debug)
+			printf("NO_NEW_PRIVS set\n");
+	}
 
 
 	//****************************************

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -748,6 +748,16 @@ int sandbox(void* sandbox_arg) {
 	}
 
 	//****************************************
+	// Set NO_NEW_PRIVS if desired
+	//****************************************
+	int no_new_privs = prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+	if(no_new_privs != 0) {
+	  errExit("NO_NEW_PRIVS");
+	} else
+	  printf("No new privileges from this point on\n");
+
+
+	//****************************************
 	// fork the application and monitor it
 	//****************************************
 	pid_t app_pid = fork();

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -750,7 +750,7 @@ int sandbox(void* sandbox_arg) {
 	//****************************************
 	// Set NO_NEW_PRIVS if desired
 	//****************************************
-	if (arg_nonewprivs) {
+	if (arg_nonewprivs || checkcfg(CFG_FORCE_NONEWPRIVS)) {
 		int no_new_privs = prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
 
 		if(no_new_privs != 0)

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -157,6 +157,9 @@ void usage(void) {
 	printf("\tuser. root user does not exist in the new namespace. This option\n");
 	printf("\tis not supported for --chroot and --overlay configurations.\n\n");
 #endif
+	printf("    --nonewprivs - sets the NO_NEW_PRIVS prctl - the child processes\n");
+	printf("\tcannot gain privileges using execve(2); in particular, this prevents\n");
+	printf("\tgaining privileges by calling a suid binary\n\n");
 	printf("    --nosound - disable sound system.\n\n");
 		
 	printf("    --output=logfile - stdout logging and log rotation. Copy stdout and stderr\n");

--- a/src/man/firejail-config.txt
+++ b/src/man/firejail-config.txt
@@ -49,6 +49,14 @@ Enable or disable user namespace support, default enabled.
 Enable or disable X11 sandboxing support, default enabled.
 
 .TP
+\fBforce-nonewprivs
+Force use of nonewprivs.  This mitigates the possibility of
+a user abusing firejail's features to trick a privileged (suid
+or file capabilities) process into loading code or configuration
+that is partially under their control.  Default disabled.
+
+
+.TP
 \fBxephyr-screen
 Screen size for --x11=xephyr, default 800x600. Run /usr/bin/xrandr for
 a full list of resolutions available on your specific setup. Examples:

--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -239,6 +239,12 @@ Enable seccomp filter and blacklist  the system calls in the list.
 \fBseccomp.keep syscall,syscall,syscall
 Enable seccomp filter and whitelist the system calls in the list.
 .TP
+\fBnonewprivs
+Sets the NO_NEW_PRIVS prctl.  This ensures that child processes
+cannot acquire new privileges using execve(2);  in particular,
+this means that calling a suid binary (or one with file capabilities)
+does not results in an increase of privilege.
+.TP
 \fBnoroot
 Use this command  to enable an user namespace. The namespace has only one user, the current user.
 There is no root account (uid 0) defined in the namespace.

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -904,6 +904,13 @@ ping: icmp open socket: Operation not permitted
 $
 
 .TP
+\fB\-\-nonewprivs
+Sets the NO_NEW_PRIVS prctl.  This ensures that child processes
+cannot acquire new privileges using execve(2);  in particular,
+this means that calling a suid binary (or one with file capabilities)
+does not results in an increase of privilege.
+
+.TP
 \fB\-\-nosound
 Disable sound system.
 .br


### PR DESCRIPTION
> Any task can set `no_new_privs`.  Once the bit is set, it is inherited across `fork`,
> `clone`, and `execve` and cannot be unset.  With `no_new_privs` set, `execve`
> promises not to grant the privilege to do anything that could not have been
> done without the `execve` call.  For example, the setuid and setgid bits will no
> longer change the uid or gid; file capabilities will not add to the permitted set,
> and LSMs will not relax constraints after `execve`.
> -- [Linux kernel documentation](https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt)

Judicious use of `no_new_privs` can both:
- prevent sandboxed applications from (attempting to) exploit privileged (setuid, setgid or fcaps) binaries;
- prevent malicious users from (attempting to) exploit privileged binaries *using firejail's features*, by setting `force-nonewprivs` system-wide.

This PR introduces the support for `NO_NEW_PRIVS` and makes it configurable through the `nonewpriv` directive, documents it, and introduces a `force-nonewprivs` configuration item.