### PR TITLE
profile for engrampa

### DIFF
--- a/etc/engrampa.profile
+++ b/etc/engrampa.profile
@@ -13,7 +13,6 @@ nogroups
 nonewprivs
 noroot
 nosound
-no3d
 protocol unix
 seccomp
 netfilter

--- a/etc/engrampa.profile
+++ b/etc/engrampa.profile
@@ -1,0 +1,26 @@
+# This file is overwritten during software install.
+# Persistent customizations should go in a .local file.
+include /etc/firejail/engrampa.local
+
+# engrampa profile
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-passwdmgr.inc
+
+caps.drop all
+nogroups
+nonewprivs
+noroot
+nosound
+no3d
+protocol unix
+seccomp
+netfilter
+shell none
+tracelog
+
+# private-bin engrampa
+# private-tmp
+private-dev
+# private-etc fonts

--- a/etc/file-roller.profile
+++ b/etc/file-roller.profile
@@ -13,6 +13,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+no3d
 protocol unix
 seccomp
 netfilter

--- a/etc/file-roller.profile
+++ b/etc/file-roller.profile
@@ -13,7 +13,6 @@ nogroups
 nonewprivs
 noroot
 nosound
-no3d
 protocol unix
 seccomp
 netfilter


### PR DESCRIPTION
Forked from file-roller.profile. Tested and works well for me.

At first I had `no3d` in the profile, but then I was under the impression that `no3d` is already included in `nogroups` (membership in the video group should be a precondition for access to hardware acceleration), and so I removed it again.

Please correct as necessary.