### PR TITLE
Harden 18 profiles using private-bin

### DIFF
--- a/etc/apktool.profile
+++ b/etc/apktool.profile
@@ -24,6 +24,7 @@ protocol unix
 seccomp
 shell none
 
+private-bin apktool,bash,java,dirname,basename,expr
 private-dev
 
 noexec ${HOME}

--- a/etc/arm.profile
+++ b/etc/arm.profile
@@ -32,7 +32,7 @@ shell none
 tracelog
 
 disable-mnt
-# private-bin arm,tor,sh,python2,python2.7,ps,lsof,ldconfig
+# private-bin arm,tor,sh,bash,python2,python2.7,ps,lsof,ldconfig
 private-dev
 private-etc tor,passwd
 private-tmp

--- a/etc/baobab.profile
+++ b/etc/baobab.profile
@@ -24,6 +24,7 @@ protocol unix
 seccomp
 shell none
 
+private-bin baobab
 private-dev
 private-tmp
 

--- a/etc/bless.profile
+++ b/etc/bless.profile
@@ -25,6 +25,7 @@ protocol unix
 seccomp
 shell none
 
+# private-bin bless,sh,bash,mono
 private-dev
 private-etc fonts,mono
 private-tmp

--- a/etc/chromium.profile
+++ b/etc/chromium.profile
@@ -31,6 +31,7 @@ nogroups
 notv
 shell none
 
+# private-bin chromium,chromium-browser,chromedriver
 private-dev
 # private-tmp - problems with multiple browser sessions
 

--- a/etc/chromium.profile
+++ b/etc/chromium.profile
@@ -11,8 +11,7 @@ noblacklist ~/.config/chromium-flags.conf
 noblacklist ~/.pki
 
 include /etc/firejail/disable-common.inc
-# chromium is distributed with a perl script on Arch
-# include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 
 mkdir ~/.cache/chromium

--- a/etc/dex2jar.profile
+++ b/etc/dex2jar.profile
@@ -25,6 +25,7 @@ protocol unix
 seccomp
 shell none
 
+private-bin dex2jar,java,sh,bash,expr,dirname,ls,uname,grep
 private-dev
 
 noexec ${HOME}

--- a/etc/flashpeak-slimjet.profile
+++ b/etc/flashpeak-slimjet.profile
@@ -15,8 +15,7 @@ noblacklist ~/.config/slimjet
 noblacklist ~/.pki
 
 include /etc/firejail/disable-common.inc
-# chromium is distributed with a perl script on Arch
-# include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 
 mkdir ~/.cache/slimjet

--- a/etc/gitg.profile
+++ b/etc/gitg.profile
@@ -26,6 +26,7 @@ protocol unix,inet,inet6
 seccomp
 shell none
 
+private-bin gitg,git,ssh
 private-dev
 private-tmp
 

--- a/etc/google-chrome-beta.profile
+++ b/etc/google-chrome-beta.profile
@@ -10,8 +10,7 @@ noblacklist ~/.config/google-chrome-beta
 noblacklist ~/.pki
 
 include /etc/firejail/disable-common.inc
-# chromium is distributed with a perl script on Arch
-# include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 
 mkdir ~/.cache/google-chrome-beta

--- a/etc/google-chrome-unstable.profile
+++ b/etc/google-chrome-unstable.profile
@@ -10,8 +10,7 @@ noblacklist ~/.config/google-chrome-unstable
 noblacklist ~/.pki
 
 include /etc/firejail/disable-common.inc
-# chromium is distributed with a perl script on Arch
-# include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 
 mkdir ~/.cache/google-chrome-unstable

--- a/etc/google-chrome.profile
+++ b/etc/google-chrome.profile
@@ -10,8 +10,7 @@ noblacklist ~/.config/google-chrome
 noblacklist ~/.pki
 
 include /etc/firejail/disable-common.inc
-# chromium is distributed with a perl script on Arch
-# include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 
 mkdir ~/.cache/google-chrome

--- a/etc/hashcat.profile
+++ b/etc/hashcat.profile
@@ -7,8 +7,10 @@ include /etc/firejail/hashcat.local
 include /etc/firejail/globals.local
 
 noblacklist ${HOME}/.hashcat
+noblacklist /usr/include
 
 include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
@@ -25,6 +27,7 @@ seccomp
 shell none
 
 disable-mnt
+private-bin hashcat
 private-dev
 private-tmp
 

--- a/etc/jd-gui.profile
+++ b/etc/jd-gui.profile
@@ -26,6 +26,7 @@ protocol unix
 seccomp
 shell none
 
+private-bin jd-gui,sh,bash
 private-dev
 private-tmp
 

--- a/etc/meld.profile
+++ b/etc/meld.profile
@@ -25,6 +25,7 @@ protocol unix
 seccomp
 shell none
 
+# private-bin meld,python2,python2.7
 private-dev
 private-tmp
 

--- a/etc/multimc5.profile
+++ b/etc/multimc5.profile
@@ -32,6 +32,8 @@ protocol unix,inet,inet6
 shell none
 
 disable-mnt
+# private-bin works, but causes weirdness
+# private-bin multimc5,bash,mkdir,which,zenity,kdialog,ldd,chmod,valgrind,apt-file,pkgfile,dnf,yum,zypper,pfl,java,grep,sort,awk,readlink,dirname
 private-dev
 private-tmp
 

--- a/etc/obs.profile
+++ b/etc/obs.profile
@@ -22,6 +22,7 @@ seccomp
 shell none
 tracelog
 
+private-bin obs
 private-dev
 private-tmp
 

--- a/etc/pdfsam.profile
+++ b/etc/pdfsam.profile
@@ -25,6 +25,7 @@ protocol unix
 seccomp
 shell none
 
+private-bin pdfsam,sh,bash,java,archlinux-java,grep,awk,dirname,uname,which,sort,find,readlink,expr,ls,java-config
 private-dev
 private-tmp
 

--- a/etc/peek.profile
+++ b/etc/peek.profile
@@ -25,6 +25,7 @@ protocol unix
 seccomp
 shell none
 
+# private-bin breaks gif mode, mp4 and webm mode work fine however
 # private-bin peek,convert,ffmpeg
 private-dev
 private-tmp

--- a/etc/pithos.profile
+++ b/etc/pithos.profile
@@ -25,6 +25,7 @@ seccomp
 shell none
 
 disable-mnt
+# private-bin pithos,python,python3,python3.6
 private-dev
 private-tmp
 

--- a/etc/sdat2img.profile
+++ b/etc/sdat2img.profile
@@ -25,6 +25,7 @@ protocol unix
 seccomp
 shell none
 
+# private-bin sdat2img,env,python,python3,python3.6
 private-dev
 
 noexec ${HOME}

--- a/etc/strings.profile
+++ b/etc/strings.profile
@@ -17,7 +17,9 @@ novideo
 shell none
 tracelog
 
+private-bin strings
 private-dev
+private-lib
 
 memory-deny-write-execute
 


### PR DESCRIPTION
What is the proper way to handle python versions?
- Chromium on Arch no longer launches via a perl script [1](https://git.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/chromium&id=a2d61887394fd1fec63d9fe5ba0d2c07325164e) [2](https://github.com/foutrelis/chromium-launcher/commit/9d112db0d19e581ba816cb552a527b5b6a4d9f2f) [3](https://github.com/foutrelis/chromium-launcher/commit/44fa2a2b57dfd3f2bc9f2bf17e738ea964f2dce2)
- strings will be the first profile with private-lib