### PR TITLE
Prevent tmux connecting to an existing session

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -213,6 +213,8 @@ blacklist /usr/lib64/virtualbox
 
 # prevent lxterminal connecting to an existing lxterminal session
 blacklist /tmp/.lxterminal-socket*
+# prevent tmux connecting to an existing session
+blacklist /tmp/tmux-*
 
 # disable terminals running as server resulting in sandbox escape
 blacklist ${PATH}/gnome-terminal


### PR DESCRIPTION
It breaks tmux inside firejail. 
--private-tmp should be used in order to use tmux inside firejail safely.