### PR TITLE
Update unbound profile to block 3D acceleration.

### DIFF
--- a/etc/unbound.profile
+++ b/etc/unbound.profile
@@ -13,5 +13,6 @@ include /etc/firejail/disable-passwdmgr.inc
 private
 private-dev
 nosound
+no3d
 seccomp.drop mount,umount2,ptrace,kexec_load,kexec_file_load,open_by_handle_at,init_module,finit_module,delete_module,iopl,ioperm,swapon,swapoff,syslog,process_vm_readv,process_vm_writev,sysfs,_sysctl,adjtimex,clock_adjtime,lookup_dcookie,perf_event_open,fanotify_init,kcmp,add_key,request_key,keyctl,uselib,acct,modify_ldt,pivot_root,io_setup,io_destroy,io_getevents,io_submit,io_cancel,remap_file_pages,mbind,get_mempolicy,set_mempolicy,migrate_pages,move_pages,vmsplice,perf_event_open
 


### PR DESCRIPTION
There is no legitimate reason for a caching DNS resolver to need 3D acceleration.  Unbound adheres to this already, so any attempts to access GPU hardware from it are by definition either bugs or the result of an exploit, so let's just block access to the GPU.

Tested on my local systems with about 2 dozen different permutations of unbound configuration, double checked by looking through the source code for Unbound.