### PR TITLE
run_no_sandbox fix

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -283,6 +283,7 @@ char *guess_shell(void);
 
 // sandbox.c
 int sandbox(void* sandbox_arg);
+void start_application(void);
 
 // network_main.c
 void net_configure_bridge(Bridge *br, char *dev_name);

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -284,7 +284,7 @@ void start_audit(void) {
 	exit(1);
 }
 
-static void start_application(void) {
+void start_application(void) {
 	//****************************************
 	// audit
 	//****************************************


### PR DESCRIPTION
Fixed problem with cmdline quoting, (see https://github.com/netblue30/firejail/issues/718#issuecomment-240412040)
To avoid code duplication `start_application` function from `sandbox.c` used.
Shell choice taken from `SHELL` env variable or guessed by `guess_shell` function.
Parses and honors `--shell`, `--zsh`, and `--csh` functions.

Should fix https://github.com/netblue30/firejail/issues/718