### PR TITLE
Eom

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -223,6 +223,7 @@ realinstall:
 	install -c -m 0644 .etc/atom-beta.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/atom.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/jitsi.profile $(DESTDIR)/$(sysconfdir)/firejail/.
+	install -c -m 0644 .etc/eom.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	sh -c "if [ ! -f $(DESTDIR)/$(sysconfdir)/firejail/login.users ]; then install -c -m 0644 etc/login.users $(DESTDIR)/$(sysconfdir)/firejail/.; fi;"
 	install -c -m 0644 etc/firejail.config $(DESTDIR)/$(sysconfdir)/firejail/.
 	rm -fr .etc

--- a/README
+++ b/README
@@ -59,6 +59,7 @@ Fred-Barclay (https://github.com/Fred-Barclay)
 	- several private-bin conversions
 	- added jitsi profile
 	- pidgin private-bin conversion
+	- added eom profile
 Jaykishan Mutkawoa (https://github.com/jmutkawoa)
 	- cpio profile
 Paupiah Yash (https://github.com/CaffeinatedStud)

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ BitTorrent: deluge, qbittorrent, rtorrent, transmission-gtk, transmission-qt, ug
 
 File transfer: filezilla
 
-Media: vlc, mpv, gnome-mplayer, audacity, rhythmbox, spotify, xplayer, xviewer
+Media: vlc, mpv, gnome-mplayer, audacity, rhythmbox, spotify, xplayer, xviewer, eom
 
-Office: evince, gthumb, fbreader, pix, atril, xreader
+Office: evince, gthumb, fbreader, pix, atril, xreader,
 
 Chat/messaging: qtox, gitter, pidgin
 
@@ -152,5 +152,5 @@ Browsers: Palemoon
 
 ## New security profiles
 
-Gitter, gThumb, mpv, Franz messenger, LibreOffice, pix, audacity, strings, xz, xzdec, gzip, cpio, less, Atom Beta, Atom, jitsi
+Gitter, gThumb, mpv, Franz messenger, LibreOffice, pix, audacity, strings, xz, xzdec, gzip, cpio, less, Atom Beta, Atom, jitsi, eom
 

--- a/RELNOTES
+++ b/RELNOTES
@@ -14,7 +14,7 @@ firejail (0.9.42~rc1) baseline; urgency=low
   * compile time support to disable global configuration file
   * new profiles: Gitter, gThumb, mpv, Franz messenger, LibreOffice
   * new profiles: pix, audacity, strings, xz, xzdec, gzip, cpio, less
-  * new profiles: Atom Beta, Atom, jitsi
+  * new profiles: Atom Beta, Atom, jitsi, eom
  -- netblue30 <netblue30@yahoo.com>  Thu, 21 Jul 2016 08:00:00 -0500
 
 firejail (0.9.40) baseline; urgency=low

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -20,6 +20,7 @@ blacklist ${HOME}/.config/xreader
 blacklist ${HOME}/.config/xviewer
 blacklist ${HOME}/.config/libreoffice
 blacklist ${HOME}/.config/pix
+blacklist ${HOME}/.config/mate/eom
 blacklist ${HOME}/.kde/share/apps/okular
 blacklist ${HOME}/.kde/share/config/okularrc
 blacklist ${HOME}/.kde/share/config/okularpartrc

--- a/etc/eom.profile
+++ b/etc/eom.profile
@@ -1,0 +1,20 @@
+# Firejail profile for Eye of Mate (eom)
+noblacklist ~/.config/mate/eom
+
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-passwdmgr.inc
+
+caps.drop all
+nogroups
+nonewprivs
+noroot
+nosound
+protocol unix
+seccomp
+shell none
+tracelog
+
+private-bin eom
+private-dev

--- a/platform/debian/conffiles
+++ b/platform/debian/conffiles
@@ -129,3 +129,4 @@
 /etc/firejail/atom-beta.profile
 /etc/firejail/atom.profile
 /etc/firejail/jitsi.profile
+/etc/firejail/eom.profile

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -40,6 +40,7 @@ midori
 netsurf
 opera-beta
 opera
+palemoon
 qutebrowser
 seamonkey
 seamonkey-bin
@@ -111,10 +112,11 @@ fbreader
 gwenview
 gthumb
 libreoffice
+localc
 lodraw
 loffice
 lofromtemplate
-loimpres
+loimpress
 lomath
 loweb
 lowriter

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -98,6 +98,7 @@ totem
 vlc
 xplayer
 xviewer
+eom
 
 # news readers
 quiterss


### PR DESCRIPTION
Profile for the Eye of Mate picture viewer.
Either `protocol unix` or `net none` works fine with eom. I found that `net none` did not affect the eom plugins **if** they were marked for use beforehand, but it did not allow changing whether they should be activated or not (the user would have to do that outside of firejail) so I went with `protocol unix`... reluctantly. :frowning: 

EDIT: found some missing/mispelt programmes in src/firecfg/firecfg.config and fixed 'em.