### PR TITLE
etc: Support local customizations in *.inc

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -1,3 +1,6 @@
+# Local customizations come here
+include /etc/firejail/disable-common.local
+
 # History files in $HOME
 blacklist-nolog ${HOME}/.history
 blacklist-nolog ${HOME}/.*_history

--- a/etc/disable-common.local
+++ b/etc/disable-common.local
@@ -1,0 +1,1 @@
+# This file is meant for local customizations of disable-common.local

--- a/etc/disable-devel.inc
+++ b/etc/disable-devel.inc
@@ -1,3 +1,6 @@
+# Local customizations come here
+include /etc/firejail/disable-devel.local
+
 # development tools
 
 # GCC

--- a/etc/disable-devel.local
+++ b/etc/disable-devel.local
@@ -1,0 +1,1 @@
+# This file is meant for local customizations of disable-devel.local

--- a/etc/disable-passwdmgr.inc
+++ b/etc/disable-passwdmgr.inc
@@ -1,3 +1,6 @@
+# Local customizations come here
+include /etc/firejail/disable-passwdmgr.local
+
 blacklist ${HOME}/.pki/nssdb
 blacklist ${HOME}/.lastpass
 blacklist ${HOME}/.keepassx

--- a/etc/disable-passwdmgr.local
+++ b/etc/disable-passwdmgr.local
@@ -1,0 +1,1 @@
+# This file is meant for local customizations of disable-passwdmgr.local

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -1,3 +1,6 @@
+# Local customizations come here
+include /etc/firejail/disable-programs.local
+
 blacklist ${HOME}/.*coin
 blacklist ${HOME}/.8pecxstudios
 blacklist ${HOME}/.Atom

--- a/etc/disable-programs.local
+++ b/etc/disable-programs.local
@@ -1,0 +1,1 @@
+# This file is meant for local customizations of disable-programs.local

--- a/etc/whitelist-common.inc
+++ b/etc/whitelist-common.inc
@@ -1,3 +1,6 @@
+# Local customizations come here
+include /etc/firejail/whitelist-common.local
+
 # common whitelist for all profiles
 
 whitelist ~/.XCompose

--- a/etc/whitelist-common.local
+++ b/etc/whitelist-common.local
@@ -1,0 +1,1 @@
+# This file is meant for local customizations of whitelist-common.local


### PR DESCRIPTION
This is useful for places, like [hashbang.sh](https://hashbang.sh), which have site-specific modifications of the *.inc files.

With the current setup, the package manager cannot automatically install updated versions of those files, as it would need to somehow merge the site-specific and upstream changes.  Having the site-specific changes in separate files solves this.