### PR TITLE
Allow env for youtube-dl in mpv profile

### DIFF
--- a/etc/mpv.profile
+++ b/etc/mpv.profile
@@ -22,4 +22,4 @@ seccomp
 
 # to test
 shell none
-private-bin mpv,youtube-dl,python,python2.7,python3.6
+private-bin mpv,youtube-dl,python,python2.7,python3.6,env


### PR DESCRIPTION
youtube-dl uses `/usr/bin/env` as its interpreter.
If `env` is not available, mpvʼs execution of youtube-dl fails.