### PR TITLE
Extend profiles to use the new `nonewprivs` feature

### DIFF
--- a/etc/0ad.profile
+++ b/etc/0ad.profile
@@ -12,6 +12,7 @@ protocol unix,inet,inet6,netlink
 netfilter
 tracelog
 noroot
+nonewprivs
 
 # Whitelists
 noblacklist ~/.cache/0ad

--- a/etc/Mathematica.profile
+++ b/etc/Mathematica.profile
@@ -16,4 +16,5 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 seccomp
+nonewprivs
 noroot

--- a/etc/abrowser.profile
+++ b/etc/abrowser.profile
@@ -11,6 +11,7 @@ seccomp
 protocol unix,inet,inet6,netlink
 netfilter
 tracelog
+nonewprivs
 noroot
 
 whitelist ${DOWNLOADS}

--- a/etc/atril.profile
+++ b/etc/atril.profile
@@ -9,6 +9,7 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot
 tracelog
 netfilter

--- a/etc/audacious.profile
+++ b/etc/audacious.profile
@@ -7,4 +7,5 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot

--- a/etc/aweather.profile
+++ b/etc/aweather.profile
@@ -12,6 +12,7 @@ include /etc/firejail/disable-programs.inc
 # Call these options
 caps.drop all
 netfilter
+nonewprivs
 noroot
 protocol unix,inet,inet6,netlink
 seccomp

--- a/etc/bitlbee.profile
+++ b/etc/bitlbee.profile
@@ -9,3 +9,4 @@ private
 private-dev
 seccomp
 netfilter
+nonewprivs

--- a/etc/cherrytree.profile
+++ b/etc/cherrytree.profile
@@ -19,6 +19,7 @@ seccomp
 protocol unix,inet,inet6,netlink
 netfilter
 tracelog
+nonewprivs
 noroot
 include /etc/firejail/whitelist-common.inc
 nosound

--- a/etc/clementine.profile
+++ b/etc/clementine.profile
@@ -7,4 +7,5 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot

--- a/etc/cmus.profile
+++ b/etc/cmus.profile
@@ -10,6 +10,7 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6
 netfilter
+nonewprivs
 noroot
 
 private-bin cmus

--- a/etc/conkeror.profile
+++ b/etc/conkeror.profile
@@ -7,6 +7,7 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6
 netfilter
+nonewprivs
 noroot
 
 whitelist ~/.conkeror.mozdev.org

--- a/etc/cyberfox.profile
+++ b/etc/cyberfox.profile
@@ -11,6 +11,7 @@ seccomp
 protocol unix,inet,inet6,netlink
 netfilter
 tracelog
+nonewprivs
 noroot
 
 whitelist ${DOWNLOADS}

--- a/etc/deadbeef.profile
+++ b/etc/deadbeef.profile
@@ -9,4 +9,5 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot

--- a/etc/default.profile
+++ b/etc/default.profile
@@ -11,5 +11,6 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6
 netfilter
+nonewprivs
 noroot
 

--- a/etc/deluge.profile
+++ b/etc/deluge.profile
@@ -9,5 +9,6 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6
 netfilter
+nonewprivs
 noroot
 nosound

--- a/etc/dillo.profile
+++ b/etc/dillo.profile
@@ -11,6 +11,7 @@ seccomp
 protocol unix,inet,inet6
 netfilter
 tracelog
+nonewprivs
 noroot
 
 whitelist ${DOWNLOADS}

--- a/etc/dnsmasq.profile
+++ b/etc/dnsmasq.profile
@@ -11,3 +11,4 @@ protocol unix,inet,inet6,netlink
 netfilter
 private
 private-dev
+nonewprivs

--- a/etc/dropbox.profile
+++ b/etc/dropbox.profile
@@ -6,4 +6,5 @@ include /etc/firejail/disable-passwdmgr.inc
 caps
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot

--- a/etc/empathy.profile
+++ b/etc/empathy.profile
@@ -7,3 +7,4 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6
 netfilter
+nonewprivs

--- a/etc/epiphany.profile
+++ b/etc/epiphany.profile
@@ -23,4 +23,4 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6
 netfilter
-
+nonewprivs

--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -7,5 +7,6 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot
 nosound

--- a/etc/fbreader.profile
+++ b/etc/fbreader.profile
@@ -10,5 +10,6 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6
 netfilter
+nonewprivs
 noroot
 nosound

--- a/etc/filezilla.profile
+++ b/etc/filezilla.profile
@@ -9,6 +9,7 @@ include /etc/firejail/disable-devel.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot
 netfilter
 nosound

--- a/etc/firefox.profile
+++ b/etc/firefox.profile
@@ -11,6 +11,7 @@ seccomp
 protocol unix,inet,inet6,netlink
 netfilter
 tracelog
+nonewprivs
 noroot
 
 whitelist ${DOWNLOADS}

--- a/etc/flashpeak-slimjet.profile
+++ b/etc/flashpeak-slimjet.profile
@@ -18,6 +18,7 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6,netlink
 netfilter
