### PR TITLE
complete autostart blacklist for KDE

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -20,6 +20,7 @@ blacklist ${HOME}/.kde4/Autostart
 blacklist ${HOME}/.kde4/share/autostart
 blacklist ${HOME}/.kde/Autostart
 blacklist ${HOME}/.kde/share/autostart
+blacklist ${HOME}/.config/autostart-scripts
 blacklist ${HOME}/.config/plasma-workspace/shutdown
 blacklist ${HOME}/.config/plasma-workspace/env
 blacklist ${HOME}/.config/lxsession/LXDE/autostart


### PR DESCRIPTION
One more autostart folder used by Plasma ([ArchWiki](https://wiki.archlinux.org/index.php/KDE#Autostarting_applications))