### PR TITLE
disable-common: Blacklist ~/.config/keybase

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -110,6 +110,7 @@ blacklist ${HOME}/.gnome2/keyrings
 blacklist ${HOME}/.kde4/share/apps/kwallet
 blacklist ${HOME}/.kde/share/apps/kwallet
 blacklist ${HOME}/.local/share/kwalletd
+blacklist ${HOME}/.config/keybase
 blacklist ${HOME}/.netrc
 blacklist ${HOME}/.gnupg
 blacklist ${HOME}/.caff


### PR DESCRIPTION
This is used by keybase.io's client to store secrets.