### PR TITLE
correction no. 2

### DIFF
--- a/README
+++ b/README
@@ -55,6 +55,7 @@ Fred-Barclay (https://github.com/Fred-Barclay)
 	- added audacity profile
 	- fixed Telegram and qtox profiles
 	- added Atom Beta and Atom profiles
+	- tightened 0ad, atril, evince, gthumb, pix, qtox, and xreader profiles.
 Jaykishan Mutkawoa (https://github.com/jmutkawoa)
 	- cpio profile
 Paupiah Yash (https://github.com/CaffeinatedStud)

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Media: vlc, mpv, gnome-mplayer
 
 Office: evince, gthumb, fbreader, pix
 
+Chat/messaging: qtox
+
 ## New security profiles
 
 Gitter, gThumb, mpv, Franz messenger, LibreOffice, pix, audacity, strings, xz, xzdec, gzip, cpio, less, Atom Beta, Atom

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ File transfer: filezilla
 
 Media: vlc, mpv, gnome-mplayer
 
-Office: evince, gthumb, fbreader, pix
+Office: evince, gthumb, fbreader, pix, atril, xreader
 
 Chat/messaging: qtox
 

--- a/etc/0ad.profile
+++ b/etc/0ad.profile
@@ -1,21 +1,13 @@
 # Firejail profile for 0ad.
+noblacklist ~/.cache/0ad
 noblacklist ~/.config/0ad
+noblacklist ~/.local/share/0ad
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
-# Call these options
-caps.drop all
-netfilter
-noroot
-nonewprivs
-protocol unix,inet,inet6,netlink
-seccomp
-tracelog
-
 # Whitelists
-noblacklist ~/.cache/0ad
 mkdir ~/.cache
 mkdir ~/.cache/0ad
 whitelist ~/.cache/0ad
@@ -24,8 +16,20 @@ mkdir ~/.config
 mkdir ~/.config/0ad
 whitelist ~/.config/0ad
 
-noblacklist ~/.local/share/0ad
 mkdir ~/.local
 mkdir ~/.local/share
 mkdir ~/.local/share/0ad
 whitelist ~/.local/share/0ad
+
+caps.drop all
+netfilter
+nonewprivs
+nogroups
+noroot
+protocol unix,inet,inet6
+seccomp
+shell none
+tracelog
+
+private-dev
+

--- a/etc/atril.profile
+++ b/etc/atril.profile
@@ -7,10 +7,14 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
 nonewprivs
+nogroups
 noroot
 nosound
-protocol unix,inet,inet6
+protocol unix
 seccomp
+shell none
 tracelog
+
+private-bin atril, atril-previewer, atril-thumbnailer
+private-dev

--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -6,9 +6,10 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 nonewprivs
+nogroups
 noroot
 nosound
-protocol unix,inet,inet6
+protocol unix
 seccomp
 
 shell none

--- a/etc/gthumb.profile
+++ b/etc/gthumb.profile
@@ -7,14 +7,15 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
 nonewprivs
+nogroups
 noroot
-protocol unix,inet,inet6
+nosound
+protocol unix
 seccomp
-
 shell none
+tracelog
+
 private-bin gthumb
 whitelist /tmp/.X11-unix
 private-dev
-nosound

--- a/etc/pix.profile
+++ b/etc/pix.profile
@@ -8,15 +8,16 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
 nonewprivs
+nogroups
 noroot
-protocol unix,inet,inet6
+nosound
+protocol unix
 seccomp
-
 shell none
+tracelog
+
 private-bin pix
 whitelist /tmp/.X11-unix
 private-dev
-nosound
 

--- a/etc/qtox.profile
+++ b/etc/qtox.profile
@@ -8,14 +8,15 @@ include /etc/firejail/disable-passwdmgr.inc
 mkdir ${HOME}/.config/tox
 whitelist ${HOME}/.config/tox
 whitelist ${DOWNLOADS}
-include /etc/firejail/whitelist-common.inc
 
 caps.drop all
 netfilter
 nonewprivs
+nogroups
 noroot
 protocol unix,inet,inet6
 seccomp
 shell none
 tracelog
 
+private-bin qtox

--- a/etc/xreader.profile
+++ b/etc/xreader.profile
@@ -9,10 +9,14 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
 nonewprivs
+nogroups
 noroot
 nosound
-protocol unix,inet,inet6
+protocol unix
 seccomp
+shell none
 tracelog
+
+private-bin xreader, xreader-previewer, xreader-thumbnailer
+private-dev

--- a/platform/debian/conffiles
+++ b/platform/debian/conffiles
@@ -1,5 +1,3 @@
-# Do not have a new/empty line on the end of this file or dpkg-deb will warn
-# that "conffile '' is not a plain file." 
 /etc/firejail/evince.profile
 /etc/firejail/chromium.profile
 /etc/firejail/chromium-browser.profile


### PR DESCRIPTION
Apparently you can't comment conffiles without problems.  This should fix my last commit that swapped one warning for another. :stuck_out_tongue_winking_eye:

EDIT: converted qtox to private-bin and tightened the profile a bit more.

EDIT 2: okay, apparently I'm editing more than I planned! So here's what's in this PR:
1. A fix for the debian conffiles that fixes my original fix (fixed by a fixated fixer). 
2. Conversion to private-bin: atril, xreader, evince, and qtox.
3. Fixed permissions warning in 0ad that brought up a debug window when launching.
4. Removed network capabilities from atril, evince, gthumb, pix, and xreader.
5. Added some security filters where appropriate.

Cheers!