### PR TITLE
Harden profiles

### DIFF
--- a/etc/0ad.profile
+++ b/etc/0ad.profile
@@ -38,3 +38,6 @@ tracelog
 private-dev
 private-tmp
 disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/2048-qt.profile
+++ b/etc/2048-qt.profile
@@ -15,9 +15,11 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 #ipc-namespace
+netfilter
 nogroups
 nonewprivs
 noroot
+nosound
 novideo
 protocol unix
 seccomp

--- a/etc/2048-qt.profile
+++ b/etc/2048-qt.profile
@@ -7,24 +7,25 @@ include /etc/firejail/2048-qt.local
 
 noblacklist ~/.config/xiaoyong
 noblacklist ~/.config/2048-qt
+
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
+#ipc-namespace
+nogroups
 nonewprivs
 noroot
-protocol unix,inet,inet6
+novideo
+protocol unix
 seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
 shell none
-# private-bin program
-# private-etc none
-# private-dev
-# private-tmp
-nosound
+
+private-dev
+private-tmp
+disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/Thunar.profile
+++ b/etc/Thunar.profile
@@ -16,7 +16,9 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 no3d
+nogroups
 nonewprivs
 noroot
 nosound

--- a/etc/Thunar.profile
+++ b/etc/Thunar.profile
@@ -16,20 +16,12 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
-nogroups
+no3d
 nonewprivs
 noroot
 nosound
+novideo
 protocol unix
 seccomp
 shell none
 tracelog
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-# private-bin program
-# private-etc none
-# private-dev
-# private-tmp

--- a/etc/Xephyr.profile
+++ b/etc/Xephyr.profile
@@ -21,7 +21,6 @@ private
 
 caps.drop all
 # Xephyr needs to be allowed access to the abstract Unix socket namespace.
-#net none
 nogroups
 nonewprivs
 # In noroot mode, Xephyr cannot create a socket in the real /tmp/.X11-unix.

--- a/etc/Xvfb.profile
+++ b/etc/Xvfb.profile
@@ -22,7 +22,6 @@ private
 
 caps.drop all
 # Xvfb needs to be allowed access to the abstract Unix socket namespace.
-#net none
 nogroups
 nonewprivs
 # In noroot mode, Xvfb cannot create a socket in the real /tmp/.X11-unix.

--- a/etc/akregator.profile
+++ b/etc/akregator.profile
@@ -5,28 +5,30 @@ include /etc/firejail/globals.local
 # Persistent customizations should go in a .local file.
 include /etc/firejail/akregator.local
 
-################################
-# Generic GUI application profile
-################################
 noblacklist ${HOME}/.config/akregatorrc
 noblacklist ${HOME}/.local/share/akregator
+
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+#ipc-namespace
 netfilter
+no3d
+nogroups
 nonewprivs
 noroot
+#nosound
+novideo
 protocol unix,inet,inet6
 seccomp
+shell none
 
-#
-# depending on your usage, you can enable some of the commands below:
-#
-# nogroups
-# shell none
-# private-bin program
-# private-etc none
-# private-dev
-# private-tmp
+private-dev
+private-tmp
+disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/ark.profile
+++ b/etc/ark.profile
@@ -14,6 +14,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/ark.profile
+++ b/etc/ark.profile
@@ -14,7 +14,6 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/atool.profile
+++ b/etc/atool.profile
@@ -19,8 +19,6 @@ nosound
 novideo
 protocol unix
 seccomp
-netfilter
-net none
 no3d
 shell none
 tracelog

--- a/etc/atool.profile
+++ b/etc/atool.profile
@@ -12,6 +12,7 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/audacity.profile
+++ b/etc/audacity.profile
@@ -15,8 +15,6 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 #ipc-namespace
-net none
-netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/audacity.profile
+++ b/etc/audacity.profile
@@ -15,7 +15,7 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 #ipc-namespace
-netfilter
+net none
 no3d
 nogroups
 nonewprivs

--- a/etc/audacity.profile
+++ b/etc/audacity.profile
@@ -15,6 +15,7 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 #ipc-namespace
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/bitlbee.profile
+++ b/etc/bitlbee.profile
@@ -9,13 +9,23 @@ include /etc/firejail/bitlbee.local
 noblacklist /sbin
 noblacklist /usr/sbin
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 netfilter
+no3d
 nonewprivs
 private
 private-dev
 protocol unix,inet,inet6
 seccomp
 nosound
+novideo
 read-write /var/lib/bitlbee
+
+private-dev
+private-tmp
+disable-mnt
+
+noexec /tmp

--- a/etc/bleachbit.profile
+++ b/etc/bleachbit.profile
@@ -28,5 +28,6 @@ shell none
 # private-tmp
 # private-etc
 
+memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp

--- a/etc/bleachbit.profile
+++ b/etc/bleachbit.profile
@@ -13,6 +13,7 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 #ipc-namespace
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/bleachbit.profile
+++ b/etc/bleachbit.profile
@@ -13,7 +13,7 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 #ipc-namespace
-netfilter
+net none
 no3d
 nogroups
 nonewprivs

--- a/etc/bleachbit.profile
+++ b/etc/bleachbit.profile
@@ -13,8 +13,6 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 #ipc-namespace
-net none
-netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/blender.profile
+++ b/etc/blender.profile
@@ -7,25 +7,21 @@ include /etc/firejail/blender.local
 
 noblacklist ~/.config/blender
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 netfilter
+nogroups
 nonewprivs
 noroot
 protocol unix,inet,inet6,netlink
 seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
 shell none
-# private-bin program
-# private-etc none
-# private-dev
-# private-tmp
 
-# blender uses the sound system
-# nosound
+private-dev
+private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/bless.profile
+++ b/etc/bless.profile
@@ -21,7 +21,7 @@ include /etc/firejail/disable-devel.inc
 #Options
 caps.drop all
 #ipc-namespace
-netfilter
+net none
 no3d
 nogroups
 nonewprivs

--- a/etc/bless.profile
+++ b/etc/bless.profile
@@ -21,8 +21,6 @@ include /etc/firejail/disable-devel.inc
 #Options
 caps.drop all
 #ipc-namespace
-net none
-netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/bless.profile
+++ b/etc/bless.profile
@@ -21,6 +21,7 @@ include /etc/firejail/disable-devel.inc
 #Options
 caps.drop all
 #ipc-namespace
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/brasero.profile
+++ b/etc/brasero.profile
@@ -30,5 +30,6 @@ tracelog
 # private-etc fonts
 # private-tmp
 
+memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp

--- a/etc/brasero.profile
+++ b/etc/brasero.profile
@@ -15,7 +15,6 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 #ipc-namespace
-net none
 nogroups
 nonewprivs
 noroot

--- a/etc/caja.profile
+++ b/etc/caja.profile
@@ -26,7 +26,6 @@ nonewprivs
 noroot
 protocol unix
 seccomp
-netfilter
 shell none
 tracelog
 

--- a/etc/caja.profile
+++ b/etc/caja.profile
@@ -21,6 +21,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/catfish.profile
+++ b/etc/catfish.profile
@@ -13,7 +13,6 @@ noblacklist ~/.config/catfish
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
-net none
 no3d
 nogroups
 nonewprivs

--- a/etc/catfish.profile
+++ b/etc/catfish.profile
@@ -13,6 +13,7 @@ noblacklist ~/.config/catfish
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
+net none
 no3d
 nogroups
 nonewprivs

