### PR TITLE
Fixed buggy typo (my fault)

### DIFF
--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -24,7 +24,7 @@ blacklist ${HOME}/.config/libreoffice
 blacklist ${HOME}/.config/pix
 blacklist ${HOME}/.config/mate/eom
 blacklist ${HOME}/.config/xed
-blacklist %{HOME}/.config/pluma
+blacklist ${HOME}/.config/pluma
 blacklist ${HOME}/.kde/share/apps/okular
 blacklist ${HOME}/.kde/share/config/okularrc
 blacklist ${HOME}/.kde/share/config/okularpartrc


### PR DESCRIPTION
I just found when firejail wouldn't start that I had typed "%{HOME}" instead of "${HOME}" for the pluma config line in disable-programs.inc. Oops!
This stopped firejail from running any profile with the line `include /etc/disable-programs.inc`.