### PR TITLE
add a firejail profile for strings

### DIFF
--- a/strings.profile
+++ b/strings.profile
@@ -1,0 +1,12 @@
+noblacklist ~/.config
+
+include /usr/local/etc/firejail/disable-common.inc
+include /usr/local/etc/firejail/disable-programs.inc
+include /usr/local/etc/firejail/disable-devel.inc
+include /usr/local/etc/firejail/disable-passwdmgr.inc
+
+caps.drop all
+noroot
+nonewprivs
+seccomp
+tracelog


### PR DESCRIPTION
From: https://lcamtuf.blogspot.com/2014/10/psa-dont-run-strings-on-untrusted-files.html

Many shell users, and certainly most of the people working in computer forensics or other fields of information security, have a habit of running /usr/bin/strings on binary files originating from the Internet. Their understanding is that the tool simply scans the file for runs of printable characters and dumps them to stdout - something that is very unlikely to put you at any risk.