### PR TITLE
fixing --hosts-file privelege check

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -453,6 +453,7 @@ void logargs(int argc, char **argv) ;
 void logerr(const char *msg);
 int copy_file(const char *srcname, const char *destname, uid_t uid, gid_t gid, mode_t mode);
 void copy_file_as_user(const char *srcname, const char *destname, uid_t uid, gid_t gid, mode_t mode);
+void copy_file_from_user_to_root(const char *srcname, const char *destname, uid_t uid, gid_t gid, mode_t mode);
 void touch_file_as_user(const char *fname, uid_t uid, gid_t gid, mode_t mode);
 int is_dir(const char *fname);
 int is_link(const char *fname);

--- a/src/firejail/fs_hostname.c
+++ b/src/firejail/fs_hostname.c
@@ -147,7 +147,7 @@ errexit:
 }
 
 void fs_store_hosts_file(void) {
-	copy_file(cfg.hosts_file, RUN_HOSTS_FILE, 0, 0, 0644); // root needed
+	copy_file_from_user_to_root(cfg.hosts_file, RUN_HOSTS_FILE, 0, 0, 0644); // root needed
 }
 
 void fs_mount_hosts_file(void) {


### PR DESCRIPTION
Currently the code uses the access() call to check if the user has an access to a file that is copied into the root as /etc/hosts. This inevitably adds a race when the user changes the file to a symbolic link pointing to an arbitrary location on the filsystem after the access check is done but before opening the file to copy it. This potentially allows to read any file on the system.

To close this the code adds a utility copy_file_from_user_to_root . It opens the copy destination file as root and then forks/drop privileges. Then as a user the utility opens the source file and do the copy into the destination descriptor that is preserved accross the fork.