+nonewprivs
 noroot
 
 whitelist ${DOWNLOADS}

--- a/etc/gnome-mplayer.profile
+++ b/etc/gnome-mplayer.profile
@@ -7,4 +7,5 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot

--- a/etc/google-play-music-desktop-player.profile
+++ b/etc/google-play-music-desktop-player.profile
@@ -9,6 +9,7 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6,netlink
+nonewprivs
 noroot
 netfilter
 

--- a/etc/gpredict.profile
+++ b/etc/gpredict.profile
@@ -12,6 +12,7 @@ include /etc/firejail/disable-programs.inc
 # Call these options
 caps.drop all
 netfilter
+nonewprivs
 noroot
 protocol unix,inet,inet6,netlink
 seccomp

--- a/etc/gwenview.profile
+++ b/etc/gwenview.profile
@@ -8,6 +8,7 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 seccomp
 protocol unix
+nonewprivs
 noroot
 nogroups
 private-dev

--- a/etc/hedgewars.profile
+++ b/etc/hedgewars.profile
@@ -7,6 +7,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+nonewprivs
 noroot
 private-dev
 seccomp

--- a/etc/hexchat.profile
+++ b/etc/hexchat.profile
@@ -9,6 +9,7 @@ include /etc/firejail/disable-devel.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot
 netfilter
 

--- a/etc/kmail.profile
+++ b/etc/kmail.profile
@@ -10,5 +10,6 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6,netlink
 netfilter
+nonewprivs
 noroot
 tracelog

--- a/etc/mcabber.profile
+++ b/etc/mcabber.profile
@@ -11,6 +11,7 @@ caps.drop all
 seccomp
 protocol inet,inet6
 netfilter
+nonewprivs
 noroot
 
 private-bin mcabber

--- a/etc/midori.profile
+++ b/etc/midori.profile
@@ -8,4 +8,5 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6
 netfilter
-
+nonewprivs
+noroot

--- a/etc/mupen64plus.profile
+++ b/etc/mupen64plus.profile
@@ -16,6 +16,7 @@ mkdir ${HOME}/.config
 mkdir ${HOME}/.config/mupen64plus
 whitelist ${HOME}/.config/mupen64plus/
 
+nonewprivs
 noroot
 caps.drop all
 seccomp

--- a/etc/netsurf.profile
+++ b/etc/netsurf.profile
@@ -11,6 +11,7 @@ seccomp
 protocol unix,inet,inet6,netlink
 netfilter
 tracelog
+nonewprivs
 noroot
 
 whitelist ${DOWNLOADS}

--- a/etc/okular.profile
+++ b/etc/okular.profile
@@ -9,6 +9,7 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 seccomp
 protocol unix
+nonewprivs
 noroot
 nogroups
 private-dev

--- a/etc/palemoon.profile
+++ b/etc/palemoon.profile
@@ -16,6 +16,7 @@ seccomp
 protocol unix,inet,inet6,netlink
 netfilter
 tracelog
+nonewprivs
 noroot
 
 whitelist ${DOWNLOADS}

--- a/etc/parole.profile
+++ b/etc/parole.profile
@@ -11,5 +11,6 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6
 netfilter
+nonewprivs
 noroot
 shell none

--- a/etc/pidgin.profile
+++ b/etc/pidgin.profile
@@ -8,4 +8,5 @@ include /etc/firejail/disable-devel.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot

--- a/etc/polari.profile
+++ b/etc/polari.profile
@@ -24,6 +24,7 @@ include /etc/firejail/whitelist-common.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot
 netfilter
 

--- a/etc/qbittorrent.profile
+++ b/etc/qbittorrent.profile
@@ -8,5 +8,6 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6
 netfilter
+nonewprivs
 noroot
 nosound

--- a/etc/qtox.profile
+++ b/etc/qtox.profile
@@ -12,4 +12,5 @@ include /etc/firejail/whitelist-common.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot

--- a/etc/quassel.profile
+++ b/etc/quassel.profile
@@ -6,5 +6,6 @@ include /etc/firejail/disable-devel.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot
 netfilter

--- a/etc/quiterss.profile
+++ b/etc/quiterss.profile
@@ -20,6 +20,7 @@ seccomp
 protocol unix,inet,inet6
 netfilter
 tracelog
+nonewprivs
 noroot
 nogroups
 shell none

--- a/etc/qutebrowser.profile
+++ b/etc/qutebrowser.profile
@@ -11,6 +11,7 @@ seccomp
 protocol unix,inet,inet6,netlink
 netfilter
 tracelog
+nonewprivs
 noroot
 
 whitelist ${DOWNLOADS}

--- a/etc/rhythmbox.profile
+++ b/etc/rhythmbox.profile
@@ -7,5 +7,6 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot
 netfilter

--- a/etc/rtorrent.profile
+++ b/etc/rtorrent.profile
@@ -8,5 +8,6 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6
 netfilter
