### PR TITLE
If .Xauthority is symlink, skip and warn

### DIFF
--- a/src/firejail/fs_home.c
+++ b/src/firejail/fs_home.c
@@ -114,8 +114,8 @@ static int store_xauthority(void) {
 	struct stat s;
 	if (stat(src, &s) == 0) {
 		if (is_link(src)) {
-			fprintf(stderr, "Error: invalid .Xauthority file\n");
-			exit(1);
+			fprintf(stderr, "Warning: invalid .Xauthority file\n");
+			return 0;
 		}
 			
 		int rv = copy_file(src, dest, -1, -1, 0600);


### PR DESCRIPTION
`~/.Xauthority` being symlink is not fatal error, warning about this and skipping it in further processing is enough.
Fix for https://github.com/netblue30/firejail/issues/821