### PR TITLE
Change hardcoded Xephyr options to close window at exit of last client.

### DIFF
--- a/src/firejail/x11.c
+++ b/src/firejail/x11.c
@@ -190,11 +190,11 @@ void x11_start_xephyr(int argc, char **argv) {
 	// start xephyr
 	char *cmd1;
 	if (checkcfg(CFG_XEPHYR_WINDOW_TITLE)) {
-		if (asprintf(&cmd1, "Xephyr -ac -br -title \"firejail x11 sandbox\" %s -terminate -screen %s :%d", xephyr_extra_params, xephyr_screen, display) == -1)
+		if (asprintf(&cmd1, "Xephyr -ac -br -title \"firejail x11 sandbox\" -terminate -screen %s %s :%d", xephyr_screen, xephyr_extra_params, display) == -1)
 			errExit("asprintf");
 	}
 	else {
-		if (asprintf(&cmd1, "Xephyr -ac -br  %s -terminate -screen %s :%d", xephyr_extra_params, xephyr_screen, display) == -1)
+		if (asprintf(&cmd1, "Xephyr -ac -br -terminate -screen %s %s :%d",  xephyr_screen, xephyr_extra_params, display) == -1)
 			errExit("asprintf");
 	}
 

--- a/src/firejail/x11.c
+++ b/src/firejail/x11.c
@@ -158,7 +158,7 @@ void fs_x11(void) {
 
 
 #ifdef HAVE_X11
-//$ Xephyr -ac -br -noreset -screen 800x600 :22 &
+//$ Xephyr -ac -br -terminate -screen 800x600 :22 &
 //$ DISPLAY=:22 firejail --net=eth0 --blacklist=/tmp/.X11-unix/x0 firefox
 void x11_start_xephyr(int argc, char **argv) {
 	EUID_ASSERT();
@@ -190,11 +190,11 @@ void x11_start_xephyr(int argc, char **argv) {
 	// start xephyr
 	char *cmd1;
 	if (checkcfg(CFG_XEPHYR_WINDOW_TITLE)) {
-		if (asprintf(&cmd1, "Xephyr -ac -br -title \"firejail x11 sandbox\" %s -noreset -screen %s :%d", xephyr_extra_params, xephyr_screen, display) == -1)
+		if (asprintf(&cmd1, "Xephyr -ac -br -title \"firejail x11 sandbox\" %s -terminate -screen %s :%d", xephyr_extra_params, xephyr_screen, display) == -1)
 			errExit("asprintf");
 	}
 	else {
-		if (asprintf(&cmd1, "Xephyr -ac -br  %s -noreset -screen %s :%d", xephyr_extra_params, xephyr_screen, display) == -1)
+		if (asprintf(&cmd1, "Xephyr -ac -br  %s -terminate -screen %s :%d", xephyr_extra_params, xephyr_screen, display) == -1)
 			errExit("asprintf");
 	}
 


### PR DESCRIPTION
See https://github.com/netblue30/firejail/issues/676.
* Change  default hard-coded option from `-noreset` to `-terminate`.
* Allow override of hard-coded options.

Tested it a bit with both single apps and openbox WM, everything works fine for me.
Old behavior can be restored by adding `xephyr-extra-params -noreset` to `/etc/firejail/firejail.config`.