### PR TITLE
Match RPM license tag with license set in COPYING

### DIFF
--- a/platform/rpm/firejail.spec
+++ b/platform/rpm/firejail.spec
@@ -3,7 +3,7 @@ Version: __VERSION__
 Release: 1
 Summary: Linux namepaces sandbox program
 
-License: GPL+
+License: GPLv2+
 Group: Development/Tools
 Source0: https://github.com/netblue30/firejail/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
 URL: http://github.com/netblue30/firejail


### PR DESCRIPTION
Known license tag should be `GPLv2+` ([full list](https://fedoraproject.org/wiki/Licensing:Main?rd=Licensing#SoftwareLicenses)).