### PR TITLE
Security filters

### DIFF
--- a/etc/palemoon.profile
+++ b/etc/palemoon.profile
@@ -23,6 +23,7 @@ shell none
 tracelog
 
 private-bin palemoon
+private-opt palemoon
 private-tmp
 
 # These are uncommented in the Firefox profile. If you run into trouble you may

--- a/etc/qbittorrent.profile
+++ b/etc/qbittorrent.profile
@@ -6,6 +6,7 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 netfilter
+nogroups
 nonewprivs
 noroot
 nosound


### PR DESCRIPTION
The palemoon installer installs the palemoon binary to /opt (and links /usr/bin/palemoon to it) so, since the profile already has private-bin, I added a private-opt filter as well.
Also `nogroups` was added to the qbittorrent profile - I've tested it and it still seems to be working great.

Cheers!
