### PR TITLE
Quiet SSH config

### DIFF
--- a/etc/ssh.profile
+++ b/etc/ssh.profile
@@ -1,4 +1,5 @@
 # ssh client
+quiet
 noblacklist ~/.ssh
 noblacklist /tmp/ssh-*
 


### PR DESCRIPTION
firejail output in ssh client breaks git+ssh for me, e.g.,

    $ git clone git@github.com:netblue30/firejail.git
    Cloning into 'firejail'...
    Reading profile /etc/firejail/ssh.profile
    Reading profile /etc/firejail/disable-common.inc
    Reading profile /etc/firejail/disable-programs.inc
    Reading profile /etc/firejail/disable-passwdmgr.inc
    fatal: protocol error: bad line length character: Pare

The "Pare" comes from "Parent pid x, child pid y".