--- a/etc/cherrytree.profile
+++ b/etc/cherrytree.profile
@@ -9,18 +9,28 @@ include /etc/firejail/cherrytree.local
 noblacklist /usr/bin/python2*
 noblacklist /usr/lib/python3*
 noblacklist ${HOME}/.config/cherrytree
+
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+#ipc-namespace
 netfilter
+no3d
 nogroups
 nonewprivs
 noroot
 nosound
 novideo
-seccomp
 protocol unix,inet,inet6,netlink
+seccomp
+shell none
 tracelog
+
+private-dev
+private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/clipit.profile
+++ b/etc/clipit.profile
@@ -8,26 +8,24 @@ include /etc/firejail/clipit.local
 noblacklist ${HOME}/.local/share/clipit
 noblacklist ${HOME}/.config/clipit
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
+no3d
+nogroups
 nonewprivs
 noroot
-novideo
-protocol unix,inet,inet6
-seccomp
-
-
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
-shell none
-# private-bin program
-# private-etc none
-# private-dev
-# private-tmp
 nosound
+novideo
+protocol unix
+seccomp
+shell none
+
+private-dev
+private-tmp
+disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/clipit.profile
+++ b/etc/clipit.profile
@@ -13,6 +13,7 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/cvlc.profile
+++ b/etc/cvlc.profile
@@ -27,3 +27,5 @@ tracelog
 #private-bin vlc,cvlc,nvlc,rvlc,qvlc,svlc
 private-dev
 private-tmp
+
+memory-deny-write-execute

--- a/etc/darktable.profile
+++ b/etc/darktable.profile
@@ -8,23 +8,24 @@ include /etc/firejail/darktable.local
 noblacklist ~/.cache/darktable
 noblacklist ~/.config/darktable
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+#ipc-namespace
 netfilter
+nogroups
 nonewprivs
 noroot
+nosound
+novideo
 protocol unix,inet,inet6
 seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-# nogroups
 shell none
-# private-bin program
-# private-etc none
-# private-dev
+
+private-dev
 private-tmp
-nosound
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/dia.profile
+++ b/etc/dia.profile
@@ -7,23 +7,24 @@ include /etc/firejail/dia.local
 
 noblacklist ~/.dia
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
+no3d
+nogroups
 nonewprivs
 noroot
+nosound
 novideo
-protocol unix,inet,inet6
+protocol unix
 seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
 shell none
-# private-bin program
-# private-etc none
+
 private-dev
 private-tmp
+disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/dia.profile
+++ b/etc/dia.profile
@@ -12,6 +12,7 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/digikam.profile
+++ b/etc/digikam.profile
@@ -31,3 +31,6 @@ shell none
 # private-etc none
 # private-dev - prevents libdc1394 loading; this lib is used to connect to a camera device
 private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/display.profile
+++ b/etc/display.profile
@@ -12,12 +12,13 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-seccomp
-protocol unix
+net none
 nonewprivs
-noroot
 nogroups
+noroot
 nosound
+protocol unix
+seccomp
 shell none
 x11 xorg
 

--- a/etc/display.profile
+++ b/etc/display.profile
@@ -14,8 +14,6 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 seccomp
 protocol unix
-netfilter
-net none
 nonewprivs
 noroot
 nogroups

--- a/etc/dolphin.profile
+++ b/etc/dolphin.profile
@@ -22,7 +22,6 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/dolphin.profile
+++ b/etc/dolphin.profile
@@ -22,6 +22,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/dragon.profile
+++ b/etc/dragon.profile
@@ -27,3 +27,6 @@ private-bin dragon
 private-dev
 private-tmp
 # private-etc
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/dropbox.profile
+++ b/etc/dropbox.profile
@@ -9,15 +9,9 @@ include /etc/firejail/dropbox.local
 noblacklist ~/.config/autostart
 noblacklist ~/.dropbox-dist
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
-
-caps
-nonewprivs
-noroot
-novideo
-protocol unix,inet,inet6
-seccomp
 
 mkdir ~/Dropbox
 whitelist ~/Dropbox
@@ -28,3 +22,20 @@ whitelist ~/.dropbox-dist
 
 mkfile ~/.config/autostart/dropbox.desktop
 whitelist ~/.config/autostart/dropbox.desktop
+
+caps.drop all
+netfilter
+no3d
+nogroups
+nonewprivs
+noroot
+nosound
+novideo
+protocol unix,inet,inet6
+seccomp
+shell none
+
+private-dev
+private-tmp
+
+noexec /tmp

--- a/etc/enchant.profile
+++ b/etc/enchant.profile
@@ -20,7 +20,6 @@ noroot
 nosound
 protocol unix
 seccomp
-netfilter
 shell none
 tracelog
 

--- a/etc/enchant.profile
+++ b/etc/enchant.profile
@@ -14,6 +14,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/engrampa.profile
+++ b/etc/engrampa.profile
@@ -19,7 +19,6 @@ nosound
 novideo
 protocol unix
 seccomp
-netfilter
 shell none
 tracelog
 

--- a/etc/engrampa.profile
+++ b/etc/engrampa.profile
@@ -12,6 +12,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/eog.profile
+++ b/etc/eog.profile
@@ -18,8 +18,6 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 #ipc-namespace
-net none
-netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/eog.profile
+++ b/etc/eog.profile
@@ -18,6 +18,7 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 #ipc-namespace
+net none
 no3d
 nogroups
 nonewprivs

--- a/etc/eog.profile
+++ b/etc/eog.profile
@@ -33,5 +33,6 @@ private-dev
 private-etc fonts
 private-tmp
 
+memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp

--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -15,6 +15,7 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 #ipc-namespace
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -32,5 +32,6 @@ private-etc fonts
 # evince needs access to /tmp/mozilla* to work in firefox
 # private-tmp
 
+memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp

--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -15,8 +15,6 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 #ipc-namespace
-netfilter
-#net none - creates some problems on some distributions
 no3d
 nogroups
 nonewprivs

--- a/etc/exiftool.profile
+++ b/etc/exiftool.profile
@@ -23,8 +23,6 @@ noroot
 nosound
 protocol unix
 seccomp
-netfilter
-net none
 no3d
 shell none
 tracelog

--- a/etc/exiftool.profile
+++ b/etc/exiftool.profile
@@ -17,6 +17,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+net none
 nogroups
 nonewprivs
 noroot

--- a/etc/feh.profile
+++ b/etc/feh.profile
@@ -12,8 +12,6 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
-net none
 nogroups
 nonewprivs
 noroot

--- a/etc/feh.profile
+++ b/etc/feh.profile
@@ -12,6 +12,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+net none
 nogroups
 nonewprivs
 noroot

--- a/etc/file-roller.profile
+++ b/etc/file-roller.profile
@@ -13,6 +13,7 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 #ipc-namespace
+net none
 no3d
 nogroups
 nonewprivs

--- a/etc/file-roller.profile
+++ b/etc/file-roller.profile
@@ -13,8 +13,6 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 #ipc-namespace
-net none
-netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/file-roller.profile
+++ b/etc/file-roller.profile
@@ -29,5 +29,6 @@ tracelog
 private-dev
 # private-etc fonts
 
+memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp

--- a/etc/file.profile
+++ b/etc/file.profile
@@ -13,6 +13,7 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 hostname file
+net none
 no3d
 nogroups
 nonewprivs

--- a/etc/file.profile
+++ b/etc/file.profile
@@ -13,8 +13,6 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 hostname file
-netfilter
-net none
 no3d
 nogroups
 nonewprivs

