### PR TITLE
Profile tightening

### DIFF
--- a/etc/0ad.profile
+++ b/etc/0ad.profile
@@ -19,8 +19,8 @@ whitelist ~/.local/share/0ad
 
 caps.drop all
 netfilter
-nonewprivs
 nogroups
+nonewprivs
 noroot
 protocol unix,inet,inet6
 seccomp
@@ -28,4 +28,4 @@ shell none
 tracelog
 
 private-dev
-
+private-tmp

--- a/etc/atom-beta.profile
+++ b/etc/atom-beta.profile
@@ -1,4 +1,4 @@
-# Firjail profile for Atom Beta.
+# Firejail profile for Atom Beta.
 noblacklist ~/.atom
 noblacklist ~/.config/Atom
 
@@ -11,9 +11,10 @@ netfilter
 nonewprivs
 nogroups
 noroot
+nosound
+protocol unix,inet,inet6,netlink
 seccomp
 shell none
 
 private-dev
-nosound
-
+private-tmp

--- a/etc/atom.profile
+++ b/etc/atom.profile
@@ -1,4 +1,4 @@
-# Firjail profile for Atom.
+# Firejail profile for Atom.
 noblacklist ~/.atom
 noblacklist ~/.config/Atom
 
@@ -11,8 +11,10 @@ netfilter
 nonewprivs
 nogroups
 noroot
+nosound
+protocol unix,inet,inet6,netlink
 seccomp
 shell none
 
 private-dev
-nosound
+private-tmp

--- a/etc/atril.profile
+++ b/etc/atril.profile
@@ -18,3 +18,4 @@ tracelog
 
 private-bin atril, atril-previewer, atril-thumbnailer
 private-dev
+private-tmp

--- a/etc/audacity.profile
+++ b/etc/audacity.profile
@@ -7,6 +7,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+netfilter
 nonewprivs
 nogroups
 noroot
@@ -17,3 +18,4 @@ tracelog
 
 private-bin audacity
 private-dev
+private-tmp

--- a/etc/aweather.profile
+++ b/etc/aweather.profile
@@ -15,10 +15,11 @@ nonewprivs
 nogroups
 noroot
 nosound
-protocol unix,inet,inet6,netlink
+protocol unix,inet,inet6
 seccomp
 shell none
 tracelog
 
 private-bin aweather
 private-dev
+private-tmp

--- a/etc/dosbox.profile
+++ b/etc/dosbox.profile
@@ -1,6 +1,5 @@
-# transmission-gtk bittorrent profile
-noblacklist ${HOME}/.config/transmission
-noblacklist ${HOME}/.cache/transmission
+# Firejail profile for dosbox
+noblacklist ~/.dosbox
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
@@ -9,15 +8,14 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 netfilter
+nogroups
 nonewprivs
 noroot
-nosound
 protocol unix,inet,inet6
 seccomp
 shell none
 tracelog
 
-private-bin transmission-gtk
-whitelist /tmp/.X11-unix
+private-bin dosbox
 private-dev
-
+private-tmp

--- a/etc/eom.profile
+++ b/etc/eom.profile
@@ -18,3 +18,4 @@ tracelog
 
 private-bin eom
 private-dev
+private-tmp

--- a/etc/gitter.profile
+++ b/etc/gitter.profile
@@ -7,12 +7,14 @@ include /etc/firejail/disable-devel.inc
 
 caps.drop all
 netfilter
-nonewprivs
 nogroups
+nonewprivs
 noroot
+nosound
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
 
 private-bin gitter
 private-dev
+private-tmp

--- a/etc/gthumb.profile
+++ b/etc/gthumb.profile
@@ -19,4 +19,3 @@ tracelog
 private-bin gthumb
 whitelist /tmp/.X11-unix
 private-dev
-private-tmp

--- a/etc/hexchat.profile
+++ b/etc/hexchat.profile
@@ -1,7 +1,8 @@
 # HexChat instant messaging profile
+# Currently in testing (may not work for all users)
 noblacklist ${HOME}/.config/hexchat
