### PR TITLE
Add some /proc dirs to firejail apparmor profile

### DIFF
--- a/etc/firejail-default
+++ b/etc/firejail-default
@@ -71,6 +71,10 @@ profile firejail-default flags=(attach_disconnected,mediate_deleted) {
 /proc/@{PID}/mounts r,
 /proc/@{PID}/mountinfo r,
 /proc/@{PID}/oom_score_adj r,
+/proc/@{PID}/auxv r,
+/proc/@{PID}/net/dev r,
+/proc/@{PID}/loginuid r,
+/proc/@{PID}/environ r,
 
 ##########
 # Allow running programs only from well-known system directories. If you need


### PR DESCRIPTION
This adds some additional paths to /proc whitelist in firejail-default aparmor profile. Those were detected by audit system logs.

```
AVC apparmor="DENIED" operation="open" profile="firejail-default" name="/proc/27/net/dev" pid=6143 comm="kodi.bin" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
AVC apparmor="DENIED" operation="open" profile="firejail-default" name="/proc/27/net/dev" pid=6143 comm="kodi.bin" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
AVC apparmor="DENIED" operation="open" profile="firejail-default" name="/proc/12/loginuid" pid=9570 comm="zsh" requested_mask="r" denied_mask="r" fsuid=1000 ouid=1000
AVC apparmor="DENIED" operation="open" profile="firejail-default" name="/proc/80/auxv" pid=9570 comm="firefox" requested_mask="r" denied_mask="r" fsuid=1000 ouid=1000
AVC apparmor="DENIED" operation="open" profile="firejail-default" name="/proc/128/auxv" pid=9570 comm="firefox" requested_mask="r" denied_mask="r" fsuid=1000 ouid=1000
AVC apparmor="DENIED" operation="open" profile="firejail-default" name="/proc/12/loginuid" pid=1583 comm="zsh" requested_mask="r" denied_mask="r" fsuid=1000 ouid=1000
AVC apparmor="DENIED" operation="open" profile="firejail-default" name="/proc/83/environ" pid=1583 comm="firefox" requested_mask="r" denied_mask="r" fsuid=1000 ouid=1000
```