### PR TITLE
restrict Dropbox to its own directories

### DIFF
--- a/etc/dropbox.profile
+++ b/etc/dropbox.profile
@@ -1,4 +1,5 @@
 # dropbox profile
+noblacklist ~/.config/autostart
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
@@ -8,3 +9,14 @@ nonewprivs
 noroot
 protocol unix,inet,inet6
 seccomp
+
+mkdir ~/Dropbox
+whitelist ~/Dropbox
+mkdir ~/.dropbox
+whitelist ~/.dropbox
+mkdir ~/.dropbox-dist
+whitelist ~/.dropbox-dist
+
+mkdir ~/.config/autostart
+mkfile ~/.config/autostart/dropbox.desktop
+whitelist ~/.config/autostart/dropbox.desktop


### PR DESCRIPTION
This restricts Dropbox's file access to its own directories. I think it's worth doing this by default because Dropbox is a proprietary app. 

The whitelisted directories are the default locations used by Dropbox.