### PR TITLE
Add netlink to --protocols in steam profile

### DIFF
--- a/etc/steam.profile
+++ b/etc/steam.profile
@@ -10,5 +10,5 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
-protocol unix,inet,inet6
+protocol unix,inet,inet6,netlink
 seccomp


### PR DESCRIPTION
Fixes #779 - Steam games unable to detect gamepads via udev