### PR TITLE
fixing and tidying up Keepass(x) profiles

### DIFF
--- a/etc/disable-passwdmgr.inc
+++ b/etc/disable-passwdmgr.inc
@@ -3,8 +3,6 @@ blacklist ${HOME}/.lastpass
 blacklist ${HOME}/.keepassx
 blacklist ${HOME}/.keepass
 blacklist ${HOME}/.password-store
-blacklist ${HOME}/keepassx.kdbx
 blacklist ${HOME}/.config/keepassx
 blacklist ${HOME}/.config/keepass
 blacklist ${HOME}/.config/KeePass
-

--- a/etc/keepass.profile
+++ b/etc/keepass.profile
@@ -1,6 +1,7 @@
 # keepass password manager profile
-noblacklist ${HOME}/.config/keepass
 noblacklist ${HOME}/.keepass
+noblacklist ${HOME}/.config/keepass
+noblacklist ${HOME}/.config/KeePass
 noblacklist ${HOME}/*.kdbx
 noblacklist ${HOME}/*.kdb
  

--- a/etc/keepass.profile
+++ b/etc/keepass.profile
@@ -1,6 +1,8 @@
 # keepass password manager profile
 noblacklist ${HOME}/.config/keepass
 noblacklist ${HOME}/.keepass
+noblacklist ${HOME}/*.kdbx
+noblacklist ${HOME}/*.kdb
  
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc

--- a/etc/keepass2.profile
+++ b/etc/keepass2.profile
@@ -1,5 +1,2 @@
 # keepass password manager profile
-#noblacklist ${HOME}/.config/KeePass
-#noblacklist ${HOME}/.keepass
- 
 include /etc/firejail/keepass.profile

--- a/etc/keepassx.profile
+++ b/etc/keepassx.profile
@@ -3,7 +3,6 @@ noblacklist ${HOME}/.config/keepassx
 noblacklist ${HOME}/.keepassx
 noblacklist ${HOME}/*.kdbx
 noblacklist ${HOME}/*.kdb
-noblacklist ${HOME}/keepassx.kdbx
  
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc

--- a/etc/keepassx.profile
+++ b/etc/keepassx.profile
@@ -1,6 +1,8 @@
 # keepassx password manager profile
 noblacklist ${HOME}/.config/keepassx
 noblacklist ${HOME}/.keepassx
+noblacklist ${HOME}/*.kdbx
+noblacklist ${HOME}/*.kdb
 noblacklist ${HOME}/keepassx.kdbx
  
 include /etc/firejail/disable-common.inc

--- a/etc/keepassx2.profile
+++ b/etc/keepassx2.profile
@@ -1,7 +1,6 @@
 # keepassx password manager profile
 noblacklist ${HOME}/.config/keepassx
 noblacklist ${HOME}/.keepassx
-noblacklist ${HOME}/keepassx.kdbx
  
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc

--- a/etc/keepassx2.profile
+++ b/etc/keepassx2.profile
@@ -1,6 +1,8 @@
 # keepassx password manager profile
 noblacklist ${HOME}/.config/keepassx
 noblacklist ${HOME}/.keepassx
+noblacklist ${HOME}/*.kdbx
+noblacklist ${HOME}/*.kdb
  
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc


### PR DESCRIPTION
*.kdb and *.kdbx files were blacklisted in ${HOME} via diable-common.inc, but this was not disabled for Keepass and KeepassX.

Further, ${HOME}/keepassx.kdbx doesn't need to be blacklisted separately, as it is already contained in above mentioned blacklist.