### PR TITLE
Automatically build each commit on Travis CI and upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ sudo: yes
 script:
   - ( cd firejail ; ./configure && make && sudo make install-strip )
   - find /usr/local
+  - ( cd /usr/local , tar cfvj * firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 . )
+  - ls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: c
+dist: trusty
+sudo: yes
+
+script:
+  - ( cd firejail ; ./configure && make && sudo make install-strip )
+  - find /usr/local

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ sudo: true
 script:
   - ( cd firejail ; ./configure --prefix=/usr && make && sudo make install-strip DESTDIR=$(readlink -f appdir) )
   - find appdir/
-  - ( cd appdir/ , tar cfvj firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 * )
-  - curl --upload-file ./appdir/firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 https://transfer.sh/firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2
+  - ( cd appdir/ , tar cfvj ../firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 * )
+  - ls
+  - curl --upload-file ./firejail-*.tar.bz2 https://transfer.sh/firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 dist: trusty
-sudo: false
+sudo: true
 
 script:
   - ( cd firejail ; ./configure --prefix=/usr && make && sudo make install-strip DESTDIR=$(readlink -f appdir) )

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 sudo: true
 
 script:
-  - ( cd firejail ; ./configure && make --prefix=/usr && sudo make install && make test )
-  - ( cd firejail ; ./configure --prefix=/usr && make && sudo make install-strip DESTDIR=$(readlink -f appdir) )
+  - ( cd firejail ; ./configure --prefix=/usr && make && sudo make install && make test )
+  - ( cd firejail ; sudo make install-strip DESTDIR=$(readlink -f appdir) )
   - ( cd appdir/ ; tar cfvj ../firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 . )
   - curl --upload-file ./firejail-*.tar.bz2 https://transfer.sh/firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ sudo: true
 script:
   - ( cd firejail ; ./configure --prefix=/usr && make && sudo make install-strip DESTDIR=$(readlink -f appdir) )
   - find appdir/
-  - ( cd appdir/ , tar cfvj ../firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 . )
+  - ( cd appdir/ ; tar cfvj ../firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 . )
   - ls
   - curl --upload-file ./firejail-*.tar.bz2 https://transfer.sh/firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 sudo: false
 
 script:
-  - ( cd firejail ; ./configure && make && sudo make install-strip )
-  - find /usr/local
-  - ( cd /usr/local , tar cfvj * firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 . )
+  - ( cd firejail ; ./configure --prefix=/usr && make && sudo make install-strip DESTDIR=$(readlink -f appdir) )
+  - find appdir/
+  - ( cd appdir/ , tar cfvj firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 * )
   - curl --upload-file ./firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 https://transfer.sh/firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: c
 dist: trusty
-sudo: yes
+sudo: false
 
 script:
   - ( cd firejail ; ./configure && make && sudo make install-strip )
   - find /usr/local
   - ( cd /usr/local , tar cfvj * firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 . )
-  - ls
+  - curl --upload-file ./firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 https://transfer.sh/firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ dist: trusty
 sudo: true
 
 script:
+  - sudo apt-get -y install expect
   - ( cd firejail ; ./configure --prefix=/usr && make && sudo make install && make test )
   - ( cd firejail ; sudo make install-strip DESTDIR=$(readlink -f appdir) )
   - ( cd appdir/ ; tar cfvj ../firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 . )
   - curl --upload-file ./firejail-*.tar.bz2 https://transfer.sh/firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2
+  - # Could use https://github.com/probonopd/uploadtool to upload to GitHub Releases instead

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ sudo: true
 script:
   - ( cd firejail ; ./configure --prefix=/usr && make && sudo make install-strip DESTDIR=$(readlink -f appdir) )
   - find appdir/
-  - ( cd appdir/ , tar cfvj ../firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 * )
+  - ( cd appdir/ , tar cfvj ../firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 . )
   - ls
   - curl --upload-file ./firejail-*.tar.bz2 https://transfer.sh/firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 sudo: true
 
 script:
-  - ( cd firejail ; ./configure --prefix=/usr && make && sudo make install-strip DESTDIR=$(readlink -f appdir) )
+  - ( cd firejail ; ./configure --prefix=/usr && make && make test && sudo make install-strip DESTDIR=$(readlink -f appdir) )
   - find appdir/
   - ( cd appdir/ ; tar cfvj ../firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 . )
   - ls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ script:
   - ( cd firejail ; ./configure --prefix=/usr && make && sudo make install-strip DESTDIR=$(readlink -f appdir) )
   - find appdir/
   - ( cd appdir/ , tar cfvj firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 * )
-  - curl --upload-file ./firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 https://transfer.sh/firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2
+  - curl --upload-file ./appdir/firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 https://transfer.sh/firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ dist: trusty
 sudo: true
 
 script:
-  - ( cd firejail ; ./configure --prefix=/usr && make && make test && sudo make install-strip DESTDIR=$(readlink -f appdir) )
-  - find appdir/
+  - ( cd firejail ; ./configure && make --prefix=/usr && sudo make install && make test )
+  - ( cd firejail ; ./configure --prefix=/usr && make && sudo make install-strip DESTDIR=$(readlink -f appdir) )
   - ( cd appdir/ ; tar cfvj ../firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2 . )
-  - ls
   - curl --upload-file ./firejail-*.tar.bz2 https://transfer.sh/firejail-build$TRAVIS_BUILD_NUMBER.tar.bz2


### PR DESCRIPTION
Currently, no binaries of recent versions are available for download.

This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload it to a temporary download URL on transfer.sh (available for 14 days). The download URL is toward the end of each Travis CI build log of each build (see below for how to set up automatic uploading to your GitHub Releases page).

For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so.

__Please note:__ Instead of storing AppImage builds temporarily for 14 days each on transfer.sh, you could use GitHub Releases to store the binaries permanently. This way, they would be visible on the Releases page of your project. This is what I recommend. See https://docs.travis-ci.com/user/deployment/releases/. If you want to do this for continuous builds, also see https://github.com/probonopd/uploadtool.

If you would like to see only one entry for the Pull Request in your project's history, then please enable [this GitHub functionality](https://help.github.com/articles/configuring-commit-squashing-for-pull-requests/) on your repo. It allows you to squash (combine) the commits when merging.