### PR TITLE
Two fixes to --join behaviour

### DIFF
--- a/src/firejail/join.c
+++ b/src/firejail/join.c
@@ -23,6 +23,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/prctl.h>
+#include <errno.h>
 
 static int apply_caps = 0;
 static uint64_t caps = 0;
@@ -337,6 +338,17 @@ void join(pid_t pid, int argc, char **argv, int index) {
 		//export PS1='\[\e[1;32m\][\u@\h \W]\$\[\e[0m\] '
 		if (setenv("PROMPT_COMMAND", "export PS1=\"\\[\\e[1;32m\\][\\u@\\h \\W]\\$\\[\\e[0m\\] \"", 1) < 0)
 			errExit("setenv");
+
+		// set nice
+		if (arg_nice) {
+			errno = 0;
+			int rv = nice(cfg.nice);
+			(void) rv;
+			if (errno) {
+				fprintf(stderr, "Warning: cannot set nice value\n");
+				errno = 0;
+			}
+		}
 
 		// run cmdline trough /bin/bash
 		if (cfg.command_line == NULL) {


### PR DESCRIPTION
* Honor `--nice` option when joining. Fixes https://github.com/netblue30/firejail/issues/632.
This is simplest implementation, and niceness is set independently on each join:
```firejail --name=test --nice=10```
and then
```firejail --join=test cmd1```
will start `cmd1` with default niceness (usually 0).
```firejail --nice=5 --join=test cmd2```
will start `cmd2` with niceness 5.

* Honor `--shell` option when joining, including `--shell=none`