### PR TITLE
Fix Spotify - "private-bin spotify" prevents Spotify loading

### DIFF
--- a/etc/spotify.profile
+++ b/etc/spotify.profile
@@ -27,5 +27,5 @@ protocol unix,inet,inet6,netlink
 seccomp
 shell none
 
-private-bin spotify
+#private-bin spotify
 private-dev


### PR DESCRIPTION
The rule `private-bin spotify` appears to prevent Spotify from loading. This seems to be a regression on the git version, compared to the release, and removing this rule will let Spotify run again.