### PR TITLE
Mousetrap

### DIFF
--- a/README
+++ b/README
@@ -56,6 +56,7 @@ Fred-Barclay (https://github.com/Fred-Barclay)
 	- fixed Telegram and qtox profiles
 	- added Atom Beta and Atom profiles
 	- tightened 0ad, atril, evince, gthumb, pix, qtox, and xreader profiles.
+	- several private-bin conversions
 Jaykishan Mutkawoa (https://github.com/jmutkawoa)
 	- cpio profile
 Paupiah Yash (https://github.com/CaffeinatedStud)

--- a/README.md
+++ b/README.md
@@ -96,11 +96,19 @@ BitTorrent: deluge, qbittorrent, rtorrent, transmission-gtk, transmission-qt, ug
 
 File transfer: filezilla
 
-Media: vlc, mpv, gnome-mplayer
+Media: vlc, mpv, gnome-mplayer, audacity, rhythmbox, spotify, xplayer, xviewer
 
 Office: evince, gthumb, fbreader, pix, atril, xreader
 
-Chat/messaging: qtox
+Chat/messaging: qtox, gitter
+
+Games: warzone2100
+
+Weather/climate: aweather
+
+Astronomy: gpredict, stellarium
+
+Browsers: Palemoon
 
 ## New security profiles
 

--- a/etc/audacity.profile
+++ b/etc/audacity.profile
@@ -7,10 +7,13 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
-netfilter
 nonewprivs
-noroot
 nogroups
-#private-bin audacity
-protocol unix,inet,inet6
+noroot
+protocol unix
 seccomp
+shell none
+tracelog
+
+private-bin audacity
+private-dev

--- a/etc/aweather.profile
+++ b/etc/aweather.profile
@@ -1,24 +1,25 @@
 # Firejail profile for aweather.
-
-# Noblacklist
 noblacklist ~/.config/aweather
-
-# Include
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
-# Call these options
-caps.drop all
-netfilter
-nonewprivs
-noroot
-protocol unix,inet,inet6,netlink
-seccomp
-tracelog
-
 # Whitelist
 mkdir ~/.config
 mkdir ~/.config/aweather
 whitelist ~/.config/aweather
+
+caps.drop all
+netfilter
+nonewprivs
+nogroups
+noroot
+nosound
+protocol unix,inet,inet6,netlink
+seccomp
+shell none
+tracelog
+
+private-bin aweather
+private-dev

--- a/etc/gitter.profile
+++ b/etc/gitter.profile
@@ -1,6 +1,5 @@
 # Firejail profile for Gitter
 noblacklist ~/.config/Gitter
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
@@ -8,6 +7,12 @@ include /etc/firejail/disable-devel.inc
 
 caps.drop all
 netfilter
+nonewprivs
+nogroups
 noroot
 protocol unix,inet,inet6,netlink
 seccomp
+shell none
+
+private-bin gitter
+private-dev

--- a/etc/gpredict.profile
+++ b/etc/gpredict.profile
@@ -1,24 +1,25 @@
 # Firejail profile for gpredict.
-
-# Noblacklist
 noblacklist ~/.config/Gpredict
-
-# Include
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
-# Call these options
-caps.drop all
-netfilter
-nonewprivs
-noroot
-protocol unix,inet,inet6,netlink
-seccomp
-tracelog
-
 # Whitelist
 mkdir ~/.config
 mkdir ~/.config/Gpredict
 whitelist ~/.config/Gpredict
+
+caps.drop all
+netfilter
+nonewprivs
+nogroups
+noroot
+nosound
+protocol unix,inet,inet6,netlink
+seccomp
+shell none
+tracelog
+
+private-bin gpredict
+private-dev

--- a/etc/palemoon.profile
+++ b/etc/palemoon.profile
@@ -1,23 +1,10 @@
 # Firejail profile for Pale Moon
-
-# Noblacklists
 noblacklist ~/.moonchild productions/pale moon
 noblacklist ~/.cache/moonchild productions/pale moon
-
-# Included profiles
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/whitelist-common.inc
-
-# Options
-caps.drop all
-netfilter
-nonewprivs
-noroot
-protocol unix,inet,inet6,netlink
-seccomp
-tracelog
 
 whitelist ${DOWNLOADS}
 mkdir ~/.moonchild productions
@@ -26,6 +13,18 @@ mkdir ~/.cache
 mkdir ~/.cache/moonchild productions
 mkdir ~/.cache/moonchild productions/pale moon
 whitelist ~/.cache/moonchild productions/pale moon
+
+caps.drop all
+netfilter
+nogroups
+nonewprivs
+noroot
+protocol unix,inet,inet6,netlink
+seccomp
+shell none
+tracelog
+
+private-bin palemoon
 
 # These are uncommented in the Firefox profile. If you run into trouble you may
 # want to uncomment (some of) them.
@@ -56,3 +55,4 @@ whitelist ~/.config/lastpass
 
 # experimental features
 #private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse
+#private-dev (disabled for now as it will interfere with webcam use in palemoon)

--- a/etc/rhythmbox.profile
+++ b/etc/rhythmbox.profile
@@ -5,8 +5,14 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+nogroups
 netfilter
 nonewprivs
 noroot
 protocol unix,inet,inet6
 seccomp
+shell none
+tracelog
+
+private-bin rhythmbox
+private-dev

--- a/etc/spotify.profile
+++ b/etc/spotify.profile
@@ -24,7 +24,12 @@ include /etc/firejail/whitelist-common.inc
 
 caps.drop all
 netfilter
+nogroups
 nonewprivs
 noroot
 protocol unix,inet,inet6,netlink
 seccomp
+shell none
+
+private-bin spotify
+private-dev

--- a/etc/stellarium.profile
+++ b/etc/stellarium.profile
@@ -1,28 +1,29 @@
 # Firejail profile for Stellarium.
-
-# Noblacklist
 noblacklist ~/.stellarium
 noblacklist ~/.config/stellarium
-
-# Include
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
-# Call these options
-caps.drop all
-netfilter
-nonewprivs
-noroot
-protocol unix,inet,inet6,netlink
-seccomp
-tracelog
-
 # Whitelist
 mkdir ~/.stellarium
 whitelist ~/.stellarium
-
 mkdir ~/.config
 mkdir ~/.config/stellarium
 whitelist ~/.config/stellarium
+
+caps.drop all
+netfilter
+nogroups
+nonewprivs
+noroot
+nosound
+protocol unix,inet,inet6,netlink
+seccomp
+shell none
+tracelog
+
+private-bin stellarium
+private-dev
+

--- a/etc/warzone2100.profile
+++ b/etc/warzone2100.profile
@@ -6,15 +6,20 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
+# Whitelist
+mkdir ~/.warzone2100-3.1
+whitelist ~/.warzone2100-3.1
+
 # Call these options
 caps.drop all
 netfilter
+nogroups
 nonewprivs
 noroot
 protocol unix,inet,inet6,netlink
 seccomp
+shell none
 tracelog
 
-# Whitelist
-mkdir ~/.warzone2100-3.1
-whitelist ~/.warzone2100-3.1
+private-bin warzone2100
+private-dev

--- a/etc/xplayer.profile
+++ b/etc/xplayer.profile
@@ -10,7 +10,12 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 netfilter
 nonewprivs
+nogroups
 noroot
 protocol unix,inet,inet6
 seccomp
+shell none
 tracelog
+
+private-bin xplayer,xplayer-audio-preview,xplayer-video-thumbnailer
+private-dev

--- a/etc/xreader.profile
+++ b/etc/xreader.profile
@@ -9,8 +9,8 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-nonewprivs
 nogroups
+nonewprivs
 noroot
 nosound
 protocol unix

--- a/etc/xviewer.profile
+++ b/etc/xviewer.profile
@@ -6,9 +6,14 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
-noroot
 nonewprivs
-protocol unix,inet,inet6
+nogroups
+noroot
+nosound
+protocol unix
 seccomp
+shell none
 tracelog
+
+private-dev
+private-bin xviewer


### PR DESCRIPTION
This converts audacity, aweather, gitter, gpredict, palemoon, rhythmbox, spotify, stellarium, warzone2100, xplayer, and xviewer to `private-bin`. I also added some additional security filters and cleaned up when appropriate.
