### PR TITLE
profile enhancements

### DIFF
--- a/etc/audacious.profile
+++ b/etc/audacious.profile
@@ -4,13 +4,21 @@ include /etc/firejail/audacious.local
 
 # Audacious media player profile
 noblacklist ~/.config/audacious
+noblacklist ~/.config/Audaciousrc
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nonewprivs
 noroot
 protocol unix,inet,inet6
 seccomp
+shell none
+tracelog
+
+private-bin audacious
+private-dev
+private-tmp

--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -165,6 +165,7 @@ blacklist ${HOME}/*.key
 blacklist ${HOME}/.muttrc
 blacklist ${HOME}/.mutt/muttrc
 blacklist ${HOME}/.msmtprc
+blacklist ${HOME}/.pki
 blacklist /etc/shadow
 blacklist /etc/gshadow
 blacklist /etc/passwd-

--- a/etc/disable-passwdmgr.inc
+++ b/etc/disable-passwdmgr.inc
@@ -2,7 +2,7 @@
 # Persistent customizations should go in a .local file.
 include /etc/firejail/disable-passwdmgr.local
 
-blacklist ${HOME}/.pki/nssdb
+blacklist ${HOME}/.pki
 blacklist ${HOME}/.lastpass
 blacklist ${HOME}/.keepassx
 blacklist ${HOME}/.keepass

--- a/etc/disable-passwdmgr.inc
+++ b/etc/disable-passwdmgr.inc
@@ -2,7 +2,6 @@
 # Persistent customizations should go in a .local file.
 include /etc/firejail/disable-passwdmgr.local
 
-blacklist ${HOME}/.pki
 blacklist ${HOME}/.lastpass
 blacklist ${HOME}/.keepassx
 blacklist ${HOME}/.keepass

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -58,6 +58,7 @@ blacklist ${HOME}/.cache/xreader
 blacklist ${HOME}/.claws-mail
 blacklist ${HOME}/.config/0ad
 blacklist ${HOME}/.config/Atom
+blacklist ${HOME}/.config/Audaciousrc
 blacklist ${HOME}/.config/Brackets
 blacklist ${HOME}/.config/Cryptocat
 blacklist ${HOME}/.config/Franz
@@ -108,6 +109,7 @@ blacklist ${HOME}/.config/google-chrome
 blacklist ${HOME}/.config/google-chrome-beta
 blacklist ${HOME}/.config/google-chrome-unstable
 blacklist ${HOME}/.config/gthumb
+blacklist ${HOME}/.config/gwenviewrc
 blacklist ${HOME}/.config/hexchat
 blacklist ${HOME}/.config/inox
 blacklist ${HOME}/.config/jd-gui.cfg
@@ -125,6 +127,7 @@ blacklist ${HOME}/.config/nautilus
 blacklist ${HOME}/.config/netsurf
 blacklist ${HOME}/.config/opera
 blacklist ${HOME}/.config/opera-beta
+blacklist ${HOME}/.config/org.kde.gwenviewrc
 blacklist ${HOME}/.config/pix
 blacklist ${HOME}/.config/pluma
 blacklist ${HOME}/.config/psi+
@@ -267,6 +270,7 @@ blacklist ${HOME}/.qemu-launcher
 blacklist ${HOME}/.remmina
 blacklist ${HOME}/.retroshare
 blacklist ${HOME}/.scribus
+blacklist ${HOME}/.scribusrc
 blacklist ${HOME}/.steam
 blacklist ${HOME}/.steampath
 blacklist ${HOME}/.steampid

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -264,7 +264,6 @@ blacklist ${HOME}/.openshot
 blacklist ${HOME}/.openshot_qt
 blacklist ${HOME}/.opera
 blacklist ${HOME}/.opera-beta
-blacklist ${HOME}/.pki
 blacklist ${HOME}/.purple
 blacklist ${HOME}/.qemu-launcher
 blacklist ${HOME}/.remmina

--- a/etc/gwenview.profile
+++ b/etc/gwenview.profile
@@ -16,7 +16,7 @@ caps.drop all
 nogroups
 nonewprivs
 noroot
-protocol unix,netlink
+protocol unix
 seccomp
 tracelog
 

--- a/etc/gwenview.profile
+++ b/etc/gwenview.profile
@@ -5,6 +5,8 @@ include /etc/firejail/gwenview.local
 # KDE gwenview profile
 noblacklist ~/.kde/share/apps/gwenview
 noblacklist ~/.kde/share/config/gwenviewrc
+noblacklist ~/.config/gwenviewrc
+noblacklist ~/.config/org.kde.gwenviewrc
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
@@ -14,13 +16,13 @@ caps.drop all
 nogroups
 nonewprivs
 noroot
-protocol unix
+protocol unix,netlink
 seccomp
-nosound
+tracelog
 
 private-dev
 
-#Experimental:
+# Experimental:
 #shell none
 #private-bin gwenview
 #private-etc X11

--- a/etc/scribus.profile
+++ b/etc/scribus.profile
@@ -5,8 +5,14 @@ include /etc/firejail/scribus.local
 # Firejail profile for Scribus
 noblacklist ~/.scribus
 noblacklist ~/.config/scribus
+noblacklist ~/.config/scribusrc
 noblacklist ~/.local/share/scribus
 noblacklist ~/.gimp*
+
+# Support for PDF readers (Scribus 1.5 and higher)
+noblacklist ~/.kde/share/apps/okular
+noblacklist ~/.kde/share/config/okularrc
+noblacklist ~/.kde/share/config/okularpartrc
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc


### PR DESCRIPTION
- harden audacious profile
- added KFileDialog history to blacklist (~/.config/Audaciousrc, ~/.config/scribusrc)
- added pdf reader support to scribus profile (feature is not yet available in scribus stable though)
- `netlink` added to gwenview profile.
**EDIT/REPEATED UPDATE:** during startup there is a complaint `UdevQt: unable to create udev monitor connection`, which disappears when the netlink protocol is allowed. 
Google shows this string is in the [sources](https://github.com/KDE/solid/blob/master/src/solid/devices/backends/shared/udevqtclient.cpp) of [solid](https://techbase.kde.org/Development/Architecture/KDE4/Solid), and apparently it is printed when monitoring of the kernel uevent netlink socket fails. Btw, other programs that depend on the solid library and show exactly the same behavior include Dolphin and Amarok.
However, [here](https://cgit.kde.org/gwenview.git/commit/?id=8c6252178b6376d593f8645bae2e8156d2e009e3&context=1&ignorews=0&dt=0) it looks like solid is used only to display more precise device information and nicer icons in gwenviews import dialogue, which has been disabled anyways for gwenview5 (but will come back in the future). 
The sources also contain two device actions for automatically opening the import dialogue, e.g. when a camera is plugged in, but as far as I understand device actions hide all that netlink stuff from the target application. Guess we don't necessarily need netlink then :) I'll remove it again.
- `nosound` removes the sound from video previews in gwenview
- added gwenview KDE5 configuration files
- ~/.pki blacklisting moved from disable-programs.inc to disable-common.inc (it's the best place I found for it, although "top secret" doesn't really describe what it is)