### PR TITLE
Gather shell selection code in one place

### DIFF
--- a/src/firejail/bandwidth.c
+++ b/src/firejail/bandwidth.c
@@ -459,13 +459,15 @@ void bandwidth_pid(pid_t pid, const char *command, const char *dev, int down, in
 	if (setregid(0, 0))
 		errExit("setregid");
 
+	assert(cfg.shell);
+
 	char *arg[4];
-	arg[0] = "/bin/bash";
+	arg[0] = cfg.shell;
 	arg[1] = "-c";
 	arg[2] = cmd;
 	arg[3] = NULL;
-	execvp("/bin/bash", arg);
+	execvp(arg[0], arg);
 	
 	// it will never get here
-	exit(0);		
+	errExit("execvp");
 }

--- a/src/firejail/env.c
+++ b/src/firejail/env.c
@@ -121,10 +121,6 @@ void env_defaults(void) {
 		errExit("setenv");
 	if (setenv("container", "firejail", 1) < 0) // LXC sets container=lxc,
 		errExit("setenv");
-	if (arg_zsh && setenv("SHELL", "/usr/bin/zsh", 1) < 0)
-		errExit("setenv");
-	if (arg_csh && setenv("SHELL", "/bin/csh", 1) < 0)
-		errExit("setenv");
 	if (cfg.shell && setenv("SHELL", cfg.shell, 1) < 0)
 		errExit("setenv");
 	// set prompt color to green

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -222,8 +222,6 @@ extern int arg_nonetwork;	// --net=none
 extern int arg_command;	// -c
 extern int arg_overlay;		// overlay option
 extern int arg_overlay_keep;	// place overlay diff directory in ~/.firejail
-extern int arg_zsh;		// use zsh as default shell
-extern int arg_csh;		// use csh as default shell
 
 extern int arg_seccomp;	// enable default seccomp filter
 

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -277,6 +277,7 @@ extern int fullargc;
 
 // main.c
 void check_user_namespace(void);
+char *guess_shell(void);
 
 // sandbox.c
 int sandbox(void* sandbox_arg);

--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -1110,14 +1110,13 @@ int fs_check_chroot_dir(const char *rootdir) {
 	}
 	free(name);
 
-	// check /bin/bash
-//	if (asprintf(&name, "%s/bin/bash", rootdir) == -1)
-//		errExit("asprintf");
-//	if (stat(name, &s) == -1) {
-//		fprintf(stderr, "Error: cannot find /bin/bash in chroot directory\n");
-//		return 1;
-//	}
-//	free(name);
+	// check shell
+	if (!arg_shell_none) {
+		if (stat(cfg.shell, &s) == -1) {
+			fprintf(stderr, "Error: cannot find %s in chroot directory\n", cfg.shell);
+			return 1;
+		}
+	}
 
 	// check x11 socket directory
 	if (getenv("FIREJAIL_X11")) {

--- a/src/firejail/fs_home.c
+++ b/src/firejail/fs_home.c
@@ -32,8 +32,9 @@
 
 static void skel(const char *homedir, uid_t u, gid_t g) {
 	char *fname;
+
 	// zsh
-	if (arg_zsh) {
+	if (!arg_shell_none && (strcmp(cfg.shell,"/usr/bin/zsh") == 0 || strcmp(cfg.shell,"/bin/zsh") == 0)) {
 		// copy skel files
 		if (asprintf(&fname, "%s/.zshrc", homedir) == -1)
 			errExit("asprintf");
@@ -63,7 +64,7 @@ static void skel(const char *homedir, uid_t u, gid_t g) {
 		free(fname);
 	}
 	// csh
-	else if (arg_csh) {
+	else if (!arg_shell_none && strcmp(cfg.shell,"/bin/csh") == 0) {
 		// copy skel files
 		if (asprintf(&fname, "%s/.cshrc", homedir) == -1)
 			errExit("asprintf");

--- a/src/firejail/join.c
+++ b/src/firejail/join.c
@@ -332,13 +332,7 @@ void join(pid_t pid, int argc, char **argv, int index) {
 
 		// run cmdline trough shell
 		if (cfg.command_line == NULL) {
-			cfg.shell = guess_shell();
-			if (!cfg.shell) {
-				fprintf(stderr, "Error: unable to guess your shell, please set explicitly by using --shell option.\n");
-				exit(1);
-			}
-			if (arg_debug)
-				printf("Autoselecting %s as shell\n", cfg.shell);
+			assert(cfg.shell);
 
 			// replace the process with a shell
 			execlp(cfg.shell, cfg.shell, NULL);
@@ -387,14 +381,8 @@ void join(pid_t pid, int argc, char **argv, int index) {
 				execvp(cfg.original_argv[cfg.original_program_index], &cfg.original_argv[cfg.original_program_index]);
 				exit(1);
 			} else {
-//				assert(cfg.shell);
-				cfg.shell = guess_shell();
-				if (!cfg.shell) {
-					fprintf(stderr, "Error: unable to guess your shell, please set explicitly by using --shell option.\n");
-					exit(1);
-				}
-				if (arg_debug)
-					printf("Autoselecting %s as shell\n", cfg.shell);
+				assert(cfg.shell);
+
 				char *arg[5];
 				arg[0] = cfg.shell;
 				arg[1] = "-c";

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1999,8 +1999,7 @@ int main(int argc, char **argv) {
 	}
 
 	// guess shell if unspecified
-//	if (!arg_shell_none && !cfg.shell) {
-	if (prog_index == -1 && !cfg.shell) {
+	if (!arg_shell_none && !cfg.shell) {
 		cfg.shell = guess_shell();
 		if (!cfg.shell) {
 			fprintf(stderr, "Error: unable to guess your shell, please set explicitly by using --shell option.\n");

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -325,20 +325,11 @@ static void start_application(void) {
 	// start the program using a shell
 	//****************************************
 	else {
-		// choose the shell requested by the user, or use bash as default
-		char *sh;
-		if (cfg.shell)
-	 		sh = cfg.shell;
-		else if (arg_zsh)
-			sh = "/usr/bin/zsh";
-		else if (arg_csh)
-			sh = "/bin/csh";
-		else
-			sh = "/bin/bash";
-			
+		assert(cfg.shell);
+
 		char *arg[5];
 		int index = 0;
-		arg[index++] = sh;
+		arg[index++] = cfg.shell;
 		arg[index++] = "-c";
 		assert(cfg.command_line);
 		if (arg_debug)
@@ -368,7 +359,7 @@ static void start_application(void) {
 		
 		if (!arg_command && !arg_quiet)
 			printf("Child process initialized\n");
-		execvp(sh, arg);
+		execvp(arg[0], arg);
 	}
 	
 	perror("execvp");


### PR DESCRIPTION
Shell selection code scattered everywere in code and causes bugs like this https://github.com/netblue30/firejail/issues/703.
So:
* new `guess_shell` function
* shell selection done once (well, except join), kept in `cfg.shell` variable.
* check for `/bin/bash` in chroot re-enabled as check for `cfg.shell`

For now calls `guess_shell` independently; also I noted that join never honored `--shell` and `--shell=none`. Will try to fix this latter.

