### PR TITLE
Make `restricted-network` prevent use of netfilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,9 @@ The following features can be enabled or disabled:
        restricted-network
               Enable  or disable restricted network support, default disabled.
               If enabled, networking features should also be enabled  (network
-              yes).   Restricted  networking  grants access to --interface and
-              --net=ethXXX only to root user. Regular users are  only  allowed
-              --net=none.
+              yes).  Restricted networking  grants access to --interface,
+              --net=ethXXX and --netfilter only to root user.  Regular users
+			  are only allowed --net=none.  Default disabled
 
        secomp Enable or disable seccomp support, default enabled.
 

--- a/etc/firejail.config
+++ b/etc/firejail.config
@@ -17,8 +17,8 @@
 
 # Enable or disable restricted network support, default disabled. If enabled,
 # networking features should also be enabled (network yes).
-# Restricted networking grants access to --interface and --net=ethXXX
-# only to root user. Regular users are only allowed --net=none.
+# Restricted networking grants access to --interface, --net=ethXXX and
+# --netfilter only to root user. Regular users are only allowed --net=none.
 # restricted-network no
 
 # Enable or disable seccomp support, default enabled.

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1675,6 +1675,18 @@ int main(int argc, char **argv) {
 
 #ifdef HAVE_NETWORK
 		else if (strcmp(argv[i], "--netfilter") == 0) {
+#ifdef HAVE_NETWORK_RESTRICTED
+			// compile time restricted networking
+			if (getuid() != 0) {
+				fprintf(stderr, "Error: --netfilter is only allowed for root\n");
+				exit(1);
+			}
+#endif
+			// run time restricted networking
+			if (checkcfg(CFG_RESTRICTED_NETWORK) && getuid() != 0) {
+				fprintf(stderr, "Error: --netfilter is only allowed for root\n");
+				exit(1);
+			}
 			if (checkcfg(CFG_NETWORK)) {
 				arg_netfilter = 1;
 			}
@@ -1685,6 +1697,18 @@ int main(int argc, char **argv) {
 		}
 
 		else if (strncmp(argv[i], "--netfilter=", 12) == 0) {
+#ifdef HAVE_NETWORK_RESTRICTED
+			// compile time restricted networking
+			if (getuid() != 0) {
+				fprintf(stderr, "Error: --netfilter is only allowed for root\n");
+				exit(1);
+			}
+#endif
+			// run time restricted networking
+			if (checkcfg(CFG_RESTRICTED_NETWORK) && getuid() != 0) {
+				fprintf(stderr, "Error: --netfilter is only allowed for root\n");
+				exit(1);
+			}
 			if (checkcfg(CFG_NETWORK)) {
 				arg_netfilter = 1;
 				arg_netfilter_file = argv[i] + 12;

--- a/src/man/firejail-config.txt
+++ b/src/man/firejail-config.txt
@@ -33,8 +33,8 @@ Enable or disable networking features, default enabled.
 \fBrestricted-network
 Enable or disable restricted network support, default disabled. If enabled,
 networking features should also be enabled (network yes).
-Restricted networking grants access to --interface and --net=ethXXX
-only to root user. Regular users are only allowed --net=none.
+Restricted networking grants access to --interface, --net=ethXXX and
+\-\-netfilter only to root user. Regular users are only allowed --net=none.
 
 .TP
 \fBsecomp


### PR DESCRIPTION
I suggest `netfilter` to be affected by `restricted-network` because it is a traditionally-privileged interface to the kernel, and the security impact of letting untrusted users run their own netfilter scripts (even on their own network namespace) is non-obvious.

Is that OK, or should I introduce a separate config flag for this?