### PR TITLE
fix steam startup with >=llvm-4

### DIFF
--- a/etc/steam.profile
+++ b/etc/steam.profile
@@ -5,6 +5,9 @@ include /etc/firejail/globals.local
 # Persistent customizations should go in a .local file.
 include /etc/firejail/steam.local
 
+# with >=llvm-4 mesa drivers need llvm stuff
+noblacklist /usr/lib/llvm*
+
 # Steam profile (applies to games/apps launched from Steam as well)
 noblacklist ${HOME}/.java
 noblacklist ${HOME}/.Steam


### PR DESCRIPTION
`libGL: dlopen /usr/lib32/dri/nouveau_dri.so failed (libLLVMObjCARCOpts.so.4: cannot open shared object file: No such file or directory)`