### PR TITLE
Improve loading of seccomp filter and memory-deny-write-execute feature

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -45,6 +45,7 @@ ifeq ($(HAVE_SECCOMP),-DHAVE_SECCOMP)
 	src/fseccomp/fseccomp default seccomp.debug allow-debuggers
 	src/fseccomp/fseccomp secondary 32 seccomp.i386
 	src/fseccomp/fseccomp secondary 64 seccomp.amd64
+	src/fseccomp/fseccomp memory-deny-write-execute seccomp.mdwx
 endif
 
 clean:
@@ -52,7 +53,7 @@ clean:
 		$(MAKE) -C $$dir clean; \
 	done
 	rm -f $(MANPAGES) $(MANPAGES:%=%.gz) firejail*.rpm
-	rm -f seccomp seccomp.debug seccomp.i386 seccomp.amd64
+	rm -f seccomp seccomp.debug seccomp.i386 seccomp.amd64 seccomp.mdwx
 	rm -f test/utils/index.html*
 	rm -f test/utils/wget-log
 	rm -f test/utils/lstesting
@@ -101,6 +102,7 @@ ifeq ($(HAVE_SECCOMP),-DHAVE_SECCOMP)
 	install -c -m 0644 seccomp.debug $(DESTDIR)/$(libdir)/firejail/.
 	install -c -m 0644 seccomp.i386 $(DESTDIR)/$(libdir)/firejail/.
 	install -c -m 0644 seccomp.amd64 $(DESTDIR)/$(libdir)/firejail/.
+	install -c -m 0644 seccomp.mdwx $(DESTDIR)/$(libdir)/firejail/.
 endif
 ifeq ($(HAVE_CONTRIB_INSTALL),yes)
 	install -c -m 0755 contrib/fix_private-bin.py $(DESTDIR)/$(libdir)/firejail/.

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -53,10 +53,12 @@
 #define RUN_SECCOMP_CFG	"/run/firejail/mnt/seccomp"			// configured filter
 #define RUN_SECCOMP_AMD64	"/run/firejail/mnt/seccomp.amd64"	// amd64 filter installed on i386 architectures
 #define RUN_SECCOMP_I386	"/run/firejail/mnt/seccomp.i386"		// i386 filter installed on amd64 architectures
+#define RUN_SECCOMP_MDWX	"/run/firejail/mnt/seccomp.mdwx"		// filter for memory-deny-write-execute
 #define PATH_SECCOMP_DEFAULT (LIBDIR "/firejail/seccomp")			// default filter built during make
 #define PATH_SECCOMP_DEFAULT_DEBUG (LIBDIR "/firejail/seccomp.debug")	// default filter built during make
 #define PATH_SECCOMP_AMD64 (LIBDIR "/firejail/seccomp.amd64")		// amd64 filter built during make
 #define PATH_SECCOMP_I386 (LIBDIR "/firejail/seccomp.i386")			// i386 filter built during make
+#define PATH_SECCOMP_MDWX (LIBDIR "/firejail/seccomp.mdwx")		// filter for memory-deny-write-execute built during make
 
 
 #define RUN_DEV_DIR		"/run/firejail/mnt/dev"
@@ -352,6 +354,7 @@ extern int arg_allusers;	// all user home directories visible
 extern int arg_machineid;	// preserve /etc/machine-id
 extern int arg_disable_mnt;	// disable /mnt and /media
 extern int arg_noprofile;	// use default.profile if none other found/specified
+extern int arg_memory_deny_write_execute;	// block writable and executable memory
 
 extern int login_shell;
 extern int parent_to_child_fds[2];

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -110,6 +110,7 @@ int arg_allow_private_blacklist = 0; 		// blacklist things in private directorie
 int arg_writable_var_log = 0;		// writable /var/log
 int arg_disable_mnt = 0;			// disable /mnt and /media
 int arg_noprofile = 0; // use default.profile if none other found/specified
+int arg_memory_deny_write_execute = 0;		// block writable and executable memory
 
 int login_shell = 0;
 
@@ -1141,6 +1142,12 @@ int main(int argc, char **argv) {
 				arg_seccomp = 1;
 				cfg.seccomp_list_keep = seccomp_check_list(argv[i] + 15);
 			}
+			else
+				exit_err_feature("seccomp");
+		}
+		else if (strcmp(argv[i], "--memory-deny-write-execute") == 0) {
+			if (checkcfg(CFG_SECCOMP))
+				arg_memory_deny_write_execute = 1;
 			else
 				exit_err_feature("seccomp");
 		}

