### PR TITLE
Tightened Spotify profile

### DIFF
--- a/README
+++ b/README
@@ -77,6 +77,7 @@ Fred-Barclay (https://github.com/Fred-Barclay)
 	- added gnome-chess profile
 	- added DOSBox profile
 	- evince profile enhancement
+	- tightened Spotify profile
 valoq (https://github.com/valoq)
 	- LibreOffice profile fixes
 	- cherrytree profile fixes

--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -172,3 +172,7 @@ blacklist ${PATH}/roxterm-config
 blacklist ${PATH}/terminix
 blacklist ${PATH}/urxvtc
 blacklist ${PATH}/urxvtcd
+
+# kernel files
+blacklist /vmlinuz*
+blacklist /initrd*

--- a/etc/spotify.profile
+++ b/etc/spotify.profile
@@ -41,7 +41,3 @@ blacklist /sbin
 blacklist /srv
 blacklist /sys
 blacklist /var
-blacklist /initrd.img
-blacklist /initrd.img.old
-blacklist /vmlinuz
-blacklist /vmlinuz.old

--- a/etc/spotify.profile
+++ b/etc/spotify.profile
@@ -7,16 +7,13 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
-# Whitelist the folders needed by Spotify - This is more restrictive
-# than a blacklist though, but this is all spotify requires for
-# streaming audio
+# Whitelist the folders needed by Spotify
 mkdir ${HOME}/.config/spotify
 whitelist ${HOME}/.config/spotify
 mkdir ${HOME}/.local/share/spotify
 whitelist ${HOME}/.local/share/spotify
 mkdir ${HOME}/.cache/spotify
 whitelist ${HOME}/.cache/spotify
-include /etc/firejail/whitelist-common.inc
 
 caps.drop all
 netfilter
@@ -27,5 +24,24 @@ protocol unix,inet,inet6,netlink
 seccomp
 shell none
 
-#private-bin spotify
+private-bin spotify
+private-etc fonts,machine-id,pulse,resolv.conf
 private-dev
+private-tmp
+
+blacklist ${HOME}/.Xauthority
+blacklist ${HOME}/.bashrc
+blacklist /boot
+blacklist /lost+found
+blacklist /media
+blacklist /mnt
+blacklist /opt
+blacklist /root
+blacklist /sbin
+blacklist /srv
+blacklist /sys
+blacklist /var
+blacklist /initrd.img
+blacklist /initrd.img.old
+blacklist /vmlinuz
+blacklist /vmlinuz.old


### PR DESCRIPTION
This should tighten the Spotify profile a good bit. Mainly I added a `private-etc` filter and blacklisted unneeded files and directories. (Some of these directories are already read-only but why even expose them since they're not necessary?)