### PR TITLE
Option to fix .desktop files for firecfg

### DIFF
--- a/src/firecfg/main.c
+++ b/src/firecfg/main.c
@@ -408,7 +408,7 @@ static void fix_desktop_files(void) {
 
 		// check if basename in PATH
 		if (!which(bname)) {
-			fprintf(stderr, "/usr/share/applications/%s - unable to fix: executable not in PATH\n", filename);
+			fprintf(stderr, "/usr/share/applications/%s - skipped, %s not in PATH\n", filename, bname);
 			continue;
 		}
 

--- a/src/man/firecfg.txt
+++ b/src/man/firecfg.txt
@@ -61,6 +61,15 @@ $ sudo firecfg --clean
 /usr/local/bin/vlc removed
 .br
 [...]
+.br
+$ firecfg --fix
+.br
+/home/user/.local/share/applications/chromium.desktop created
+.br
+/home/user/.local/share/applications/vlc.desktop created
+.br
+[...]
+
 
 .SH LICENSE
 This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.

--- a/src/man/firecfg.txt
+++ b/src/man/firecfg.txt
@@ -26,6 +26,9 @@ Print options end exit.
 \fB\-\-list
 List all firejail symbolic links
 .TP
+\fB\-\-fix
+Fix .desktop files. Some .desktop files use full path to executable. Firecfg will check .desktop files in /usr/share/applications/, replace full path by name if it is in PATH, and write result to $HOME/.local/share/applications/.
+.TP
 \fB\-\-version
 Print program version and exit.
 


### PR DESCRIPTION
Some `.desktop` files use full path to executable. As result, just running `firecfg` is not enough to run those apps in firejail using menu or file manager.
With `--fix` option firecfg will check `.desktop` files in `/usr/share/applications/`, replace full path by name if it is in PATH, and write result to `$HOME/.local/share/applications/`.