### PR TITLE
Tighten security

### DIFF
--- a/src/firejail/appimage.c
+++ b/src/firejail/appimage.c
@@ -81,6 +81,7 @@ void appimage_set(const char *appimage_path) {
 		fprintf(stderr, "Error: cannot create temporary directory\n");
 		exit(1);
 	}
+	ASSERT_PERMS(mntdir, getuid(), getgid(), 0700);
 	
 	char *mode;
 	if (asprintf(&mode, "mode=700,uid=%d,gid=%d", getuid(), getgid()) == -1)

--- a/src/firejail/appimage.c
+++ b/src/firejail/appimage.c
@@ -39,15 +39,20 @@ void appimage_set(const char *appimage_path) {
 	assert(appimage_path);
 	assert(devloop == NULL);	// don't call this twice!
 	EUID_ASSERT();
-	
+
 	// check appimage_path
 	if (access(appimage_path, R_OK) == -1) {
 		fprintf(stderr, "Error: cannot access AppImage file\n");
 		exit(1);
 	}
-	
+
+	// open as user to prevent race condition
+	int ffd = open(appimage_path, O_RDONLY|O_CLOEXEC);
+	if (ffd == -1)
+		errExit("open");
+
 	EUID_ROOT();
-	
+
 	// find or allocate a free loop device to use
 	int cfd = open("/dev/loop-control", O_RDWR);
 	int devnr = ioctl(cfd, LOOP_CTL_GET_FREE);
@@ -59,7 +64,6 @@ void appimage_set(const char *appimage_path) {
 	if (asprintf(&devloop, "/dev/loop%d", devnr) == -1)
 		errExit("asprintf");
 		
-	int ffd = open(appimage_path, O_RDONLY|O_CLOEXEC);
 	int lfd = open(devloop, O_RDONLY);
 	if (ioctl(lfd, LOOP_SET_FD, ffd) == -1) {
 		fprintf(stderr, "Error: cannot configure the loopback device\n");
@@ -68,22 +72,21 @@ void appimage_set(const char *appimage_path) {
 	close(lfd);
 	close(ffd);
 	
+	EUID_USER();
+
+	// creates directory with perms 0700
 	char dirname[] = "/tmp/firejail-mnt-XXXXXX";
 	mntdir =  strdup(mkdtemp(dirname));
 	if (mntdir == NULL) {
 		fprintf(stderr, "Error: cannot create temporary directory\n");
 		exit(1);
 	}
-	mkdir(mntdir, 755);
-	if (chown(mntdir, getuid(), getgid()) == -1)
-		errExit("chown");
-	if (chmod(mntdir, 755) == -1)
-		errExit("chmod");
 	
 	char *mode;
-	if (asprintf(&mode, "mode=755,uid=%d,gid=%d", getuid(), getgid()) == -1)
+	if (asprintf(&mode, "mode=700,uid=%d,gid=%d", getuid(), getgid()) == -1)
 		errExit("asprintf");
 
+	EUID_ROOT();
 	if (mount(devloop, mntdir, "iso9660",MS_MGC_VAL|MS_RDONLY,  mode) < 0)
 		errExit("mounting appimage");
 

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -75,6 +75,27 @@
 #define DEFAULT_ROOT_PROFILE	"server"
 #define MAX_INCLUDE_LEVEL 6		// include levels in profile files
 
+
+#define ASSERT_PERMS(file, uid, gid, mode) \
+	do { \
+		assert(file);\
+		struct stat s;\
+		if (stat(file, &s) == -1) errExit("stat");\
+		assert(s.st_uid == uid && s.st_gid == gid && (s.st_mode & 07777) == mode);\
+	} while (0)
+#define ASSERT_PERMS_FD(fd, uid, gid, mode) \
+	do { \
+		struct stat s;\
+		if (stat(fd, &s) == -1) errExit("stat");\
+		assert(s.st_uid == uid && s.st_gid == gid && (s.st_mode & 07777) == mode);\
+	} while (0)
+#define ASSERT_PERMS_STREAM(file, uid, gid, mode) \
+	do { \
+		int fd = fileno(file);\
+		if (fd == -1) errExit("fileno");\
+		ASSERT_PERMS_FD(fd, uid, gid, mode);\
+	} while (0)
+
 // main.c
 typedef struct bridge_t {
 	// on the host
@@ -386,7 +407,7 @@ void logsignal(int s);
 void logmsg(const char *msg);
 void logargs(int argc, char **argv) ;
 void logerr(const char *msg);
-int copy_file(const char *srcname, const char *destname);
+int copy_file(const char *srcname, const char *destname, uid_t uid, gid_t gid, mode_t mode);
 int is_dir(const char *fname);
 int is_link(const char *fname);
 char *line_remove_spaces(const char *buf);

--- a/src/firejail/fs_home.c
+++ b/src/firejail/fs_home.c
@@ -43,9 +43,7 @@ static void skel(const char *homedir, uid_t u, gid_t g) {
 		if (stat(fname, &s) == 0)
 			return;
 		if (stat("/etc/skel/.zshrc", &s) == 0) {
-			if (copy_file("/etc/skel/.zshrc", fname) == 0) {
-				if (chown(fname, u, g) == -1)
-					errExit("chown");
+			if (copy_file("/etc/skel/.zshrc", fname, u, g, 0644) == 0) {
 				fs_logger("clone /etc/skel/.zshrc");
 			}
 		}
@@ -73,9 +71,7 @@ static void skel(const char *homedir, uid_t u, gid_t g) {
 		if (stat(fname, &s) == 0)
 			return;
 		if (stat("/etc/skel/.cshrc", &s) == 0) {
-			if (copy_file("/etc/skel/.cshrc", fname) == 0) {
-				if (chown(fname, u, g) == -1)
-					errExit("chown");
+			if (copy_file("/etc/skel/.cshrc", fname, u, g, 0644) == 0) {
 				fs_logger("clone /etc/skel/.cshrc");
 			}
 		}
@@ -104,10 +100,7 @@ static void skel(const char *homedir, uid_t u, gid_t g) {
 		if (stat(fname, &s) == 0) 
 			return;
 		if (stat("/etc/skel/.bashrc", &s) == 0) {
-			if (copy_file("/etc/skel/.bashrc", fname) == 0) {
-				/* coverity[toctou] */
-				if (chown(fname, u, g) == -1)
-					errExit("chown");
+			if (copy_file("/etc/skel/.bashrc", fname, u, g, 0644) == 0) {
 				fs_logger("clone /etc/skel/.bashrc");
 			}
 		}
@@ -131,7 +124,7 @@ static int store_xauthority(void) {
 			exit(1);
 		}
 			
-		int rv = copy_file(src, dest);
+		int rv = copy_file(src, dest, -1, -1, 0600);
 		if (rv) {
 			fprintf(stderr, "Warning: cannot transfer .Xauthority in private home directory\n");
 			return 0;
@@ -167,7 +160,7 @@ static int store_asoundrc(void) {
 			free(rp);
 		}
 
-		int rv = copy_file(src, dest);
+		int rv = copy_file(src, dest, -1, -1, -0644);
 		if (rv) {
 			fprintf(stderr, "Warning: cannot transfer .asoundrc in private home directory\n");
 			return 0;
@@ -184,7 +177,7 @@ static void copy_xauthority(void) {
 	char *dest;
 	if (asprintf(&dest, "%s/.Xauthority", cfg.homedir) == -1)
 		errExit("asprintf");
-	int rv = copy_file(src, dest);
+	int rv = copy_file(src, dest, -1, -1, 0600);
 	if (rv)
 		fprintf(stderr, "Warning: cannot transfer .Xauthority in private home directory\n");
 	else {
@@ -207,7 +200,7 @@ static void copy_asoundrc(void) {
 	char *dest;
 	if (asprintf(&dest, "%s/.asoundrc", cfg.homedir) == -1)
 		errExit("asprintf");
-	int rv = copy_file(src, dest);
+	int rv = copy_file(src, dest, -1 , -1, 0644);
 	if (rv)
 		fprintf(stderr, "Warning: cannot transfer .asoundrc in private home directory\n");
 	else {
@@ -360,11 +353,9 @@ int fs_copydir(const char *path, const struct stat *st, int ftype, struct FTW *s
          return(0);
       if (stat(path, &s) == 0) {
          if(ftype == FTW_F) {
-            if (copy_file(path, dest) == 0) {
+            if (copy_file(path, dest, u, g, 0644) == 0) {
                if (arg_debug)
                   printf("copy from %s to %s\n", path, dest);
-               if (chown(dest, u, g) == -1)
-                  errExit("chown");
                fs_logger2("clone", path);
             }
          }

--- a/src/firejail/ls.c
+++ b/src/firejail/ls.c
@@ -374,11 +374,7 @@ void sandboxfs(int op, pid_t pid, const char *path) {
 		}
 		// copy file
 		EUID_ROOT();
-		copy_file(src_fname, dest_fname);
-		if (chown(dest_fname, getuid(), getgid()) == -1)
-			errExit("chown");
-		if (chmod(dest_fname, 0644) == -1)
-			errExit("chmod");
+		copy_file(src_fname, dest_fname, getuid(), getgid(), 0644);
 		printf("Transfer complete\n");
 		EUID_USER();
 	}

--- a/src/firejail/pulseaudio.c
+++ b/src/firejail/pulseaudio.c
@@ -114,7 +114,7 @@ void pulseaudio_init(void) {
 	char *pulsecfg = NULL;
 	if (asprintf(&pulsecfg, "%s/client.conf", RUN_PULSE_DIR) == -1)
 		errExit("asprintf");
-	if (copy_file("/etc/pulse/client.conf", pulsecfg))
+	if (copy_file("/etc/pulse/client.conf", pulsecfg, -1, -1, 0644))
 		errExit("copy_file");
 	FILE *fp = fopen(pulsecfg, "a+");
 	if (!fp)

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -170,7 +170,7 @@ void logerr(const char *msg) {
 
 
 // return -1 if error, 0 if no error
-int copy_file(const char *srcname, const char *destname) {
+int copy_file(const char *srcname, const char *destname, uid_t uid, gid_t gid, mode_t mode) {
 	assert(srcname);
 	assert(destname);
 
@@ -206,6 +206,11 @@ int copy_file(const char *srcname, const char *destname) {
 			done += rv;
 		}
 	}
+
+	if (fchown(dst, uid, gid) == -1)
+		errExit("fchown");
+	if (fchmod(dst, mode) == -1)
+		errExit("fchmod");
 
 	close(src);
 	close(dst);

--- a/src/include/euid_common.h
+++ b/src/include/euid_common.h
@@ -37,11 +37,15 @@ extern uid_t firejail_uid;
 static inline void EUID_ROOT(void) {
 	if (seteuid(0) == -1)
 		fprintf(stderr, "Warning: cannot switch euid to root\n");
+	if (setegid(0) == -1)
+		fprintf(stderr, "Warning: cannot switch egid to root\n");
 }
 
 static inline void EUID_USER(void) {
 	if (seteuid(firejail_uid) == -1)
-		fprintf(stderr, "Warning: cannot switch euid to user\n");
+		errExit("seteuid");
+	if (setegid(firejail_uid) == -1)
+		errExit("setegid");
 }
 
 static inline void EUID_PRINT(void) {


### PR DESCRIPTION
**appimage.c**:
* remove redundant `mkdir`, `chown`, `chmod` calls, last two also pose race condition risk.
* open appimage file as user, to avoid race condition, that may alllow attacker mount appimage/iso file that unreadable to user.

**firejail.h**:
* add `ASSERT_PERMS` macros

**util.c**:
* change `copy_file` function to take `uid`, `gid`, and `mode` for new file, use `fchown` and `fchmod` to prevent race condition when setting owner and permissions.

**euid_common.h**:
* set `egid` when switching `euid`, so files created as root won't need additional `chown` to change group.
* exit with error if unable to switch `euid`/`egid` to user - if we continue to run code than intended to run as user with root privileges - this is disaster.

**fs.c** and other:
* Avoid `chown` and `chroot` where possible, using functions and macros mentioned above.