### PR TITLE
uzbl-browser.profile: enabled support for pass password-manager

### DIFF
--- a/etc/uzbl-browser.profile
+++ b/etc/uzbl-browser.profile
@@ -1,7 +1,6 @@
 # Firejail profile for uzbl-browser
 
 noblacklist ~/.config/uzbl
-noblacklist ~/.cache/uzbl
 noblacklist ~/.gnupg
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
@@ -17,8 +16,6 @@ tracelog
 
 mkdir ~/.config/uzbl
 whitelist ~/.config/uzbl
-mkdir ~/.cache/uzbl
-whitelist ~/.cache/uzbl
 mkdir ~/.local/share/uzbl
 whitelist ~/.local/share/uzbl
 

--- a/etc/uzbl-browser.profile
+++ b/etc/uzbl-browser.profile
@@ -2,10 +2,10 @@
 
 noblacklist ~/.config/uzbl
 noblacklist ~/.cache/uzbl
+noblacklist ~/.gnupg
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
-include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 netfilter
@@ -23,5 +23,10 @@ mkdir ~/.local/share/uzbl
 whitelist ~/.local/share/uzbl
 
 whitelist ${DOWNLOADS}
+
+mkdir ~/.gnupg
+whitelist ~/.gnupg
+mkdir ~/.password-store
+whitelist ~/.password-store
 
 include /etc/firejail/whitelist-common.inc


### PR DESCRIPTION
Personally, I only whitelist **~/.gnupg/gpg-agent.conf** and **~/.gnupg/pubring.gpg**, but that might be too restrictive for other users.