### PR TITLE
blacklist keepass plugins

### DIFF
--- a/etc/disable-passwdmgr.inc
+++ b/etc/disable-passwdmgr.inc
@@ -2,6 +2,8 @@
 # Persistent customizations should go in a .local file.
 include /etc/firejail/disable-passwdmgr.local
 
+blacklist ${HOME}/.local/share/KeePass
+blacklist ${HOME}/.local/share/keepass
 blacklist ${HOME}/.config/KeePass
 blacklist ${HOME}/.config/keepass
 blacklist ${HOME}/.config/keepassx

--- a/etc/keepass.profile
+++ b/etc/keepass.profile
@@ -6,6 +6,8 @@ include /etc/firejail/keepass.local
 noblacklist ${HOME}/.keepass
 noblacklist ${HOME}/.config/keepass
 noblacklist ${HOME}/.config/KeePass
+noblacklist ${HOME}/.local/share/keepass
+noblacklist ${HOME}/.local/share/KeePass
 noblacklist ${HOME}/*.kdbx
 noblacklist ${HOME}/*.kdb
  


### PR DESCRIPTION
write access to keepass plugins is a security risk, and on the keepass homepage stated as such