### PR TITLE
Prevent running shells recursively

### DIFF
--- a/src/firejail/no_sandbox.c
+++ b/src/firejail/no_sandbox.c
@@ -229,5 +229,9 @@ void run_no_sandbox(int argc, char **argv) {
 		"%s will run without any additional sandboxing features\n", command);
 
 	arg_quiet = 1;
+
+  // we don't want to run a shell, otherwise it will be recursively
+  arg_shell_none = 1;
+
 	start_application();
 }


### PR DESCRIPTION
When running a login shell, it occurred to me that the shell was being opened recursively. This commit will prevent recursive login shells.