### PR TITLE
Add profile for Liferea

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,5 +97,5 @@ Use this issue to request new profiles: [#1139](https://github.com/netblue30/fir
 
 ## New profiles:
 
-curl, mplayer2, SMPlayer, Calibre, ebook-viewer, KWrite, Geary
+curl, mplayer2, SMPlayer, Calibre, ebook-viewer, KWrite, Geary, Liferea
 

--- a/etc/liferea.profile
+++ b/etc/liferea.profile
@@ -1,0 +1,29 @@
+# Persistent global definitions go here
+include /etc/firejail/global.local
+
+# This file is overwritten during software install.
+# Persistent customizations should go in a .local file.
+include /etc/firejail/liferea.local
+
+#######################
+# profile for Liferea #
+#######################
+noblacklist ~/.config/liferea
+mkdir ~/.config/liferea
+whitelist ~/.config/liferea
+
+noblacklist ~/.local/share/liferea
+mkdir ~/.local/share/liferea
+whitelist ~/.local/share/liferea
+
+noblacklist ~/.cache/liferea
+mkdir ~/.cache/liferea
+whitelist ~/.cache/liferea
+
+include /etc/firejail/whitelist-common.inc
+include /etc/firejail/default.profile
+
+nogroups
+shell none
+private-dev
+private-tmp

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -142,6 +142,7 @@ kwrite
 leafpad
 less
 libreoffice
+liferea
 localc
 lodraw
 loffice


### PR DESCRIPTION
Note that profile comes with a small problem:
Liferea allows to import and export the current feed list.
However, I don't know which directory I should allow for this?
Maybe ~/Downloads?

With the current profile, the export/import feature does NOT work.
