### PR TITLE
Fix race condition when setting up /run/firejail files (#1013)

### DIFF
--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -821,7 +821,9 @@ void create_empty_dir_as_root(const char *dir, mode_t mode) {
 		if (arg_debug)
 			printf("Creating empty %s directory\n", dir);
 		/* coverity[toctou] */
-		if (mkdir(dir, mode) == -1)
+		// don't fail if directory already exists. This can be the case in a race
+		// condition, when two jails launch at the same time. See #1013
+		if (mkdir(dir, mode) == -1 && errno != EEXIST)
 			errExit("mkdir");
 		if (set_perms(dir, 0, 0, mode))
 			errExit("set_perms");


### PR DESCRIPTION
This attempts to fix #1013 

Which is caused by a race condition in `create_empty_dir_as_root` between `stat` and `mkdir`.

Note 1: I'm not quite sure what the comment `/* coverity[toctou] */` does. Is it necessary that it stays in the line right above to the if statement? If yes, please tell me, then I'll reorder the comments.

Note 2: There are a bunch of calls to `mkdir` throughout the code, some of them behind a similar `stat`-gate. Should I also add a similar change to these?

Note 3: For testing, I forced race conditions by inserting a sleep right after the call to `stat`