### PR TITLE
kwallet typo

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -95,8 +95,8 @@ read-only ${HOME}/bin
 blacklist ${HOME}/.ssh
 blacklist ${HOME}/.cert
 blacklist ${HOME}/.gnome2/keyrings
-blacklist ${HOME}/kde4/share/apps/kwallet
-blacklist ${HOME}/kde/share/apps/kwallet
+blacklist ${HOME}/.kde4/share/apps/kwallet
+blacklist ${HOME}/.kde/share/apps/kwallet
 blacklist ${HOME}/.local/share/kwalletd
 blacklist ${HOME}/.netrc
 blacklist ${HOME}/.gnupg


### PR DESCRIPTION
kde and kde4 are hidden. At least on my pc