### PR TITLE
Implement the --allow-private-blacklist option

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -564,6 +564,7 @@ void network_del_run_file(pid_t pid);
 void network_set_run_file(pid_t pid);
 
 // fs_etc.c
+void fs_machineid(void);
 void fs_private_dir_list(const char *private_dir, const char *private_run_dir, const char *private_list);
 
 // no_sandbox.c

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -208,7 +208,7 @@ typedef struct config_t {
 	char *bin_private_keep;	// keep list for private bin directory
 	char *cwd;		// current working directory
 	char *overlay_dir;
-   char *private_template; // template dir for tmpfs home
+	char *private_template; // template dir for tmpfs home
 
 	// networking
 	char *name;		// sandbox name
@@ -285,6 +285,7 @@ void clear_run_files(pid_t pid);
 
 extern int arg_private;		// mount private /home
 extern int arg_private_template; // private /home template
+extern int arg_allow_private_blacklist;  // blacklist things in private directories
 extern int arg_debug;		// print debug messages
 extern int arg_debug_check_filename;		// print debug messages for filename checking
 extern int arg_debug_blacklists;	// print debug messages for blacklists

--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -216,6 +216,15 @@ static void globbing(OPERATION op, const char *pattern, const char *noblacklist[
 				exit(1);
 			}
 		}
+
+		// We don't usually need to blacklist things in private home directories
+		if (okay_to_blacklist
+		 && cfg.homedir
+		 && arg_private
+		 && (!arg_allow_private_blacklist)
+		 && (strncmp(path, cfg.homedir, strlen(cfg.homedir)) == 0))
+			okay_to_blacklist = false;
+
 		if (okay_to_blacklist)
 			disable_file(op, path);
 		else if (arg_debug)

--- a/src/firejail/fs_etc.c
+++ b/src/firejail/fs_etc.c
@@ -21,6 +21,7 @@
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <time.h>
 #include <unistd.h>
 
 // spoof /etc/machine_id

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -112,6 +112,7 @@ int arg_x11_block = 0;				// block X11
 int arg_x11_xorg = 0;				// use X11 security extention
 int arg_allusers = 0;				// all user home directories visible
 int arg_machineid = 0;				// preserve /etc/machine-id
+int arg_allow_private_blacklist = 0;  // blacklist things in private directories
 
 int login_shell = 0;
 
@@ -1462,6 +1463,9 @@ int main(int argc, char **argv) {
 		}
 		else if (strcmp(argv[i], "--machine-id") == 0) {
 			arg_machineid = 1;
+		}
+		else if (strcmp(argv[i], "--allow-private-blacklist") == 0) {
+			arg_allow_private_blacklist = 1;
 		}
 		else if (strcmp(argv[i], "--private") == 0) {
 			arg_private = 1;

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -30,12 +30,14 @@ void usage(void) {
 	printf("Options:\n");
 	printf("    -- - signal the end of options and disables further option processing.\n");
 	printf("    --allow-debuggers - allow tools such as strace and gdb inside the sandbox.\n");
+	printf("    --allow-private-blacklist - allow blacklisting things in private\n");
+	printf("\tdirectories.\n");
 	printf("    --allusers - all user home directories are visible inside the sandbox.\n");
 	printf("    --apparmor - enable AppArmor confinement.\n");
 	printf("    --appimage - sandbox an AppImage application.\n");
 	printf("    --audit[=test-program] - audit the sandbox.\n");
 #ifdef HAVE_NETWORK	
-	printf("    --bandwidth=name|pid - set  bandwidth  limits\n");
+	printf("    --bandwidth=name|pid - set bandwidth limits.\n");
 #endif
 #ifdef HAVE_BIND		
 	printf("    --bind=dirname1,dirname2 - mount-bind dirname1 on top of dirname2.\n");


### PR DESCRIPTION
This patch implements the `--allow-private-blacklist` command line option and disables blacklists in `${HOME}` by default if `${HOME}` is a private directory. The `--allow-private-blacklist` option makes them take effect again (the previous default behaviour).

The patch also cleans up a few compiler warnings in Ubuntu 16.04 and tidies up some miscellaneous code formatting issues.