### PR TITLE
Pidgin private-bin conversion

### DIFF
--- a/README
+++ b/README
@@ -58,6 +58,7 @@ Fred-Barclay (https://github.com/Fred-Barclay)
 	- tightened 0ad, atril, evince, gthumb, pix, qtox, and xreader profiles.
 	- several private-bin conversions
 	- added jitsi profile
+	- pidgin private-bin conversion
 Jaykishan Mutkawoa (https://github.com/jmutkawoa)
 	- cpio profile
 Paupiah Yash (https://github.com/CaffeinatedStud)

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Media: vlc, mpv, gnome-mplayer, audacity, rhythmbox, spotify, xplayer, xviewer
 
 Office: evince, gthumb, fbreader, pix, atril, xreader
 
-Chat/messaging: qtox, gitter
+Chat/messaging: qtox, gitter, pidgin
 
 Games: warzone2100
 

--- a/etc/pidgin.profile
+++ b/etc/pidgin.profile
@@ -2,11 +2,19 @@
 noblacklist ${HOME}/.purple
 
 include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 caps.drop all
+netfilter
 nonewprivs
+nogroups
 noroot
 protocol unix,inet,inet6
 seccomp
+shell none
+tracelog
+
+private-bin pidgin
+private-dev


### PR DESCRIPTION
This converts pidgin to private-bin, and tightens the profile a bit.

I included `private-dev` which will break video chatting on pidgin, but searching online indicated that this is already broken in pidgin for the most part so `private-dev` will probably have no practical effect on users. What do you think?