### PR TITLE
Proposed

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -206,6 +206,7 @@ realinstall:
 	install -c -m 0644 .etc/lomath.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/loweb.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/lowriter.profile $(DESTDIR)/$(sysconfdir)/firejail/.
+	install -c -m 0644 .etc/pix.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	sh -c "if [ ! -f $(DESTDIR)/$(sysconfdir)/firejail/login.users ]; then install -c -m 0644 etc/login.users $(DESTDIR)/$(sysconfdir)/firejail/.; fi;"
 	install -c -m 0644 etc/firejail.config $(DESTDIR)/$(sysconfdir)/firejail/.
 	rm -fr .etc

--- a/README
+++ b/README
@@ -89,6 +89,7 @@ Fred-Barclay (https://github.com/Fred-Barclay)
 	- added Gitter profile
 	- various organising
 	- added Libreoffice profile
+	- added pix profile
 Petter Reinholdtsen (pere@hungry.com)
 	- Opera profile patch
 n1trux (https://github.com/n1trux)

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ File transfer: filezilla
 
 Media: vlc, mpv, gnome-mplayer
 
-Office: evince, gthumb, fbreader
+Office: evince, gthumb, fbreader, pix
 
 ## New security profiles
 
-Gitter, gThumb, mpv, Franz messenger, LibreOffice
+Gitter, gThumb, mpv, Franz messenger, LibreOffice, pix

--- a/RELNOTES
+++ b/RELNOTES
@@ -4,6 +4,7 @@ firejail (0.9.41) baseline; urgency=low
   * compile time support to disable global configuration file
   * some profiles have been converted to private-bin
   * new profiles: Gitter, gThumb, mpv, Franz messenger, LibreOffice
+  * new profiles: pix
  -- netblue30 <netblue30@yahoo.com>  Tue, 31 May 2016 08:00:00 -0500
 
 firejail (0.9.40) baseline; urgency=low

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -17,6 +17,7 @@ blacklist ${HOME}/.config/atril
 blacklist ${HOME}/.config/xreader
 blacklist ${HOME}/.config/xviewer
 blacklist ${HOME}/.config/libreoffice
+blacklist ${HOME}/.config/pix
 blacklist ${HOME}/.kde/share/apps/okular
 blacklist ${HOME}/.kde/share/config/okularrc
 blacklist ${HOME}/.kde/share/config/okularpartrc
@@ -120,3 +121,4 @@ blacklist ${HOME}/.local/share/0ad
 blacklist ${HOME}/.local/share/xplayer
 blacklist ${HOME}/.local/share/totem
 blacklist ${HOME}/.local/share/psi+
+blacklist ${HOME}/.local/share/pix

--- a/etc/pix.profile
+++ b/etc/pix.profile
@@ -1,0 +1,19 @@
+# gthumb profile
+noblacklist ${HOME}/.config/pix
+noblacklist ${HOME}/.local/share/pix
+
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-passwdmgr.inc
+
+caps.drop all
+netfilter
+nonewprivs
+noroot
+protocol unix,inet,inet6
+seccomp
+
+shell none
+private-bin pix
+whitelist /tmp/.X11-unix

--- a/platform/debian/conffiles
+++ b/platform/debian/conffiles
@@ -116,5 +116,4 @@
 /etc/firejail/lomath.profile
 /etc/firejail/loweb.profile
 /etc/firejail/lowriter.profile
-
-
+/etc/firejail/pix.profile

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -118,6 +118,7 @@ lowriter
 Mathematica
 mathematica
 okular
+pix
 xreader
 
 # other


### PR DESCRIPTION
Profile for pix (one of Linux Mint's xapps). Pix was forked from gthumb so the profiles are practically identical and it already uses private-bin.

It worked fine on my end without `whitelist /tmp/.X11-unix` but I figured you had a good reason for including it on gthumb. Do you think it's necessary here?