### PR TITLE
make Baloo experiment more meaningful

### DIFF
--- a/etc/baloo_file.profile
+++ b/etc/baloo_file.profile
@@ -30,6 +30,7 @@ private-tmp
 
 # Make home directory read-only and allow writing only to Baloo's database.
 # Note: Baloo will not be able to update the first run key in its configuration files.
+# Older versions will issue a warning message.
 #read-only  ${HOME}
 #read-write ${HOME}/.local/share/baloo
 #read-write ${HOME}/.local/share/akonadi/search_db

--- a/etc/baloo_file.profile
+++ b/etc/baloo_file.profile
@@ -28,13 +28,8 @@ x11 xorg
 private-dev
 private-tmp
 
-# Experimental: make home directory read-only and allow writing only
-# to Baloo configuration files and databases
+# Make home directory read-only and allow writing only to Baloo's database.
+# Note: Baloo will not be able to update the first run key in its configuration files.
 #read-only  ${HOME}
-#read-write ${HOME}/.kde4/share/config/baloofilerc
-#read-write ${HOME}/.kde4/share/config/baloorc
-#read-write ${HOME}/.kde/share/config/baloofilerc
-#read-write ${HOME}/.kde/share/config/baloorc
-#read-write ${HOME}/.config/baloofilerc
 #read-write ${HOME}/.local/share/baloo
 #read-write ${HOME}/.local/share/akonadi/search_db


### PR DESCRIPTION
Baloo will fail to update its configuration file, unless the whole config folder is writable (it seems it wants to create a lock file). But if the whole config folder writable, having ${HOME} read-only doesn't make so much sense any more.

So I propose to remove not necessary lines and to add a note.