### PR TITLE
Allow ~/.netrc for youtube-dl

### DIFF
--- a/etc/mpv.profile
+++ b/etc/mpv.profile
@@ -7,6 +7,7 @@ include /etc/firejail/mpv.local
 
 # mpv media player profile
 noblacklist ${HOME}/.config/mpv
+noblacklist ${HOME}/.netrc
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc

--- a/etc/youtube-dl.profile
+++ b/etc/youtube-dl.profile
@@ -7,6 +7,7 @@ include /etc/firejail/globals.local
 include /etc/firejail/youtube-dl.local
 
 # Firejail profile for youtube-dl
+noblacklist ${HOME}/.netrc
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc


### PR DESCRIPTION
youtube-dl can use `.netrc` for site authentication ([`netrc` option](https://github.com/rg3/youtube-dl/blob/master/README.md#authentication-with-netrc-file)).