### PR TITLE
Allow evince to access /tmp

### DIFF
--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -15,5 +15,4 @@ shell none
 tracelog
 
 private-bin evince,evince-previewer,evince-thumbnailer
-whitelist /tmp/.X11-unix
 private-dev


### PR DESCRIPTION
firefox will save files under /tmp/mozilla_* and try to open
them with evince when evince is the default PDF reader.