### PR TITLE
Adds icedove directories in thunderbird profile

### DIFF
--- a/etc/thunderbird.profile
+++ b/etc/thunderbird.profile
@@ -14,6 +14,10 @@ noblacklist ~/.thunderbird
 mkdir ~/.thunderbird
 whitelist ~/.thunderbird
 
+noblacklist ~/.icedove
+mkdir ~/.icedove
+whitelist ~/.icedove
+
 # allow browsers
 ignore private-tmp
 include /etc/firejail/firefox.profile


### PR DESCRIPTION
In debian stretch icedove is renamed to thunderbird. This happens
as of icedove version 1:45.7.1-1, see debian bug #816679 for
details.

Thunderbird debian package, as of stretch, contains a migration
script for user profiles. Namely /usr/bin/thunderbird is a wrapper
script, thunderbird-wrapper.sh. This scripts symlinks ~/.icedove
(if exists) to ~/.thunderbird thus ensuring Thunderbird will be
able to read old user's profiles.

That symlink breaks thunderbird when run with firejail since
firejail thunderbird.profile does not allow access to ~/.icedove.

This commit modifies accordingly the thunderbird.profile.