### PR TITLE
Change KDE4 services folder to read-only

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -52,7 +52,7 @@ read-only ${HOME}/.kde4/share/config/kdeglobals
 blacklist ${HOME}/.kde4/share/config/khotkeysrc
 blacklist ${HOME}/.kde4/share/config/krunnerrc
 blacklist ${HOME}/.kde4/share/config/plasma-desktop-appletsrc
-blacklist ${HOME}/.kde4/share/kde4/services
+read-only ${HOME}/.kde4/share/kde4/services
 blacklist ${HOME}/.kde/share/apps/konsole
 blacklist ${HOME}/.kde/share/apps/kwin
 blacklist ${HOME}/.kde/share/apps/plasma
@@ -62,7 +62,7 @@ read-only ${HOME}/.kde/share/config/kdeglobals
 blacklist ${HOME}/.kde/share/config/khotkeysrc
 blacklist ${HOME}/.kde/share/config/krunnerrc
 blacklist ${HOME}/.kde/share/config/plasma-desktop-appletsrc
-blacklist ${HOME}/.kde/share/kde4/services
+read-only ${HOME}/.kde/share/kde4/services
 blacklist ${HOME}/.config/*.notifyrc
 read-only ${HOME}/.config/kdeglobals
 blacklist ${HOME}/.config/khotkeysrc

--- a/etc/dolphin.profile
+++ b/etc/dolphin.profile
@@ -11,8 +11,6 @@ include /etc/firejail/dolphin.local
 
 noblacklist ~/.config/dolphinrc
 noblacklist ~/.local/share/dolphin
-noblacklist ~/.kde4/share/kde4/services
-noblacklist ~/.kde/share/kde4/services
 noblacklist ${HOME}/.local/share/Trash
 
 include /etc/firejail/disable-common.inc


### PR DESCRIPTION
Parallels #1428

Configurations in this location don't have much value as a secret, but need to be protected from manipulation. Let's make them available to all KDE apps for legitimate use. 
Looking at Dolphin, it is actually a security improvement.