### PR TITLE
Improve libtrace / libtracelog

### DIFF
--- a/README
+++ b/README
@@ -35,6 +35,7 @@ Thomas Jarosch (https://github.com/thomasjfox)
 	- disable keepassx in disable-passwdmgr.inc
 	- added uudeview profile
 	- improved profile list
+	- fixed small variable glitch in stat64() / lstat64() (libtracelog)
 Niklas Haas (https://github.com/haasn)
 	- blacklisting for keybase.io's client
 Aleksey Manevich (https://github.com/manevich)

--- a/README
+++ b/README
@@ -36,6 +36,7 @@ Thomas Jarosch (https://github.com/thomasjfox)
 	- added uudeview profile
 	- improved profile list
 	- fixed small variable glitch in stat64() / lstat64() (libtracelog)
+	- added lstat() / lstat64() support to libtrace
 Niklas Haas (https://github.com/haasn)
 	- blacklisting for keybase.io's client
 Aleksey Manevich (https://github.com/manevich)

--- a/src/libtrace/libtrace.c
+++ b/src/libtrace/libtrace.c
@@ -423,11 +423,11 @@ int stat(const char *pathname, struct stat *buf) {
 typedef int (*orig_stat64_t)(const char *pathname, struct stat64 *buf);
 static orig_stat64_t orig_stat64 = NULL;
 int stat64(const char *pathname, struct stat64 *buf) {
-	if (!orig_stat)
+	if (!orig_stat64)
 		orig_stat64 = (orig_stat64_t)dlsym(RTLD_NEXT, "stat64");
 			
 	int rv = orig_stat64(pathname, buf);
-	printf("%u:%s:stat %s:%d\n", pid(), name(), pathname, rv);
+	printf("%u:%s:stat64 %s:%d\n", pid(), name(), pathname, rv);
 	return rv;
 }
 #endif /* __GLIBC__ */

--- a/src/libtrace/libtrace.c
+++ b/src/libtrace/libtrace.c
@@ -432,6 +432,31 @@ int stat64(const char *pathname, struct stat64 *buf) {
 }
 #endif /* __GLIBC__ */
 
+// lstat
+typedef int (*orig_lstat_t)(const char *pathname, struct stat *buf);
+static orig_lstat_t orig_lstat = NULL;
+int lstat(const char *pathname, struct stat *buf) {
+	if (!orig_lstat)
+		orig_lstat = (orig_lstat_t)dlsym(RTLD_NEXT, "lstat");
+
+	int rv = orig_lstat(pathname, buf);
+	printf("%u:%s:lstat %s:%d\n", pid(), name(), pathname, rv);
+	return rv;
+}
+
+#ifdef __GLIBC__
+typedef int (*orig_lstat64_t)(const char *pathname, struct stat64 *buf);
+static orig_lstat64_t orig_lstat64 = NULL;
+int lstat64(const char *pathname, struct stat64 *buf) {
+	if (!orig_lstat64)
+		orig_lstat64 = (orig_lstat64_t)dlsym(RTLD_NEXT, "lstat64");
+
+	int rv = orig_lstat64(pathname, buf);
+	printf("%u:%s:lstat64 %s:%d\n", pid(), name(), pathname, rv);
+	return rv;
+}
+#endif /* __GLIBC__ */
+
 // opendir
 typedef DIR *(*orig_opendir_t)(const char *pathname);
 static orig_opendir_t orig_opendir = NULL;

--- a/src/libtracelog/libtracelog.c
+++ b/src/libtracelog/libtracelog.c
@@ -562,7 +562,7 @@ int stat64(const char *pathname, struct stat64 *buf) {
 #ifdef DEBUG
 	printf("%s %s\n", __FUNCTION__, pathname);
 #endif
-	if (!orig_stat)
+	if (!orig_stat64)
 		orig_stat64 = (orig_stat64_t)dlsym(RTLD_NEXT, "stat64");
 	if (!blacklist_loaded)
 		load_blacklist();
@@ -598,7 +598,7 @@ int lstat64(const char *pathname, struct stat64 *buf) {
 #ifdef DEBUG
 	printf("%s %s\n", __FUNCTION__, pathname);
 #endif
-	if (!orig_lstat)
+	if (!orig_lstat64)
 		orig_lstat64 = (orig_lstat64_t)dlsym(RTLD_NEXT, "lstat64");
 	if (!blacklist_loaded)
 		load_blacklist();


### PR DESCRIPTION
Small improvements for libtrace / libtracelog.

If a program would have called stat() and then stat64(),
the traced program probably would crash with a NULL pointer access on orig_stat64.
