### PR TITLE
Fix for uudeview

### DIFF
--- a/etc/uudeview.profile
+++ b/etc/uudeview.profile
@@ -3,7 +3,6 @@ quiet
 ignore noroot
 include /etc/firejail/default.profile
 
-blacklist /etc
 
 hostname uudeview
 net none
@@ -13,3 +12,4 @@ tracelog
 
 private-bin uudeview
 private-dev
+private-etc ld.so.preload


### PR DESCRIPTION
Hopefully this fixes #1032. The error was from the `blacklist /etc` line so I replaced it with `private-etc ld.so.preload`.

Cheers!
Fred