### PR TITLE
Busybox workaround + expand ${PATH} macro in noblacklist entries

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -16,6 +16,7 @@ NAME=@PACKAGE_NAME@
 PACKAGE_TARNAME=@PACKAGE_TARNAME@
 DOCDIR=@docdir@
 HAVE_APPARMOR=@HAVE_APPARMOR@
+BUSYBOX_WORKAROUND=@BUSYBOX_WORKAROUND@
 
 .PHONY: mylibs $(MYLIBS)
 mylibs: $(MYLIBS)
@@ -79,7 +80,7 @@ realinstall:
 	install -c -m 0644 README $(DESTDIR)/$(DOCDIR)/.
 	install -c -m 0644 RELNOTES $(DESTDIR)/$(DOCDIR)/.
 	# etc files
-	./mketc.sh $(sysconfdir)
+	./mketc.sh $(sysconfdir) $(BUSYBOX_WORKAROUND)
 	install -m 0755 -d $(DESTDIR)/$(sysconfdir)/firejail
 	for file in .etc/* etc/firejail.config; do \
 		install -c -m 0644 $$file $(DESTDIR)/$(sysconfdir)/firejail; \

--- a/configure
+++ b/configure
@@ -625,6 +625,7 @@ ac_includes_default="\
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
 HAVE_SECCOMP_H
+BUSYBOX_WORKAROUND
 HAVE_FATAL_WARNINGS
 HAVE_WHITELIST
 HAVE_FILE_TRANSFER
@@ -703,6 +704,7 @@ enable_x11
 enable_file_transfer
 enable_whitelist
 enable_fatal_warnings
+enable_busybox_workaround
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1336,6 +1338,8 @@ Optional Features:
   --disable-file-transfer disable file transfer
   --disable-whitelist     disable whitelist
   --enable-fatal-warnings -W -Wall -Werror
+  --enable-busybox-workaround
+                          enable busybox workaround
 
 Some influential environment variables:
   CC          C compiler command
@@ -3647,6 +3651,20 @@ if test "x$enable_fatal_warnings" = "xyes"; then :
 
 fi
 
+BUSYBOX_WORKAROUND="no"
+# Check whether --enable-busybox-workaround was given.
+if test "${enable_busybox_workaround+set}" = set; then :
+  enableval=$enable_busybox_workaround;
+fi
+
+if test "x$enable_busybox_workaround" = "xyes"; then :
+
+	BUSYBOX_WORKAROUND="yes"
+
+
+fi
+
+
 
 # checking pthread library
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lpthread" >&5
@@ -4905,6 +4923,7 @@ echo "   X11 sandboxing support: $HAVE_X11"
 echo "   whitelisting: $HAVE_WHITELIST"
 echo "   file transfer support: $HAVE_FILE_TRANSFER"
 echo "   fatal warnings: $HAVE_FATAL_WARNINGS"
+echo "   busybox workaround: $BUSYBOX_WORKAROUND"
 printf "   uid_min: "; grep UID_MIN uids.h
 printf "   gid_min: "; grep GID_MIN uids.h
 printf "   EXTRA_LDFLAGS: $EXTRA_LDFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -115,6 +115,15 @@ AS_IF([test "x$enable_fatal_warnings" = "xyes"], [
 	AC_SUBST(HAVE_FATAL_WARNINGS)
 ])
 
+BUSYBOX_WORKAROUND="no"
+AC_ARG_ENABLE([busybox-workaround],
+    AS_HELP_STRING([--enable-busybox-workaround], [enable busybox workaround]))
+AS_IF([test "x$enable_busybox_workaround" = "xyes"], [
+	BUSYBOX_WORKAROUND="yes"
+	AC_SUBST(BUSYBOX_WORKAROUND)
+])
+
+
 
 # checking pthread library
 AC_CHECK_LIB([pthread], [main], [], AC_MSG_ERROR([*** POSIX thread support not installed ***]))
@@ -148,6 +157,7 @@ echo "   X11 sandboxing support: $HAVE_X11"
 echo "   whitelisting: $HAVE_WHITELIST"
 echo "   file transfer support: $HAVE_FILE_TRANSFER"
 echo "   fatal warnings: $HAVE_FATAL_WARNINGS"
+echo "   busybox workaround: $BUSYBOX_WORKAROUND"
 printf "   uid_min: "; grep UID_MIN uids.h
 printf "   gid_min: "; grep GID_MIN uids.h
 printf "   EXTRA_LDFLAGS: $EXTRA_LDFLAGS"

--- a/mketc.sh
+++ b/mketc.sh
@@ -6,3 +6,17 @@ for file in etc/*.profile etc/*.inc etc/*.net;
 do
 	sed "s;/etc/firejail;$1/firejail;g" $file > .$file
 done
+
+if [ "x$2" = "xyes" ]
+then
+sed -i -e '
+1i# Workaround for systems where common UNIX utilities are symlinks to busybox.\
+# If this is not your case you can remove --enable-busybox-workaround from\
+# ./configure options, for added security.\
+noblacklist \${PATH}/mount\
+noblacklist \${PATH}/umount\
+noblacklist \${PATH}/su\
+noblacklist \${PATH}/sudo\
+noblacklist \${PATH}/nc\
+' .etc/disable-common.inc
+fi


### PR DESCRIPTION
* Workaround for systems where common UNIX utilities are symlinks to busybox.
Aside of embedded, this includes Alpine Linux, for example.

* Expand `${PATH}` macro in `noblacklist` entries.
My busybox workaround depends on this.