### PR TITLE
Add new skypeforlinux profile.

### DIFF
--- a/etc/skypeforlinux.profile
+++ b/etc/skypeforlinux.profile
@@ -1,0 +1,12 @@
+# skypeforlinux profile
+noblacklist ${HOME}/.config/skypeforlinux
+include /etc/firejail/disable-mgmt.inc
+include /etc/firejail/disable-secret.inc
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-terminals.inc
+caps.drop all
+netfilter
+noroot
+seccomp
+protocol unix,inet,inet6,netlink


### PR DESCRIPTION
Per recommendation of @netblue30, allow use of the netlink protocol in order for skypeforlinux to properly function in a firejail environment, per discussion in Github issue #656.