### PR TITLE
comment private-dev in VLC

### DIFF
--- a/etc/vlc.profile
+++ b/etc/vlc.profile
@@ -22,7 +22,8 @@ seccomp
 shell none
 
 private-bin vlc,cvlc,nvlc,rvlc,qvlc,svlc
-private-dev
+# DVB (Digital Video Broadcast) devices stop working with private-dev
+# private-dev
 private-tmp
 
 noexec ${HOME}


### PR DESCRIPTION
it unfortunately breaks [DVB](https://en.wikipedia.org/wiki/Digital_Video_Broadcasting) (devices are registered under /dev/dvb/...)