### PR TITLE
Add Electron and Riot profiles

### DIFF
--- a/etc/electron.profile
+++ b/etc/electron.profile
@@ -1,0 +1,12 @@
+# Generic Firejail profile for Electron applications.
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-passwdmgr.inc
+
+caps.drop all
+netfilter
+nogroups
+nonewprivs
+noroot
+protocol unix,inet,inet6,netlink
+seccomp

--- a/etc/riot-web.profile
+++ b/etc/riot-web.profile
@@ -1,0 +1,5 @@
+# Firejail profile for Riot.
+noblacklist ~/.config/Riot
+whitelist ~/.config/Riot
+
+include /etc/firejail/electron.profile


### PR DESCRIPTION
* Add a generic profile for Electron applications.
* Add a specific profile for Riot based on this new Electron profile.
* Addresses vector-im/riot-web#3004
* Fulfils profile request for Riot.im in netblue30/firejail#1139