### PR TITLE
allow python3 for youtube-dl in MPV profile

### DIFF
--- a/etc/mpv.profile
+++ b/etc/mpv.profile
@@ -19,4 +19,4 @@ seccomp
 
 # to test
 shell none
-private-bin mpv,youtube-dl,python2.7
+private-bin mpv,youtube-dl,python2.7,python3.6


### PR DESCRIPTION
This is required for MPV to successfully use youtube-dl on Arch. I'm not sure if other distros still ship youtube-dl with python2.