### PR TITLE
Added more overlay options

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -221,7 +221,8 @@ extern int arg_debug_whitelists;	// print debug messages for whitelists
 extern int arg_nonetwork;	// --net=none
 extern int arg_command;	// -c
 extern int arg_overlay;		// overlay option
-extern int arg_overlay_keep;	// place overlay diff directory in ~/.firejail
+extern int arg_overlay_keep;	// place overlay diff in a known directory
+extern int arg_overlay_reuse;	// allow the reuse of overlays
 extern int arg_zsh;		// use zsh as default shell
 extern int arg_csh;		// use csh as default shell
 

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -59,7 +59,8 @@ int arg_debug_whitelists;			// print debug messages for whitelists
 int arg_nonetwork = 0;				// --net=none
 int arg_command = 0;				// -c
 int arg_overlay = 0;				// overlay option
-int arg_overlay_keep = 0;			// place overlay diff directory in ~/.firejail
+int arg_overlay_keep = 0;			// place overlay diff in a known directory
+int arg_overlay_reuse = 0;			// allow the reuse of overlays
 int arg_zsh = 0;				// use zsh as default shell
 int arg_csh = 0;				// use csh as default shell
 
@@ -691,6 +692,41 @@ static void delete_x11_file(pid_t pid) {
 	free(fname);
 }
 
