### PR TITLE
Add profiles for tar (gtar), unzip and unrar

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -131,6 +131,7 @@ realinstall:
 	install -c -m 0644 .etc/epiphany.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/evince.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/fbreader.profile $(DESTDIR)/$(sysconfdir)/firejail/.
+	install -c -m 0644 .etc/file.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/filezilla.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/firefox-esr.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/firefox.profile $(DESTDIR)/$(sysconfdir)/firejail/.

--- a/Makefile.in
+++ b/Makefile.in
@@ -144,6 +144,7 @@ realinstall:
 	install -c -m 0644 .etc/google-chrome.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/google-play-music-desktop-player.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/gpredict.profile $(DESTDIR)/$(sysconfdir)/firejail/.
+	install -c -m 0644 .etc/gtar.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/gthumb.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/gwenview.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/gzip.profile $(DESTDIR)/$(sysconfdir)/firejail/.
@@ -201,6 +202,7 @@ realinstall:
 	install -c -m 0644 .etc/steam.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/stellarium.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/strings.profile $(DESTDIR)/$(sysconfdir)/firejail/.
+	install -c -m 0644 .etc/tar.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/telegram.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/thunderbird.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/totem.profile $(DESTDIR)/$(sysconfdir)/firejail/.
@@ -208,6 +210,8 @@ realinstall:
 	install -c -m 0644 .etc/transmission-qt.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/uget-gtk.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/unbound.profile $(DESTDIR)/$(sysconfdir)/firejail/.
+	install -c -m 0644 .etc/unrar.profile $(DESTDIR)/$(sysconfdir)/firejail/.
+	install -c -m 0644 .etc/unzip.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/uudeview.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/vivaldi-beta.profile $(DESTDIR)/$(sysconfdir)/firejail/.
 	install -c -m 0644 .etc/vivaldi.profile $(DESTDIR)/$(sysconfdir)/firejail/.

--- a/README
+++ b/README
@@ -34,6 +34,7 @@ Peter Hogg (https://github.com/pigmonkey)
 Thomas Jarosch (https://github.com/thomasjfox)
 	- disable keepassx in disable-passwdmgr.inc
 	- added uudeview profile
+	- added tar (gtar), unzip and unrar profile
 	- improved profile list
 Niklas Haas (https://github.com/haasn)
 	- blacklisting for keybase.io's client

--- a/README
+++ b/README
@@ -35,6 +35,7 @@ Thomas Jarosch (https://github.com/thomasjfox)
 	- disable keepassx in disable-passwdmgr.inc
 	- added uudeview profile
 	- added tar (gtar), unzip and unrar profile
+	- added file profile
 	- improved profile list
 Niklas Haas (https://github.com/haasn)
 	- blacklisting for keybase.io's client

--- a/README.md
+++ b/README.md
@@ -156,4 +156,5 @@ Browsers: Palemoon
 ## New security profiles
 
 Gitter, gThumb, mpv, Franz messenger, LibreOffice, pix, audacity, strings, xz, xzdec, gzip, cpio, less, Atom Beta, Atom, jitsi, eom, uudeview
+tar (gtar), unzip, unrar
 

--- a/README.md
+++ b/README.md
@@ -156,5 +156,5 @@ Browsers: Palemoon
 ## New security profiles
 
 Gitter, gThumb, mpv, Franz messenger, LibreOffice, pix, audacity, strings, xz, xzdec, gzip, cpio, less, Atom Beta, Atom, jitsi, eom, uudeview
-tar (gtar), unzip, unrar
+tar (gtar), unzip, unrar, file
 

--- a/RELNOTES
+++ b/RELNOTES
@@ -16,6 +16,7 @@ firejail (0.9.42~rc2) baseline; urgency=low
   * new profiles: Gitter, gThumb, mpv, Franz messenger, LibreOffice
   * new profiles: pix, audacity, strings, xz, xzdec, gzip, cpio, less
   * new profiles: Atom Beta, Atom, jitsi, eom, uudeview
+  * new profiles: tar (gtar), unzip, unrar, file
  -- netblue30 <netblue30@yahoo.com>  Thu, 21 Jul 2016 08:00:00 -0500
 
 firejail (0.9.40) baseline; urgency=low

--- a/etc/file.profile
+++ b/etc/file.profile
@@ -1,0 +1,11 @@
+# file profile
+include /etc/firejail/default.profile
+
+tracelog
+net none
+shell none
+private-bin file
+private-dev
+private-etc magic.mgc,magic,localtime
+hostname file
+nosound

--- a/etc/gtar.profile
+++ b/etc/gtar.profile
@@ -1,0 +1,1 @@
+include /etc/firejail/tar.profile

--- a/etc/tar.profile
+++ b/etc/tar.profile
@@ -1,0 +1,13 @@
+# tar profile
+include /etc/firejail/default.profile
+
+tracelog
+net none
+shell none
+
+# support compressed archives
+private-bin tar,gtar,compress,gzip,lzma,xz,bzip2,lbzip2,lzip,lzop
+private-dev
+private-etc passwd,group,localtime
+hostname tar
+nosound

--- a/etc/unrar.profile
+++ b/etc/unrar.profile
@@ -1,0 +1,11 @@
+# unrar profile
+include /etc/firejail/default.profile
+
+tracelog
+net none
+shell none
+private-bin unrar
+private-dev
+private-etc passwd,group,localtime
+hostname unrar
+nosound

--- a/etc/unzip.profile
+++ b/etc/unzip.profile
@@ -1,0 +1,11 @@
+# unzip profile
+include /etc/firejail/default.profile
+
+tracelog
+net none
+shell none
+private-bin unzip
+private-dev
+private-etc passwd,group,localtime
+hostname unzip
+nosound

--- a/platform/debian/conffiles
+++ b/platform/debian/conffiles
@@ -36,6 +36,7 @@
 /etc/firejail/epiphany.profile
 /etc/firejail/evince.profile
 /etc/firejail/fbreader.profile
+/etc/firejail/file.profile
 /etc/firejail/filezilla.profile
 /etc/firejail/firefox-esr.profile
 /etc/firejail/firefox.profile

--- a/platform/debian/conffiles
+++ b/platform/debian/conffiles
@@ -50,6 +50,7 @@
 /etc/firejail/google-chrome.profile
 /etc/firejail/google-play-music-desktop-player.profile
 /etc/firejail/gpredict.profile
+/etc/firejail/gtar.profile
 /etc/firejail/gthumb.profile
 /etc/firejail/gwenview.profile
 /etc/firejail/gzip.profile
@@ -108,6 +109,7 @@
 /etc/firejail/steam.profile
 /etc/firejail/stellarium.profile
 /etc/firejail/strings.profile
+/etc/firejail/tar.profile
 /etc/firejail/telegram.profile
 /etc/firejail/thunderbird.profile
 /etc/firejail/totem.profile
@@ -115,6 +117,8 @@
 /etc/firejail/transmission-qt.profile
 /etc/firejail/uget-gtk.profile
 /etc/firejail/unbound.profile
+/etc/firejail/unrar.profile
+/etc/firejail/unzip.profile
 /etc/firejail/uudeview.profile
 /etc/firejail/vivaldi-beta.profile
 /etc/firejail/vivaldi.profile


### PR DESCRIPTION
I've tested compression and uncompression of
various tar formats and also straced unzip/unrar
regarding their file access in /etc.

-> should be fine.

If you want to unpack files in /usr/bin or so,
then use the --ignore=private-bin switch.
