### PR TITLE
Add access to trash for eog

### DIFF
--- a/etc/eog.profile
+++ b/etc/eog.profile
@@ -9,6 +9,7 @@ include /etc/firejail/eog.local
 noblacklist ~/.config/eog
 noblacklist ~/.Steam
 noblacklist ~/.steam
+noblacklist ~/.local/share/Trash
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc


### PR DESCRIPTION
Eog needs access to the users trash folder to delete files.