### PR TITLE
Add profile support for Slack

### DIFF
--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -78,6 +78,7 @@ blacklist ${HOME}/.TelegramDesktop
 blacklist ${HOME}/.config/Gitter
 blacklist ${HOME}/.config/Franz
 blacklist ${HOME}/.jitsi
+blacklist ${HOME}/.config/Slack
 
 # Games
 blacklist ${HOME}/.hedgewars

--- a/etc/slack.profile
+++ b/etc/slack.profile
@@ -1,0 +1,27 @@
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-passwdmgr.inc
+
+mkdir ${HOME}/.config
+mkdir ${HOME}/.config/Slack
+whitelist ${HOME}/.config/Slack
+whitelist ~/Downloads
+
+protocol unix,inet,inet6,netlink
+private-dev
+private-tmp
+private-etc fonts,resolv.conf,ld.so.conf,ld.so.cache,localtime
+name slack
+blacklist /var
+
+include /etc/firejail/whitelist-common.inc
+
+caps.drop all
+seccomp
+netfilter
+nonewprivs
+nogroups
+noroot
+shell none
+private-bin slack


### PR DESCRIPTION
Add a profile for Slack, and include Slack's config directory within the global blacklist