### PR TITLE
Change ${HOME}/.local/share/kservices5 to read-only

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -70,7 +70,7 @@ blacklist ${HOME}/.config/krunnerrc
 blacklist ${HOME}/.config/plasma-org.kde.plasma.desktop-appletsrc
 blacklist ${HOME}/.local/share/kglobalaccel
 blacklist ${HOME}/.local/share/konsole
-blacklist ${HOME}/.local/share/kservices5
+read-only ${HOME}/.local/share/kservices5
 blacklist ${HOME}/.local/share/kwin
 blacklist ${HOME}/.local/share/plasma
 blacklist ${HOME}/.local/share/solid


### PR DESCRIPTION
`${HOME}/.local/share/kservices5` is blacklisted since https://github.com/netblue30/firejail/pull/1177 but there is no explanation for this. Some applications try to read this directory and it has legitimate use cases. Also `/usr/share/kservices5` isn't blacklisted so blacklisting only it's local variant isn't consistent. Changing it to read-only is both safe and don't trigger blacklist violations.

```
blacklist violation - sandbox 20831, exe okular, syscall opendir, path /home/mr/.local/share/kservices5
blacklist violation - sandbox 22050, exe gwenview, syscall opendir, path /home/mr/.local/share/kservices5
blacklist violation - sandbox 22386, exe kde-open5, syscall opendir, path /home/mr/.local/share/kservices5
```