### PR TITLE
Additional fixes of command line quoting

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -2022,11 +2022,7 @@ int main(int argc, char **argv) {
 		char *ptr1 = cfg.command_line;
 		char *ptr2 = cfg.window_title;
 		for (i = 0; i < argcnt; i++) {
-			// detect bash commands
-			if (strstr(argv[i + prog_index], "&&") || strstr(argv[i + prog_index], "||")) {
-				sprintf(ptr1, "%s ", argv[i + prog_index]);
-			}
-			else if (arg_command){
+			if (arg_shell_none){
 				sprintf(ptr1, "%s ", argv[i + prog_index]);
 			}
 			else {

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -2022,12 +2022,7 @@ int main(int argc, char **argv) {
 		char *ptr1 = cfg.command_line;
 		char *ptr2 = cfg.window_title;
 		for (i = 0; i < argcnt; i++) {
-			if (arg_shell_none){
-				sprintf(ptr1, "%s ", argv[i + prog_index]);
-			}
-			else {
-				sprintf(ptr1, "\'%s\' ", argv[i + prog_index]);
-			}
+			sprintf(ptr1, "\'%s\' ", argv[i + prog_index]);
 			sprintf(ptr2, "%s ", argv[i + prog_index]);
 
 			ptr1 += strlen(ptr1);

--- a/src/firejail/run_symlink.c
+++ b/src/firejail/run_symlink.c
@@ -103,16 +103,7 @@ void run_symlink(int argc, char **argv) {
 	a[1] = program;
 	int i;
 	for (i = 0; i < (argc - 1); i++) {
-		// look for & character
-		if (strchr(argv[i + 1], '&')) {
-			char *str = malloc(strlen(argv[i + 1]));
-			if (str == NULL)
-				errExit("malloc");
-			sprintf(str, "\"%s\"", argv[i + 1]);
-			a[i + 2] = str;
-		}
-		else
-			a[i + 2] = argv[i + 1];
+		a[i + 2] = argv[i + 1];
 	}
 	a[i + 2] = NULL;
 	execvp(a[0], a); 


### PR DESCRIPTION
[Previous fix](https://github.com/netblue30/firejail/pull/613) of command line quoting was only partial.
Code execution still was possible using constructions like this:
`firejail 'echo $(uname -a) && echo'`
`firejail -c 'echo $(uname -a)'`

Changes to `main.c`:
I see only 2 cases for quoting:
1. Arguments passed to shell should always be quoted by single quotes.
2. Arguments passed directly to program (--shell=none) should never be quoted.

Code removed from `run_symlink.c` not just redundant, but also caused obscure problems when symlinked program used with `shell none` in profile.
For example:
```
touch '1&2'
$SUCH_PROGRAM 1\&2
```
results in  "file not found" error, while
`firejail $SUCH_PROGRAM 1\&2`
and
`firejail $SUCH_PROGRAM '1&2'`
both work fine.


`--join` command's behaviour is still not fixed, will look at it later.