### PR TITLE
Allow fish_config

### DIFF
--- a/etc/firefox.profile
+++ b/etc/firefox.profile
@@ -43,6 +43,7 @@ whitelist ~/.config/qpdfview
 whitelist ~/.local/share/qpdfview
 whitelist ~/.kde4/share/apps/okular
 whitelist ~/.kde/share/apps/okular
+whitelist ~/.cache/fish
 
 # silverlight
 whitelist ~/.wine-pipelight


### PR DESCRIPTION
[fish_config](https://fishshell.com/docs/current/commands.html#fish_config) command launches the default web browser pointing to `~/.cache/fish/web_config-<six random chars>.html`. This allows to edit fish shell configuration with sandboxed firefox.