--- a/etc/flowblade.profile
+++ b/etc/flowblade.profile
@@ -8,13 +8,23 @@ include /etc/firejail/flowblade.local
 # FlowBlade profile
 noblacklist ${HOME}/.flowblade
 noblacklist ${HOME}/.config/flowblade
+
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 netfilter
+nogroups
 nonewprivs
 noroot
 protocol unix,inet,inet6,netlink
 seccomp
+shell none
+
+private-dev
+private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/fontforge.profile
+++ b/etc/fontforge.profile
@@ -6,23 +6,24 @@ include /etc/firejail/globals.local
 include /etc/firejail/fontforge.local
 
 noblacklist ${HOME}/.FontForge
+
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
+nogroups
 nonewprivs
 noroot
-protocol unix,inet,inet6
+nosound
+novideo
+protocol unix
 seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
 shell none
-# private-bin program
-# private-etc none
+
 private-dev
 private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/fontforge.profile
+++ b/etc/fontforge.profile
@@ -13,6 +13,7 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/franz.profile
+++ b/etc/franz.profile
@@ -13,14 +13,6 @@ include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
-caps.drop all
-netfilter
-nonewprivs
-noroot
-protocol unix,inet,inet6,netlink
-seccomp
-#tracelog
-
 whitelist ${DOWNLOADS}
 mkdir ~/.config/Franz
 whitelist ~/.config/Franz
@@ -30,3 +22,21 @@ mkdir ~/.pki
 whitelist ~/.pki
 
 include /etc/firejail/whitelist-common.inc
+
+caps.drop all
+#ipc-namespace
+netfilter
+nogroups
+nonewprivs
+noroot
+protocol unix,inet,inet6,netlink
+seccomp
+shell none
+tracelog
+
+private-dev
+private-tmp
+disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/franz.profile
+++ b/etc/franz.profile
@@ -32,7 +32,7 @@ noroot
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
-tracelog
+#tracelog
 
 private-dev
 private-tmp

--- a/etc/galculator.profile
+++ b/etc/galculator.profile
@@ -17,6 +17,7 @@ mkdir ~/.config/galculator
 whitelist ~/.config/galculator
 
 caps.drop all
+net none
 nogroups
 nonewprivs
 noroot

--- a/etc/galculator.profile
+++ b/etc/galculator.profile
@@ -17,7 +17,6 @@ mkdir ~/.config/galculator
 whitelist ~/.config/galculator
 
 caps.drop all
-net none
 nogroups
 nonewprivs
 noroot

--- a/etc/geany.profile
+++ b/etc/geany.profile
@@ -12,17 +12,15 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 netfilter
+no3d
+nogroups
 nonewprivs
 noroot
+nosound
+novideo
 protocol unix,inet,inet6
 seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
 shell none
-# private-bin program
-# private-etc none
+
 private-dev
 private-tmp

--- a/etc/gedit.profile
+++ b/etc/gedit.profile
@@ -18,6 +18,7 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 #ipc-namespace
+net none
 no3d
 nogroups
 nonewprivs

--- a/etc/gedit.profile
+++ b/etc/gedit.profile
@@ -18,8 +18,6 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 #ipc-namespace
-netfilter
-net none
 no3d
 nogroups
 nonewprivs

--- a/etc/gimp.profile
+++ b/etc/gimp.profile
@@ -12,6 +12,7 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+net none
 nogroups
 nonewprivs
 noroot

--- a/etc/gimp.profile
+++ b/etc/gimp.profile
@@ -12,8 +12,6 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
-net none
 nogroups
 nonewprivs
 noroot

--- a/etc/globaltime.profile
+++ b/etc/globaltime.profile
@@ -7,22 +7,25 @@ include /etc/firejail/globaltime.local
 
 noblacklist ${HOME}/.config/globaltime
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 netfilter
+no3d
+nogroups
 nonewprivs
 noroot
+nosound
+novideo
 protocol unix,inet,inet6
 seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
 shell none
-# private-bin program
-# private-etc none
+
 private-dev
-# private-tmp
+private-tmp
+disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/gnome-books.profile
+++ b/etc/gnome-books.profile
@@ -24,7 +24,6 @@ nosound
 novideo
 protocol unix
 seccomp
-netfilter
 shell none
 tracelog
 

--- a/etc/gnome-books.profile
+++ b/etc/gnome-books.profile
@@ -16,6 +16,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/gnome-calculator.profile
+++ b/etc/gnome-calculator.profile
@@ -30,6 +30,7 @@ protocol unix,inet,inet6
 seccomp
 shell none
 
+private
 private-bin gnome-calculator
 private-dev
 #private-etc fonts

--- a/etc/gnome-calculator.profile
+++ b/etc/gnome-calculator.profile
@@ -37,5 +37,6 @@ private-dev
 private-tmp
 disable-mnt
 
+memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp

--- a/etc/gnome-documents.profile
+++ b/etc/gnome-documents.profile
@@ -17,6 +17,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/gnome-documents.profile
+++ b/etc/gnome-documents.profile
@@ -25,7 +25,6 @@ nosound
 novideo
 protocol unix
 seccomp
-netfilter
 shell none
 tracelog
 

--- a/etc/gnome-music.profile
+++ b/etc/gnome-music.profile
@@ -14,6 +14,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/gnome-music.profile
+++ b/etc/gnome-music.profile
@@ -21,7 +21,6 @@ noroot
 novideo
 protocol unix
 seccomp
-netfilter
 shell none
 tracelog
 

--- a/etc/gnome-photos.profile
+++ b/etc/gnome-photos.profile
@@ -17,6 +17,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/gnome-photos.profile
+++ b/etc/gnome-photos.profile
@@ -23,7 +23,6 @@ noroot
 nosound
 protocol unix
 seccomp
-netfilter
 shell none
 tracelog
 

--- a/etc/goobox.profile
+++ b/etc/goobox.profile
@@ -17,7 +17,6 @@ nonewprivs
 noroot
 protocol unix
 seccomp
-netfilter
 shell none
 tracelog
 

--- a/etc/goobox.profile
+++ b/etc/goobox.profile
@@ -12,6 +12,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/google-chrome-beta.profile
+++ b/etc/google-chrome-beta.profile
@@ -16,8 +16,6 @@ include /etc/firejail/disable-programs.inc
 # include /etc/firejail/disable-devel.inc
 #
 
-netfilter
-
 whitelist ${DOWNLOADS}
 mkdir ~/.config/google-chrome-beta
 whitelist ~/.config/google-chrome-beta
@@ -26,6 +24,16 @@ whitelist ~/.cache/google-chrome-beta
 mkdir ~/.pki
 whitelist ~/.pki
 include /etc/firejail/whitelist-common.inc
+
+caps.keep sys_chroot,sys_admin
+#ipc-namespace
+netfilter
+nogroups
+shell none
+
+private-dev
+#private-tmp - problems with multiple browser sessions
+#disable-mnt
 
 noexec ${HOME}
 noexec /tmp

--- a/etc/google-chrome-beta.profile
+++ b/etc/google-chrome-beta.profile
@@ -26,3 +26,6 @@ whitelist ~/.cache/google-chrome-beta
 mkdir ~/.pki
 whitelist ~/.pki
 include /etc/firejail/whitelist-common.inc
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/google-chrome-unstable.profile
+++ b/etc/google-chrome-unstable.profile
@@ -16,8 +16,6 @@ include /etc/firejail/disable-programs.inc
 # include /etc/firejail/disable-devel.inc
 #
 
-netfilter
-
 whitelist ${DOWNLOADS}
 mkdir ~/.config/google-chrome-unstable
 whitelist ~/.config/google-chrome-unstable
