### PR TITLE
minor bugfix: Correctly dereference "subdirname" variable

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1332,7 +1332,7 @@ int main(int argc, char **argv) {
 				arg_overlay_reuse = 1;
 
 				char *subdirname = argv[i] + 16;
-				if (subdirname == '\0') {
+				if (*subdirname == '\0') {
 					fprintf(stderr, "Error: invalid overlay option\n");
 					exit(1);
 				}

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -852,7 +852,7 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 			arg_overlay_reuse = 1;
 
 			char *subdirname = ptr + 14;
-			if (subdirname == '\0') {
+			if (*subdirname == '\0') {
 				fprintf(stderr, "Error: invalid overlay option\n");
 				exit(1);
 			}


### PR DESCRIPTION
cppcheck reported:
[firejail/main.c:1335]: (warning) Char literal compared with pointer 'subdirname'. Did you intend to dereference it?