### PR TITLE
blacklist file-manager python scripts

### DIFF
--- a/etc/caja.profile
+++ b/etc/caja.profile
@@ -8,8 +8,8 @@ include /etc/firejail/caja.local
 # is already a caja process running on MATE desktops firejail will have no effect.
 
 noblacklist ~/.config/caja
-noblacklist ~/.local/share/caja
-noblacklist ${HOME}/.local/share/Trash
+noblacklist ~/.local/share/caja-python
+noblacklist ~/.local/share/Trash
 
 include /etc/firejail/disable-common.inc
 # caja needs to be able to start arbitrary applications so we cannot blacklist their files

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -236,6 +236,7 @@ blacklist ${HOME}/.local/share/Terraria
 blacklist ${HOME}/.local/share/TpLogger
 blacklist ${HOME}/.local/share/aspyr-media
 blacklist ${HOME}/.local/share/baloo
+blacklist ${HOME}/.local/share/caja-python
 blacklist ${HOME}/.local/share/cdprojektred
 blacklist ${HOME}/.local/share/data/Mumble
 blacklist ${HOME}./local/share/dino
@@ -255,7 +256,9 @@ blacklist ${HOME}/.local/share/meld
 blacklist ${HOME}/.local/share/multimc5
 blacklist ${HOME}/.local/share/mupen64plus
 blacklist ${HOME}/.local/share/nautilus
+blacklist ${HOME}/.local/share/nautilus-python
 blacklist ${HOME}/.local/share/nemo
+blacklist ${HOME}/.local/share/nemo-python
 blacklist ${HOME}/.local/share/okular
 blacklist ${HOME}/.local/share/orage
 blacklist ${HOME}/.local/share/org.kde.gwenview

--- a/etc/nautilus.profile
+++ b/etc/nautilus.profile
@@ -5,10 +5,11 @@ include /etc/firejail/nautilus.local
 # nautilus profile
 
 # Nautilus is started by systemd on most systems. Therefore it is not firejailed by default. Since there
- # is already a nautilus process running on gnome desktops firejail will have no effect.
+# is already a nautilus process running on gnome desktops firejail will have no effect.
 
 noblacklist ~/.config/nautilus
 noblacklist ~/.local/share/nautilus
+noblacklist ~/.local/share/nautilus-python
 
 include /etc/firejail/disable-common.inc
 # nautilus needs to be able to start arbitrary applications so we cannot blacklist their files

--- a/etc/nautilus.profile
+++ b/etc/nautilus.profile
@@ -10,6 +10,7 @@ include /etc/firejail/nautilus.local
 noblacklist ~/.config/nautilus
 noblacklist ~/.local/share/nautilus
 noblacklist ~/.local/share/nautilus-python
+noblacklist ~/.local/share/Trash
 
 include /etc/firejail/disable-common.inc
 # nautilus needs to be able to start arbitrary applications so we cannot blacklist their files

--- a/etc/nemo.profile
+++ b/etc/nemo.profile
@@ -2,8 +2,9 @@
 # Persistent customizations should go in a .local file.
 include /etc/firejail/nemo.local
 
-noblacklist ${HOME}/.local/share/nemo
 noblacklist ${HOME}/.config/nemo
+noblacklist ${HOME}/.local/share/nemo
+noblacklist ${HOME}/.local/share/nemo-python
 noblacklist ${HOME}/.local/share/Trash
 
 include /etc/firejail/disable-common.inc


### PR DESCRIPTION
and
- permit Nautilus to access Trash
- remove `noblacklist ~/.local/share/caja` from profile, as folder is not used by Caja