### PR TITLE
Replace keepassx whitelisting with keepass whitelisting

### DIFF
--- a/etc/abrowser.profile
+++ b/etc/abrowser.profile
@@ -29,13 +29,13 @@ whitelist ~/.config/gnome-mplayer
 whitelist ~/.cache/gnome-mplayer/plugin
 whitelist ~/.pki
 
-# lastpass, keepassx
-whitelist ~/.keepassx
-whitelist ~/.config/keepassx
-whitelist ~/keepassx.kdbx
+# lastpass, keepass
+# for keepass we additionally need to whitelist our .kdbx password database
+whitelist ~/.keepass
+whitelist ~/.config/keepass
+whitelist ~/.config/KeePass
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass
-
 
 #silverlight
 whitelist ~/.wine-pipelight

--- a/etc/chromium.profile
+++ b/etc/chromium.profile
@@ -18,10 +18,11 @@ whitelist ~/.cache/chromium
 mkdir ~/.pki
 whitelist ~/.pki
 
-# lastpass, keepassx
-whitelist ~/.keepassx
-whitelist ~/.config/keepassx
-whitelist ~/keepassx.kdbx
+# lastpass, keepass
+# for keepass we additionally need to whitelist our .kdbx password database
+whitelist ~/.keepass
+whitelist ~/.config/keepass
+whitelist ~/.config/KeePass
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass
 

--- a/etc/cyberfox.profile
+++ b/etc/cyberfox.profile
@@ -29,13 +29,13 @@ whitelist ~/.config/gnome-mplayer
 whitelist ~/.cache/gnome-mplayer/plugin
 whitelist ~/.pki
 
-# lastpass, keepassx
-whitelist ~/.keepassx
-whitelist ~/.config/keepassx
-whitelist ~/keepassx.kdbx
+# lastpass, keepass
+# for keepass we additionally need to whitelist our .kdbx password database
+whitelist ~/.keepass
+whitelist ~/.config/keepass
+whitelist ~/.config/KeePass
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass
-
 
 #silverlight
 whitelist ~/.wine-pipelight

--- a/etc/firefox.profile
+++ b/etc/firefox.profile
@@ -35,13 +35,13 @@ whitelist ~/.config/qpdfview
 whitelist ~/.local/share/qpdfview
 whitelist ~/.kde/share/apps/okular
 
-# lastpass, keepassx
-whitelist ~/.keepassx
-whitelist ~/.config/keepassx
-whitelist ~/keepassx.kdbx
+# lastpass, keepass
+# for keepass we additionally need to whitelist our .kdbx password database
+whitelist ~/.keepass
+whitelist ~/.config/keepass
+whitelist ~/.config/KeePass
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass
-
 
 #silverlight
 whitelist ~/.wine-pipelight

--- a/etc/flashpeak-slimjet.profile
+++ b/etc/flashpeak-slimjet.profile
@@ -29,10 +29,11 @@ whitelist ~/.cache/slimjet
 mkdir ~/.pki
 whitelist ~/.pki
 
-# lastpass, keepassx
-whitelist ~/.keepassx
-whitelist ~/.config/keepassx
-whitelist ~/keepassx.kdbx
+# lastpass, keepass
+# for keepass we additionally need to whitelist our .kdbx password database
+whitelist ~/.keepass
+whitelist ~/.config/keepass
+whitelist ~/.config/KeePass
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass
 

--- a/etc/google-chrome-beta.profile
+++ b/etc/google-chrome-beta.profile
@@ -19,9 +19,10 @@ mkdir ~/.pki
 whitelist ~/.pki
 include /etc/firejail/whitelist-common.inc
 
-# lastpass, keepassx
-whitelist ~/.keepassx
-whitelist ~/.config/keepassx
-whitelist ~/keepassx.kdbx
+# lastpass, keepass
+# for keepass we additionally need to whitelist our .kdbx password database
+whitelist ~/.keepass
+whitelist ~/.config/keepass
+whitelist ~/.config/KeePass
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass

--- a/etc/google-chrome-unstable.profile
+++ b/etc/google-chrome-unstable.profile
@@ -19,9 +19,10 @@ mkdir ~/.pki
 whitelist ~/.pki
 include /etc/firejail/whitelist-common.inc
 
-# lastpass, keepassx
-whitelist ~/.keepassx
-whitelist ~/.config/keepassx
-whitelist ~/keepassx.kdbx
+# lastpass, keepass
+# for keepass we additionally need to whitelist our .kdbx password database
+whitelist ~/.keepass
+whitelist ~/.config/keepass
+whitelist ~/.config/KeePass
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass

--- a/etc/google-chrome.profile
+++ b/etc/google-chrome.profile
@@ -19,10 +19,10 @@ mkdir ~/.pki
 whitelist ~/.pki
 include /etc/firejail/whitelist-common.inc
 
-# lastpass, keepassx
-whitelist ~/.keepassx
-whitelist ~/.config/keepassx
-whitelist ~/keepassx.kdbx
+# lastpass, keepass
+# for keepass we additionally need to whitelist our .kdbx password database
+whitelist ~/.keepass
+whitelist ~/.config/keepass
+whitelist ~/.config/KeePass
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass
-

--- a/etc/icecat.profile
+++ b/etc/icecat.profile
@@ -29,13 +29,13 @@ whitelist ~/.config/gnome-mplayer
 whitelist ~/.cache/gnome-mplayer/plugin
 whitelist ~/.pki
 
-# lastpass, keepassx
-whitelist ~/.keepassx
-whitelist ~/.config/keepassx
-whitelist ~/keepassx.kdbx
+# lastpass, keepass
+# for keepass we additionally need to whitelist our .kdbx password database
+whitelist ~/.keepass
+whitelist ~/.config/keepass
+whitelist ~/.config/KeePass
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass
-
 
 #silverlight
 whitelist ~/.wine-pipelight

--- a/etc/inox.profile
+++ b/etc/inox.profile
@@ -17,6 +17,7 @@ whitelist ~/.pki
 # lastpass, keepass
 # for keepass we additionally need to whitelist our .kdbx password database
 whitelist ~/.keepass
+whitelist ~/.config/keepass
 whitelist ~/.config/KeePass
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass

--- a/etc/inox.profile
+++ b/etc/inox.profile
@@ -14,10 +14,10 @@ whitelist ~/.cache/inox
 mkdir ~/.pki
 whitelist ~/.pki
 
-# lastpass, keepassx
-whitelist ~/.keepassx
-whitelist ~/.config/keepassx
-whitelist ~/keepassx.kdbx
+# lastpass, keepass
+# for keepass we additionally need to whitelist our .kdbx password database
+whitelist ~/.keepass
+whitelist ~/.config/KeePass
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass
 

--- a/etc/netsurf.profile
+++ b/etc/netsurf.profile
@@ -19,10 +19,11 @@ whitelist ~/.config/netsurf
 mkdir ~/.cache/netsurf
 whitelist ~/.cache/netsurf
 
-# lastpass, keepassx
-whitelist ~/.keepassx
-whitelist ~/.config/keepassx
-whitelist ~/keepassx.kdbx
+# lastpass, keepass
+# for keepass we additionally need to whitelist our .kdbx password database
+whitelist ~/.keepass
+whitelist ~/.config/keepass
+whitelist ~/.config/KeePass
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass
 

--- a/etc/opera-beta.profile
+++ b/etc/opera-beta.profile
@@ -19,6 +19,7 @@ include /etc/firejail/whitelist-common.inc
 # lastpass, keepass
 # for keepass we additionally need to whitelist our .kdbx password database
 whitelist ~/.keepass
+whitelist ~/.config/keepass
 whitelist ~/.config/KeePass
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass

--- a/etc/opera-beta.profile
+++ b/etc/opera-beta.profile
@@ -16,10 +16,9 @@ mkdir ~/.pki
 whitelist ~/.pki
 include /etc/firejail/whitelist-common.inc
 