@@ -26,6 +24,16 @@ whitelist ~/.cache/google-chrome-unstable
 mkdir ~/.pki
 whitelist ~/.pki
 include /etc/firejail/whitelist-common.inc
+
+caps.keep sys_chroot,sys_admin
+#ipc-namespace
+netfilter
+nogroups
+shell none
+
+private-dev
+#private-tmp - problems with multiple browser sessions
+#disable-mnt
 
 noexec ${HOME}
 noexec /tmp

--- a/etc/google-chrome-unstable.profile
+++ b/etc/google-chrome-unstable.profile
@@ -26,3 +26,6 @@ whitelist ~/.cache/google-chrome-unstable
 mkdir ~/.pki
 whitelist ~/.pki
 include /etc/firejail/whitelist-common.inc
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/google-chrome.profile
+++ b/etc/google-chrome.profile
@@ -16,9 +16,6 @@ include /etc/firejail/disable-programs.inc
 # include /etc/firejail/disable-devel.inc
 #
 
-caps.keep sys_chroot,sys_admin
-netfilter
-
 whitelist ${DOWNLOADS}
 mkdir ~/.config/google-chrome
 whitelist ~/.config/google-chrome
@@ -27,6 +24,16 @@ whitelist ~/.cache/google-chrome
 mkdir ~/.pki
 whitelist ~/.pki
 include /etc/firejail/whitelist-common.inc
+
+caps.keep sys_chroot,sys_admin
+#ipc-namespace
+netfilter
+nogroups
+shell none
+
+private-dev
+#private-tmp - problems with multiple browser sessions
+#disable-mnt
 
 noexec ${HOME}
 noexec /tmp

--- a/etc/google-chrome.profile
+++ b/etc/google-chrome.profile
@@ -27,3 +27,6 @@ whitelist ~/.cache/google-chrome
 mkdir ~/.pki
 whitelist ~/.pki
 include /etc/firejail/whitelist-common.inc
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/google-play-music-desktop-player.profile
+++ b/etc/google-play-music-desktop-player.profile
@@ -13,13 +13,25 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
-caps.drop all
-nonewprivs
-noroot
-netfilter
-protocol unix,inet,inet6,netlink
-seccomp
-
 #whitelist ~/.pulse
 #whitelist ~/.config/pulse
 whitelist ~/.config/Google Play Music Desktop Player
+
+caps.drop all
+#ipc-namespace
+netfilter
+no3d
+nogroups
+nonewprivs
+noroot
+novideo
+protocol unix,inet,inet6,netlink
+seccomp
+shell none
+
+private-dev
+private-tmp
+disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/gpicview.profile
+++ b/etc/gpicview.profile
@@ -14,6 +14,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+net none
 nogroups
 nonewprivs
 noroot

--- a/etc/gpicview.profile
+++ b/etc/gpicview.profile
@@ -14,7 +14,6 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-net none
 nogroups
 nonewprivs
 noroot

--- a/etc/guayadeque.profile
+++ b/etc/guayadeque.profile
@@ -24,3 +24,6 @@ shell none
 private-bin guayadeque
 private-dev
 private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/gucharmap.profile
+++ b/etc/gucharmap.profile
@@ -5,25 +5,26 @@ include /etc/firejail/globals.local
 # Persistent customizations should go in a .local file.
 include /etc/firejail/gucharmap.local
 
-private
-#include /etc/firejail/disable-common.inc
-#include /etc/firejail/disable-programs.inc
-#include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 caps.drop all
-netfilter
+no3d
+nogroups
 nonewprivs
 noroot
-protocol unix,inet,inet6
-seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
-shell none
-# private-bin program
-# private-etc none
-# private-dev
-# private-tmp
 nosound
+novideo
+protocol unix
+seccomp
+shell none
+
+private
+private-dev
+private-tmp
+disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/gucharmap.profile
+++ b/etc/gucharmap.profile
@@ -11,6 +11,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/gwenview.profile
+++ b/etc/gwenview.profile
@@ -32,3 +32,6 @@ private-dev
 
 # Experimental:
 #private-etc X11
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/handbrake.profile
+++ b/etc/handbrake.profile
@@ -7,24 +7,23 @@ include /etc/firejail/handbrake.local
 
 noblacklist ~/.config/ghb
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 netfilter
+nogroups
 nonewprivs
 noroot
-# netlink required!
+nosound
+novideo
 protocol unix,inet,inet6,netlink
 seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
 shell none
-# private-bin program
-# private-etc none
-#private-dev
+
+private-dev
 private-tmp
-nosound
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/highlight.profile
+++ b/etc/highlight.profile
@@ -12,6 +12,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+net none
 nogroups
 nonewprivs
 noroot

--- a/etc/highlight.profile
+++ b/etc/highlight.profile
@@ -18,8 +18,6 @@ noroot
 nosound
 protocol unix
 seccomp
-netfilter
-net none
 no3d
 shell none
 tracelog

--- a/etc/hugin.profile
+++ b/etc/hugin.profile
@@ -6,24 +6,24 @@ include /etc/firejail/globals.local
 include /etc/firejail/hugin.local
 
 noblacklist ${HOME}/.hugin
+
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
+nogroups
 nonewprivs
 noroot
-protocol unix,inet,inet6
+nosound
+novideo
+protocol unix
 seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
 shell none
-# private-bin program
-# private-etc none
+
 private-dev
 private-tmp
-nosound
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/hugin.profile
+++ b/etc/hugin.profile
@@ -13,6 +13,7 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/icecat.profile
+++ b/etc/icecat.profile
@@ -48,3 +48,6 @@ include /etc/firejail/whitelist-common.inc
 
 # experimental features
 #private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/img2txt.profile
+++ b/etc/img2txt.profile
@@ -12,6 +12,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/img2txt.profile
+++ b/etc/img2txt.profile
@@ -12,7 +12,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
+net none
 nogroups
 nonewprivs
 noroot

--- a/etc/img2txt.profile
+++ b/etc/img2txt.profile
@@ -18,8 +18,6 @@ noroot
 nosound
 protocol unix
 seccomp
-netfilter
-net none
 shell none
 tracelog
 

--- a/etc/inkscape.profile
+++ b/etc/inkscape.profile
@@ -13,6 +13,7 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/inkscape.profile
+++ b/etc/inkscape.profile
@@ -8,20 +8,22 @@ include /etc/firejail/inkscape.local
 # inkscape
 noblacklist ${HOME}/.inkscape
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
 nogroups
 nonewprivs
 noroot
 nosound
+novideo
 protocol unix
 seccomp
-
-noexec ${HOME}
-noexec /tmp
+shell none
 
 private-dev
 private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/jd-gui.profile
+++ b/etc/jd-gui.profile
@@ -21,6 +21,7 @@ include /etc/firejail/disable-devel.inc
 #Options
 caps.drop all
 #ipc-namespace
+net none
 no3d
 nogroups
 nonewprivs

--- a/etc/jd-gui.profile
+++ b/etc/jd-gui.profile
@@ -21,8 +21,6 @@ include /etc/firejail/disable-devel.inc
 #Options
 caps.drop all
 #ipc-namespace
-net none
-netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/kate.profile
+++ b/etc/kate.profile
@@ -19,6 +19,7 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/kate.profile
+++ b/etc/kate.profile
@@ -25,7 +25,6 @@ noroot
 nosound
 protocol unix
 seccomp
-netfilter
 shell none
 tracelog
 

--- a/etc/kcalc.profile
+++ b/etc/kcalc.profile
@@ -5,27 +5,26 @@ include /etc/firejail/globals.local
 # Persistent customizations should go in a .local file.
 include /etc/firejail/kcalc.local
 
