### PR TITLE
telegram is called telegram-desktop in Debian

### DIFF
--- a/etc/telegram-desktop.profile
+++ b/etc/telegram-desktop.profile
@@ -3,7 +3,7 @@ include /etc/firejail/globals.local
 
 # This file is overwritten during software install.
 # Persistent customizations should go in a .local file.
-include /etc/firejail/Telegram.local
+include /etc/firejail/telegram-desktop.local
 
 # Telegram profile
 include /etc/firejail/telegram.profile

--- a/etc/telegram.profile
+++ b/etc/telegram.profile
@@ -5,7 +5,7 @@ include /etc/firejail/globals.local
 # Persistent customizations should go in a .local file.
 include /etc/firejail/telegram.local
 
-# Telegram IRC profile
+# Telegram profile
 noblacklist ${HOME}/.TelegramDesktop
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc


### PR DESCRIPTION
The Telegram client is called `telegram-desktop` in Debian: https://packages.debian.org/sid/telegram-desktop. (It's also not an IRC client, but uses its own protocol.