-# lastpass, keepassx
-whitelist ~/.keepassx
-whitelist ~/.config/keepassx
-whitelist ~/keepassx.kdbx
+# lastpass, keepass
+# for keepass we additionally need to whitelist our .kdbx password database
+whitelist ~/.keepass
+whitelist ~/.config/KeePass
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass
-

--- a/etc/opera.profile
+++ b/etc/opera.profile
@@ -19,10 +19,10 @@ mkdir ~/.pki
 whitelist ~/.pki
 include /etc/firejail/whitelist-common.inc
 
-# lastpass, keepassx
-whitelist ~/.keepassx
-whitelist ~/.config/keepassx
-whitelist ~/keepassx.kdbx
+# lastpass, keepass
+# for keepass we additionally need to whitelist our .kdbx password database
+whitelist ~/.keepass
+whitelist ~/.config/keepass
+whitelist ~/.config/KeePass
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass
-

--- a/etc/palemoon.profile
+++ b/etc/palemoon.profile
@@ -44,11 +44,11 @@ private-tmp
 #whitelist ~/.config/pipelight-widevine
 #whitelist ~/.config/pipelight-silverlight5.1
 
-
-# lastpass, keepassx
-whitelist ~/.keepassx
-whitelist ~/.config/keepassx
-whitelist ~/keepassx.kdbx
+# lastpass, keepass
+# for keepass we additionally need to whitelist our .kdbx password database
+whitelist ~/.keepass
+whitelist ~/.config/keepass
+whitelist ~/.config/KeePass
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass
 

--- a/etc/seamonkey.profile
+++ b/etc/seamonkey.profile
@@ -31,10 +31,11 @@ whitelist ~/.cache/gnome-mplayer/plugin
 whitelist ~/.pki
 include /etc/firejail/whitelist-common.inc
 
-# lastpass, keepassx
-whitelist ~/.keepassx
-whitelist ~/.config/keepassx
-whitelist ~/keepassx.kdbx
+# lastpass, keepass
+# for keepass we additionally need to whitelist our .kdbx password database
+whitelist ~/.keepass
+whitelist ~/.config/keepass
+whitelist ~/.config/KeePass
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass
 

--- a/etc/vivaldi.profile
+++ b/etc/vivaldi.profile
@@ -14,10 +14,9 @@ mkdir ~/.cache/vivaldi
 whitelist ~/.cache/vivaldi
 include /etc/firejail/whitelist-common.inc
 
-# lastpass, keepassx
-whitelist ~/.keepassx
-whitelist ~/.config/keepassx
-whitelist ~/keepassx.kdbx
+# lastpass, keepass
+# for keepass we additionally need to whitelist our .kdbx password database
+whitelist ~/.keepass
+whitelist ~/.config/KeePass
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass
-

--- a/etc/vivaldi.profile
+++ b/etc/vivaldi.profile
@@ -17,6 +17,7 @@ include /etc/firejail/whitelist-common.inc
 # lastpass, keepass
 # for keepass we additionally need to whitelist our .kdbx password database
 whitelist ~/.keepass
+whitelist ~/.config/keepass
 whitelist ~/.config/KeePass
 whitelist ~/.lastpass
 whitelist ~/.config/lastpass


### PR DESCRIPTION
1. Removing KeePassX from browser profiles: KeePassX currently doesn't support browser extensions, and thus all browser extensions continue to rely on KeePass, a fitting KeePass plugin and Mono. While this may change in the future and make it necessary to include whitelisting for KeePassX again, its configuration file contains information that can be valuable for attackers (password generator settings, other security settings), and so I would like to join the suggestion of @derekyerger to remove KeePassX whitelisting from browser profiles as long as it is not necessary.

2. Addition of KeePass to browser profiles: as detailed above.

3. Removing the `whitelist ~/keepassx.kdbx`: Harmonized with keepass.profile, where this file is blacklisted (via disable-passwdmgr.inc).

#937 