### PR TITLE
Small fixes (icecat.profile, disable-common.inc and whitelist-common.inc)

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -14,6 +14,7 @@ blacklist /etc/xdg/autostart
 blacklist ${HOME}/.kde4/Autostart
 blacklist ${HOME}/.kde4/share/autostart
 blacklist ${HOME}/.kde/Autostart
+blacklist ${HOME}/.kde/share/autostart
 blacklist ${HOME}/.config/plasma-workspace/shutdown
 blacklist ${HOME}/.config/plasma-workspace/env
 blacklist ${HOME}/.config/lxsession/LXDE/autostart
@@ -168,3 +169,5 @@ blacklist ${PATH}/roxterm-config
 blacklist ${PATH}/terminix
 blacklist ${PATH}/urxvtc
 blacklist ${PATH}/urxvtcd
+blacklist ${PATH}/konsole
+blacklist ${PATH}/yakuake

--- a/etc/icecat.profile
+++ b/etc/icecat.profile
@@ -1,2 +1,51 @@
 # Firejail profile for GNU Icecat
-include /etc/firejail/firefox.profile
+
+noblacklist ~/.mozilla
+noblacklist ~/.cache/mozilla
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
+
+caps.drop all
+netfilter
+nonewprivs
+noroot
+protocol unix,inet,inet6,netlink
+seccomp
+tracelog
+
+whitelist ${DOWNLOADS}
+mkdir ~/.mozilla
+whitelist ~/.mozilla
+mkdir ~/.cache/mozilla/icecat
+whitelist ~/.cache/mozilla/icecat
+whitelist ~/dwhelper
+whitelist ~/.zotero
+whitelist ~/.vimperatorrc
+whitelist ~/.vimperator
+whitelist ~/.pentadactylrc
+whitelist ~/.pentadactyl
+whitelist ~/.keysnail.js
+whitelist ~/.config/gnome-mplayer
+whitelist ~/.cache/gnome-mplayer/plugin
+whitelist ~/.pki
+
+# lastpass, keepassx
+whitelist ~/.keepassx
+whitelist ~/.config/keepassx
+whitelist ~/keepassx.kdbx
+whitelist ~/.lastpass
+whitelist ~/.config/lastpass
+
+
+#silverlight
+whitelist ~/.wine-pipelight
+whitelist ~/.wine-pipelight64
+whitelist ~/.config/pipelight-widevine
+whitelist ~/.config/pipelight-silverlight5.1
+
+include /etc/firejail/whitelist-common.inc
+
+# experimental features
+#private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse
+

--- a/etc/whitelist-common.inc
+++ b/etc/whitelist-common.inc
@@ -20,8 +20,11 @@ whitelist ~/.cache/fontconfig
 # gtk
 whitelist ~/.gtkrc
 whitelist ~/.gtkrc-2.0
+whitelist ~/.config/gtk-2.0
 whitelist ~/.config/gtk-3.0
 whitelist ~/.themes
+whitelist ~/.kde/share/config/gtkrc
+whitelist ~/.kde/share/config/gtkrc-2.0
 
 # dconf
 mkdir ~/.config/dconf


### PR DESCRIPTION
Hi!

Three pretty small fixes:

1. The `icecat.profile` was updated (some dir paths mismatch with the generic `firefox.profile`).
2. New KDE terminal emulators added (_Konsole_ and _Yakuake_) besides adding a new blacklist rule.
3. GTK rendering issues fixed (related to _oxygen-gtk_) in some distributions still use KDE4, Slackware for example.

I appreciate your effort. Have a nice day!

