### PR TITLE
Various

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -187,6 +187,7 @@ realinstall:
 	install -c -m 0644 .etc/corebird.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/konversation.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/psi-plus.profile $(DESTDIR)/$(sysconfdir)/firejail/.
+	install -c -m 0644 .etc/brave.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	sh -c "if [ ! -f $(DESTDIR)/$(sysconfdir)/firejail/login.users ]; then install -c -m 0644 etc/login.users $(DESTDIR)/$(sysconfdir)/firejail/.; fi;"
 	sh -c "if [ ! -f $(DESTDIR)/$(sysconfdir)/firejail/firejail.config ]; then install -c -m 0644 etc/firejail.config $(DESTDIR)/$(sysconfdir)/firejail/.; fi;"
 	rm -fr .etc

--- a/README
+++ b/README
@@ -77,6 +77,8 @@ Fred-Barclay (https://github.com/Fred-Barclay)
 	- blacklisted escape-happy terminals in disable-common.inc
 	- blacklisted g++
 	- added xplayer, xreader, and xviewer profiles
+	- added Brave profile
+	- added "shutdown" filter for x86_64 arch to seccomp
 Petter Reinholdtsen (pere@hungry.com)
 	- Opera profile patch
 n1trux (https://github.com/n1trux)

--- a/README.md
+++ b/README.md
@@ -290,6 +290,4 @@ $ man firejail-profile
 lxterminal, Epiphany, cherrytree, Polari, Vivaldi, Atril, qutebrowser, SlimJet, Battle for Wesnoth, Hedgewars, qTox,
 OpenSSH client, OpenBox window manager, Dillo, cmus, dnsmasq, PaleMoon, Icedove, abrowser, 0ad, netsurf,
 Warzone2100, okular, gwenview, Gpredict, Aweather, Stellarium, Google-Play-Music-Desktop-Player, quiterss,
-cyberfox, generic Ubuntu snap application profile, xplayer, xreader, xviewer, mcabber, Psi+, Corebird, Konversation
-
-
+cyberfox, generic Ubuntu snap application profile, xplayer, xreader, xviewer, mcabber, Psi+, Corebird, Konversation, Brave

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ The following features can be enabled or disabled:
 
 ## Default seccomp filter update
 
-Currently 50 syscalls are blacklisted by default, out of a total of 318 calls (AMD64, Debian Jessie).
+Currently 51 syscalls are blacklisted by default, out of a total of 318 calls (AMD64, Debian Jessie).
 
 ## STUN/WebRTC disabled in default netfilter configuration
 

--- a/RELNOTES
+++ b/RELNOTES
@@ -25,6 +25,7 @@ firejail (0.9.40) baseline; urgency=low
   * new profiles: Aweather, Stellarium, gpredict, quiterss, cyberfox
   * new profiles: generic Ubuntu snap application profile, xplayer
   * new profiles: xreader, xviewer, mcabber, Psi+, Corebird, Konversation
+  * new profiles: Brave
   * generic.profile renamed default.profile
   * build rpm packages using "make rpms"
   * bugfixes

--- a/etc/atril.profile
+++ b/etc/atril.profile
@@ -12,3 +12,4 @@ protocol unix,inet,inet6
 noroot
 tracelog
 netfilter
+nosound

--- a/etc/brave.profile
+++ b/etc/brave.profile
@@ -1,0 +1,18 @@
+# Profile for Brave browser
+
+noblacklist ~/.config/brave
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
+
+caps.drop all
+seccomp
+protocol unix,inet,inet6,netlink
+netfilter
+noroot
+
+whitelist ${DOWNLOADS}
+
+mkdir ~/.config
+mkdir ~/.config/brave
+whitelist ~/.config/brave

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -51,6 +51,7 @@ blacklist ${HOME}/.config/epiphany
 blacklist ${HOME}/.config/slimjet
 blacklist ${HOME}/.config/qutebrowser
 blacklist ${HOME}/.8pecxstudios
+blacklist ${HOME}/.config/brave
 
 # Instant Messaging
 blacklist ${HOME}/.config/hexchat

--- a/etc/xreader.profile
+++ b/etc/xreader.profile
@@ -14,3 +14,4 @@ protocol unix,inet,inet6
 noroot
 tracelog
 netfilter
+nosound

--- a/platform/debian/conffiles
+++ b/platform/debian/conffiles
@@ -101,3 +101,4 @@
 /etc/firejail/corebird.profile
 /etc/firejail/konversation.profile
 /etc/firejail/psi-plus.profile
+/etc/firejail/brave.profile

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -35,6 +35,7 @@ vivaldi-beta
 vivaldi
 dillo
 netsurf
+brave
 
 # bittorrent/ftp
 deluge

--- a/src/firejail/seccomp.c
+++ b/src/firejail/seccomp.c
@@ -445,6 +445,7 @@ void seccomp_filter_64(void) {
 		BLACKLIST(169), // reboot
 		BLACKLIST(180), // nfsservctl
 		BLACKLIST(177), // get_kernel_syms
+		BLACKLIST(48),  // shutdown
 		RETURN_ALLOW
 	};
 

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -1189,7 +1189,7 @@ add_key, request_key, keyctl, uselib, acct, modify_ldt, pivot_root, io_setup,
 io_destroy, io_getevents, io_submit, io_cancel,
 remap_file_pages, mbind, get_mempolicy, set_mempolicy,
 migrate_pages, move_pages, vmsplice, perf_event_open, chroot,
-tuxcall, reboot, mfsservctl and get_kernel_syms.
+tuxcall, reboot, mfsservctl, get_kernel_syms, and shutdown.
 .br
 
 .br


### PR DESCRIPTION
This adds a profile for the Brave browser, and I added "nosound" to the atril and xreader profiles (since pdf's shouldn't really be making noise :smile_cat: )

I also blacklisted "shutdown" in seccomp for amd64 machines--apparently it's not a syscall for 32-bit kernels??? "Reboot" is already blacklisted and I figured that shutdown should be too. ;)

Cheers!
Fred