### PR TITLE
Zoom cache dir

### DIFF
--- a/etc/zoom.profile
+++ b/etc/zoom.profile
@@ -17,7 +17,7 @@ include /etc/firejail/disable-devel.inc
 
 mkdir ~/.zoom
 whitelist ~/.zoom
-
+whitelist ~/.cache/zoom
 
 caps.drop all
 netfilter


### PR DESCRIPTION
Zoom seems to use of a QT cache-disk feature which depends upon a `~/.cache/<app>/qmlcache` directory.
If it can not, Zoom will segfault with
`mprotect failed in ExecutableAllocator::makeExecutable: Permission denied`