### PR TITLE
cpio sandbox profile for decompression

### DIFF
--- a/etc/cpio.profile
+++ b/etc/cpio.profile
@@ -1,0 +1,7 @@
+include /usr/local/etc/firejail/server.profile
+include /usr/local/etc/firejail/disable-common.inc
+include /usr/local/etc/firejail/disable-programs.inc
+include /usr/local/etc/firejail/disable-passwdmgr.inc
+caps.drop all
+shell none
+seccomp

--- a/etc/cpio.profile
+++ b/etc/cpio.profile
@@ -3,5 +3,6 @@ include /usr/local/etc/firejail/disable-common.inc
 include /usr/local/etc/firejail/disable-programs.inc
 include /usr/local/etc/firejail/disable-passwdmgr.inc
 caps.drop all
+net none
 shell none
 seccomp


### PR DESCRIPTION
For decompression purposes, this will allows CPIO to execute in a sandbox environment.
FYI, according to CVE 2016-2037, the cpio_safer_name_suffix function in util.c in cpio 2.11 allows remote attackers to cause a denial of service (out-of-bounds write) via a crafted cpio file.
Other vulnerabilities listed are:
https://www.cvedetails.com/vulnerability-list/vendor_id-72/product_id-5080/GNU-Cpio.html