### PR TITLE
Don't touch aliases

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -81,6 +81,7 @@ read-only ${HOME}/.profile
 read-only ${HOME}/.antigen
 read-only ${HOME}/.bash_login
 read-only ${HOME}/.bashrc
+read-only ${HOME}/.bash_aliases
 read-only ${HOME}/.bash_profile
 read-only ${HOME}/.bash_logout
 read-only ${HOME}/.zsh.d


### PR DESCRIPTION
.bash_aliases is called from .bashrc and can contain any kind of bash script. As a consequence, this file (which usually only exists if created deliberately) should be restricted as read-only.