### PR TITLE
Fix error in Slack profile

### DIFF
--- a/etc/slack.profile
+++ b/etc/slack.profile
@@ -1,3 +1,6 @@
+noblacklist ${HOME}/.config/Slack
+noblacklist ${HOME}/Downloads
+
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
@@ -6,7 +9,7 @@ include /etc/firejail/disable-passwdmgr.inc
 mkdir ${HOME}/.config
 mkdir ${HOME}/.config/Slack
 whitelist ${HOME}/.config/Slack
-whitelist ~/Downloads
+whitelist ${HOME}/Downloads
 
 protocol unix,inet,inet6,netlink
 private-dev


### PR DESCRIPTION
noblacklist must appear before the includes, to avoid the default
profiles from invoking blacklists. This commit resolves this.