-noblacklist /usr/lib/python2*
-noblacklist /usr/lib/python3*
+#noblacklist /usr/lib/python2*
+#noblacklist /usr/lib/python3*
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
@@ -14,11 +15,14 @@ noroot
 nosound
 protocol unix,inet,inet6
 seccomp
+shell none
+tracelog
 
 mkdir ~/.config/hexchat
 whitelist ~/.config/hexchat
 include /etc/firejail/whitelist-common.inc
 
-# private-bin requires perl, python, etc.
+private-bin hexchat
+#debug note: private-bin requires perl, python, etc on some systems
 private-dev
 private-tmp

--- a/etc/libreoffice.profile
+++ b/etc/libreoffice.profile
@@ -7,6 +7,7 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 netfilter
+nogroups
 nonewprivs
 noroot
 protocol unix,inet,inet6,netlink
@@ -15,5 +16,3 @@ tracelog
 
 private-dev
 whitelist /tmp/.X11-unix/
-nosound
-

--- a/etc/palemoon.profile
+++ b/etc/palemoon.profile
@@ -23,6 +23,7 @@ shell none
 tracelog
 
 private-bin palemoon
+private-tmp
 
 # These are uncommented in the Firefox profile. If you run into trouble you may
 # want to uncomment (some of) them.

--- a/etc/pidgin.profile
+++ b/etc/pidgin.profile
@@ -18,3 +18,4 @@ tracelog
 
 private-bin pidgin
 private-dev
+private-tmp

--- a/etc/qtox.profile
+++ b/etc/qtox.profile
@@ -20,3 +20,4 @@ shell none
 tracelog
 
 private-bin qtox
+private-tmp

--- a/etc/rhythmbox.profile
+++ b/etc/rhythmbox.profile
@@ -16,3 +16,4 @@ tracelog
 
 private-bin rhythmbox
 private-dev
+private-tmp

--- a/etc/stellarium.profile
+++ b/etc/stellarium.profile
@@ -25,4 +25,4 @@ tracelog
 
 private-bin stellarium
 private-dev
-
+private-tmp

--- a/etc/vlc.profile
+++ b/etc/vlc.profile
@@ -17,3 +17,5 @@ shell none
 tracelog
 
 private-bin vlc,cvlc,nvlc,rvlc,qvlc,svlc
+private-dev
+private-tmp

--- a/etc/warzone2100.profile
+++ b/etc/warzone2100.profile
@@ -23,3 +23,4 @@ tracelog
 
 private-bin warzone2100
 private-dev
+private-tmp

--- a/etc/xplayer.profile
+++ b/etc/xplayer.profile
@@ -19,3 +19,4 @@ tracelog
 
 private-bin xplayer,xplayer-audio-preview,xplayer-video-thumbnailer
 private-dev
+private-tmp

--- a/etc/xreader.profile
+++ b/etc/xreader.profile
@@ -20,3 +20,4 @@ tracelog
 
 private-bin xreader, xreader-previewer, xreader-thumbnailer
 private-dev
+private-tmp

--- a/etc/xviewer.profile
+++ b/etc/xviewer.profile
@@ -6,8 +6,8 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-nonewprivs
 nogroups
+nonewprivs
 noroot
 nosound
 protocol unix
@@ -17,3 +17,4 @@ tracelog
 
 private-dev
 private-bin xviewer
+private-tmp


### PR DESCRIPTION
These tighten many profiles a bit--mostly via `private-tmp`. I've also added a profile for dosbox, and removed private-tmp from the gthumb profile since it already had a /tmp whitelist. 
The profiles in the "tested and stable" commit have all been tested and I don't expect them to break anything.
I've also committed a revised hexchat profile in "may break on some systems" and added a private-bin filter. It works perfectly on my machine, but I suspect it may break on other distros that require python or perl for hexchat since they are not included in the private-bin filter (I don't know which distros these would be, but I remember something about this from an old bug report). If you do commit this, we'll probably need to revise the profile a couple of times based on the bug reports that might trickle in. 
Then again, it might work perfectly as-is.

Cheers!
Fred