### PR TITLE
enable/disable join support in /etc/firejail/firejail.config

### DIFF
--- a/etc/firejail.config
+++ b/etc/firejail.config
@@ -43,6 +43,10 @@
 # that is partially under their control.  Default disabled.
 # force-nonewprivs no
 
+# Allow sandbox joining as a regular user, default enabled.
+# root user can always join sandboxes.
+# join yes
+
 # Enable or disable networking features, default enabled.
 # network yes
 

--- a/src/firejail/checkcfg.c
+++ b/src/firejail/checkcfg.c
@@ -92,6 +92,15 @@ int checkcfg(int val) {
 				else
 					goto errout;
 			}
+			// join
+			else if (strncmp(ptr, "join ", 5) == 0) {
+				if (strcmp(ptr + 5, "yes") == 0)
+					cfg_val[CFG_JOIN] = 1;
+				else if (strcmp(ptr + 5, "no") == 0)
+					cfg_val[CFG_JOIN] = 0;
+				else
+					goto errout;
+			}
 			// x11
 			else if (strncmp(ptr, "x11 ", 4) == 0) {
 				if (strcmp(ptr + 4, "yes") == 0)

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -686,6 +686,7 @@ enum {
 	CFG_FOLLOW_SYMLINK_PRIVATE_BIN,
 	CFG_DISABLE_MNT,
 	CFG_CACHE_TMPFS,
+	CFG_JOIN,
 	CFG_MAX // this should always be the last entry
 };
 extern char *xephyr_screen;


### PR DESCRIPTION
I introduced a config param in /etc/fierjail/firejail.confg to disable --join command for non-root users.