### PR TITLE
Fix typo for fnet moveif invocation on 2nd interface.

### DIFF
--- a/src/firejail/network_main.c
+++ b/src/firejail/network_main.c
@@ -314,7 +314,7 @@ void network_main(pid_t child) {
 		sbox_run(SBOX_ROOT | SBOX_CAPS_NETWORK | SBOX_SECCOMP, 4, PATH_FNET, "moveif", cfg.interface1.dev, cstr);
 	}
 	if (cfg.interface2.configured) {
-		sbox_run(SBOX_ROOT | SBOX_CAPS_NETWORK | SBOX_SECCOMP, 4, PATH_FNET, "moveif", cfg.interface3.dev, cstr);
+		sbox_run(SBOX_ROOT | SBOX_CAPS_NETWORK | SBOX_SECCOMP, 4, PATH_FNET, "moveif", cfg.interface2.dev, cstr);
 	}
 	if (cfg.interface3.configured) {
 		sbox_run(SBOX_ROOT | SBOX_CAPS_NETWORK | SBOX_SECCOMP, 4, PATH_FNET, "moveif", cfg.interface3.dev, cstr);


### PR DESCRIPTION
I noticed a fair bit of copy pasta here.  While that may not necessarily be bad in itself, is there a reason where the duplication can be easily parameterized to avoid using C preprocessor macros with the ## operator to avoid this sort of typo?