### PR TITLE
disable-common: Make directories commonly found in $PATH read-only

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -117,8 +117,11 @@ read-only ${HOME}/.reportbugrc
 read-only ${HOME}/.xmonad
 read-only ${HOME}/.xscreensaver
 
-# The user ~/bin directory can override commands such as ls
+# Make directories commonly found in $PATH read-only
 read-only ${HOME}/bin
+read-only ${HOME}/.gem
+read-only ${HOME}/.luarocks
+read-only ${HOME}/.npm-packages
 
 # top secret
 blacklist ${HOME}/.ecryptfs


### PR DESCRIPTION
This covers node's NPM, Ruby gems, luarocks packages and the `~/.local` directory.