-################################
-# Generic GUI application profile
-################################
 include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 caps.drop all
-netfilter
+no3d
+nogroups
 nonewprivs
 noroot
-protocol unix,inet,inet6
+nosound
+novideo
+protocol unix
 seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-private
-nogroups
 shell none
-# private-bin program
-# private-etc none
+
+private
 private-dev
 private-tmp
+disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/kcalc.profile
+++ b/etc/kcalc.profile
@@ -11,6 +11,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/keepassx.profile
+++ b/etc/keepassx.profile
@@ -18,6 +18,7 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 machine-id
+net none
 no3d
 nogroups
 nonewprivs

--- a/etc/keepassx.profile
+++ b/etc/keepassx.profile
@@ -18,7 +18,6 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 machine-id
-net none
 no3d
 nogroups
 nonewprivs

--- a/etc/keepassx2.profile
+++ b/etc/keepassx2.profile
@@ -17,7 +17,6 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-net none
 no3d
 nogroups
 nonewprivs

--- a/etc/keepassx2.profile
+++ b/etc/keepassx2.profile
@@ -17,6 +17,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+net none
 no3d
 nogroups
 nonewprivs

--- a/etc/keepassxc.profile
+++ b/etc/keepassxc.profile
@@ -33,5 +33,6 @@ private-dev
 private-etc fonts,ld.so.cache
 private-tmp
 
+memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp

--- a/etc/keepassxc.profile
+++ b/etc/keepassxc.profile
@@ -16,10 +16,8 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
-# To use KeePassHTTP, comment out `net none`
 caps.drop all
 #ipc-namespace
-net none
 no3d
 nogroups
 nonewprivs

--- a/etc/keepassxc.profile
+++ b/etc/keepassxc.profile
@@ -18,6 +18,7 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 #ipc-namespace
+net none
 no3d
 nogroups
 nonewprivs

--- a/etc/kino.profile
+++ b/etc/kino.profile
@@ -5,28 +5,25 @@ include /etc/firejail/globals.local
 # Persistent customizations should go in a .local file.
 include /etc/firejail/kino.local
 
-################################
-# Generic GUI application profile
-################################
 noblacklist ~/.kinorc
 noblacklist ~/.kino-history
+
 include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 caps.drop all
-netfilter
+nogroups
 nonewprivs
 noroot
-protocol unix,inet,inet6
+novideo
+protocol unix
 seccomp
+shell none
 
-#
-# depending on your usage, you can enable some of the commands below:
-#
-# nogroups
-# shell none
-# private-bin program
-# private-etc none
-# private-dev
-# private-tmp
+private-dev
+private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/kino.profile
+++ b/etc/kino.profile
@@ -14,6 +14,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/knotes.profile
+++ b/etc/knotes.profile
@@ -20,7 +20,6 @@ noroot
 nosound
 protocol unix
 seccomp
-netfilter
 shell none
 tracelog
 

--- a/etc/knotes.profile
+++ b/etc/knotes.profile
@@ -14,6 +14,7 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/ktorrent.profile
+++ b/etc/ktorrent.profile
@@ -5,16 +5,15 @@ include /etc/firejail/globals.local
 # Persistent customizations should go in a .local file.
 include /etc/firejail/ktorrent.local
 
-################################
-# Generic GUI application profile
-################################
 noblacklist ~/.config/ktorrentrc
 noblacklist ~/.local/share/ktorrent
 noblacklist ~/.kde/share/config/ktorrentrc
 noblacklist ~/.kde4/share/config/ktorrentrc
 noblacklist ~/.kde/share/apps/ktorrent
 noblacklist ~/.kde4/share/apps/ktorrent
+
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
@@ -36,17 +35,18 @@ include /etc/firejail/whitelist-common.inc
 
 caps.drop all
 netfilter
+no3d
+nogroups
 nonewprivs
 noroot
+nosound
+novideo
 protocol unix,inet,inet6
 seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
 shell none
-# private-bin program
-# private-etc none
+
 private-dev
-# private-tmp
+private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/kwrite.profile
+++ b/etc/kwrite.profile
@@ -19,6 +19,7 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/kwrite.profile
+++ b/etc/kwrite.profile
@@ -25,7 +25,6 @@ noroot
 #nosound - KWrite is using ALSA!
 protocol unix
 seccomp
-netfilter
 shell none
 tracelog
 

--- a/etc/leafpad.profile
+++ b/etc/leafpad.profile
@@ -6,24 +6,24 @@ include /etc/firejail/globals.local
 include /etc/firejail/leafpad.local
 
 noblacklist ${HOME}/.config/leafpad
+
 include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 caps.drop all
-netfilter
+no3d
+nogroups
 nonewprivs
 noroot
-protocol unix,inet,inet6
-seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
-shell none
-# private-bin program
-# private-etc none
-# private-dev
-# private-tmp
 nosound
+novideo
+protocol unix
+seccomp
+shell none
+
+private-dev
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/leafpad.profile
+++ b/etc/leafpad.profile
@@ -13,6 +13,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/less.profile
+++ b/etc/less.profile
@@ -21,5 +21,6 @@ blacklist /tmp/.X11-unix
 
 private-dev
 
+memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp

--- a/etc/liferea.profile
+++ b/etc/liferea.profile
@@ -20,10 +20,28 @@ noblacklist ~/.cache/liferea
 mkdir ~/.cache/liferea
 whitelist ~/.cache/liferea
 
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 include /etc/firejail/whitelist-common.inc
-include /etc/firejail/default.profile
 
+caps.drop all
+#ipc-namespace
+netfilter
+#no3d
 nogroups
+nonewprivs
+noroot
+#nosound
+novideo
+protocol unix,inet,inet6
+seccomp
 shell none
+
 private-dev
 private-tmp
+disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/luminance-hdr.profile
+++ b/etc/luminance-hdr.profile
@@ -15,6 +15,7 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 #ipc-namespace
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/luminance-hdr.profile
+++ b/etc/luminance-hdr.profile
@@ -7,24 +7,26 @@ include /etc/firejail/luminance-hdr.local
 
 # luminance-hdr
 noblacklist ${HOME}/.config/Luminance
+
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 #ipc-namespace
-netfilter
 nogroups
 nonewprivs
 noroot
 nosound
+novideo
 protocol unix
 seccomp
 shell none
 tracelog
 
-noexec ${HOME}
-noexec /tmp
-
 private-tmp
 private-dev
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/lximage-qt.profile
+++ b/etc/lximage-qt.profile
@@ -6,24 +6,25 @@ include /etc/firejail/globals.local
 include /etc/firejail/lximage-qt.local
 
 noblacklist .config/lximage-qt
+
 include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 caps.drop all
-netfilter
+no3d
+nogroups
 nonewprivs
 noroot
-protocol unix,inet,inet6
-seccomp
-
-#
-# depending on your usage, you can enable some of the commands below: 
-#
-nogroups
-shell none
-# private-bin program
-# private-etc none
-# private-dev
-# private-tmp
 nosound
+novideo
+protocol unix
+seccomp
+shell none
+
+private-dev
+private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/lximage-qt.profile
+++ b/etc/lximage-qt.profile
@@ -13,6 +13,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/lxmusic.profile
+++ b/etc/lxmusic.profile
@@ -14,6 +14,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/lxmusic.profile
+++ b/etc/lxmusic.profile
@@ -7,24 +7,24 @@ include /etc/firejail/lxmusic.local
 
 noblacklist ~/.cache/xmms2
 noblacklist ~/.config/xmms2
