### PR TITLE
blacklist GNOME keyring and Konqueror

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -127,6 +127,7 @@ blacklist ${HOME}/.Private
 blacklist ${HOME}/.ssh
 blacklist ${HOME}/.cert
 blacklist ${HOME}/.gnome2/keyrings
+blacklist ${HOME}/.local/share/keyrings
 blacklist ${HOME}/.kde4/share/apps/kwallet
 blacklist ${HOME}/.kde/share/apps/kwallet
 blacklist ${HOME}/.local/share/kwalletd

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -175,6 +175,7 @@ blacklist ${HOME}/.inkscape
 blacklist ${HOME}/.jitsi
 blacklist ${HOME}/.kde/share/apps/gwenview
 blacklist ${HOME}/.kde/share/apps/kcookiejar
+blacklist ${HOME}/.kde/share/apps/khtml/formcompletions
 blacklist ${HOME}/.kde/share/apps/konqueror
 blacklist ${HOME}/.kde/share/apps/okular
 blacklist ${HOME}/.kde/share/config/gwenviewrc

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -173,6 +173,7 @@ blacklist ${HOME}/.hedgewars
 blacklist ${HOME}/.icedove
 blacklist ${HOME}/.inkscape
 blacklist ${HOME}/.jitsi
+blacklist ${HOME}/.kde/share/apps/kcookiejar
 blacklist ${HOME}/.kde/share/apps/gwenview
 blacklist ${HOME}/.kde/share/apps/okular
 blacklist ${HOME}/.kde/share/config/gwenviewrc

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -175,11 +175,12 @@ blacklist ${HOME}/.inkscape
 blacklist ${HOME}/.jitsi
 blacklist ${HOME}/.kde/share/apps/gwenview
 blacklist ${HOME}/.kde/share/apps/kcookiejar
-blacklist ${HOME}/.kde/share/apps/khtml/formcompletions
+blacklist ${HOME}/.kde/share/apps/khtml
 blacklist ${HOME}/.kde/share/apps/konqsidebartng
 blacklist ${HOME}/.kde/share/apps/konqueror
 blacklist ${HOME}/.kde/share/apps/okular
 blacklist ${HOME}/.kde/share/config/gwenviewrc
+blacklist ${HOME}/.kde/share/config/khtmlrc
 blacklist ${HOME}/.kde/share/config/konq_history
 blacklist ${HOME}/.kde/share/config/konqsidebartngrc
 blacklist ${HOME}/.kde/share/config/konquerorrc

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -180,6 +180,7 @@ blacklist ${HOME}/.kde/share/apps/konqsidebartng
 blacklist ${HOME}/.kde/share/apps/konqueror
 blacklist ${HOME}/.kde/share/apps/okular
 blacklist ${HOME}/.kde/share/config/gwenviewrc
+blacklist ${HOME}/.kde/share/config/kcookiejarrc
 blacklist ${HOME}/.kde/share/config/khtmlrc
 blacklist ${HOME}/.kde/share/config/konq_history
 blacklist ${HOME}/.kde/share/config/konqsidebartngrc

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -176,10 +176,12 @@ blacklist ${HOME}/.jitsi
 blacklist ${HOME}/.kde/share/apps/gwenview
 blacklist ${HOME}/.kde/share/apps/kcookiejar
 blacklist ${HOME}/.kde/share/apps/khtml/formcompletions
+blacklist ${HOME}/.kde/share/apps/konqsidebartng
 blacklist ${HOME}/.kde/share/apps/konqueror
 blacklist ${HOME}/.kde/share/apps/okular
 blacklist ${HOME}/.kde/share/config/gwenviewrc
 blacklist ${HOME}/.kde/share/config/konq_history
+blacklist ${HOME}/.kde/share/config/konqsidebartngrc
 blacklist ${HOME}/.kde/share/config/konquerorrc
 blacklist ${HOME}/.kde/share/config/okularpartrc
 blacklist ${HOME}/.kde/share/config/okularrc

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -173,10 +173,13 @@ blacklist ${HOME}/.hedgewars
 blacklist ${HOME}/.icedove
 blacklist ${HOME}/.inkscape
 blacklist ${HOME}/.jitsi
-blacklist ${HOME}/.kde/share/apps/kcookiejar
 blacklist ${HOME}/.kde/share/apps/gwenview
+blacklist ${HOME}/.kde/share/apps/kcookiejar
+blacklist ${HOME}/.kde/share/apps/konqueror
 blacklist ${HOME}/.kde/share/apps/okular
 blacklist ${HOME}/.kde/share/config/gwenviewrc
+blacklist ${HOME}/.kde/share/config/konq_history
+blacklist ${HOME}/.kde/share/config/konquerorrc
 blacklist ${HOME}/.kde/share/config/okularpartrc
 blacklist ${HOME}/.kde/share/config/okularrc
 blacklist ${HOME}/.killingfloor


### PR DESCRIPTION
- Storage locations for GNOME keyring should be blacklisted.
- Blacklisting data and configuration files associated with Konqueror.