### PR TITLE
Okular and Gwenview profiles, Baloo blacklist

### DIFF
--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -96,6 +96,8 @@ blacklist ${HOME}/.config/mupen64plus
 blacklist ${HOME}/.config/nautilus
 blacklist ${HOME}/.config/nemo
 blacklist ${HOME}/.config/netsurf
+blacklist ${HOME}/.config/okularpartrc
+blacklist ${HOME}/.config/okularrc
 blacklist ${HOME}/.config/opera
 blacklist ${HOME}/.config/opera-beta
 blacklist ${HOME}/.config/org.kde.gwenviewrc
@@ -225,6 +227,7 @@ blacklist ${HOME}/.local/share/multimc5
 blacklist ${HOME}/.local/share/mupen64plus
 blacklist ${HOME}/.local/share/nautilus
 blacklist ${HOME}/.local/share/nemo
+blacklist ${HOME}/.local/share/okular
 blacklist ${HOME}/.local/share/org.kde.gwenview
 blacklist ${HOME}/.local/share/pix
 blacklist ${HOME}/.local/share/psi+

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -45,6 +45,8 @@ blacklist ${HOME}/.config/arkrc
 blacklist ${HOME}/.config/atril
 blacklist ${HOME}/.config/audacious
 blacklist ${HOME}/.config/aweather
+blacklist ${HOME}/.config/baloofilerc
+blacklist ${HOME}/.config/baloorc
 blacklist ${HOME}/.config/blender
 blacklist ${HOME}/.config/bless
 blacklist ${HOME}/.config/borg
@@ -159,6 +161,7 @@ blacklist ${HOME}/.kde4/share/apps/khtml
 blacklist ${HOME}/.kde4/share/apps/konqsidebartng
 blacklist ${HOME}/.kde4/share/apps/konqueror
 blacklist ${HOME}/.kde4/share/apps/okular
+blacklist ${HOME}/.kde4/share/config/baloofilerc
 blacklist ${HOME}/.kde4/share/config/gwenviewrc
 blacklist ${HOME}/.kde4/share/config/k3brc
 blacklist ${HOME}/.kde4/share/config/kcookiejarrc
@@ -174,6 +177,7 @@ blacklist ${HOME}/.kde/share/apps/khtml
 blacklist ${HOME}/.kde/share/apps/konqsidebartng
 blacklist ${HOME}/.kde/share/apps/konqueror
 blacklist ${HOME}/.kde/share/apps/okular
+blacklist ${HOME}/.kde/share/config/baloofilerc
 blacklist ${HOME}/.kde/share/config/gwenviewrc
 blacklist ${HOME}/.kde/share/config/k3brc
 blacklist ${HOME}/.kde/share/config/kcookiejarrc
@@ -202,6 +206,7 @@ blacklist ${HOME}/.local/share/SuperHexagon
 blacklist ${HOME}/.local/share/Terraria
 blacklist ${HOME}/.local/share/TpLogger
 blacklist ${HOME}/.local/share/aspyr-media
+blacklist ${HOME}/.local/share/baloo
 blacklist ${HOME}/.local/share/cdprojektred
 blacklist ${HOME}/.local/share/data/Mumble
 blacklist ${HOME}/.local/share/dolphin

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -82,6 +82,7 @@ blacklist ${HOME}/.config/gwenviewrc
 blacklist ${HOME}/.config/hexchat
 blacklist ${HOME}/.config/inox
 blacklist ${HOME}/.config/jd-gui.cfg
+blacklist ${HOME}/.config/k3brc
 blacklist ${HOME}/.config/katepartrc
 blacklist ${HOME}/.config/katerc
 blacklist ${HOME}/.config/kateschemarc

--- a/etc/firefox.profile
+++ b/etc/firefox.profile
@@ -9,6 +9,7 @@ noblacklist ~/.config/qpdfview
 noblacklist ~/.local/share/qpdfview
 noblacklist ~/.kde4/share/apps/okular
 noblacklist ~/.kde/share/apps/okular
+noblacklist ~/.local/share/okular
 noblacklist ~/.pki
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
@@ -43,6 +44,7 @@ whitelist ~/.config/qpdfview
 whitelist ~/.local/share/qpdfview
 whitelist ~/.kde4/share/apps/okular
 whitelist ~/.kde/share/apps/okular
+whitelist ~/.local/share/okular
 
 # silverlight
 whitelist ~/.wine-pipelight

--- a/etc/gwenview.profile
+++ b/etc/gwenview.profile
@@ -27,5 +27,5 @@ private-dev
 
 # Experimental:
 #shell none
-#private-bin gwenview
+#private-bin gwenview,kbuildsycoca4,gimp,gimp-2.8
 #private-etc X11

--- a/etc/gwenview.profile
+++ b/etc/gwenview.profile
@@ -21,11 +21,11 @@ nonewprivs
 noroot
 protocol unix
 seccomp
+shell none
 tracelog
 
+private-bin gwenview,kbuildsycoca4,gimp,gimp-2.8
 private-dev
 
 # Experimental:
-#shell none
-#private-bin gwenview,kbuildsycoca4,gimp,gimp-2.8
 #private-etc X11

--- a/etc/okular.profile
+++ b/etc/okular.profile
@@ -25,7 +25,7 @@ seccomp
 shell none
 tracelog
 
-# private-bin okular,kbuildsycoca4,kbuildsycoca5  
+# private-bin okular,kbuildsycoca4,kbuildsycoca5,lpr
 # private-etc fonts,X11
 private-dev
 private-tmp

--- a/etc/okular.profile
+++ b/etc/okular.profile
@@ -9,6 +9,9 @@ noblacklist ~/.kde4/share/config/okularpartrc
 noblacklist ~/.kde/share/apps/okular
 noblacklist ~/.kde/share/config/okularrc
 noblacklist ~/.kde/share/config/okularpartrc
+noblacklist ~/.local/share/okular
+noblacklist ~/.config/okularrc
+noblacklist ~/.config/okularpartrc
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc

--- a/etc/okular.profile
+++ b/etc/okular.profile
@@ -28,7 +28,7 @@ seccomp
 shell none
 tracelog
 
-# private-bin okular,kbuildsycoca4,kbuildsycoca5,lpr
+# private-bin okular,kbuildsycoca4,lpr
 # private-etc fonts,X11
 private-dev
 private-tmp

--- a/etc/scribus.profile
+++ b/etc/scribus.profile
@@ -16,6 +16,9 @@ noblacklist ~/.kde4/share/config/okularpartrc
 noblacklist ~/.kde/share/apps/okular
 noblacklist ~/.kde/share/config/okularrc
 noblacklist ~/.kde/share/config/okularpartrc
+noblacklist ~/.local/share/okular
+noblacklist ~/.config/okularrc
+noblacklist ~/.config/okularpartrc
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc


### PR DESCRIPTION
- Gwenview: This patch is necessary for the KDE4 build, the KF5 build doesn't need any of it.
- Okular: It was already described in #421, and I can confirm that printing from okular is not possible without `private-bin lpr`