### PR TITLE
Misc fixes

### DIFF
--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -77,6 +77,7 @@ blacklist ${HOME}/.8pecxstudios
 blacklist ${HOME}/.config/brave
 blacklist ${HOME}/.config/inox
 blacklist ${HOME}/.muttrc
+blacklist ${HOME}/.mutt
 blacklist ${HOME}/.mutt/muttrc
 blacklist ${HOME}/.msmtprc
 blacklist ${HOME}/.config/evolution

--- a/etc/mutt.profile
+++ b/etc/mutt.profile
@@ -2,6 +2,7 @@
 
 noblacklist ~/.muttrc
 noblacklist ~/.mutt
+noblacklist ~/.mutt/muttrc
 noblacklist ~/.mailcap
 noblacklist ~/.gnupg
 noblacklist ~/.mail

--- a/mkuid.sh
+++ b/mkuid.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "extracting UID_MIN and GID_MIN"
 echo "#ifndef FIREJAIL_UIDS_H" > uids.h

--- a/src/firemon/procevent.c
+++ b/src/firemon/procevent.c
@@ -28,6 +28,8 @@
 #include <arpa/inet.h>
 #include <time.h>
 #include <fcntl.h>
+//#include <sys/uio.h>
+
 #define PIDS_BUFLEN 4096
 #define SERVER_PORT 889	// 889-899 is left unassigned by IANA
 

--- a/src/firemon/procevent.c
+++ b/src/firemon/procevent.c
@@ -28,7 +28,7 @@
 #include <arpa/inet.h>
 #include <time.h>
 #include <fcntl.h>
-//#include <sys/uio.h>
+#include <sys/uio.h>
 
 #define PIDS_BUFLEN 4096
 #define SERVER_PORT 889	// 889-899 is left unassigned by IANA


### PR DESCRIPTION
* fix building on systems without bash
* add missing include: `writev` on [src/firemon/procevent.c:176](https://github.com/manevich/firejail/blob/4ac74f0621fbb33a90dd4e3aa181ccd727c57514/src/firemon/procevent.c#L176) requires `sys/uio.h`
* fix mutt.profile