### PR TITLE
fix baloo_file.profile (x11 isolation)

### DIFF
--- a/etc/baloo_file.profile
+++ b/etc/baloo_file.profile
@@ -23,7 +23,7 @@ protocol unix
 # Baloo makes ioprio_set system calls, which are blacklisted by default.
 seccomp.drop mount,umount2,ptrace,kexec_load,kexec_file_load,name_to_handle_at,open_by_handle_at,create_module,init_module,finit_module,delete_module,iopl,ioperm,swapon,swapoff,syslog,process_vm_readv,process_vm_writev,sysfs,_sysctl,adjtimex,clock_adjtime,lookup_dcookie,perf_event_open,fanotify_init,kcmp,add_key,request_key,keyctl,uselib,acct,modify_ldt,pivot_root,io_setup,io_destroy,io_getevents,io_submit,io_cancel,remap_file_pages,mbind,get_mempolicy,set_mempolicy,migrate_pages,move_pages,vmsplice,chroot,tuxcall,reboot,mfsservctl,get_kernel_syms,bpf,clock_settime,personality,process_vm_writev,query_module,settimeofday,stime,umount,userfaultfd,ustat,vm86,vm86old
 
-blacklist /tmp/.X11-unix
+x11 xorg
 
 private-dev
 private-tmp


### PR DESCRIPTION
The last one of my commits from yesterday introduced X11 isolation but also a bug into the profile. Blacklisting /tmp/.X11-unix causes Baloo to hang after a while. I don't know why Baloo cares about X11, but we need to either remove this line or replace it with `x11 xorg`, which works for me.