### PR TITLE
Tighten keepassx

### DIFF
--- a/etc/keepassx.profile
+++ b/etc/keepassx.profile
@@ -1,6 +1,6 @@
 # This file is overwritten during software install.
 # Persistent customizations should go in a .local file.
-include /etc/firejail/keepassx.local
+include /etc/firejail/keepassx2.local
 
 # keepassx password manager profile
 noblacklist ${HOME}/.config/keepassx
@@ -13,14 +13,17 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+net none
 nogroups
 nonewprivs
 noroot
 nosound
 protocol unix
 seccomp
-netfilter
 shell none
+tracelog
 
+private-bin keepassx
+private-etc fonts
+private-dev
 private-tmp
-private-dev 

--- a/etc/keepassx.profile
+++ b/etc/keepassx.profile
@@ -1,6 +1,6 @@
 # This file is overwritten during software install.
 # Persistent customizations should go in a .local file.
-include /etc/firejail/keepassx2.local
+include /etc/firejail/keepassx.local
 
 # keepassx password manager profile
 noblacklist ${HOME}/.config/keepassx

--- a/etc/keepassx2.profile
+++ b/etc/keepassx2.profile
@@ -13,14 +13,16 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+net none
 nogroups
 nonewprivs
 noroot
 nosound
 protocol unix
 seccomp
-netfilter
 shell none
 
+private-bin keepassx2
+private-etc fonts
+private-dev
 private-tmp
-private-dev 


### PR DESCRIPTION
G'day @netblue30 . This tightens the keepassx profiles a little bit.

I was under the impression `net none` meant the netlink socket was closed, but `firejail --audit` says:
```MAYBE: I can connect to netlink socket. Network utilities such as iproute2 will work fine in the sandbox. You can use "--protocol" to disable the socket.```
So I've kept `protocol unix` in addition to adding `net none`. Is that correct?

Cheers!