### PR TITLE
Guayadeque profile

### DIFF
--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -1,19 +1,59 @@
 # various programs
+blacklist ${HOME}/.Atom
 blacklist ${HOME}/.remmina
 blacklist ${HOME}/.tconn
 blacklist ${HOME}/.FBReader
 blacklist ${HOME}/.wine
 blacklist ${HOME}/.Mathematica
 blacklist ${HOME}/.Wolfram Research
+blacklist ${HOME}/.stellarium
+blacklist ${HOME}/.sword
+blacklist ${HOME}/.xiphos
+blacklist ${HOME}/.config/Atom
+blacklist ${HOME}/.config/gthumb
 blacklist ${HOME}/.config/mupen64plus
 blacklist ${HOME}/.config/transmission
 blacklist ${HOME}/.config/uGet
+blacklist ${HOME}/.config/Gpredict
+blacklist ${HOME}/.config/aweather
+blacklist ${HOME}/.config/stellarium
+blacklist ${HOME}/.config/atril
+blacklist ${HOME}/.config/xreader
+blacklist ${HOME}/.config/xviewer
+blacklist ${HOME}/.config/libreoffice
+blacklist ${HOME}/.config/pix
+blacklist ${HOME}/.config/mate/eom
+blacklist ${HOME}/.kde/share/apps/okular
+blacklist ${HOME}/.kde/share/config/okularrc
+blacklist ${HOME}/.kde/share/config/okularpartrc
+blacklist ${HOME}/.kde/share/apps/gwenview
+blacklist ${HOME}/.kde/share/config/gwenviewrc
+blacklist ${HOME}/.config/qpdfview
+blacklist ${HOME}/.config/Luminance
+blacklist ${HOME}/.config/synfig
+blacklist ${HOME}/.synfig
+blacklist ${HOME}/.inkscape
+blacklist ${HOME}/.gimp*
+blacklist ${HOME}/.config/zathura
+blacklist ${HOME}/.config/cherrytree
+blacklist ${HOME}/.xpdfrc
+blacklist ${HOME}/.openshot
+blacklist ${HOME}/.openshot_qt
+blacklist ${HOME}/.flowblade
+blacklist ${HOME}/.config/flowblade
+blacklist ${HOME}/.config/eog
+
 
 # Media players
 blacklist ${HOME}/.config/cmus
 blacklist ${HOME}/.config/deadbeef
 blacklist ${HOME}/.config/spotify
 blacklist ${HOME}/.config/vlc
+blacklist ${HOME}/.config/mpv
+blacklist ${HOME}/.config/totem
+blacklist ${HOME}/.config/xplayer
+blacklist ${HOME}/.audacity-data
+blacklist ${HOME}/.guayadeque
 
 # HTTP / FTP / Mail
 blacklist ${HOME}/.icedove
@@ -36,24 +76,46 @@ blacklist ${HOME}/.conkeror.mozdev.org
 blacklist ${HOME}/.config/epiphany
 blacklist ${HOME}/.config/slimjet
 blacklist ${HOME}/.config/qutebrowser
+blacklist ${HOME}/.8pecxstudios
+blacklist ${HOME}/.config/brave
+blacklist ${HOME}/.config/inox
+blacklist ${HOME}/.muttrc
+blacklist ${HOME}/.mutt
+blacklist ${HOME}/.mutt/muttrc
+blacklist ${HOME}/.msmtprc
+blacklist ${HOME}/.config/evolution
+blacklist ${HOME}/.local/share/evolution
+blacklist ${HOME}/.cache/evolution
 
 # Instant Messaging
 blacklist ${HOME}/.config/hexchat
 blacklist ${HOME}/.mcabber
+blacklist ${HOME}/.mcabberrc
 blacklist ${HOME}/.purple
 blacklist ${HOME}/.config/psi+
 blacklist ${HOME}/.retroshare
 blacklist ${HOME}/.weechat
 blacklist ${HOME}/.config/xchat
 blacklist ${HOME}/.Skype
+blacklist ${HOME}/.config/skypeforlinux
 blacklist ${HOME}/.config/tox
 blacklist ${HOME}/.TelegramDesktop
+blacklist ${HOME}/.config/Gitter
+blacklist ${HOME}/.config/Franz
+blacklist ${HOME}/.jitsi
+blacklist ${HOME}/.config/Slack
+blacklist ${HOME}/.cache/gajim
+blacklist ${HOME}/.local/share/gajim
+blacklist ${HOME}/.config/gajim
+blacklist ${HOME}/.config/Wire
 
 # Games
 blacklist ${HOME}/.hedgewars
 blacklist ${HOME}/.steam
 blacklist ${HOME}/.config/wesnoth
 blacklist ${HOME}/.config/0ad
+blacklist ${HOME}/.warzone2100-3.1
+blacklist ${HOME}/.dosbox
 
 # Cryptocoins
 blacklist ${HOME}/.*coin
@@ -83,6 +145,9 @@ blacklist ${HOME}/.cache/icedove
 blacklist ${HOME}/.cache/transmission
 blacklist ${HOME}/.cache/wesnoth
 blacklist ${HOME}/.cache/0ad
+blacklist ${HOME}/.cache/8pecxstudios
+blacklist ${HOME}/.cache/xreader
+blacklist ${HOME}/.cache/Franz
 
 # share
 blacklist ${HOME}/.local/share/epiphany
@@ -91,3 +156,13 @@ blacklist ${HOME}/.local/share/spotify
 blacklist ${HOME}/.local/share/steam
 blacklist ${HOME}/.local/share/wesnoth
 blacklist ${HOME}/.local/share/0ad
+blacklist ${HOME}/.local/share/xplayer
+blacklist ${HOME}/.local/share/totem
+blacklist ${HOME}/.local/share/psi+
+blacklist ${HOME}/.local/share/pix
+blacklist ${HOME}/.local/share/gnome-chess
+blacklist ${HOME}/.local/share/qpdfview
+blacklist ${HOME}/.local/share/zathura
+
+# ssh
+blacklist /tmp/ssh-*

--- a/etc/guayadeque.profile
+++ b/etc/guayadeque.profile
@@ -1,0 +1,19 @@
+noblacklist ${HOME}/.guayadeque
+
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-devel.inc
+
+caps.drop all
+netfilter
+nogroups
+nonewprivs
+noroot
+protocol unix,inet,inet6,netlink
+seccomp
+shell none
+
+private-bin guayadeque
+private-dev
+private-tmp


### PR DESCRIPTION
I created a profile for Guayadeque which works well for me on Fedora 24. I also added 

`blacklist ${HOME}/.guayadeque`

to the media players section in disable-programs.inc.