### PR TITLE
gimp profile fix

### DIFF
--- a/etc/gimp.profile
+++ b/etc/gimp.profile
@@ -9,7 +9,6 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-ipc-namespace
 netfilter
 net none
 nogroups


### PR DESCRIPTION
removing `ipc-namespace` fixes:

```
The program 'gimp' received an X Window System error.
This probably reflects a bug in the program.
The error was 'BadAccess (attempt to access private resource denied)'.
  (Details: serial 194 error_code 10 request_code 130 minor_code 1)
  (Note to programmers: normally, X errors are reported asynchronously;
   that is, you will receive the error a while after causing it.
   To debug your program, run it with the --sync command line
   option to change this behavior. You can then get a meaningful
   backtrace from your debugger if you break on the gdk_x_error() function.)
```