--- a/src/firejail/preproc.c
+++ b/src/firejail/preproc.c
@@ -83,6 +83,8 @@ void preproc_mount_mnt_dir(void) {
 		else
 			copy_file(PATH_SECCOMP_DEFAULT, RUN_SECCOMP_CFG, getuid(), getgid(), 0644); // root needed
 
+		if (arg_memory_deny_write_execute)
+			copy_file(PATH_SECCOMP_MDWX, RUN_SECCOMP_MDWX, getuid(), getgid(), 0644); // root needed
 		// as root, create an empty RUN_SECCOMP_PROTOCOL file
 		create_empty_file_as_root(RUN_SECCOMP_PROTOCOL, 0644);
 		if (set_perms(RUN_SECCOMP_PROTOCOL, getuid(), getgid(), 0644))

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -595,6 +595,17 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		return 0;
 	}
 
+	// memory deny write&execute
+	if (strncmp(ptr, "memory-deny-write-execute ", sizeof("memory-deny-write-execute ") - 1) == 0) {
+#ifdef HAVE_SECCOMP
+		if (checkcfg(CFG_SECCOMP))
+			arg_memory_deny_write_execute = 1;
+		else
+			warning_feature_disabled("seccomp");
+#endif
+		return 0;
+	}
+
 	// caps drop list
 	if (strncmp(ptr, "caps.drop ", 10) == 0) {
 		arg_caps_drop = 1;

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -935,6 +935,11 @@ int sandbox(void* sandbox_arg) {
 		else
 			seccomp_filter_drop(enforce_seccomp);
 	}
+	if (arg_memory_deny_write_execute) {
+		if (arg_debug)
+			printf("Install memory write&execute filter\n");
+		seccomp_load(RUN_SECCOMP_MDWX);	// install filter
+	}
 #endif
 
 	//****************************************

--- a/src/fseccomp/fseccomp.h
+++ b/src/fseccomp/fseccomp.h
@@ -48,6 +48,7 @@ void seccomp_secondary_64(const char *fname);
 void seccomp_secondary_32(const char *fname);
 
 // seccomp_file.c
+void write_to_file(int fd, const void *data, int size);
 void filter_init(int fd);
 void filter_add_whitelist(int fd, int syscall, int arg);
 void filter_add_blacklist(int fd, int syscall, int arg);
@@ -64,6 +65,8 @@ void seccomp_drop(const char *fname, char *list, int allow_debuggers);
 void seccomp_default_drop(const char *fname, char *list, int allow_debuggers);
 // whitelisted filter
 void seccomp_keep(const char *fname, char *list);
+// block writable and executable memory
+void memory_deny_write_execute(const char *fname);
 
 // seccomp_print
 void filter_print(const char *fname);

--- a/src/fseccomp/main.c
+++ b/src/fseccomp/main.c
@@ -35,6 +35,7 @@ static void usage(void) {
 	printf("\tfseccomp default drop file list\n");
 	printf("\tfseccomp default drop file list allow-debuggers\n");
 	printf("\tfseccomp keep file list\n");
+	printf("\tfseccomp memory-deny-write-execute file\n");
 	printf("\tfseccomp print file\n");
 }
 
@@ -87,6 +88,8 @@ printf("\n");
 		seccomp_default_drop(argv[3], argv[4], 1);
 	else if (argc == 4 && strcmp(argv[1], "keep") == 0)
 		seccomp_keep(argv[2], argv[3]);
+	else if (argc == 3 && strcmp(argv[1], "memory-deny-write-execute") == 0)
+		memory_deny_write_execute(argv[2]);
 	else if (argc == 3 && strcmp(argv[1], "print") == 0)
 		filter_print(argv[2]);
 	else {

--- a/src/fseccomp/seccomp_file.c
+++ b/src/fseccomp/seccomp_file.c
@@ -21,7 +21,7 @@
 #include "../include/seccomp.h"
 #include <sys/syscall.h>
 
-static void write_to_file(int fd, void *data, int size) {
+void write_to_file(int fd, const void *data, int size) {
 	assert(data);
 	assert(size);
 

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -740,6 +740,12 @@ Example:
 $ firejail \-\-machine-id
 
 .TP
+\fB\-\-memory-deny-write-execute
+Install a seccomp filter to block attempts to create memory mappings
+that are both writable and executable, to change mappings to be
+executable or to create executable shared memory.
+
+.TP
 \fB\-\-mtu=number
 Assign a MTU value to the last network interface defined by a \-\-net option.
 .br


### PR DESCRIPTION
The seccomp patch also fixes a memory leak and double load.

Memory-deny-write-execute is similar to systemd directive with same name (sans CamelCase).