+nonewprivs
 noroot
 nosound

--- a/etc/seamonkey.profile
+++ b/etc/seamonkey.profile
@@ -10,6 +10,7 @@ seccomp
 protocol unix,inet,inet6,netlink
 netfilter
 tracelog
+nonewprivs
 noroot
 
 whitelist ${DOWNLOADS}

--- a/etc/skype.profile
+++ b/etc/skype.profile
@@ -6,6 +6,7 @@ include /etc/firejail/disable-devel.inc
 
 caps.drop all
 netfilter
+nonewprivs
 noroot
 seccomp
 protocol unix,inet,inet6

--- a/etc/spotify.profile
+++ b/etc/spotify.profile
@@ -26,5 +26,6 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6,netlink
 netfilter
+nonewprivs
 noroot
 

--- a/etc/ssh.profile
+++ b/etc/ssh.profile
@@ -9,4 +9,5 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6
 netfilter
+nonewprivs
 noroot

--- a/etc/steam.profile
+++ b/etc/steam.profile
@@ -8,6 +8,7 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 netfilter
+nonewprivs
 noroot
 seccomp
 protocol unix,inet,inet6

--- a/etc/stellarium.profile
+++ b/etc/stellarium.profile
@@ -13,6 +13,7 @@ include /etc/firejail/disable-programs.inc
 # Call these options
 caps.drop all
 netfilter
+nonewprivs
 noroot
 protocol unix,inet,inet6,netlink
 seccomp

--- a/etc/telegram.profile
+++ b/etc/telegram.profile
@@ -7,6 +7,7 @@ include /etc/firejail/disable-devel.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot
 netfilter
 

--- a/etc/totem.profile
+++ b/etc/totem.profile
@@ -10,5 +10,6 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot
 netfilter

--- a/etc/transmission-gtk.profile
+++ b/etc/transmission-gtk.profile
@@ -11,6 +11,7 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6
 netfilter
+nonewprivs
 noroot
 tracelog
 nosound

--- a/etc/transmission-qt.profile
+++ b/etc/transmission-qt.profile
@@ -11,6 +11,7 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6
 netfilter
+nonewprivs
 noroot
 tracelog
 nosound

--- a/etc/uget-gtk.profile
+++ b/etc/uget-gtk.profile
@@ -9,6 +9,7 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6
 netfilter
+nonewprivs
 noroot
 
 whitelist ${DOWNLOADS}

--- a/etc/vivaldi.profile
+++ b/etc/vivaldi.profile
@@ -6,6 +6,7 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
 netfilter
+nonewprivs
 
 whitelist ${DOWNLOADS}
 mkdir ~/.config

--- a/etc/vlc.profile
+++ b/etc/vlc.profile
@@ -9,5 +9,6 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot
 netfilter

--- a/etc/warzone2100.profile
+++ b/etc/warzone2100.profile
@@ -9,6 +9,7 @@ include /etc/firejail/disable-programs.inc
 # Call these options
 caps.drop all
 netfilter
+nonewprivs
 noroot
 protocol unix,inet,inet6,netlink
 seccomp

--- a/etc/weechat.profile
+++ b/etc/weechat.profile
@@ -7,5 +7,6 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6
 netfilter
+nonewprivs
 noroot
 netfilter

--- a/etc/wesnoth.profile
+++ b/etc/wesnoth.profile
@@ -11,6 +11,7 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot
 
 private-dev

--- a/etc/wine.profile
+++ b/etc/wine.profile
@@ -9,5 +9,6 @@ include /etc/firejail/disable-devel.inc
 
 caps.drop all
 netfilter
+nonewprivs
 noroot
 seccomp

--- a/etc/xchat.profile
+++ b/etc/xchat.profile
@@ -8,4 +8,5 @@ include /etc/firejail/disable-devel.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot

--- a/etc/xplayer.profile
+++ b/etc/xplayer.profile
@@ -10,6 +10,7 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot
 tracelog
 netfilter

--- a/etc/xreader.profile
+++ b/etc/xreader.profile
@@ -11,6 +11,7 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 seccomp
 protocol unix,inet,inet6
+nonewprivs
 noroot
 tracelog
 netfilter

--- a/etc/xviewer.profile
+++ b/etc/xviewer.profile
@@ -9,5 +9,6 @@ caps.drop all
 seccomp
 protocol unix,inet,inet6
 noroot
+nonewprivs
 tracelog
 netfilter


### PR DESCRIPTION
This adds `nonewprivs` in profiles where I thought it made sense.

**WARNING**: I didn't test most profiles, simply because I don't use the corresponding software.
I'm only submitting this PR here so that other people know where it might be interesting to add `nonewprivs`.

One specific caveat deserves mention: some `sendmail` implementations are broken by `NO_NEW_PRIVS`, because they rely on the setgid bit to be able to write new mails directly in the mail queue, so in general this cannot be set on any program that may call (directly or not) `sendmail`.