### PR TITLE
Make ~/.local read-only

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -117,8 +117,11 @@ read-only ${HOME}/.reportbugrc
 read-only ${HOME}/.xmonad
 read-only ${HOME}/.xscreensaver
 
-# The user ~/bin directory can override commands such as ls
+# Make directories commonly found in $PATH read-only
 read-only ${HOME}/bin
+read-only ${HOME}/.gem
+read-only ${HOME}/.luarocks
+read-only ${HOME}/.npm-packages
 
 # top secret
 blacklist ${HOME}/.ecryptfs

--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -123,6 +123,11 @@ read-only ${HOME}/.gem
 read-only ${HOME}/.luarocks
 read-only ${HOME}/.npm-packages
 
+# Make the contents of ~/.local read-only,
+#  except the commonly-used ~/.local/share
+read-only  ${HOME}/.local
+read-write ${HOME}/.local/share
+
 # top secret
 blacklist ${HOME}/.ecryptfs
 blacklist ${HOME}/.Private


### PR DESCRIPTION
This is a stab at handling @reinerh's comments in #1036:
making `~/.local` read-only, and `~/.local/share` read-writeable.

Pro:
- likely doesn't break most things;
- provides sensible protection for `~/.local/{bin,lib,...}`

Con:
- breaks the few applications that write to `~/.local/${app}` directly (I'm not aware of any impacted profile, though);
- doesn't provide any isolation in `~/.local/share`.

I would happily welcome some discussion about what are our options there.