### PR TITLE
CVE-2016-7545 fix improvement

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -143,7 +143,17 @@ static void myexit(int rv) {
 	EUID_ROOT();
 	clear_run_files(sandbox_pid);
 	appimage_clear();
-	ioctl(0, TCFLSH, TCIFLUSH);
+
+	int fd = open("/dev/tty", O_RDWR);
+	if (fd != -1) {
+		ioctl(fd, TCFLSH, TCIFLUSH);
+		close(fd);
+	} else {
+		fprintf(stderr, "Warning: can't open /dev/tty, flushing stdin, stdout and stderr file descriptors instead\n");
+		ioctl(0, TCFLSH, TCIFLUSH);
+		ioctl(1, TCFLSH, TCIFLUSH);
+		ioctl(2, TCFLSH, TCIFLUSH);
+	}
 		
 	exit(rv); 
 }


### PR DESCRIPTION
Improved your fix a bit: it's better to flush `/dev/tty` than `stdin`, as `stdin` descriptor may be redirected to something else.
Test program
```c
#include <unistd.h>
#include <sys/ioctl.h>
#include <termios.h>
#include <fcntl.h>

int main()
{
    char *cmd = "ls /proc\n";
    while(*cmd)
     ioctl(1, TIOCSTI, cmd++);

     return 0;
}
```
and command
`firejail ./CVE-2016-7545 </dev/null`