+
 include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 caps.drop all
-netfilter
+no3d
+nogroups
 nonewprivs
 noroot
-protocol unix,inet,inet6
+novideo
+protocol unix
 seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
 shell none
-# private-bin program
-# private-etc none
-# private-dev
-# private-tmp
-# nosound
+
+private-dev
+private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/mate-calc.profile
+++ b/etc/mate-calc.profile
@@ -6,24 +6,26 @@ include /etc/firejail/globals.local
 include /etc/firejail/mate-calc.local
 
 noblacklist ${HOME}/.config/mate-calc
+
 include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 caps.drop all
-netfilter
+no3d
+nogroups
 nonewprivs
 noroot
-protocol unix,inet,inet6
-seccomp
-
-#
-# depending on your usage, you can enable some of the commands below: 
-#
-nogroups
-shell none
-# private-bin program
-# private-etc none
-# private-dev
-# private-tmp
 nosound
+novideo
+protocol unix
+seccomp
+shell none
+
+private-dev
+private-tmp
+disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/mate-calc.profile
+++ b/etc/mate-calc.profile
@@ -13,6 +13,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/mate-color-select.profile
+++ b/etc/mate-color-select.profile
@@ -3,27 +3,28 @@ include /etc/firejail/globals.local
 
 # This file is overwritten during software install.
 # Persistent customizations should go in a .local file.
-include /etc/firejail/default.local
+include /etc/firejail/mate-color-select.local
 
-private
-#include /etc/firejail/disable-common.inc
-#include /etc/firejail/disable-programs.inc
-#include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 caps.drop all
-netfilter
+no3d
+nogroups
 nonewprivs
 noroot
-protocol unix,inet,inet6
-seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
-shell none
-# private-bin program
-# private-etc none
-# private-dev
-# private-tmp
 nosound
+novideo
+protocol unix
+seccomp
+shell none
+
+private
+private-dev
+private-tmp
+disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/mate-color-select.profile
+++ b/etc/mate-color-select.profile
@@ -11,6 +11,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/mate-dictionary.profile
+++ b/etc/mate-dictionary.profile
@@ -6,24 +6,27 @@ include /etc/firejail/globals.local
 include /etc/firejail/mate-dictionary.local
 
 noblacklist ${HOME}/.config/mate/mate-dictionary
+
 include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 caps.drop all
 netfilter
+no3d
+nogroups
 nonewprivs
 noroot
+nosound
+novideo
 protocol unix,inet,inet6
 seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
 shell none
-# private-bin program
-# private-etc none
-# private-dev
-# private-tmp
-nosound
+
+private-dev
+private-tmp
+disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/mediainfo.profile
+++ b/etc/mediainfo.profile
@@ -12,15 +12,13 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-nogroups
 nonewprivs
+nogroups
 noroot
 nosound
 no3d
 protocol unix
 seccomp
-netfilter
-net none
 shell none
 tracelog
 

--- a/etc/mediainfo.profile
+++ b/etc/mediainfo.profile
@@ -12,6 +12,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+net none
 nonewprivs
 nogroups
 noroot

--- a/etc/meld.profile
+++ b/etc/meld.profile
@@ -15,8 +15,6 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 #ipc-namespace
-net none
-netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/meld.profile
+++ b/etc/meld.profile
@@ -15,6 +15,7 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 #ipc-namespace
+net none
 no3d
 nogroups
 nonewprivs

--- a/etc/mousepad.profile
+++ b/etc/mousepad.profile
@@ -14,6 +14,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/mousepad.profile
+++ b/etc/mousepad.profile
@@ -14,7 +14,6 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/mumble.profile
+++ b/etc/mumble.profile
@@ -35,5 +35,6 @@ private-bin mumble
 private-tmp
 disable-mnt
 
+memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp

--- a/etc/mupdf.profile
+++ b/etc/mupdf.profile
@@ -18,8 +18,6 @@ noroot
 nosound
 protocol unix
 seccomp
-netfilter
-net none
 shell none
 tracelog
 

--- a/etc/mupdf.profile
+++ b/etc/mupdf.profile
@@ -12,6 +12,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+net none
 nogroups
 nonewprivs
 noroot

--- a/etc/nautilus.profile
+++ b/etc/nautilus.profile
@@ -22,12 +22,10 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-nogroups
 nonewprivs
 noroot
 protocol unix
 seccomp
-netfilter
 shell none
 tracelog
 

--- a/etc/nautilus.profile
+++ b/etc/nautilus.profile
@@ -22,6 +22,8 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
+nogroups
 nonewprivs
 noroot
 protocol unix

--- a/etc/nemo.profile
+++ b/etc/nemo.profile
@@ -17,6 +17,7 @@ include /etc/firejail/disable-devel.inc
 caps.drop all
 netfilter
 no3d
+nogroups
 nonewprivs
 noroot
 nosound

--- a/etc/nemo.profile
+++ b/etc/nemo.profile
@@ -16,18 +16,14 @@ include /etc/firejail/disable-devel.inc
 
 caps.drop all
 netfilter
+no3d
 nonewprivs
 noroot
+nosound
+novideo
 protocol unix,inet,inet6
 seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
 shell none
-# private-bin program
-# private-etc none
-# private-dev
-# private-tmp
-# nosound
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/odt2txt.profile
+++ b/etc/odt2txt.profile
@@ -12,6 +12,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+net none
 nogroups
 nonewprivs
 noroot

--- a/etc/odt2txt.profile
+++ b/etc/odt2txt.profile
@@ -18,8 +18,6 @@ noroot
 nosound
 protocol unix
 seccomp
-netfilter
-net none
 no3d
 shell none
 tracelog

--- a/etc/okular.profile
+++ b/etc/okular.profile
@@ -34,3 +34,6 @@ tracelog
 # private-etc fonts,X11
 private-dev
 private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/okular.profile
+++ b/etc/okular.profile
@@ -21,6 +21,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nonewprivs
 nogroups
 noroot

--- a/etc/okular.profile
+++ b/etc/okular.profile
@@ -21,7 +21,6 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
 nonewprivs
 nogroups
 noroot

--- a/etc/openshot.profile
+++ b/etc/openshot.profile
@@ -8,13 +8,23 @@ include /etc/firejail/openshot.local
 # OpenShot profile
 noblacklist ${HOME}/.openshot
 noblacklist ${HOME}/.openshot_qt
+
 include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 caps.drop all
 netfilter
+nogroups
 nonewprivs
 noroot
 protocol unix,inet,inet6,netlink
 seccomp
+shell none
+
+private-dev
+private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/orage.profile
+++ b/etc/orage.profile
@@ -7,24 +7,26 @@ include /etc/firejail/orage.local
 
 noblacklist ${HOME}/.config/orage
 noblacklist ${HOME}/.local/share/orage
+
 include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 caps.drop all
-netfilter
+no3d
+nogroups
 nonewprivs
 noroot
-protocol unix,inet,inet6
+nosound
+novideo
+protocol unix
 seccomp
-
-#
-# depending on your usage, you can enable some of the commands below: 
-#
-nogroups
 shell none
-# private-bin program
-# private-etc none
-private-dev
-# private-tmp
 
+private-dev
+private-tmp
+disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/orage.profile
+++ b/etc/orage.profile
@@ -14,6 +14,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/pcmanfm.profile
+++ b/etc/pcmanfm.profile
@@ -15,6 +15,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+net none
 no3d
 nonewprivs
 noroot

