### PR TITLE
qutebrowser fixes

### DIFF
--- a/etc/qutebrowser.profile
+++ b/etc/qutebrowser.profile
@@ -18,4 +18,6 @@ mkdir ~/.config/qutebrowser
 whitelist ~/.config/qutebrowser
 mkdir ~/.cache/qutebrowser
 whitelist ~/.cache/qutebrowser
+mkdir ~/.local/share/qutebrowser
+whitelist ~/.local/share/qutebrowser
 include /etc/firejail/whitelist-common.inc


### PR DESCRIPTION
qutebrowser stores sessions/history and other stuff in ~/.local/share/qutebrowser when using the webengine backend.