### PR TITLE
Whitelist Arch's chromium-flags.conf to Chromium

### DIFF
--- a/etc/chromium.profile
+++ b/etc/chromium.profile
@@ -25,4 +25,7 @@ whitelist ~/keepassx.kdbx
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass
 
+# specific to Arch
+whitelist ~/.config/chromium-flags.conf
+
 include /etc/firejail/whitelist-common.inc


### PR DESCRIPTION
Hi,

Arch has an optional configuration file for Chromium (https://wiki.archlinux.org/index.php/Chromium/Tips_and_tricks#Making_flags_persistent) that needs to be readable by /usr/bin/chromium. I just whitelisted it.

Best regards!