### PR TITLE
Add keepassx2 profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ prefix your command with “firejail”:
 
 `````
 $ firejail firefox            # starting Mozilla Firefox
-$ firejail transmission-gtk   # starting Transmission BitTorrent 
+$ firejail transmission-gtk   # starting Transmission BitTorrent
 $ firejail vlc                # starting VideoLAN Client
 $ sudo firejail /etc/init.d/nginx start
 `````
@@ -88,5 +88,5 @@ amarok, ark, atool, bleachbit, brasero, dolphin, dragon, elinks, enchant, exifto
 gjs, gnome-books, gnome-clocks, gnome-documents, gnome-maps, gnome-music, gnome-photos, gnome-weather,
 goobox, gpa, gpg, gpg-agent, highlight, img2txt, k3b, kate, lynx, mediainfo, nautilus, odt2txt, pdftotext,
 simple-scan, skanlite, ssh-agent, tracker, transmission-cli, transmission-show, w3m, xfburn, xpra, wget,
-xed, pluma, Cryptocat, Bless, Gnome 2048, Gnome Calculator, Gnome Contacts, JD-GUI, Lollypop, MultiMC5, 
-PDFSam, Pithos, Xonotic, wireshark
+xed, pluma, Cryptocat, Bless, Gnome 2048, Gnome Calculator, Gnome Contacts, JD-GUI, Lollypop, MultiMC5,
+PDFSam, Pithos, Xonotic, wireshark, keepassx2

--- a/RELNOTES
+++ b/RELNOTES
@@ -16,9 +16,9 @@ firejail (0.9.45) baseline; urgency=low
   * feature: config support for firejail prompt in terminal
   * new profiles: xiphos, Tor Browser Bundle, display (imagemagik), Wire,
   * new profiles: mumble, zoom, Guayadeque, qemu, keypass2, xed, pluma,
-  * new profiles: Cryptocat, Bless, Gnome 2048, Gnome Calculator, 
+  * new profiles: Cryptocat, Bless, Gnome 2048, Gnome Calculator,
   * new profiles: Gnome Contacts, JD-GUI, Lollypop, MultiMC5, PDFSam, Pithos,
-  * new profies: Xonotic, wireshark
+  * new profies: Xonotic, wireshark, keepassx2
   * bugfixes
  -- netblue30 <netblue30@yahoo.com>  Sun, 23 Oct 2016 08:00:00 -0500
 
@@ -32,7 +32,7 @@ firejail (0.9.44) baseline; urgency=low
   * feature: support starting/joining sandbox is a single command
     (--join-or-start)
   * feature: X11 detection support for --audit
-  * feature: assign a name to the interface connected to the bridge 
+  * feature: assign a name to the interface connected to the bridge
     (--veth-name)
   * feature: all user home directories are visible (--allusers)
   * feature: add files to sandbox container (--put)
@@ -265,7 +265,7 @@ firejail (0.9.24) baseline; urgency=low
   * two build patches from Reiner Herman (tickets 11, 12)
   * man page patch from Reiner Herman (ticket 13)
   * output patch (ticket 15) from sshirokov
-  
+
  -- netblue30 <netblue30@yahoo.com>  Sun, 5 Apr 2015 08:00:00 -0500
 
 firejail (0.9.22) baseline; urgency=low
@@ -330,7 +330,7 @@ firejail (0.9.16) baseline; urgency=low
  -- netblue30 <netblue30@yahoo.com>  Tue, 4 Nov 2014 10:00:00 -0500
 
 firejail (0.9.14) baseline; urgency=low
-  * Linux capabilities and seccomp filters are automatically enabled in 
+  * Linux capabilities and seccomp filters are automatically enabled in
     chroot mode (--chroot option) if the sandbox is started as regular user
   * Added support for user defined seccomp blacklists
   * Added syscall trace support
@@ -382,7 +382,7 @@ firejail (0.9.8.1) baseline; urgency=low
   * FIxed a number of bugs introduced in 0.9.8
 
  -- netblue30 <netblue30@yahoo.com>  Fri, 25 Jul 2014 07:25:00 -0500
-  
+
 firejail (0.9.8) baseline; urgency=low
   * Implemented nowrap mode for firejail --list command option
   * Added --top option in both firejail and firemon
@@ -391,7 +391,7 @@ firejail (0.9.8) baseline; urgency=low
   * bugfixes
 
  -- netblue30 <netblue30@yahoo.com>  Tue, 24 Jul 2014 08:51:00 -0500
-  
+
 firejail (0.9.6) baseline; urgency=low
 
   * Mounting tmpfs on top of /var/log, required by several server programs
@@ -430,7 +430,7 @@ firejail (0.9.2) baseline; urgency=low
   * Added an expect-based testing framework for the project
   * Added bash completion support
   * Added support for multiple networks
-  
+
  -- netblue30 <netblue30@yahoo.com>  Fri, 25 Apr 2014 08:00:00 -0500
 
 firejail (0.9) baseline; urgency=low

