### PR TITLE
add --private-template=directory option

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -136,6 +136,7 @@ typedef struct config_t {
 	char *bin_private_keep;	// keep list for private bin directory
 	char *cwd;		// current working directory
 	char *overlay_dir;
+   char *private_template; // template dir for tmpfs home
 
 	// networking
 	char *name;		// sandbox name
@@ -327,6 +328,9 @@ void fs_chroot(const char *rootdir);
 int fs_check_chroot_dir(const char *rootdir);
 void fs_private_tmp(void);
 
+// copy all (normal) files and directory recursively
+int fs_copydir(const char *path, const struct stat *st, int ftype, struct FTW *sftw);
+
 // profile.c
 // find and read the profile specified by name from dir directory
 int profile_find(const char *name, const char *dir);
@@ -417,9 +421,12 @@ void fs_dev_disable_sound();
 void fs_private(void);
 // private mode (--private=homedir)
 void fs_private_homedir(void);
+// private template (--private-template=templatedir)
+void fs_private_template(void);
 // check new private home directory (--private= option) - exit if it fails
 void fs_check_private_dir(void);
-
+// check new private template home directory (--private-template= option) exit if it fails
+void fs_check_private_template(void);
 
 // seccomp.c
 int seccomp_filter_drop(int enforce_seccomp);

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -213,6 +213,7 @@ static inline int any_interface_configured(void) {
 void clear_run_files(pid_t pid);
 
 extern int arg_private;		// mount private /home
+extern int arg_private_template; // private /home template
 extern int arg_debug;		// print debug messages
 extern int arg_debug_check_filename;		// print debug messages for filename checking
 extern int arg_debug_blacklists;	// print debug messages for blacklists
@@ -327,9 +328,6 @@ void fs_overlayfs(void);
 void fs_chroot(const char *rootdir);
 int fs_check_chroot_dir(const char *rootdir);
 void fs_private_tmp(void);
-
-// copy all (normal) files and directory recursively
-int fs_copydir(const char *path, const struct stat *st, int ftype, struct FTW *sftw);
 
 // profile.c
 // find and read the profile specified by name from dir directory

--- a/src/firejail/fs_home.c
+++ b/src/firejail/fs_home.c
@@ -28,6 +28,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <grp.h>
+#include <ftw.h>
 
 static void skel(const char *homedir, uid_t u, gid_t g) {
 	char *fname;
@@ -334,6 +335,43 @@ void fs_private(void) {
 
 }
 
+int fs_copydir(const char *path, const struct stat *st, int ftype, struct FTW *sftw)
+{
+
+   char *homedir = cfg.homedir;
+   char *dest;
+	int  srcbaselen = 0;
+   assert(homedir);
+   uid_t u = getuid();
+   gid_t g = getgid();
+	srcbaselen = strlen(cfg.private_template);
+
+   if(ftype == FTW_F || ftype == FTW_D) {
+    	if (asprintf(&dest, "%s/%s", homedir, path + srcbaselen) == -1)
+         errExit("asprintf");
+      struct stat s;
+      // don't copy it if we already have the file
+      if (stat(dest, &s) == 0)
+         return 0;
+      if (stat(path, &s) == 0) {
+         if (copy_file(path, dest) == 0) {
+            if (chown(dest, u, g) == -1)
+               errExit("chown");
+            fs_logger("clone %s", path);
+         }
+      }
+		free(dest);
+   }
+ 	return(0);
+}
+
+void fs_private_template(void) {
+	fs_private();
+	if(!nftw(cfg.private_template, fs_copydir, 1, FTW_PHYS)) {
+		fprintf(stderr, "Error: unable to copy template dir\n");
+		exit(1);
+	}
+}
 
 // check new private home directory (--private= option) - exit if it fails
 void fs_check_private_dir(void) {
@@ -372,4 +410,43 @@ void fs_check_private_dir(void) {
 		exit(1);
 	}
 }
+
+// check new template home directoty (--private-template= option) - exit if it fails
+void fs_check_private_template(void) {
+   EUID_ASSERT();
+   invalid_filename(cfg.private_template);
+
+   // Expand the home directory
+   char *tmp = expand_home(cfg.private_template, cfg.homedir);
+   cfg.private_template = realpath(tmp, NULL);
+   free(tmp);
+
+   if (!cfg.private_template
+    || !is_dir(cfg.private_template)
+    || is_link(cfg.private_template)
+    || strstr(cfg.private_template, "..")) {
+      fprintf(stderr, "Error: invalid private template directory\n");
+      exit(1);
+   }
+
+   // check home directory and chroot home directory have the same owner
+   struct stat s2;
+   int rv = stat(cfg.private_template, &s2);
+   if (rv < 0) {
+      fprintf(stderr, "Error: cannot find %s directory\n", cfg.private_template);
+      exit(1);
+   }
+
+   struct stat s1;
+   rv = stat(cfg.homedir, &s1);
+   if (rv < 0) {
+      fprintf(stderr, "Error: cannot find %s directory, full path name required\n", cfg.homedir);
+      exit(1);
+   }
+   if (s1.st_uid != s2.st_uid) {
+      printf("Error: --private-template directory should be owned by the current user\n");
+      exit(1);
+   }
+}
+
 

--- a/src/firejail/fs_home.c
+++ b/src/firejail/fs_home.c
@@ -335,6 +335,9 @@ void fs_private(void) {
 
 }
 
+int fs_copydir(const char *path, const struct stat *st, int ftype, struct FTW *sftw);
+
+
 int fs_copydir(const char *path, const struct stat *st, int ftype, struct FTW *sftw)
 {
 
@@ -357,7 +360,7 @@ int fs_copydir(const char *path, const struct stat *st, int ftype, struct FTW *s
          if (copy_file(path, dest) == 0) {
             if (chown(dest, u, g) == -1)
                errExit("chown");
-            fs_logger("clone %s", path);
+            fs_logger2("clone", path);
          }
       }
 		free(dest);

--- a/src/firejail/fs_home.c
+++ b/src/firejail/fs_home.c
@@ -369,6 +369,8 @@ int fs_copydir(const char *path, const struct stat *st, int ftype, struct FTW *s
          else if(ftype == FTW_D) {
             if (mkdir(dest, s.st_mode) == -1) 
                errExit("mkdir");
+            if (chown(dest, u, g) < 0)
+                errExit("chown");
             if (arg_debug)
                printf("copy from %s to %s\n", path, dest);
             fs_logger2("clone", path);

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -51,6 +51,7 @@ uid_t firejail_uid = 0;
 static char child_stack[STACK_SIZE];		// space for child's stack
 Config cfg;					// configuration
 int arg_private = 0;				// mount private /home and /tmp directoryu
+int arg_private_template = 0; // mount private /home using a template
 int arg_debug = 0;				// print debug messages
 int arg_debug_check_filename;		// print debug messages for filename checking
 int arg_debug_blacklists;			// print debug messages for blacklists
@@ -1360,6 +1361,19 @@ int main(int argc, char **argv) {
 			fs_check_private_dir();
 			arg_private = 1;
 		}
+      else if (strcmp(argv[i], "--private-template=", 19) == 0) {
+         cfg.private_template = argv[i] + 14;
+         if (arg_private) {
+            fprintf(stderr, "Error: --private and --private-template are mutually exclusive\n");
+            exit(1);
+         }
+         if (*cfg.private_template == '\0') {
+            fprintf(stderr, "Error: invalid private-template option\n");
+            exit(1);
+         }
+         fs_check_private_template();
+         arg_private_template = 1;
+      }
 		else if (strcmp(argv[i], "--private-dev") == 0) {
 			arg_private_dev = 1;
 		}

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1361,7 +1361,7 @@ int main(int argc, char **argv) {
 			fs_check_private_dir();
 			arg_private = 1;
 		}
-      else if (strcmp(argv[i], "--private-template=", 19) == 0) {
+      else if (strncmp(argv[i], "--private-template=", 19) == 0) {
          cfg.private_template = argv[i] + 14;
          if (arg_private) {
             fprintf(stderr, "Error: --private and --private-template are mutually exclusive\n");

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1349,9 +1349,18 @@ int main(int argc, char **argv) {
 		else if (strcmp(argv[i], "--writable-var") == 0) {
 			arg_writable_var = 1;
 		}
-		else if (strcmp(argv[i], "--private") == 0)
+		else if (strcmp(argv[i], "--private") == 0) {
+         if (arg_private_template) {
+            fprintf(stderr, "Error: --private and --private-template are mutually exclusive\n");
+            exit(1);
+         }
 			arg_private = 1;
+      }
 		else if (strncmp(argv[i], "--private=", 10) == 0) {
+         if (arg_private_template) {
+            fprintf(stderr, "Error: --private and --private-template are mutually exclusive\n");
+            exit(1);
+         }
 			// extract private home dirname
 			cfg.home_private = argv[i] + 10;
 			if (*cfg.home_private == '\0') {
@@ -1362,7 +1371,7 @@ int main(int argc, char **argv) {
 			arg_private = 1;
 		}
       else if (strncmp(argv[i], "--private-template=", 19) == 0) {
-         cfg.private_template = argv[i] + 14;
+         cfg.private_template = argv[i] + 19;
          if (arg_private) {
             fprintf(stderr, "Error: --private and --private-template are mutually exclusive\n");
             exit(1);

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -169,10 +169,6 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		arg_private = 1;
 		return 0;
 	}
-   else if (strcmp(ptr, "private-template") == 0) {
-      arg_private_template = 1;
-      return 0;
-   }
 	else if (strcmp(ptr, "private-dev") == 0) {
 		arg_private_dev = 1;
 		return 0;
@@ -626,6 +622,8 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
       cfg.private_template = ptr + 17;
       fs_check_private_template();
       arg_private_template = 1;
+
+      return 0;
    }
 	// private /etc list of files and directories
 	if (strncmp(ptr, "private-etc ", 12) == 0) {

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -169,6 +169,10 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		arg_private = 1;
 		return 0;
 	}
+   else if (strcmp(ptr, "private-template") == 0) {
+      arg_private_template = 1;
+      return 0;
+   }
 	else if (strcmp(ptr, "private-dev") == 0) {
 		arg_private_dev = 1;
 		return 0;
@@ -614,6 +618,15 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		return 0;
 	}
 
+   if (strncmp(ptr, "private-template ", 17) == 0) {
+      if (arg_private) {
+         fprintf(stderr, "Error: --private and --private-template are mutually exclusive\n");
+         exit(1);
+      }
+      cfg.private_template = ptr + 17;
+      fs_check_private_template();
+      arg_private_template = 1;
+   }
 	// private /etc list of files and directories
 	if (strncmp(ptr, "private-etc ", 12) == 0) {
 		if (arg_writable_etc) {

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -524,6 +524,9 @@ int sandbox(void* sandbox_arg) {
 			fs_private();
 	}
 	
+   if (arg_private_template) 
+      fs_private_template();
+
 	if (arg_private_dev)
 		fs_private_dev();
 	if (arg_private_etc) {

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -189,6 +189,9 @@ void usage(void) {
 	printf("\tclosed.\n\n");
 	printf("    --private=directory - use directory as user home.\n\n");
 
+   printf("    --private-template=directory - same as --private but copy the\n");
+   printf("\ttemplatedirectory in the tmpfs mounted user home.\n\n");
+
 	printf("    --private-bin=file,file - build a new /bin in a temporary filesystem,\n");
 	printf("\tand copy the programs in the list.\n\n");
 

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -1045,6 +1045,18 @@ Example:
 $ firejail \-\-private=/home/netblue/firefox-home firefox
 
 .TP
+\fB\-\-private-template=templatedir
+Mount new /root and /home/user directories in temporary
+filesystems, and copy all files in templatedir. All modifications are discarded when the sandbox is
+closed.
+.br
+
+.br
+Example:
+.br
+$ firejail \-\-private-template=/home/netblue/.config/mozilla firefox
+
+.TP
 \fB\-\-private-bin=file,file
 Build a new /bin in a temporary filesystem, and copy the programs in the list.
 If no listed file is found, /bin directory will be empty.


### PR DESCRIPTION
--private mount a tmpfs over the user home, so, things like browser extensions and configurations are back to the defaults and you cannot pre-configure it easily.

--private=directory, on the other side, make the user home persistent.

--private-template=directory aim to /opt/firejail/templates/usernamebe an alternative, it act like --private mounting a tmpfs over the user home, and then it copy recursively all the files and dirs from a template directory to the created empty user home.

This way you can put, for example, a preconfigured .config/cromium directory let's says in /opt/firejail/templates/username, and then use 
`firejail --private-template=/opt/firejail/templates/username cromium` 

NOTE: as the copy from template is done after mounting the tmpfs to mask the user home, the template directory cannot be copied from inside the original user home.