### PR TITLE
Add option to block X11

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -315,6 +315,7 @@ extern int arg_audit;		// audit
 extern char *arg_audit_prog;	// audit
 extern int arg_apparmor;	// apparmor
 extern int arg_allow_debuggers;	// allow debuggers
+extern int arg_x11_block;	// block X11
 
 extern int login_shell;
 extern int parent_to_child_fds[2];
@@ -623,6 +624,7 @@ int x11_display(void);
 void x11_start(int argc, char **argv);
 void x11_start_xpra(int argc, char **argv);
 void x11_start_xephyr(int argc, char **argv);
+void x11_block(void);
 
 // ls.c
 #define SANDBOX_FS_LS 0

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -105,6 +105,7 @@ int arg_audit = 0;				// audit
 char *arg_audit_prog = NULL;			// audit
 int arg_apparmor = 0;				// apparmor
 int arg_allow_debuggers = 0;			// allow debuggers
+int arg_x11_block = 0;				// block X11
 int login_shell = 0;
 
 int parent_to_child_fds[2];
@@ -2118,6 +2119,9 @@ int main(int argc, char **argv) {
 				return 1;
 			}
 		}
+		else if (strcmp(argv[i], "--x11=block") == 0) {
+			arg_x11_block = 1;
+		}
 		else if (strcmp(argv[i], "--") == 0) {
 			// double dash - positional params to follow
 			arg_doubledash = 1;
@@ -2283,6 +2287,10 @@ int main(int argc, char **argv) {
 				printf("\n** Note: you can use --noprofile to disable %s.profile **\n\n", profile_name);
 		}
 	}
+
+	// block X11 sockets
+	if (arg_x11_block)
+		x11_block();
 
 	// check network configuration options - it will exit if anything went wrong
 	net_check_cfg();

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -625,6 +625,45 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		arg_private = 1;
 		return 0;
 	}
+
+	if (strcmp(ptr, "x11 block") == 0) {
+#ifdef HAVE_X11
+		arg_x11_block = 1;
+#endif
+		return 0;
+	}
+
+	if (strcmp(ptr, "x11 xephyr") == 0) {
+#ifdef HAVE_X11
+		if (checkcfg(CFG_X11)) {
+			char *x11env = getenv("FIREJAIL_X11");
+			if (x11env && strcmp(x11env, "yes") == 0)
+				return 0;
+			else {
+				// start x11
+				x11_start_xephyr(cfg.original_argc, cfg.original_argv);
+				exit(0);
+			}
+		}
+#endif
+		return 0;
+	}
+
+	if (strcmp(ptr, "x11 xpra") == 0) {
+#ifdef HAVE_X11
+		if (checkcfg(CFG_X11)) {
+			char *x11env = getenv("FIREJAIL_X11");
+			if (x11env && strcmp(x11env, "yes") == 0)
+				return 0;
+			else {
+				// start x11
+				x11_start_xpra(cfg.original_argc, cfg.original_argv);
+				exit(0);
+			}
+		}
+#endif
+		return 0;
+	}
 	
 	if (strcmp(ptr, "x11") == 0) {
 #ifdef HAVE_X11

--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -267,6 +267,17 @@ There is no root account (uid 0) defined in the namespace.
 .TP
 \fBx11
 Enable X11 sandboxing.
+.TP
+\fBx11 xpra
+Enable X11 sandboxing with xpra.
+.TP
+\fBx11 xephyr
+Enable X11 sandboxing with xephyr.
+.TP
+\fBx11 block
+Blacklist /tmp/.X11-unix directory, ${HOME}/.Xauthority and file specified in ${XAUTHORITY} enviroment variable.
+Remove DISPLAY and XAUTHORITY enviroment variables.
+Stop with error message if X11 abstract socket will be accessible in jail.
 
 .SH Resource limits, CPU affinity, Control Groups
 These profile entries define the limits on system resources (rlimits) for the processes inside the sandbox.

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -1673,6 +1673,13 @@ Example:
 $ firejail \-\-x11=xephyr --net=eth0 openbox
 
 .TP
+\fB\-\-x11=block
+Blacklist /tmp/.X11-unix directory, ${HOME}/.Xauthority and file specified in ${XAUTHORITY} enviroment variable.
+Remove DISPLAY and XAUTHORITY enviroment variables.
+Stop with error message if X11 abstract socket will be accessible in jail.
+.br
+
+.TP
 \fB\-\-zsh
 Use /usr/bin/zsh as default user shell.
 .br


### PR DESCRIPTION
Add `--x11=block` command line option, `x11 block`, `x11 xephyr`, `x11 xpra` profile options.

X11 blacklisting implemented simplest way:
* Blacklist `/tmp/.X11-unix` and `.Xauthority`
* It's up to user to decide how to deal with abstract sockets, just stop with explanatory error message if abstract socket will be accessible in jail.