### PR TITLE
Various

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -188,6 +188,7 @@ realinstall:
 	install -c -m 0644 .etc/konversation.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/psi-plus.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/brave.profile $(DESTDIR)/$(sysconfdir)/firejail/.
+	install -c -m 0644 .etc/gitter.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	sh -c "if [ ! -f $(DESTDIR)/$(sysconfdir)/firejail/login.users ]; then install -c -m 0644 etc/login.users $(DESTDIR)/$(sysconfdir)/firejail/.; fi;"
 	sh -c "if [ ! -f $(DESTDIR)/$(sysconfdir)/firejail/firejail.config ]; then install -c -m 0644 etc/firejail.config $(DESTDIR)/$(sysconfdir)/firejail/.; fi;"
 	rm -fr .etc

--- a/README
+++ b/README
@@ -79,7 +79,8 @@ Fred-Barclay (https://github.com/Fred-Barclay)
 	- blacklisted g++
 	- added xplayer, xreader, and xviewer profiles
 	- added Brave profile
-	- added "shutdown" filter for x86_64 arch to seccomp
+	- added Gitter profile
+	- various organising
 Petter Reinholdtsen (pere@hungry.com)
 	- Opera profile patch
 n1trux (https://github.com/n1trux)

--- a/README.md
+++ b/README.md
@@ -290,4 +290,4 @@ $ man firejail-profile
 lxterminal, Epiphany, cherrytree, Polari, Vivaldi, Atril, qutebrowser, SlimJet, Battle for Wesnoth, Hedgewars, qTox,
 OpenSSH client, OpenBox window manager, Dillo, cmus, dnsmasq, PaleMoon, Icedove, abrowser, 0ad, netsurf,
 Warzone2100, okular, gwenview, Gpredict, Aweather, Stellarium, Google-Play-Music-Desktop-Player, quiterss,
-cyberfox, generic Ubuntu snap application profile, xplayer, xreader, xviewer, mcabber, Psi+, Corebird, Konversation, Brave
+cyberfox, generic Ubuntu snap application profile, xplayer, xreader, xviewer, mcabber, Psi+, Corebird, Konversation, Brave, Gitter

--- a/RELNOTES
+++ b/RELNOTES
@@ -25,7 +25,7 @@ firejail (0.9.40) baseline; urgency=low
   * new profiles: Aweather, Stellarium, gpredict, quiterss, cyberfox
   * new profiles: generic Ubuntu snap application profile, xplayer
   * new profiles: xreader, xviewer, mcabber, Psi+, Corebird, Konversation
-  * new profiles: Brave
+  * new profiles: Brave, Gitter
   * generic.profile renamed default.profile
   * build rpm packages using "make rpms"
   * bugfixes

--- a/etc/0ad.profile
+++ b/etc/0ad.profile
@@ -7,12 +7,12 @@ include /etc/firejail/disable-programs.inc
 
 # Call these options
 caps.drop all
-seccomp
-protocol unix,inet,inet6,netlink
 netfilter
-tracelog
 noroot
 nonewprivs
+protocol unix,inet,inet6,netlink
+seccomp
+tracelog
 
 # Whitelists
 noblacklist ~/.cache/0ad

--- a/etc/Mathematica.profile
+++ b/etc/Mathematica.profile
@@ -15,6 +15,6 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
 nonewprivs
 noroot
+seccomp

--- a/etc/abrowser.profile
+++ b/etc/abrowser.profile
@@ -7,12 +7,12 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6,netlink
 netfilter
-tracelog
 nonewprivs
 noroot
+protocol unix,inet,inet6,netlink
+seccomp
+tracelog
 
 whitelist ${DOWNLOADS}
 mkdir ~/.mozilla
@@ -41,13 +41,12 @@ whitelist ~/.config/lastpass
 
 
 #silverlight
-whitelist ~/.wine-pipelight 
-whitelist ~/.wine-pipelight64 
-whitelist ~/.config/pipelight-widevine 
+whitelist ~/.wine-pipelight
+whitelist ~/.wine-pipelight64
+whitelist ~/.config/pipelight-widevine
 whitelist ~/.config/pipelight-silverlight5.1
 
 include /etc/firejail/whitelist-common.inc
 
 # experimental features
 #private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse
-

--- a/etc/atril.profile
+++ b/etc/atril.profile
@@ -7,10 +7,10 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
+netfilter
 nonewprivs
 noroot
-tracelog
-netfilter
 nosound
+protocol unix,inet,inet6
+seccomp
+tracelog

--- a/etc/audacious.profile
+++ b/etc/audacious.profile
@@ -5,7 +5,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 nonewprivs
 noroot
+protocol unix,inet,inet6
+seccomp

--- a/etc/bitlbee.profile
+++ b/etc/bitlbee.profile
@@ -4,9 +4,9 @@ noblacklist /usr/sbin
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 
-protocol unix,inet,inet6
-private
-private-dev
-seccomp
 netfilter
 nonewprivs
+private
+private-dev
+protocol unix,inet,inet6
+seccomp

--- a/etc/brave.profile
+++ b/etc/brave.profile
@@ -6,10 +6,11 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6,netlink
 netfilter
+nonewprivs
 noroot
+protocol unix,inet,inet6,netlink
+seccomp
 
 whitelist ${DOWNLOADS}
 

--- a/etc/cherrytree.profile
+++ b/etc/cherrytree.profile
@@ -15,11 +15,12 @@ mkdir ~/.local/share
 whitelist ${HOME}/.local/share/
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6,netlink
 netfilter
-tracelog
 nonewprivs
 noroot
-include /etc/firejail/whitelist-common.inc
 nosound
+seccomp
+protocol unix,inet,inet6,netlink
+tracelog
+
+include /etc/firejail/whitelist-common.inc

--- a/etc/clementine.profile
+++ b/etc/clementine.profile
@@ -5,7 +5,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 nonewprivs
 noroot
+protocol unix,inet,inet6
+seccomp

--- a/etc/cmus.profile
+++ b/etc/cmus.profile
@@ -7,11 +7,11 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 nonewprivs
 noroot
+protocol unix,inet,inet6
+seccomp
 
 private-bin cmus
 private-etc group

--- a/etc/conkeror.profile
+++ b/etc/conkeror.profile
@@ -4,11 +4,11 @@ include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 nonewprivs
 noroot
+protocol unix,inet,inet6
+seccomp
 
 whitelist ~/.conkeror.mozdev.org
 whitelist ~/Downloads

--- a/etc/corebird.profile
+++ b/etc/corebird.profile
@@ -6,7 +6,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 noroot
+protocol unix,inet,inet6
+seccomp

--- a/etc/cyberfox.profile
+++ b/etc/cyberfox.profile
@@ -7,12 +7,12 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6,netlink
 netfilter
-tracelog
 nonewprivs
 noroot
+protocol unix,inet,inet6,netlink
+seccomp
+tracelog
 
 whitelist ${DOWNLOADS}
 mkdir ~/.8pecxstudios
@@ -41,13 +41,12 @@ whitelist ~/.config/lastpass
 
 
 #silverlight
-whitelist ~/.wine-pipelight 
-whitelist ~/.wine-pipelight64 
-whitelist ~/.config/pipelight-widevine 
+whitelist ~/.wine-pipelight
+whitelist ~/.wine-pipelight64
+whitelist ~/.config/pipelight-widevine
 whitelist ~/.config/pipelight-silverlight5.1
 
 include /etc/firejail/whitelist-common.inc
 
 # experimental features
 #private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse
-

--- a/etc/deadbeef.profile
+++ b/etc/deadbeef.profile
@@ -7,7 +7,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 nonewprivs
 noroot
+protocol unix,inet,inet6
+seccomp

--- a/etc/default.profile
+++ b/etc/default.profile
@@ -8,9 +8,8 @@ include /etc/firejail/disable-passwdmgr.inc
 #blacklist ${HOME}/.wine
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 nonewprivs
 noroot
-
+protocol unix,inet,inet6
+seccomp

--- a/etc/deluge.profile
+++ b/etc/deluge.profile
@@ -6,9 +6,9 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 nonewprivs
 noroot
 nosound
+protocol unix,inet,inet6
+seccomp

--- a/etc/dillo.profile
+++ b/etc/dillo.profile
@@ -7,12 +7,12 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
-tracelog
 nonewprivs
 noroot
+protocol unix,inet,inet6
+seccomp
+tracelog
 
 whitelist ${DOWNLOADS}
 mkdir ~/.dillo
@@ -21,6 +21,3 @@ mkdir ~/.fltk
 whitelist ~/.fltk
 
 include /etc/firejail/whitelist-common.inc
-
-
-

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -65,6 +65,7 @@ blacklist ${HOME}/.config/xchat
 blacklist ${HOME}/.Skype
 blacklist ${HOME}/.config/tox
 blacklist ${HOME}/.TelegramDesktop
+blacklist ${HOME}/.config/Gitter
 
 # Games
 blacklist ${HOME}/.hedgewars

--- a/etc/dnsmasq.profile
+++ b/etc/dnsmasq.profile
@@ -5,10 +5,11 @@ include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-devel.inc
+
 caps
-seccomp
-protocol unix,inet,inet6,netlink
 netfilter
+nonewprivs
 private
 private-dev
-nonewprivs
+protocol unix,inet,inet6,netlink
+seccomp

--- a/etc/dropbox.profile
+++ b/etc/dropbox.profile
@@ -4,7 +4,7 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps
-seccomp
-protocol unix,inet,inet6
 nonewprivs
 noroot
+protocol unix,inet,inet6
+seccomp

--- a/etc/empathy.profile
+++ b/etc/empathy.profile
@@ -4,7 +4,7 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 nonewprivs
+protocol unix,inet,inet6
+seccomp

--- a/etc/epiphany.profile
+++ b/etc/epiphany.profile
@@ -19,8 +19,9 @@ mkdir ${HOME}/.cache
 mkdir ${HOME}/.cache/epiphany
 whitelist ${HOME}/.cache/epiphany
 include /etc/firejail/whitelist-common.inc
+
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 nonewprivs
+protocol unix,inet,inet6
+seccomp

--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -5,8 +5,8 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 nonewprivs
 noroot
 nosound
+protocol unix,inet,inet6
+seccomp

--- a/etc/fbreader.profile
+++ b/etc/fbreader.profile
@@ -7,9 +7,9 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 nonewprivs
 noroot
 nosound
+protocol unix,inet,inet6
+seccomp

--- a/etc/filezilla.profile
+++ b/etc/filezilla.profile
@@ -7,9 +7,9 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
+netfilter
 nonewprivs
 noroot
-netfilter
 nosound
+protocol unix,inet,inet6
+seccomp

--- a/etc/firefox.profile
+++ b/etc/firefox.profile
@@ -7,12 +7,12 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6,netlink
 netfilter
-tracelog
 nonewprivs
 noroot
+protocol unix,inet,inet6,netlink
+seccomp
+tracelog
 
 whitelist ${DOWNLOADS}
 mkdir ~/.mozilla
@@ -41,14 +41,12 @@ whitelist ~/.config/lastpass
 
 
 #silverlight
-whitelist ~/.wine-pipelight 
-whitelist ~/.wine-pipelight64 
-whitelist ~/.config/pipelight-widevine 
+whitelist ~/.wine-pipelight
+whitelist ~/.wine-pipelight64
+whitelist ~/.config/pipelight-widevine
 whitelist ~/.config/pipelight-silverlight5.1
 
 include /etc/firejail/whitelist-common.inc
 
 # experimental features
 #private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse
-
-

--- a/etc/flashpeak-slimjet.profile
+++ b/etc/flashpeak-slimjet.profile
@@ -15,11 +15,11 @@ include /etc/firejail/disable-programs.inc
 #
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6,netlink
 netfilter
 nonewprivs
 noroot
+protocol unix,inet,inet6,netlink
+seccomp
 
 whitelist ${DOWNLOADS}
 mkdir ~/.config

--- a/etc/gitter.profile
+++ b/etc/gitter.profile
@@ -1,0 +1,13 @@
+# Firejail profile for Gitter
+noblacklist ~/.config/Gitter
+
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
+
+caps.drop all
+seccomp
+netfilter
+noroot
+protocol unix,inet,inet6,netlink

--- a/etc/gitter.profile
+++ b/etc/gitter.profile
@@ -7,7 +7,7 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
-seccomp
 netfilter
 noroot
 protocol unix,inet,inet6,netlink
+seccomp

--- a/etc/gnome-mplayer.profile
+++ b/etc/gnome-mplayer.profile
@@ -5,7 +5,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 nonewprivs
 noroot
+protocol unix,inet,inet6
+seccomp

--- a/etc/google-play-music-desktop-player.profile
+++ b/etc/google-play-music-desktop-player.profile
@@ -7,11 +7,11 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6,netlink
 nonewprivs
 noroot
 netfilter
+protocol unix,inet,inet6,netlink
+seccomp
 
 #whitelist ~/.pulse
 #whitelist ~/.config/pulse

--- a/etc/gwenview.profile
+++ b/etc/gwenview.profile
@@ -5,16 +5,16 @@ include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
+
 caps.drop all
-seccomp
-protocol unix
 nonewprivs
 noroot
 nogroups
 private-dev
+protocol unix
+seccomp
 
 #Experimental:
 #shell none
 #private-bin gwenview
 #private-etc X11
-

--- a/etc/hexchat.profile
+++ b/etc/hexchat.profile
@@ -7,11 +7,11 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 nonewprivs
 noroot
 netfilter
+protocol unix,inet,inet6
+seccomp
 
 mkdir ~/.config
 mkdir ~/.config/hexchat

--- a/etc/kmail.profile
+++ b/etc/kmail.profile
@@ -7,9 +7,9 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6,netlink
 netfilter
 nonewprivs
 noroot
+protocol unix,inet,inet6,netlink
+seccomp
 tracelog

--- a/etc/konversation.profile
+++ b/etc/konversation.profile
@@ -6,7 +6,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 noroot
+seccomp
+protocol unix,inet,inet6

--- a/etc/lxterminal.profile
+++ b/etc/lxterminal.profile
@@ -5,7 +5,7 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
+protocol unix,inet,inet6
+seccomp
 #noroot - somehow this breaks on Debian Jessie!

--- a/etc/mcabber.profile
+++ b/etc/mcabber.profile
@@ -8,11 +8,11 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol inet,inet6
 netfilter
 nonewprivs
 noroot
+protocol inet,inet6
+seccomp
 
 private-bin mcabber
 private-etc null

--- a/etc/midori.profile
+++ b/etc/midori.profile
@@ -5,8 +5,8 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 nonewprivs
 noroot
+protocol unix,inet,inet6
+seccomp

--- a/etc/mupen64plus.profile
+++ b/etc/mupen64plus.profile
@@ -16,8 +16,8 @@ mkdir ${HOME}/.config
 mkdir ${HOME}/.config/mupen64plus
 whitelist ${HOME}/.config/mupen64plus/
 
+caps.drop all
+net none
 nonewprivs
 noroot
-caps.drop all
 seccomp
-net none

--- a/etc/netsurf.profile
+++ b/etc/netsurf.profile
@@ -7,12 +7,12 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6,netlink
 netfilter
-tracelog
 nonewprivs
 noroot
+protocol unix,inet,inet6,netlink
+seccomp
+tracelog
 
 whitelist ${DOWNLOADS}
 mkdir ~/.config
@@ -30,6 +30,3 @@ whitelist ~/.lastpass
 whitelist ~/.config/lastpass
 
 include /etc/firejail/whitelist-common.inc
-
-
-

--- a/etc/okular.profile
+++ b/etc/okular.profile
@@ -6,17 +6,17 @@ include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
+
 caps.drop all
-seccomp
-protocol unix
 nonewprivs
-noroot
 nogroups
+noroot
 private-dev
+protocol unix
+seccomp
 
 #Experimental:
 #net none
 #shell none
 #private-bin okular,kbuildsycoca4,kbuildsycoca5
 #private-etc X11
-

--- a/etc/openbox.profile
+++ b/etc/openbox.profile
@@ -5,8 +5,7 @@
 include /etc/firejail/disable-common.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 noroot
-
+protocol unix,inet,inet6
+seccomp

--- a/etc/palemoon.profile
+++ b/etc/palemoon.profile
@@ -12,12 +12,12 @@ include /etc/firejail/whitelist-common.inc
 
 # Options
 caps.drop all
-seccomp
-protocol unix,inet,inet6,netlink
 netfilter
-tracelog
 nonewprivs
 noroot
+protocol unix,inet,inet6,netlink
+seccomp
+tracelog
 
 whitelist ${DOWNLOADS}
 mkdir ~/.moonchild productions
@@ -41,9 +41,9 @@ whitelist ~/.cache/moonchild productions/pale moon
 #whitelist ~/.pki
 
 # For silverlight
-#whitelist ~/.wine-pipelight 
-#whitelist ~/.wine-pipelight64 
-#whitelist ~/.config/pipelight-widevine 
+#whitelist ~/.wine-pipelight
+#whitelist ~/.wine-pipelight64
+#whitelist ~/.config/pipelight-widevine
 #whitelist ~/.config/pipelight-silverlight5.1
 
 

--- a/etc/parole.profile
+++ b/etc/parole.profile
@@ -8,9 +8,9 @@ private-etc passwd,group,fonts
 private-bin parole,dbus-launch
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 nonewprivs
 noroot
+protocol unix,inet,inet6
+seccomp
 shell none

--- a/etc/pidgin.profile
+++ b/etc/pidgin.profile
@@ -6,7 +6,7 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 nonewprivs
 noroot
+protocol unix,inet,inet6
+seccomp

--- a/etc/polari.profile
+++ b/etc/polari.profile
@@ -22,9 +22,8 @@ whitelist ${HOME}/.purple
 include /etc/firejail/whitelist-common.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
+netfilter
 nonewprivs
 noroot
-netfilter
-
+protocol unix,inet,inet6
+seccomp

--- a/etc/psi-plus.profile
+++ b/etc/psi-plus.profile
@@ -21,7 +21,7 @@ whitelist ~/.cache/psi+
 include /etc/firejail/whitelist-common.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 noroot
+protocol unix,inet,inet6
+seccomp

--- a/etc/qbittorrent.profile
+++ b/etc/qbittorrent.profile
@@ -5,9 +5,9 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 nonewprivs
 noroot
 nosound
+protocol unix,inet,inet6
+seccomp

--- a/etc/qtox.profile
+++ b/etc/qtox.profile
@@ -10,7 +10,7 @@ whitelist ${DOWNLOADS}
 include /etc/firejail/whitelist-common.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 nonewprivs
 noroot
+protocol unix,inet,inet6
+seccomp

--- a/etc/quassel.profile
+++ b/etc/quassel.profile
@@ -4,8 +4,8 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 nonewprivs
 noroot
 netfilter
+protocol unix,inet,inet6
+seccomp

--- a/etc/quiterss.profile
+++ b/etc/quiterss.profile
@@ -16,15 +16,16 @@ mkdir ~/.cache/QuiteRss
 whitelist ${HOME}/.cache/QuiteRss
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
-tracelog
 nonewprivs
-noroot
 nogroups
-shell none
-private-dev
+noroot
 private-bin quiterss
+private-dev
 #private-etc X11,ssl
+protocol unix,inet,inet6
+seccomp
+shell none
+tracelog
+
 include /etc/firejail/whitelist-common.inc

--- a/etc/qutebrowser.profile
+++ b/etc/qutebrowser.profile
@@ -7,12 +7,12 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6,netlink
 netfilter
-tracelog
 nonewprivs
 noroot
+protocol unix,inet,inet6,netlink
+seccomp
+tracelog
 
 whitelist ${DOWNLOADS}
 mkdir ~/.config/qutebrowser

--- a/etc/rhythmbox.profile
+++ b/etc/rhythmbox.profile
@@ -5,8 +5,8 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
+netfilter
 nonewprivs
 noroot
-netfilter
+protocol unix,inet,inet6
+seccomp

--- a/etc/rtorrent.profile
+++ b/etc/rtorrent.profile
@@ -5,9 +5,9 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 nonewprivs
 noroot
 nosound
+protocol unix,inet,inet6
+seccomp

--- a/etc/seamonkey.profile
+++ b/etc/seamonkey.profile
@@ -6,12 +6,12 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6,netlink
 netfilter
-tracelog
 nonewprivs
 noroot
+protocol unix,inet,inet6,netlink
+seccomp
+tracelog
 
 whitelist ${DOWNLOADS}
 mkdir ~/.mozilla
@@ -42,11 +42,10 @@ whitelist ~/.lastpass
 whitelist ~/.config/lastpass
 
 #silverlight
-whitelist ~/.wine-pipelight 
-whitelist ~/.wine-pipelight64 
-whitelist ~/.config/pipelight-widevine 
+whitelist ~/.wine-pipelight
+whitelist ~/.wine-pipelight64
+whitelist ~/.config/pipelight-widevine
 whitelist ~/.config/pipelight-silverlight5.1
 
 # experimental features
 #private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse
-

--- a/etc/skype.profile
+++ b/etc/skype.profile
@@ -8,5 +8,5 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
-seccomp
 protocol unix,inet,inet6
+seccomp

--- a/etc/spotify.profile
+++ b/etc/spotify.profile
@@ -7,8 +7,8 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
-# Whitelist the folders needed by Spotify - This is more restrictive 
-# than a blacklist though, but this is all spotify requires for 
+# Whitelist the folders needed by Spotify - This is more restrictive
+# than a blacklist though, but this is all spotify requires for
 # streaming audio
 mkdir ${HOME}/.config
 mkdir ${HOME}/.config/spotify
@@ -23,9 +23,8 @@ whitelist ${HOME}/.cache/spotify
 include /etc/firejail/whitelist-common.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6,netlink
 netfilter
 nonewprivs
 noroot
-
+protocol unix,inet,inet6,netlink
+seccomp

--- a/etc/ssh.profile
+++ b/etc/ssh.profile
@@ -6,8 +6,8 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 nonewprivs
 noroot
+protocol unix,inet,inet6
+seccomp

--- a/etc/steam.profile
+++ b/etc/steam.profile
@@ -10,5 +10,5 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
-seccomp
 protocol unix,inet,inet6
+seccomp

--- a/etc/telegram.profile
+++ b/etc/telegram.profile
@@ -5,11 +5,11 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
+netfilter
 nonewprivs
 noroot
-netfilter
+protocol unix,inet,inet6
+seccomp
 
 whitelist ~/Downloads/Telegram Desktop
 mkdir ${HOME}/.TelegramDesktop

--- a/etc/totem.profile
+++ b/etc/totem.profile
@@ -8,8 +8,8 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 nonewprivs
 noroot
 netfilter
+protocol unix,inet,inet6
+seccomp

--- a/etc/transmission-gtk.profile
+++ b/etc/transmission-gtk.profile
@@ -8,10 +8,10 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 nonewprivs
 noroot
-tracelog
 nosound
+protocol unix,inet,inet6
+seccomp
+tracelog

--- a/etc/transmission-qt.profile
+++ b/etc/transmission-qt.profile
@@ -8,10 +8,10 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 nonewprivs
 noroot
-tracelog
 nosound
+protocol unix,inet,inet6
+seccomp
+tracelog

--- a/etc/uget-gtk.profile
+++ b/etc/uget-gtk.profile
@@ -6,11 +6,11 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 nonewprivs
 noroot
+protocol unix,inet,inet6
+seccomp
 
 whitelist ${DOWNLOADS}
 mkdir ~/.config

--- a/etc/vlc.profile
+++ b/etc/vlc.profile
@@ -7,8 +7,8 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
+netfilter
 nonewprivs
 noroot
-netfilter
+protocol unix,inet,inet6
+seccomp

--- a/etc/weechat.profile
+++ b/etc/weechat.profile
@@ -4,9 +4,8 @@ include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 netfilter
 nonewprivs
 noroot
-netfilter
+protocol unix,inet,inet6
+seccomp

--- a/etc/wesnoth.profile
+++ b/etc/wesnoth.profile
@@ -9,10 +9,10 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 nonewprivs
 noroot
+protocol unix,inet,inet6
+seccomp
 
 private-dev
 

--- a/etc/xchat.profile
+++ b/etc/xchat.profile
@@ -6,7 +6,7 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
 nonewprivs
 noroot
+protocol unix,inet,inet6
+seccomp

--- a/etc/xplayer.profile
+++ b/etc/xplayer.profile
@@ -8,9 +8,9 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
+netfilter
 nonewprivs
 noroot
+protocol unix,inet,inet6
+seccomp
 tracelog
-netfilter

--- a/etc/xreader.profile
+++ b/etc/xreader.profile
@@ -9,10 +9,10 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
+netfilter
 nonewprivs
 noroot
-tracelog
-netfilter
 nosound
+protocol unix,inet,inet6
+seccomp
+tracelog

--- a/etc/xviewer.profile
+++ b/etc/xviewer.profile
@@ -6,9 +6,9 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix,inet,inet6
+netfilter
 noroot
 nonewprivs
+protocol unix,inet,inet6
+seccomp
 tracelog
-netfilter

--- a/platform/debian/conffiles
+++ b/platform/debian/conffiles
@@ -102,3 +102,4 @@
 /etc/firejail/konversation.profile
 /etc/firejail/psi-plus.profile
 /etc/firejail/brave.profile
+/etc/firejail/gitter.profile

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -85,6 +85,7 @@ pidgin
 qtox
 quassel
 xchat
+gitter
 
 # games
 0ad

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -6,89 +6,114 @@
 gpredict
 stellarium
 
-# weather/climate
-aweather
-
-# browsers/email
-firefox
-iceweasel
-chromium-browser
-chromium
-conkeror
-thunderbird
-epiphany
-flashpeak-slimjet
-google-chrome-beta
-google-chrome-stable
-google-chrome-unstable
-google-chrome
-icecat
-icedove
-kmail
-midori
-opera-beta
-opera
-qutebrowser
-seamonkey
-seamonkey-bin
-vivaldi-beta
-vivaldi
-dillo
-netsurf
-brave
-
 # bittorrent/ftp
 deluge
+dropbox
 filezilla
 qbittorrent
 rtorrent
 transmission-gtk
 transmission-qt
+uget-gtk
 
-# office
-cherrytree
-evince
-fbreader
-localc
-lodraw
-loffice
-lofromtemplate
-loimpress
-lomath
-loweb
-lowriter
-Mathematica
-mathematica
-gwenview
-okular
-atril
-xreader
-
-# Media
-vlc
-audacious
-clementine
-deadbeef
-parole
-rhythmbox
-totem
-cmus
-xplayer
-xviewer
+# browsers/email
+abrowser
+brave
+chromium
+chromium-browser
+conkeror
+cyberfox
+firefox
+flashpeak-slimjet
+epiphany
+dillo
+google-chrome
+google-chrome-beta
+google-chrome-stable
+google-chrome-unstable
+iceweasel
+icecat
+icedove
+kmail
+midori
+netsurf
+opera-beta
+opera
+qutebrowser
+seamonkey
+seamonkey-bin
+thunderbird
+vivaldi-beta
+vivaldi
 
 # chat/messaging
 bitlbee
+corebird
 empathy
-gnome-mplayer
+gitter
 hexchat
+konversation
 pidgin
+polari
+psi-plus
 qtox
 quassel
+skype
+telegram
+weechat
+weechat-curses
 xchat
-gitter
+
+# dns
+dnscrypt-proxy
+dnsmaq
+unbound
+
+# emulators/compatibility layers
+mupen64plus
+wine
 
 # games
 0ad
 hedgewars
+steam
 wesnot
 warzone2100
+
+# Media
+audacious
+clementine
+cmus
+deadbeef
+gnome-mplayer
+google-play-music-desktop-player
+parole
+rhythmbox
+spotify
+totem
+vlc
+xplayer
+xviewer
+
+# news readers
+quiterss
+
+# office
+atril
+cherrytree
+evince
+fbreader
+gwenview
+Mathematica
+mathematica
+okular
+xreader
+
+# other
+lxterminal
+openbox
+snap
+ssh
+
+# weather/climate
+aweather


### PR DESCRIPTION
Gitter now has a profile.
I was looking into src/firecfg/firecfg.conf and realised that several profiles weren't mentioned in it. I've added them and alphabetised the file.

I also alphabetised the security filters in all the profiles, to hopefully make them even easier to read. There were a few redundancies (weechat had netfilter twice IIRC) so they *should* be gone as well. :wink: 
Hope this helps!