### PR TITLE
Allow BitlBee to write /var/lib/bitlbee

### DIFF
--- a/etc/bitlbee.profile
+++ b/etc/bitlbee.profile
@@ -11,4 +11,4 @@ private-dev
 protocol unix,inet,inet6
 seccomp
 nosound
-
+read-write /var/lib/bitlbee


### PR DESCRIPTION
Bitlbee stores its configuration in /var/lib/bitlbee. It must be able to write to this directory in order to save config changes (adding accounts, writing OTR keys, etc).