+static char *create_and_check_overlay_dir(const char *subdirname, int allow_reuse) {
+	// create ~/.firejail directory
+	struct stat s;
+	char *dirname;
+	if (asprintf(&dirname, "%s/.firejail", cfg.homedir) == -1)
+		errExit("asprintf");
+	if (stat(dirname, &s) == -1) {
+		/* coverity[toctou] */
+		if (mkdir(dirname, 0700))
+			errExit("mkdir");
+		if (chown(dirname, getuid(), getgid()) < 0)
+			errExit("chown");
+		if (chmod(dirname, 0700) < 0)
+			errExit("chmod");
+	}
+	else if (is_link(dirname)) {
+		fprintf(stderr, "Error: invalid ~/.firejail directory\n");
+		exit(1);
+	}
+
+	free(dirname);
+
+	// check overlay directory
+	if (asprintf(&dirname, "%s/.firejail/%s", cfg.homedir, subdirname) == -1)
+		errExit("asprintf");
+	if (allow_reuse == 0) {
+		if (stat(dirname, &s) == 0) {
+			fprintf(stderr, "Error: overlay directory already exists: %s\n", dirname);
+			exit(1);
+		}
+	}
+
+	return dirname;
+}
+
 static void detect_quiet(int argc, char **argv) {
 	int i;
 	
@@ -1193,34 +1229,54 @@ int main(int argc, char **argv) {
 			arg_overlay = 1;
 			arg_overlay_keep = 1;
 			
-			// create ~/.firejail directory
-			char *dirname;
-			if (asprintf(&dirname, "%s/.firejail", cfg.homedir) == -1)
+			char *subdirname;
+			if (asprintf(&subdirname, "%d", getpid()) == -1)
 				errExit("asprintf");
-			if (stat(dirname, &s) == -1) {
-				/* coverity[toctou] */
-				if (mkdir(dirname, 0700))
-					errExit("mkdir");
-				if (chown(dirname, getuid(), getgid()) < 0)
-					errExit("chown");
-				if (chmod(dirname, 0700) < 0)
-					errExit("chmod");
-			}
-			else if (is_link(dirname)) {
-				fprintf(stderr, "Error: invalid ~/.firejail directory\n");
+			cfg.overlay_dir = create_and_check_overlay_dir(subdirname, arg_overlay_reuse);
+
+			free(subdirname);
+		}
+		else if (strncmp(argv[i], "--overlay-named=", 16) == 0) {
+			if (cfg.chrootdir) {
+				fprintf(stderr, "Error: --overlay and --chroot options are mutually exclusive\n");
 				exit(1);
 			}
-			
-			free(dirname);
-			
-			// check overlay directory
-			if (asprintf(&dirname, "%s/.firejail/%d", cfg.homedir, getpid()) == -1)
-				errExit("asprintf");
-			if (stat(dirname, &s) == 0) {
-				fprintf(stderr, "Error: overlay directory already exists: %s\n", dirname);
+			struct stat s;
+			if (stat("/proc/sys/kernel/grsecurity", &s) == 0) {
+				fprintf(stderr, "Error: --overlay option is not available on Grsecurity systems\n");
 				exit(1);
 			}
-			cfg.overlay_dir = dirname;
+			arg_overlay = 1;
+			arg_overlay_keep = 1;
+			arg_overlay_reuse = 1;
+			
+			char *subdirname = argv[i] + 16;
+			if (subdirname == '\0') {
+				fprintf(stderr, "Error: invalid overlay option\n");
+				exit(1);
+			}
+			cfg.overlay_dir = create_and_check_overlay_dir(subdirname, arg_overlay_reuse);
+		}
+		else if (strncmp(argv[i], "--overlay-path=", 15) == 0) {
+			if (cfg.chrootdir) {
+				fprintf(stderr, "Error: --overlay and --chroot options are mutually exclusive\n");
+				exit(1);
+			}
+			struct stat s;
+			if (stat("/proc/sys/kernel/grsecurity", &s) == 0) {
+				fprintf(stderr, "Error: --overlay option is not available on Grsecurity systems\n");
+				exit(1);
+			}
+			arg_overlay = 1;
+			arg_overlay_keep = 1;
+			arg_overlay_reuse = 1;
+			
+			char *dirname = argv[i] + 15;
+			if (dirname == '\0') {
+				fprintf(stderr, "Error: invalid overlay option\n");
+				exit(1);
+			}
+			cfg.overlay_dir = expand_home(dirname, cfg.homedir);
 		}
 		else if (strcmp(argv[i], "--overlay-tmpfs") == 0) {
 			if (cfg.chrootdir) {

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -176,16 +176,26 @@ void usage(void) {
 	
 	printf("    --overlay - mount a filesystem overlay on top of the current filesystem.\n");
 	printf("\tThe upper filesystem layer is persistent, and stored in\n");
-	printf("\t$HOME/.firejail directory. (OverlayFS support is required in\n");
-	printf("\tLinux kernel for this option to work). \n\n");   
+	printf("\t$HOME/.firejail/<PID> directory. (OverlayFS support is required in\n");
+	printf("\tLinux kernel for this option to work). \n\n");
 
-	printf("    --overlay-clean - clean all overlays stored in $HOME/.firejail directory.\n\n");
-	
+	printf("    --overlay-named=name - mount a filesystem overlay on top of the current\n");
+	printf("\tfilesystem. The upper filesystem layer is persistent, and stored in\n");
+	printf("\t$HOME/.firejail/<NAME> directory. (OverlayFS support is required in\n");
+	printf("\tLinux kernel for this option to work). \n\n");
+
+	printf("    --overlay-path=path - mount a filesystem overlay on top of the current\n");
+	printf("\tfilesystem. The upper filesystem layer is persistent, and stored in\n");
+	printf("\tthe specified path. (OverlayFS support is required in Linux kernel for\n");
+	printf("\tthis option to work). \n\n");
+
 	printf("    --overlay-tmpfs - mount a filesystem overlay on top of the current\n");
 	printf("\tfilesystem. The upper layer is stored in a tmpfs filesystem,\n");
 	printf("\tand it is discarded when the sandbox is closed. (OverlayFS\n");
 	printf("\tsupport is required in Linux kernel for this option to work).\n\n");   
 	
+	printf("    --overlay-clean - clean all overlays stored in $HOME/.firejail directory.\n\n");
+
 	printf("    --private - mount new /root and /home/user directories in temporary\n");
 	printf("\tfilesystems. All modifications are discarded when the sandbox is\n");
 	printf("\tclosed.\n\n");

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -994,7 +994,7 @@ $ ls -l sandboxlog*
 \fB\-\-overlay
 Mount a filesystem overlay on top of the current filesystem.  Unlike the regular filesystem container,
 the system directories are mounted read-write. All filesystem modifications go into the overlay.
-The overlay is stored in $HOME/.firejail directory. This option is not available on Grsecurity systems.
+The overlay is stored in $HOME/.firejail/<PID> directory. This option is not available on Grsecurity systems.
 .br
 
 .br
@@ -1008,14 +1008,40 @@ Example:
 $ firejail \-\-overlay firefox
 
 .TP
-\fB\-\-overlay-clean
-Clean all overlays stored in $HOME/.firejail directory.
+\fB\-\-overlay-named=name
+Mount a filesystem overlay on top of the current filesystem.  Unlike the regular filesystem container,
+the system directories are mounted read-write. All filesystem modifications go into the overlay.
+The overlay is stored in $HOME/.firejail/<NAME> directory. The created overlay can be reused between multiple
+sessions. This option is not available on Grsecurity systems.
+.br
+
+.br
+OverlayFS support is required in Linux kernel for this option to work.
+OverlayFS was officially introduced in Linux kernel version 3.18
 .br
 
 .br
 Example:
 .br
-$ firejail \-\-overlay-clean
+$ firejail \-\-overlay-named=jail1 firefox
+
+.TP
+\fB\-\-overlay-path=path
+Mount a filesystem overlay on top of the current filesystem.  Unlike the regular filesystem container,
+the system directories are mounted read-write. All filesystem modifications go into the overlay.
+The overlay is stored in the specified path. The created overlay can be reused between multiple sessions.
+This option is not available on Grsecurity systems.
+.br
+
+.br
+OverlayFS support is required in Linux kernel for this option to work.
+OverlayFS was officially introduced in Linux kernel version 3.18
+.br
+
+.br
+Example:
+.br
+$ firejail \-\-overlay-path=~/jails/jail1 firefox
 
 .TP
 \fB\-\-overlay-tmpfs
@@ -1032,6 +1058,16 @@ OverlayFS was officially introduced in Linux kernel version 3.18
 Example:
 .br
 $ firejail \-\-overlay-tmpfs firefox
+
+.TP
+\fB\-\-overlay-clean
+Clean all overlays stored in $HOME/.firejail directory.
+.br
+
+.br
+Example:
+.br
+$ firejail \-\-overlay-clean
 
 .TP
 \fB\-\-private


### PR DESCRIPTION
This pull request adds two new overlay options:
-  `--overlay-named` - creates and uses a named overlay in the ~/.firejail directory
- `--overlay-path` - creates and uses an overlay in an arbitrary location

These changes fulfil the enhancement requests outlined in #239. 
Now, the comments in that issue did mention a security problem with this feature, so I am not sure if my changes qualify as safe. Would love to see some comments about that.
