### PR TITLE
tidy up

### DIFF
--- a/etc/abrowser.profile
+++ b/etc/abrowser.profile
@@ -6,7 +6,6 @@ include /etc/firejail/abrowser.local
 noblacklist ~/.mozilla
 noblacklist ~/.cache/mozilla
 noblacklist ~/.pki
-noblacklist ~/.lastpass
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc

--- a/etc/cyberfox.profile
+++ b/etc/cyberfox.profile
@@ -6,7 +6,6 @@ include /etc/firejail/cyberfox.local
 noblacklist ~/.8pecxstudios
 noblacklist ~/.cache/8pecxstudios
 noblacklist ~/.pki
-noblacklist ~/.lastpass
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc

--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -6,11 +6,8 @@ include /etc/firejail/disable-common.local
 blacklist-nolog ${HOME}/.history
 blacklist-nolog ${HOME}/.*_history
 blacklist-nolog ${HOME}/.bash_history
-blacklist ${HOME}/.local/share/systemd
-blacklist ${HOME}/.config/systemd
 blacklist-nolog ${HOME}/.adobe
 blacklist-nolog ${HOME}/.macromedia
-read-only ${HOME}/.local/share/applications
 
 # X11 session autostart
 blacklist ${HOME}/.xinitrc
@@ -73,6 +70,10 @@ blacklist ${HOME}/.local/share/konsole
 blacklist ${HOME}/.local/share/kservices5
 blacklist ${HOME}/.local/share/plasma
 blacklist ${HOME}/.local/share/solid
+
+# systemd
+blacklist ${HOME}/.local/share/systemd
+blacklist ${HOME}/.config/systemd
 
 # VirtualBox
 blacklist ${HOME}/.VirtualBox
@@ -177,9 +178,11 @@ read-only ${HOME}/.luarocks
 read-only ${HOME}/.npm-packages
 
 # Make the contents of ~/.local read-only,
-#  except the commonly-used ~/.local/share
+#  except the commonly-used ~/.local/share,
+#   but including ~/.local/share/applications
 read-only  ${HOME}/.local
 read-write ${HOME}/.local/share
+read-only  ${HOME}/.local/share/applications
 
 # top secret
 blacklist ${HOME}/.ecryptfs

--- a/etc/firefox.profile
+++ b/etc/firefox.profile
@@ -10,7 +10,6 @@ noblacklist ~/.local/share/qpdfview
 noblacklist ~/.kde4/share/apps/okular
 noblacklist ~/.kde/share/apps/okular
 noblacklist ~/.pki
-noblacklist ~/.lastpass
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc

--- a/etc/icecat.profile
+++ b/etc/icecat.profile
@@ -6,7 +6,6 @@ include /etc/firejail/icecat.local
 noblacklist ~/.mozilla
 noblacklist ~/.cache/mozilla
 noblacklist ~/.pki
-noblacklist ~/.lastpass
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc

--- a/etc/midori.profile
+++ b/etc/midori.profile
@@ -8,7 +8,6 @@ noblacklist ~/.local/share/midori
 noblacklist ~/.local/share/webkit
 noblacklist ~/.local/share/webkitgtk
 noblacklist ~/.pki
-noblacklist ~/.lastpass
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc

--- a/etc/seamonkey.profile
+++ b/etc/seamonkey.profile
@@ -6,7 +6,6 @@ include /etc/firejail/seamonkey.local
 noblacklist ~/.mozilla
 noblacklist ~/.cache/mozilla
 noblacklist ~/.pki
-noblacklist ~/.lastpass
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc


### PR DESCRIPTION
1. `noblacklist ~/.lastpass` is redundant code, because there is no `include /etc/firejail/disable-passwdmgr.inc` in these profiles...... and I myself introduced it! I can't recall the details of how this happened, but please let's get rid of it.
2. minor reorganization in disable-common.inc