### PR TITLE
Quickfix for problem found in SELinux that affects Firejail too.

### DIFF
--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -290,6 +290,10 @@ void start_audit(void) {
 }
 
 void start_application(void) {
+	// fix problem found in SELinux (CVE-2016-7545) that affects Firejail too
+	if (setsid() == -1)
+		errExit("setsid");
+
 	//****************************************
 	// audit
 	//****************************************


### PR DESCRIPTION
Quickfix for problem found in SELinux (CVE-2016-7545) that affects Firejail too.
See https://security-tracker.debian.org/tracker/CVE-2016-7545 and http://seclists.org/oss-sec/2016/q3/606.
Fixed by calling `setsid()` as done in SELinux. Side effect of this is broken job control in shell:
```
$ firejail --quiet
bash: cannot set terminal process group (-1): Inappropriate ioctl for device
bash: no job control in this shell
$ fg
bash: fg: no job control
$ bg
bash: bg: no job control
```
But this should be fine until somebody comes with better solution.

EDIT: grsecurity prevents exploitation of this problem.