### PR TITLE
evolution.profile: add local mail dirs

### DIFF
--- a/etc/evolution.profile
+++ b/etc/evolution.profile
@@ -6,6 +6,9 @@ noblacklist ~/.pki
 noblacklist ~/.pki/nssdb
 noblacklist ~/.gnupg
 
+noblacklist /var/spool/mail
+noblacklist /var/mail
+
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc


### PR DESCRIPTION
`/var/spool/mail/$USERNAME` and `/var/mail/$USERNAME` are valid paths for local mails.

This change is probably also required on other email clients.