### PR TITLE
profile fixes

### DIFF
--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -136,6 +136,7 @@ blacklist ${HOME}/.config/pluma
 blacklist ${HOME}/.config/psi+
 blacklist ${HOME}/.config/ristretto
 blacklist ${HOME}/.config/qBittorrent
+blacklist ${HOME}/.config/qBittorrentrc
 blacklist ${HOME}/.config/qpdfview
 blacklist ${HOME}/.config/qt5ct
 blacklist ${HOME}/.config/qupzilla
@@ -284,6 +285,7 @@ blacklist ${HOME}/.local/share/gnome-2048
 blacklist ${HOME}/.local/share/gnome-chess
 blacklist ${HOME}/.local/share/gnome-music
 blacklist ${HOME}/.local/share/gnome-photos
+blacklist ${HOME}/.local/share/gwenview
 blacklist ${HOME}/.local/share/kate
 blacklist ${HOME}/.local/share/kwrite
 blacklist ${HOME}/.local/share/ktorrentrc

--- a/etc/gwenview.profile
+++ b/etc/gwenview.profile
@@ -12,6 +12,7 @@ noblacklist ~/.kde/share/apps/gwenview
 noblacklist ~/.kde/share/config/gwenviewrc
 noblacklist ~/.config/gwenviewrc
 noblacklist ~/.config/org.kde.gwenviewrc
+noblacklist ~/.local/share/gwenview
 noblacklist ~/.local/share/org.kde.gwenview
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
@@ -27,7 +28,7 @@ seccomp
 shell none
 tracelog
 
-private-bin gwenview,kbuildsycoca4,gimp,gimp-2.8
+private-bin gwenview,kbuildsycoca4,kbuildsycoca5,gimp,gimp-2.8
 private-dev
 
 # Experimental:

--- a/etc/qbittorrent.profile
+++ b/etc/qbittorrent.profile
@@ -8,6 +8,7 @@ include /etc/firejail/qbittorrent.local
 # qbittorrent bittorrent profile
 noblacklist ~/.config/qt5ct
 noblacklist ~/.config/qBittorrent
+noblacklist ~/.config/qBittorrentrc
 noblacklist ~/.cache/qBittorrent
 
 include /etc/firejail/disable-common.inc
@@ -20,6 +21,7 @@ whitelist ~/.local/share/data/qBittorrent
 whitelist ~/.config/qt5ct
 mkdir ~/.config/qBittorrent
 whitelist ~/.config/qBittorrent
+whitelist ~/.config/qBittorrentrc
 mkdir ~/.cache/qBittorrent
 whitelist ~/.cache/qBittorrent
 whitelist  ${DOWNLOADS}


### PR DESCRIPTION
Added directories which are used for tracking recently opened files and dirs by `qBittorrent` and `gwenview` apps. Similar dirs are already included in many other profiles. Also added KDE 5 version of `kbuildsycoca` to private-bin for `gwenview`.