### PR TITLE
Add profile for uudeview

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -225,6 +225,7 @@ realinstall:
 	install -c -m 0644 .etc/jitsi.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/eom.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/Cyberfox.profile $(DESTDIR)/$(sysconfdir)/firejail/.
+	install -c -m 0644 .etc/uudeview.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	sh -c "if [ ! -f $(DESTDIR)/$(sysconfdir)/firejail/login.users ]; then install -c -m 0644 etc/login.users $(DESTDIR)/$(sysconfdir)/firejail/.; fi;"
 	install -c -m 0644 etc/firejail.config $(DESTDIR)/$(sysconfdir)/firejail/.
 	rm -fr .etc

--- a/README
+++ b/README
@@ -27,6 +27,7 @@ Reiner Herrmann (https://github.com/reinerh)
 	- unit testing framework
 Thomas Jarosch (https://github.com/thomasjfox)
 	- disable keepassx in disable-passwdmgr.inc
+	- added uudeview profile
 Niklas Haas (https://github.com/haasn)
 	- blacklisting for keybase.io's client
 Aleksey Manevich (https://github.com/manevich)

--- a/README.md
+++ b/README.md
@@ -155,5 +155,5 @@ Browsers: Palemoon
 
 ## New security profiles
 
-Gitter, gThumb, mpv, Franz messenger, LibreOffice, pix, audacity, strings, xz, xzdec, gzip, cpio, less, Atom Beta, Atom, jitsi, eom
+Gitter, gThumb, mpv, Franz messenger, LibreOffice, pix, audacity, strings, xz, xzdec, gzip, cpio, less, Atom Beta, Atom, jitsi, eom, uudeview
 

--- a/RELNOTES
+++ b/RELNOTES
@@ -14,7 +14,7 @@ firejail (0.9.42~rc1) baseline; urgency=low
   * compile time support to disable global configuration file
   * new profiles: Gitter, gThumb, mpv, Franz messenger, LibreOffice
   * new profiles: pix, audacity, strings, xz, xzdec, gzip, cpio, less
-  * new profiles: Atom Beta, Atom, jitsi, eom
+  * new profiles: Atom Beta, Atom, jitsi, eom, uudeview
  -- netblue30 <netblue30@yahoo.com>  Thu, 21 Jul 2016 08:00:00 -0500
 
 firejail (0.9.40) baseline; urgency=low

--- a/etc/uudeview.profile
+++ b/etc/uudeview.profile
@@ -1,0 +1,13 @@
+# uudeview profile
+# the default profile will disable root user, enable seccomp filter etc.
+include /etc/firejail/default.profile
+
+tracelog
+net none
+shell none
+private-bin uudeview
+private-dev
+private-tmp
+private-etc nonexisting_fakefile_for_empty_etc
+hostname uudeview
+nosound

--- a/platform/debian/conffiles
+++ b/platform/debian/conffiles
@@ -131,3 +131,4 @@
 /etc/firejail/atom.profile
 /etc/firejail/jitsi.profile
 /etc/firejail/eom.profile
+/etc/firejail/uudeview.profile


### PR DESCRIPTION
uudeview might access unsafe email content,
therefore restrict it as much as possible.

In fact it's best to call firejail with a private home dir, too.