### PR TITLE
Fixed conffiles warning for soffice

### DIFF
--- a/platform/debian/conffiles
+++ b/platform/debian/conffiles
@@ -117,3 +117,4 @@
 /etc/firejail/loweb.profile
 /etc/firejail/lowriter.profile
 /etc/firejail/pix.profile
+/etc/firejail/soffice.profile


### PR DESCRIPTION
When building a .deb package from source, lintian warns that "file in etc not marked as conffile **etc/firejail/soffice.profile**". This should handle that.