### PR TITLE
Add License field to Debian control file

### DIFF
--- a/platform/debian/control
+++ b/platform/debian/control
@@ -7,6 +7,7 @@ Depends: libc6
 Suggests: python, python3
 Section: admin
 Priority: extra
+License: GPL-2+
 Homepage: http://github.com/netblue30/firejail
 Description: Linux namepaces sandbox program.
  Firejail  is  a  SUID sandbox program that reduces the risk of security


### PR DESCRIPTION
Matches license in COPYING file.
https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/#license-syntax