### PR TITLE
more novideo options, enhanced mediathekview

### DIFF
--- a/etc/dolphin.profile
+++ b/etc/dolphin.profile
@@ -14,6 +14,7 @@ noblacklist ~/.local/share/dolphin
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
+# dolphin needs to be able to start arbitrary applications so we cannot blacklist their files
 # include /etc/firejail/disable-programs.inc
 
 caps.drop all
@@ -21,11 +22,11 @@ netfilter
 nogroups
 nonewprivs
 noroot
+novideo
 protocol unix
 seccomp
 shell none
 
-# dolphin needs to be able to start arbitrary applications so we cannot blacklist their files
 # private-bin
 # private-dev
 # private-etc

--- a/etc/k3b.profile
+++ b/etc/k3b.profile
@@ -19,6 +19,7 @@ no3d
 nonewprivs
 noroot
 nosound
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/kate.profile
+++ b/etc/kate.profile
@@ -23,6 +23,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/keepass.profile
+++ b/etc/keepass.profile
@@ -25,6 +25,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/keepassx.profile
+++ b/etc/keepassx.profile
@@ -23,6 +23,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/keepassx2.profile
+++ b/etc/keepassx2.profile
@@ -22,6 +22,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/kwrite.profile
+++ b/etc/kwrite.profile
@@ -23,6 +23,7 @@ nogroups
 nonewprivs
 noroot
 # nosound - KWrite is using ALSA!
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/mediathekview.profile
+++ b/etc/mediathekview.profile
@@ -5,9 +5,14 @@ include /etc/firejail/mediathekview.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+noblacklist ~/.config/mpv
+noblacklist ~/.config/smplayer
+noblacklist ~/.config/totem
 noblacklist ~/.config/vlc
 noblacklist ~/.java
+noblacklist ~/.local/share/totem
 noblacklist ~/.mediathek3
+noblacklist ~/.mplayer
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc

--- a/etc/mediathekview.profile
+++ b/etc/mediathekview.profile
@@ -28,7 +28,6 @@ protocol unix,inet,inet6
 seccomp
 tracelog
 
-disable-mnt
 private-dev
 private-tmp
 

--- a/etc/mediathekview.profile
+++ b/etc/mediathekview.profile
@@ -23,6 +23,7 @@ protocol unix,inet,inet6
 seccomp
 tracelog
 
+disable-mnt
 private-dev
 private-tmp
 

--- a/etc/pdftotext.profile
+++ b/etc/pdftotext.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+novideo
 protocol unix
 seccomp
 shell none


### PR DESCRIPTION
- A couple of novideo additions
- While VLC is the default, other media players can be used in Mediathekview also. The current list might be not complete yet, but these are all players with a Firejail profile from which I know they work with Mediathekview.