### PR TITLE
Gwenview: drop kbuildsycoca5 from private-bin

### DIFF
--- a/etc/gwenview.profile
+++ b/etc/gwenview.profile
@@ -28,7 +28,7 @@ seccomp
 shell none
 tracelog
 
-private-bin gwenview,kbuildsycoca4,kbuildsycoca5,gimp,gimp-2.8
+private-bin gwenview,kbuildsycoca4,gimp,gimp-2.8
 private-dev
 
 # Experimental:


### PR DESCRIPTION
According to https://github.com/netblue30/firejail/pull/1430#pullrequestreview-54257466 it may be unnecessary. It was also proposed and dropped from okular profile https://github.com/netblue30/firejail/pull/1198/commits/fbfa5df3ba9e92c256101c0c3eddb98d102c9b8a . No other profile uses it currently so adding it was probably mistake. Sorry.