### PR TITLE
allow multiple private-argv

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1500,6 +1500,10 @@ int main(int argc, char **argv) {
 				}
 				
 				// extract private home dirname
+				if (*(argv[i] + 15) == '\0') {
+					fprintf(stderr, "Error: invalid private-home option\n");
+					exit(1);
+				}
 				cfg.home_private_keep = argv[i] + 15;
 				arg_private = 1;
 			}

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1521,38 +1521,38 @@ int main(int argc, char **argv) {
 			}
 			
 			// extract private etc list
-			cfg.etc_private_keep = argv[i] + 14;
-			if (*cfg.etc_private_keep == '\0') {
+			if (*(argv[i] + 14) == '\0') {
 				fprintf(stderr, "Error: invalid private-etc option\n");
 				exit(1);
 			}
+			cfg.etc_private_keep = argv[i] + 14;
 			arg_private_etc = 1;
 		}
 		else if (strncmp(argv[i], "--private-opt=", 14) == 0) {
 			// extract private opt list
-			cfg.opt_private_keep = argv[i] + 14;
-			if (*cfg.opt_private_keep == '\0') {
+			if (*(argv[i] + 14) == '\0') {
 				fprintf(stderr, "Error: invalid private-opt option\n");
 				exit(1);
 			}
+			cfg.opt_private_keep = argv[i] + 14;
 			arg_private_opt = 1;
 		}
 		else if (strncmp(argv[i], "--private-srv=", 14) == 0) {
 			// extract private srv list
-			cfg.srv_private_keep = argv[i] + 14;
-			if (*cfg.srv_private_keep == '\0') {
+			if (*(argv[i] + 14) == '\0') {
 				fprintf(stderr, "Error: invalid private-etc option\n");
 				exit(1);
 			}
+			cfg.srv_private_keep = argv[i] + 14;
 			arg_private_srv = 1;
 		}
 		else if (strncmp(argv[i], "--private-bin=", 14) == 0) {
 			// extract private bin list
-			cfg.bin_private_keep = argv[i] + 14;
-			if (*cfg.bin_private_keep == '\0') {
+			if (*(argv[i] + 14) == '\0') {
 				fprintf(stderr, "Error: invalid private-bin option\n");
 				exit(1);
 			}
+			cfg.bin_private_keep = argv[i] + 14;
 			arg_private_bin = 1;
 		}
 		else if (strcmp(argv[i], "--private-tmp") == 0) {

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1504,7 +1504,11 @@ int main(int argc, char **argv) {
 					fprintf(stderr, "Error: invalid private-home option\n");
 					exit(1);
 				}
-				cfg.home_private_keep = argv[i] + 15;
+				if (cfg.home_private_keep) {
+					if ( asprintf(&cfg.home_private_keep, "%s,%s", cfg.home_private_keep, argv[i] + 15) < 0 )
+						errExit("asprintf");
+				} else
+					cfg.home_private_keep = argv[i] + 15;
 				arg_private = 1;
 			}
 			else
@@ -1525,7 +1529,11 @@ int main(int argc, char **argv) {
 				fprintf(stderr, "Error: invalid private-etc option\n");
 				exit(1);
 			}
-			cfg.etc_private_keep = argv[i] + 14;
+			if (cfg.etc_private_keep) {
+				if ( asprintf(&cfg.etc_private_keep, "%s,%s", cfg.etc_private_keep, argv[i] + 14) < 0 )
+					errExit("asprintf");
+			} else
+				cfg.etc_private_keep = argv[i] + 14;
 			arg_private_etc = 1;
 		}
 		else if (strncmp(argv[i], "--private-opt=", 14) == 0) {
@@ -1534,7 +1542,11 @@ int main(int argc, char **argv) {
 				fprintf(stderr, "Error: invalid private-opt option\n");
 				exit(1);
 			}
-			cfg.opt_private_keep = argv[i] + 14;
+			if (cfg.opt_private_keep) {
+				if ( asprintf(&cfg.opt_private_keep, "%s,%s", cfg.opt_private_keep, argv[i] + 14) < 0 )
+					errExit("asprintf");
+			} else
+				cfg.opt_private_keep = argv[i] + 14;
 			arg_private_opt = 1;
 		}
 		else if (strncmp(argv[i], "--private-srv=", 14) == 0) {
@@ -1543,7 +1555,11 @@ int main(int argc, char **argv) {
 				fprintf(stderr, "Error: invalid private-etc option\n");
 				exit(1);
 			}
-			cfg.srv_private_keep = argv[i] + 14;
+			if (cfg.srv_private_keep) {
+				if ( asprintf(&cfg.srv_private_keep, "%s,%s", cfg.srv_private_keep, argv[i] + 14) < 0 )
+					errExit("asprintf");
+			} else
+				cfg.srv_private_keep = argv[i] + 14;
 			arg_private_srv = 1;
 		}
 		else if (strncmp(argv[i], "--private-bin=", 14) == 0) {
@@ -1552,7 +1568,11 @@ int main(int argc, char **argv) {
 				fprintf(stderr, "Error: invalid private-bin option\n");
 				exit(1);
 			}
-			cfg.bin_private_keep = argv[i] + 14;
+			if (cfg.bin_private_keep) {
+				if ( asprintf(&cfg.bin_private_keep, "%s,%s", cfg.bin_private_keep, argv[i] + 14) < 0 )
+					errExit("asprintf");
+			} else
+				cfg.bin_private_keep = argv[i] + 14;
 			arg_private_bin = 1;
 		}
 		else if (strcmp(argv[i], "--private-tmp") == 0) {

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -179,7 +179,11 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 	if (strncmp(ptr, "private-home ", 13) == 0) {
 #ifdef HAVE_PRIVATE_HOME
 		if (checkcfg(CFG_PRIVATE_HOME)) {
-			cfg.home_private_keep = ptr + 13;
+			if (cfg.home_private_keep) {
+				if ( asprintf(&cfg.home_private_keep, "%s,%s", cfg.home_private_keep, ptr + 13) < 0 )
+					errExit("asprintf");
+			} else
+				cfg.home_private_keep = ptr + 13;
 			arg_private = 1;
 		}
 		else
@@ -748,7 +752,12 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 			fprintf(stderr, "Error: --private-etc and --writable-etc are mutually exclusive\n");
 			exit(1);
 		}
-		cfg.etc_private_keep = ptr + 12;
+		if (cfg.etc_private_keep) {
+			if ( asprintf(&cfg.etc_private_keep, "%s,%s", cfg.etc_private_keep, ptr + 12) < 0 )
+				errExit("asprintf");
+		} else {
+			cfg.etc_private_keep = ptr + 12;
+		}
 		arg_private_etc = 1;
 		
 		return 0;
@@ -756,7 +765,12 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 
 	// private /opt list of files and directories
 	if (strncmp(ptr, "private-opt ", 12) == 0) {
-		cfg.opt_private_keep = ptr + 12;
+		if (cfg.opt_private_keep) {
+			if ( asprintf(&cfg.opt_private_keep, "%s,%s", cfg.opt_private_keep, ptr + 12) < 0 )
+				errExit("asprintf");
+		} else {
+			cfg.opt_private_keep = ptr + 12;
+		}
 		arg_private_opt = 1;
 		
 		return 0;
@@ -764,7 +778,12 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 
 	// private /srv list of files and directories
 	if (strncmp(ptr, "private-srv ", 12) == 0) {
-		cfg.srv_private_keep = ptr + 12;
+		if (cfg.srv_private_keep) {
+			if ( asprintf(&cfg.srv_private_keep, "%s,%s", cfg.srv_private_keep, ptr + 12) < 0 )
+				errExit("asprintf");
+		} else {
+			cfg.srv_private_keep = ptr + 12;
+		}
 		arg_private_srv = 1;
 		
 		return 0;
@@ -772,7 +791,12 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 
 	// private /bin list of files
 	if (strncmp(ptr, "private-bin ", 12) == 0) {
-		cfg.bin_private_keep = ptr + 12;
+		if (cfg.bin_private_keep) {
+			if ( asprintf(&cfg.bin_private_keep, "%s,%s", cfg.bin_private_keep, ptr + 12) < 0 )
+				errExit("asprintf");
+		} else {
+			cfg.bin_private_keep = ptr + 12;
+		}
 		arg_private_bin = 1;
 		return 0;
 	}


### PR DESCRIPTION
take an example of this ```test.profile```.
```
private-home testA
private-home testB

# default profile
include /usr/local/etc/firejail/default.profile
```

 - running ```firejail --private --profile=test.profile``` copies only ```testB```.
 - running ```firejail --private --profile=test.profile --private-home=testC``` copies only ```testC```
 - running ```firejail --private --profile=test.profile --private-home=testC --private-home=testD``` copies only ```testD```

after this patch:
 - running ```firejail --private --profile=test.profile``` copies  ```testA``` and ```testB```.
 - running ```firejail --private --profile=test.profile --private-home=testC``` copies ```testA```, ```testB``` and ```testC```
 - running ```firejail --private --profile=test.profile --private-home=testC --private-home=testD``` copies ```testA```, ```testB```, ```testC```, and ```testD```

same logic applies for nested ```include``` of other profile files.