### PR TITLE
fixed recovery issue

### DIFF
--- a/etc/libreoffice.profile
+++ b/etc/libreoffice.profile
@@ -1,5 +1,6 @@
 # Firejail profile for LibreOffice
 noblacklist ~/.config/libreoffice
+noblacklist /usr/local/sbin
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
@@ -10,9 +11,9 @@ netfilter
 nogroups
 nonewprivs
 noroot
-protocol unix,inet,inet6,netlink
+protocol unix,inet,inet6
 seccomp
 tracelog
 
 private-dev
-whitelist /tmp/.X11-unix/
+# whitelist /tmp/.X11-unix/


### PR DESCRIPTION
When starting two instances of libreoffice, the second one will start the document recovery for already open documents of the first instance.
This was caused by using a too restrictive whitelist on /tmp, which prevented libreoffice from writing several temporary files.

There was also an issue about libreoffice not being able to look for java in /usr/local/sbin.
This was solved by noblacklist /usr/local/sbin
