### PR TITLE
Set $APPIMAGE and $APPDIR environment variables

### DIFF
--- a/src/firejail/appimage.c
+++ b/src/firejail/appimage.c
@@ -88,7 +88,7 @@ void appimage_set(const char *appimage_path) {
 		printf("appimage mounted on %s\n", mntdir);
 	EUID_USER();
 
-	if (mntdir && setenv("APPIMAGE", appimage_path, 1) < 0)
+	if (appimage_path && setenv("APPIMAGE", appimage_path, 1) < 0)
 		errExit("setenv");
 	
 	if (mntdir && setenv("APPDIR", mntdir, 1) < 0)

--- a/src/firejail/appimage.c
+++ b/src/firejail/appimage.c
@@ -87,7 +87,13 @@ void appimage_set(const char *appimage_path) {
 	if (arg_debug)
 		printf("appimage mounted on %s\n", mntdir);
 	EUID_USER();
+
+	if (mntdir && setenv("APPIMAGE", appimage_path, 1) < 0)
+		errExit("setenv");
 	
+	if (mntdir && setenv("APPDIR", mntdir, 1) < 0)
+		errExit("setenv");
+
 	// build new command line
 	if (asprintf(&cfg.command_line, "%s/AppRun", mntdir) == -1)
 		errExit("asprintf");


### PR DESCRIPTION
Partly fixes #560

The software inside AppImages might may the following [environment variables to be set:](https://github.com/probonopd/AppImageKit/blob/34defc0d9fc0b79735b3cdf84cd5c4d3234f9639/runtime.c#L360-L361)
* `$APPIMAGE` should contain the full path of the AppImage that has been mounted
* `$APPDIR` should contain the full path to the mountpoint where the AppImage that has been mounted

Please [squash commits](https://help.github.com/articles/about-pull-request-merge-squashing/) when merging, thanks.