--- a/etc/pcmanfm.profile
+++ b/etc/pcmanfm.profile
@@ -15,21 +15,12 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
-nogroups
+no3d
 nonewprivs
 noroot
 nosound
+novideo
 protocol unix
 seccomp
 shell none
 tracelog
-
-#
-# depending on your usage, you can enable some of the commands below: 
-#
-# private-bin program
-# private-etc none
-# private-dev
-# private-tmp
-

--- a/etc/pdfsam.profile
+++ b/etc/pdfsam.profile
@@ -19,6 +19,7 @@ include /etc/firejail/disable-devel.inc
 #Options
 caps.drop all
 #ipc-namespace
+net none
 no3d
 nogroups
 nonewprivs

--- a/etc/pdfsam.profile
+++ b/etc/pdfsam.profile
@@ -19,8 +19,6 @@ include /etc/firejail/disable-devel.inc
 #Options
 caps.drop all
 #ipc-namespace
-net none
-netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/pdftotext.profile
+++ b/etc/pdftotext.profile
@@ -12,6 +12,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+net none
 nogroups
 nonewprivs
 noroot

--- a/etc/pdftotext.profile
+++ b/etc/pdftotext.profile
@@ -18,8 +18,6 @@ noroot
 nosound
 protocol unix
 seccomp
-netfilter
-net none
 no3d
 shell none
 tracelog

--- a/etc/peek.profile
+++ b/etc/peek.profile
@@ -14,7 +14,6 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
-net none
 no3d
 nogroups
 nonewprivs

--- a/etc/peek.profile
+++ b/etc/peek.profile
@@ -14,6 +14,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+net none
 no3d
 nogroups
 nonewprivs

--- a/etc/peek.profile
+++ b/etc/peek.profile
@@ -28,5 +28,6 @@ shell none
 private-dev
 private-tmp
 
+memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp

--- a/etc/psi-plus.profile
+++ b/etc/psi-plus.profile
@@ -8,7 +8,9 @@ include /etc/firejail/psi-plus.local
 # Firejail profile for Psi+
 noblacklist ${HOME}/.config/psi+
 noblacklist ${HOME}/.local/share/psi+
+
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
@@ -20,10 +22,22 @@ whitelist ~/.local/share/psi+
 mkdir ~/.cache/psi+
 whitelist ~/.cache/psi+
 
+include /etc/firejail/whitelist-common.inc
+
 caps.drop all
 netfilter
+no3d
+nogroups
+nonewprivs
 noroot
+novideo
 protocol unix,inet,inet6
 seccomp
+shell none
 
-include /etc/firejail/whitelist-common.inc
+private-dev
+private-tmp
+disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/qemu-launcher.profile
+++ b/etc/qemu-launcher.profile
@@ -23,3 +23,5 @@ shell none
 tracelog
 
 private-tmp
+
+noexec /tmp

--- a/etc/qemu-system-x86_64.profile
+++ b/etc/qemu-system-x86_64.profile
@@ -21,3 +21,5 @@ shell none
 tracelog
 
 private-tmp
+
+noexec /tmp

--- a/etc/qlipper.profile
+++ b/etc/qlipper.profile
@@ -13,6 +13,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/qlipper.profile
+++ b/etc/qlipper.profile
@@ -6,26 +6,26 @@ include /etc/firejail/globals.local
 include /etc/firejail/qlipper.local
 
 noblacklist ${HOME}/.config/Qlipper
+
 include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 caps.drop all
-netfilter
+no3d
+nogroups
 nonewprivs
 noroot
-protocol unix,inet,inet6
-seccomp
-
-
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
-shell none
-# private-bin program
-# private-etc none
-# private-dev
-# private-tmp
 nosound
+novideo
+protocol unix
+seccomp
+shell none
+
+private-dev
+private-tmp
+disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/quiterss.profile
+++ b/etc/quiterss.profile
@@ -42,3 +42,6 @@ private-dev
 disable-mnt
 
 include /etc/firejail/whitelist-common.inc
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/ranger.profile
+++ b/etc/ranger.profile
@@ -18,14 +18,10 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
-net none
-nogroups
 nonewprivs
 noroot
 protocol unix
 seccomp
 nosound
 
-private-tmp
 private-dev

--- a/etc/ranger.profile
+++ b/etc/ranger.profile
@@ -18,6 +18,8 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+net none
+nogroups
 nonewprivs
 noroot
 protocol unix

--- a/etc/ristretto.profile
+++ b/etc/ristretto.profile
@@ -10,22 +10,23 @@ noblacklist ~/.Steam
 noblacklist ~/.steam
 
 include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 caps.drop all
-netfilter
+no3d
+nogroups
 nonewprivs
 noroot
-protocol unix,inet,inet6
+nosound
+novideo
+protocol unix
 seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
 shell none
-# private-bin program
-# private-etc none
+
 private-dev
-# private-tmp
+private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/ristretto.profile
+++ b/etc/ristretto.profile
@@ -15,6 +15,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/skype.profile
+++ b/etc/skype.profile
@@ -7,17 +7,22 @@ include /etc/firejail/skype.local
 
 # Skype profile
 noblacklist ${HOME}/.Skype
+
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
 caps.drop all
 netfilter
+nogroups
 nonewprivs
 noroot
 protocol unix,inet,inet6
 seccomp
+shell none
 
+private-dev
 private-tmp
 disable-mnt
 

--- a/etc/skypeforlinux.profile
+++ b/etc/skypeforlinux.profile
@@ -7,16 +7,22 @@ include /etc/firejail/skypeforlinux.local
 
 # skypeforlinux profile
 noblacklist ${HOME}/.config/skypeforlinux
+
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 netfilter
+nogroups
+nonewprivs
 noroot
-seccomp
 protocol unix,inet,inet6,netlink
+seccomp
+shell none
 
+private-dev
 private-tmp
 disable-mnt
 

--- a/etc/ssh.profile
+++ b/etc/ssh.profile
@@ -31,5 +31,6 @@ tracelog
 private-dev
 #private-tmp #Breaks when exiting
 
+memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp

--- a/etc/strings.profile
+++ b/etc/strings.profile
@@ -18,3 +18,5 @@ shell none
 tracelog
 private-dev
 blacklist /tmp/.X11-unix
+
+memory-deny-write-execute

--- a/etc/synfigstudio.profile
+++ b/etc/synfigstudio.profile
@@ -15,6 +15,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/synfigstudio.profile
+++ b/etc/synfigstudio.profile
@@ -8,19 +8,24 @@ include /etc/firejail/synfigstudio.local
 # synfigstudio
 noblacklist ${HOME}/.config/synfig
 noblacklist ${HOME}/.synfig
+
 include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 caps.drop all
-netfilter
+nogroups
 nonewprivs
 noroot
+nosound
+novideo
 protocol unix
 seccomp
-
-noexec ${HOME}
-noexec /tmp
+shell none
 
 private-dev
 private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/tracker.profile
+++ b/etc/tracker.profile
@@ -22,7 +22,6 @@ nosound
 no3d
 protocol unix
 seccomp
-netfilter
 shell none
 tracelog
 

--- a/etc/tracker.profile
+++ b/etc/tracker.profile
@@ -15,6 +15,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/transmission-cli.profile
+++ b/etc/transmission-cli.profile
@@ -28,3 +28,5 @@ tracelog
 private-tmp
 private-dev
 private-etc none
+
+memory-deny-write-execute

--- a/etc/transmission-gtk.profile
+++ b/etc/transmission-gtk.profile
@@ -34,3 +34,5 @@ tracelog
 private-bin transmission-gtk
 private-dev
 private-tmp
