### PR TITLE
Extra profiles

### DIFF
--- a/README
+++ b/README
@@ -70,7 +70,7 @@ Fred-Barclay (https://github.com/Fred-Barclay)
 	- added audacity profile
 	- fixed Telegram and qtox profiles
 	- added Atom Beta and Atom profiles
-	- tightened 0ad, atril, evince, gthumb, pix, qtox, and xreader profiles.
+	- tightened 0ad, atril, evince, gthumb, pix, qtox, and xreader profiles
 	- several private-bin conversions
 	- added jitsi profile
 	- pidgin private-bin conversion
@@ -79,6 +79,7 @@ Fred-Barclay (https://github.com/Fred-Barclay)
 	- added DOSBox profile
 	- evince profile enhancement
 	- tightened Spotify profile
+	- added xiphos and Tor Browser Bundle profiles
 valoq (https://github.com/valoq)
 	- LibreOffice profile fixes
 	- cherrytree profile fixes

--- a/README.md
+++ b/README.md
@@ -48,4 +48,9 @@ Use this issue to request new profiles: https://github.com/netblue30/firejail/is
 
 `````
 # Current development version: 0.9.45
+`````
+
+`````
+## New Profiles
+xiphos, Tor Browser Bundle
 

--- a/RELNOTES
+++ b/RELNOTES
@@ -1,6 +1,7 @@
 firejail (0.9.45) baseline; urgency=low
   * development version, work in progress
  -- netblue30 <netblue30@yahoo.com>  Sun, 23 Oct 2016 08:00:00 -0500
+  * new profiles: xiphos, Tor Browser Bundle
 
 firejail (0.9.44) baseline; urgency=low
   * CVE-2016-7545 submitted by Aleksey Manevich

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -7,6 +7,8 @@ blacklist ${HOME}/.wine
 blacklist ${HOME}/.Mathematica
 blacklist ${HOME}/.Wolfram Research
 blacklist ${HOME}/.stellarium
+blacklist ${HOME}/.sword
+blacklist ${HOME}/.xiphos
 blacklist ${HOME}/.config/Atom
 blacklist ${HOME}/.config/gthumb
 blacklist ${HOME}/.config/mupen64plus

--- a/etc/gpredict.profile
+++ b/etc/gpredict.profile
@@ -10,8 +10,8 @@ whitelist ~/.config/Gpredict
 
 caps.drop all
 netfilter
-nonewprivs
 nogroups
+nonewprivs
 noroot
 nosound
 protocol unix,inet,inet6

--- a/etc/gpredict.profile
+++ b/etc/gpredict.profile
@@ -16,10 +16,10 @@ noroot
 nosound
 protocol unix,inet,inet6
 seccomp
-#shell none
+shell none
 tracelog
 
-#private-bin gpredict
+private-bin gpredict
 private-etc fonts,resolv.conf
 private-dev
 private-tmp

--- a/etc/start-tor-browser.profile
+++ b/etc/start-tor-browser.profile
@@ -1,25 +1,20 @@
-# Firejail profile for gpredict.
-noblacklist ~/.config/Gpredict
+# Firejail profile for the Tor Brower Bundle
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
-# Whitelist
-whitelist ~/.config/Gpredict
-
 caps.drop all
 netfilter
-nonewprivs
 nogroups
+nonewprivs
 noroot
-nosound
 protocol unix,inet,inet6
 seccomp
-#shell none
+shell none
 tracelog
 
-#private-bin gpredict
-private-etc fonts,resolv.conf
+private-bin bash,grep,sed,tail,env,gpg,id,readlink,dirname,test,mkdir,ln,sed,cp,rm,getconf
+private-etc fonts
 private-dev
 private-tmp

--- a/etc/xiphos.profile
+++ b/etc/xiphos.profile
@@ -1,25 +1,30 @@
-# Firejail profile for gpredict.
-noblacklist ~/.config/Gpredict
+# Firejail profile for xiphos
+noblacklist ~/.sword
+noblacklist ~/.xiphos
+
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
-# Whitelist
-whitelist ~/.config/Gpredict
+blacklist ~/.bashrc
+blacklist ~/.Xauthority
 
 caps.drop all
 netfilter
-nonewprivs
 nogroups
+nonewprivs
 noroot
 nosound
 protocol unix,inet,inet6
 seccomp
-#shell none
+shell none
 tracelog
 
-#private-bin gpredict
-private-etc fonts,resolv.conf
+private-bin xiphos
+private-etc fonts,resolv.conf,sword
 private-dev
 private-tmp
+
+whitelist ${HOME}/.sword
+whitelist ${HOME}/.xiphos

--- a/platform/debian/conffiles
+++ b/platform/debian/conffiles
@@ -166,3 +166,5 @@
 /etc/firejail/flowblade.profile
 /etc/firejail/eog.profile
 /etc/firejail/evolution.profile
+/etc/firejail/start-tor-browser.profile
+/etc/firejail/xiphos.profile

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -42,6 +42,7 @@ opera-beta
 opera
 palemoon
 qutebrowser
+start-tor-browser
 seamonkey
 seamonkey-bin
 thunderbird
@@ -150,6 +151,7 @@ atom
 ranger
 keepass
 keepassx
+xiphos
 
 # weather/climate
 aweather


### PR DESCRIPTION
I've edited the gpredict profile and added profiles for xiphos and the Tor Browser Bundle (the bundle from upstream, not the one from the PPA mentioned in #825). The TBB profile may need to be tweaked over time as other people test it but it's working pretty well on my end. 

(Credits to chiraag-nataraj's repo (https://github.com/chiraag-nataraj/firejail-profiles) for the `private-bin` filters.)