### PR TITLE
new baloo profile

### DIFF
--- a/etc/baloo_file.profile
+++ b/etc/baloo_file.profile
@@ -20,9 +20,13 @@ nonewprivs
 noroot
 nosound
 protocol unix
-# Baloo makes ioprio_set system calls, which are blacklisted by default. 
+# Baloo makes ioprio_set system calls, which are blacklisted by default.
 # That's why we need to disable seccomp
 #seccomp
+# The Baloo file daemon can be isolated from X11. If there is an X11
+# abstract Unix socket, it must be disabled first by passing "-nolisten local"
+# to the X server. See the Firejail manual for further instructions
+#x11 none
 
 private-dev
 private-tmp

--- a/etc/baloo_file.profile
+++ b/etc/baloo_file.profile
@@ -23,10 +23,8 @@ protocol unix
 # Baloo makes ioprio_set system calls, which are blacklisted by default.
 # That's why we need to disable seccomp
 #seccomp
-# The Baloo file daemon can be isolated from X11. If there is an X11
-# abstract Unix socket, it must be disabled first by passing "-nolisten local"
-# to the X server. See the Firejail manual for further instructions
-#x11 none
+
+blacklist /tmp/.X11-unix
 
 private-dev
 private-tmp

--- a/etc/baloo_file.profile
+++ b/etc/baloo_file.profile
@@ -1,0 +1,39 @@
+# This file is overwritten during software install.
+# Persistent customizations should go in a .local file.
+include /etc/firejail/baloo_file.local
+
+# KDE Baloo file daemon profile
+noblacklist ${HOME}/.kde4/share/config/baloofilerc
+noblacklist ${HOME}/.kde4/share/config/baloorc
+noblacklist ${HOME}/.kde/share/config/baloofilerc
+noblacklist ${HOME}/.kde/share/config/baloorc
+noblacklist ${HOME}/.config/baloofilerc
+noblacklist ${HOME}/.local/share/baloo
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-passwdmgr.inc
+
+caps.drop all
+nogroups
+nonewprivs
+noroot
+nosound
+protocol unix
+# Baloo makes ioprio_set system calls, which are blacklisted by default. 
+# That's why we need to disable seccomp
+#seccomp
+
+private-dev
+private-tmp
+
+# Experimental: make home directory read-only and allow writing only
+# to Baloo configuration files and databases
+#read-only  ${HOME}
+#read-write ${HOME}/.kde4/share/config/baloofilerc
+#read-write ${HOME}/.kde4/share/config/baloorc
+#read-write ${HOME}/.kde/share/config/baloofilerc
+#read-write ${HOME}/.kde/share/config/baloorc
+#read-write ${HOME}/.config/baloofilerc
+#read-write ${HOME}/.local/share/baloo
+#read-write ${HOME}/.local/share/akonadi/search_db

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -165,6 +165,7 @@ blacklist ${HOME}/.kde4/share/apps/konqsidebartng
 blacklist ${HOME}/.kde4/share/apps/konqueror
 blacklist ${HOME}/.kde4/share/apps/okular
 blacklist ${HOME}/.kde4/share/config/baloofilerc
+blacklist ${HOME}/.kde4/share/config/baloorc
 blacklist ${HOME}/.kde4/share/config/gwenviewrc
 blacklist ${HOME}/.kde4/share/config/k3brc
 blacklist ${HOME}/.kde4/share/config/kcookiejarrc
@@ -181,6 +182,7 @@ blacklist ${HOME}/.kde/share/apps/konqsidebartng
 blacklist ${HOME}/.kde/share/apps/konqueror
 blacklist ${HOME}/.kde/share/apps/okular
 blacklist ${HOME}/.kde/share/config/baloofilerc
+blacklist ${HOME}/.kde/share/config/baloorc
 blacklist ${HOME}/.kde/share/config/gwenviewrc
 blacklist ${HOME}/.kde/share/config/k3brc
 blacklist ${HOME}/.kde/share/config/kcookiejarrc


### PR DESCRIPTION
seccomp needs to stay disabled, because baloo makes ioprio_set system calls, which are on the seccomp blacklist.

Tested both on KDE4 and KDE5.