+
+memory-deny-write-execute

--- a/etc/transmission-show.profile
+++ b/etc/transmission-show.profile
@@ -15,6 +15,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+net none
 nonewprivs
 noroot
 nosound

--- a/etc/transmission-show.profile
+++ b/etc/transmission-show.profile
@@ -15,8 +15,6 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
-net none
 nonewprivs
 noroot
 nosound

--- a/etc/viewnior.profile
+++ b/etc/viewnior.profile
@@ -19,7 +19,6 @@ blacklist ~/.bashrc
 blacklist ~/.Xauthority
 
 caps.drop all
-net none
 nogroups
 nonewprivs
 noroot

--- a/etc/viewnior.profile
+++ b/etc/viewnior.profile
@@ -19,6 +19,7 @@ blacklist ~/.bashrc
 blacklist ~/.Xauthority
 
 caps.drop all
+net none
 nogroups
 nonewprivs
 noroot

--- a/etc/vivaldi.profile
+++ b/etc/vivaldi.profile
@@ -22,3 +22,6 @@ whitelist ~/.config/vivaldi
 mkdir ~/.cache/vivaldi
 whitelist ~/.cache/vivaldi
 include /etc/firejail/whitelist-common.inc
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/vivaldi.profile
+++ b/etc/vivaldi.profile
@@ -14,7 +14,6 @@ include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
 
-netfilter
 
 whitelist ${DOWNLOADS}
 mkdir ~/.config/vivaldi
@@ -22,6 +21,16 @@ whitelist ~/.config/vivaldi
 mkdir ~/.cache/vivaldi
 whitelist ~/.cache/vivaldi
 include /etc/firejail/whitelist-common.inc
+
+caps.keep sys_chroot,sys_admin
+#ipc-namespace
+netfilter
+nogroups
+shell none
+
+private-dev
+#private-tmp - problems with multiple browser sessions
+#disable-mnt
 
 noexec ${HOME}
 noexec /tmp

--- a/etc/vlc.profile
+++ b/etc/vlc.profile
@@ -27,5 +27,6 @@ private-bin vlc,cvlc,nvlc,rvlc,qvlc,svlc
 private-dev
 private-tmp
 
+memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp

--- a/etc/vym.profile
+++ b/etc/vym.profile
@@ -13,6 +13,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/vym.profile
+++ b/etc/vym.profile
@@ -6,25 +6,26 @@ include /etc/firejail/globals.local
 include /etc/firejail/vym.local
 
 noblacklist ./.config/InSilmaril
+
 include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 caps.drop all
-netfilter
+no3d
+nogroups
 nonewprivs
 noroot
-# no network connectivity
+nosound
+novideo
 protocol unix
 seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
 shell none
-# private-bin vym
-# private-etc none
+
 private-dev
 private-tmp
-nosound
+disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/xfburn.profile
+++ b/etc/xfburn.profile
@@ -20,7 +20,6 @@ noroot
 nosound
 protocol unix
 seccomp
-netfilter
 shell none
 tracelog
 

--- a/etc/xfburn.profile
+++ b/etc/xfburn.profile
@@ -14,6 +14,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+netfilter
 nogroups
 nonewprivs
 noroot

--- a/etc/xfce4-dict.profile
+++ b/etc/xfce4-dict.profile
@@ -6,24 +6,27 @@ include /etc/firejail/globals.local
 include /etc/firejail/xfce4-dict.local
 
 noblacklist ${HOME}/.config/xfce4-dict
+
 include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 caps.drop all
 netfilter
+no3d
+nogroups
 nonewprivs
 noroot
+nosound
+novideo
 protocol unix,inet,inet6
 seccomp
-
-#
-# depending on your usage, you can enable some of the commands below: 
-#
-nogroups
 shell none
-# private-bin program
-# private-etc none
-private-dev
-# private-tmp
 
+private-dev
+private-tmp
+disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/xfce4-notes.profile
+++ b/etc/xfce4-notes.profile
@@ -8,23 +8,26 @@ include /etc/firejail/xfce4-notes.local
 noblacklist ${HOME}/.config/xfce4/xfce4-notes.rc
 noblacklist ${HOME}/.config/xfce4/xfce4-notes.gtkrc
 noblacklist ${HOME}/.local/share/notes
+
 include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 caps.drop all
-netfilter
+no3d
+nogroups
 nonewprivs
 noroot
-protocol unix,inet,inet6
+nosound
+novideo
+protocol unix
 seccomp
-
-#
-# depending on your usage, you can enable some of the commands below:
-#
-nogroups
 shell none
-# private-bin program
-# private-etc none
+
 private-dev
-# private-tmp
+private-tmp
+disable-mnt
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/xfce4-notes.profile
+++ b/etc/xfce4-notes.profile
@@ -15,6 +15,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+netfilter
 no3d
 nogroups
 nonewprivs

--- a/etc/xonotic.profile
+++ b/etc/xonotic.profile
@@ -30,6 +30,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/xpdf.profile
+++ b/etc/xpdf.profile
@@ -16,6 +16,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+net none
 no3d
 nogroups
 nonewprivs

--- a/etc/xpdf.profile
+++ b/etc/xpdf.profile
@@ -9,17 +9,25 @@ include /etc/firejail/xpdf.local
 # xpdf application profile
 ################################
 noblacklist ${HOME}/.xpdfrc
+
 include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
 
 caps.drop all
-net none
+no3d
+nogroups
 nonewprivs
 noroot
+nosound
+novideo
 protocol unix
-shell none
 seccomp
+shell none
 
 private-dev
 private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/xpra.profile
+++ b/etc/xpra.profile
@@ -23,7 +23,6 @@ include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
 # xpra needs to be allowed access to the abstract Unix socket namespace.
-#net none
 nogroups
 nonewprivs
 # In noroot mode, xpra cannot create a socket in the real /tmp/.X11-unix.

--- a/etc/zathura.profile
+++ b/etc/zathura.profile
@@ -14,6 +14,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
+net none
 nogroups
 nonewprivs
 noroot

--- a/etc/zathura.profile
+++ b/etc/zathura.profile
@@ -14,8 +14,6 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 
 caps.drop all
-netfilter
-net none
 nogroups
 nonewprivs
 noroot


### PR DESCRIPTION
- Added 'disable-devel.conf' to many profiles
- Added 'disable-mnt' to many profiles
- Added 'noexec' to many profiles
- Added 'memory-deny-write-execute' to some profiles
- Removed 'netfilter' and 'net none' from profiles with 'protocol unix'
- Cleaned up profiles using defaults
- Partially synchronized Chromium-based profiles


**Only somewhat tested**. I've looked over it a few times, but would like some more eyes to go over it. Looking back I should've broken it up, but it got out of hand pretty quickly.

Commands used
```
List all profiles with incorrect .local: grep -l "default.local" *.profile
List all profiles with defaults: grep -l "depending on your usage" *.profile
List all 'disable-mnt' candidates: grep -L "disable-mnt" $(grep -l "whitelist-common" *.profile)
List all profiles with 'net none' and 'netfilter': grep -l netfilter $(grep -l "net none" *.profile)
List all profiles with 'disable-*.inc' but without 'disable-devel.inc': grep -L "disable-devel" $(grep -l "disable" *.profile)
List all profiles with 'net none' and 'protocol unix': grep -l "net none" $(grep -l "protocol unix" $(grep -L "protocol unix,inet" *.profile))
```

Also I'm not going to make a pull request just yet, but review on https://github.com/SpotComms/firejail/tree/pr/etc would be nice.