--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -39,19 +39,19 @@ blacklist /usr/share/applications/veracrypt.*
 blacklist /usr/share/pixmaps/veracrypt.*
 blacklist ${HOME}/.VeraCrypt
 
-# TrueCrypt                                                                                                                                                                                                         
-blacklist ${PATH}/truecrypt                                                                                                                                                                                         
-blacklist ${PATH}/truecrypt-uninstall.sh                                                                                                                                                                            
-blacklist /usr/share/truecrypt                                                                                                                                                                                      
-blacklist /usr/share/applications/truecrypt.*                                                                                                                                                                       
-blacklist /usr/share/pixmaps/truecrypt.*                                                                                                                                                                            
-blacklist ${HOME}/.TrueCrypt 
+# TrueCrypt
+blacklist ${PATH}/truecrypt
+blacklist ${PATH}/truecrypt-uninstall.sh
+blacklist /usr/share/truecrypt
+blacklist /usr/share/applications/truecrypt.*
+blacklist /usr/share/pixmaps/truecrypt.*
+blacklist ${HOME}/.TrueCrypt
 
-# zuluCrypt                                                                                                                                                                                                         
-blacklist ${HOME}/.zuluCrypt                                                                                                                                                                                        
-blacklist ${HOME}/.zuluCrypt-socket                                                                                                                                                                                 
-blacklist ${PATH}/zuluCrypt-cli                                                                                                                                                                                     
-blacklist ${PATH}/zuluMount-cli                                                                                                                                                                                                                                                                                                                                                              
+# zuluCrypt
+blacklist ${HOME}/.zuluCrypt
+blacklist ${HOME}/.zuluCrypt-socket
+blacklist ${PATH}/zuluCrypt-cli
+blacklist ${PATH}/zuluMount-cli
 
 # var
 blacklist /var/spool/cron
@@ -154,7 +154,7 @@ blacklist /etc/ssh
 blacklist /var/backup
 blacklist /home/.ecryptfs
 
-# system directories	
+# system directories
 blacklist /sbin
 blacklist /usr/sbin
 blacklist /usr/local/sbin

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -107,7 +107,7 @@ blacklist ${HOME}/.config/katepartrc
 blacklist ${HOME}/.config/katerc
 blacklist ${HOME}/.config/kateschemarc
 blacklist ${HOME}/.config/katesyntaxhighlightingrc
-blacklist ${HOME}/.config/katevirc
+blacklist ${HOME}/.config/katevir
 blacklist ${HOME}/.config/libreoffice
 blacklist ${HOME}/.config/mate/eom
 blacklist ${HOME}/.config/midori
@@ -148,7 +148,7 @@ blacklist ${HOME}/.config/xreader
 blacklist ${HOME}/.config/xviewer
 blacklist ${HOME}/.config/zathura
 blacklist ${HOME}/.config/zoomus.conf
-blacklist ${HOME}/.conkeror.mozdev.org 
+blacklist ${HOME}/.conkeror.mozdev.org
 blacklist ${HOME}/.dillo
 blacklist ${HOME}/.dosbox
 blacklist ${HOME}/.dropbox-dist

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -107,7 +107,7 @@ blacklist ${HOME}/.config/katepartrc
 blacklist ${HOME}/.config/katerc
 blacklist ${HOME}/.config/kateschemarc
 blacklist ${HOME}/.config/katesyntaxhighlightingrc
-blacklist ${HOME}/.config/katevir
+blacklist ${HOME}/.config/katevirc
 blacklist ${HOME}/.config/libreoffice
 blacklist ${HOME}/.config/mate/eom
 blacklist ${HOME}/.config/midori

--- a/etc/keepassx2.profile
+++ b/etc/keepassx2.profile
@@ -1,0 +1,22 @@
+# keepassx password manager profile
+noblacklist ${HOME}/.config/keepassx
+noblacklist ${HOME}/.keepassx
+noblacklist ${HOME}/keepassx.kdbx
+ 
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-passwdmgr.inc
+
+caps.drop all
+nogroups
+nonewprivs
+noroot
+nosound
+protocol unix
+seccomp
+netfilter
+shell none
+
+private-tmp
+private-dev 

--- a/platform/debian/conffiles
+++ b/platform/debian/conffiles
@@ -111,6 +111,7 @@
 /etc/firejail/keepass.profile
 /etc/firejail/keepass2.profile
 /etc/firejail/keepassx.profile
+/etc/firejail/keepassx2.profile
 /etc/firejail/kmail.profile
 /etc/firejail/konversation.profile
 /etc/firejail/less.profile

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -190,6 +190,7 @@ ranger
 keepass
 keepass2
 keepassx
+keepassx2
 pluma
 tracker
 wireshark
@@ -204,4 +205,3 @@ gnome-weather
 ark
 atool
 file-roller
-


### PR DESCRIPTION
Arch uses the `keepassx2` command for keepassx v2, while Debian (Stable, at least) just used `keepassx` for both v1 and v2, so we've now got separate but identical profiles. 

I also removed a bunch of whitespace from disable-common.inc. :smile: 

EDIT: Apparently Atom automatically removes trailing whitespaces, so a few are gone as well.