### PR TITLE
Add quiet to exiftool profile

### DIFF
--- a/etc/exiftool.profile
+++ b/etc/exiftool.profile
@@ -1,3 +1,4 @@
+quiet
 # Persistent global definitions go here
 include /etc/firejail/globals.local
 


### PR DESCRIPTION
Firejail output interferes with usage in a pipeline.

Example (without `quiet`):
```
exiftool -q -q -p '$ImageWidth/$ImageHeight' firetools-main.png | bc -l
Reading profile /etc/firejail/exiftool.profile
Reading profile /etc/firejail/disable-common.inc
Reading profile /etc/firejail/disable-programs.inc
Reading profile /etc/firejail/disable-devel.inc
Reading profile /etc/firejail/disable-passwdmgr.inc
Warning: skipping none for private /etc
(standard_in) 1: syntax error
(standard_in) 2: illegal character: ^[
(standard_in) 2: illegal character: $
(standard_in) 2: illegal character: I
(standard_in) 2: syntax error
(standard_in) 2: illegal character: W
(standard_in) 2: illegal character: $
(standard_in) 2: illegal character: I
(standard_in) 2: illegal character: H
(standard_in) 2: syntax error
(standard_in) 2: syntax error
(standard_in) 2: illegal character: ^G
(standard_in) 3: illegal character: P
(standard_in) 3: syntax error
(standard_in) 5: illegal character: P
(standard_in) 5: syntax error
```
Expected (with `quiet`):
```
$ exiftool -q -q -p '$ImageWidth/$ImageHeight' firetools-main.png | bc -l
1.34819897084048027444
```