### PR TITLE
Fix improper quoting of arguments

### DIFF
--- a/src/firejail/join.c
+++ b/src/firejail/join.c
@@ -62,9 +62,9 @@ static void extract_command(int argc, char **argv, int index) {
 	*cfg.command_line = '\0';
 	for (i = index; i < argc; i++) {
 		if (strchr(argv[i], '&')) {
-			strcat(cfg.command_line, "\"");
+			strcat(cfg.command_line, "\'");
 			strcat(cfg.command_line, argv[i]);
-			strcat(cfg.command_line, "\" ");
+			strcat(cfg.command_line, "\' ");
 		}
 		else {
 			strcat(cfg.command_line, argv[i]);

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -2005,7 +2005,7 @@ int main(int argc, char **argv) {
 				sprintf(ptr1, "%s ", argv[i + prog_index]);
 			}
 			else {
-				sprintf(ptr1, "\"%s\" ", argv[i + prog_index]);
+				sprintf(ptr1, "\'%s\' ", argv[i + prog_index]);
 			}
 			sprintf(ptr2, "%s ", argv[i + prog_index]);
 


### PR DESCRIPTION
Using double quote instead of single quote for `cfg.command_line` allows  arbitrary command execution inside of jail if command args (eg. filenames) contain special sequences (backtick, $(), etc).

How to reproduce:
`touch '`uname -a`'`
`touch '$(cal)'`
in same directory:
`firejail cat *uname*`
command `uname -a` will be executed in jail
`firejail cat *cal*`
command `cal` will be executed in jail.

This hopefully fixes it.