### PR TITLE
Fix notv placement

### DIFF
--- a/etc/0ad.profile
+++ b/etc/0ad.profile
@@ -27,6 +27,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -39,4 +40,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/2048-qt.profile
+++ b/etc/2048-qt.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -30,4 +31,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/7z.profile
+++ b/etc/7z.profile
@@ -12,7 +12,7 @@ ignore noroot
 net none
 no3d
 nosound
-nosound
+notv
 novideo
 shell none
 tracelog
@@ -20,4 +20,3 @@ tracelog
 private-dev
 
 include /etc/firejail/default.profile
-notv

--- a/etc/Cryptocat.profile
+++ b/etc/Cryptocat.profile
@@ -18,10 +18,10 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
 
 private-dev
 private-tmp
-notv

--- a/etc/Mathematica.profile
+++ b/etc/Mathematica.profile
@@ -23,5 +23,5 @@ include /etc/firejail/whitelist-common.inc
 caps.drop all
 nonewprivs
 noroot
-seccomp
 notv
+seccomp

--- a/etc/Thunar.profile
+++ b/etc/Thunar.profile
@@ -21,9 +21,9 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
 shell none
 tracelog
-notv

--- a/etc/Xephyr.profile
+++ b/etc/Xephyr.profile
@@ -27,6 +27,7 @@ nonewprivs
 # In noroot mode, Xephyr cannot create a socket in the real /tmp/.X11-unix.
 # noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -38,4 +39,3 @@ private
 private-dev
 # private-etc ld.so.conf,ld.so.cache,resolv.conf,host.conf,nsswitch.conf,gai.conf,hosts,hostname
 private-tmp
-notv

--- a/etc/Xvfb.profile
+++ b/etc/Xvfb.profile
@@ -28,6 +28,7 @@ nonewprivs
 # In noroot mode, Xvfb cannot create a socket in the real /tmp/.X11-unix.
 #noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -39,4 +40,3 @@ private
 private-dev
 private-etc ld.so.conf,ld.so.cache,resolv.conf,host.conf,nsswitch.conf,gai.conf,hosts,hostname
 private-tmp
-notv

--- a/etc/abrowser.profile
+++ b/etc/abrowser.profile
@@ -39,9 +39,9 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 tracelog
 
 # private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse
-notv

--- a/etc/akregator.profile
+++ b/etc/akregator.profile
@@ -19,6 +19,7 @@ no3d
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -30,4 +31,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/amarok.profile
+++ b/etc/amarok.profile
@@ -16,6 +16,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 # seccomp
 shell none
@@ -24,4 +25,3 @@ shell none
 private-dev
 # private-etc none
 private-tmp
-notv

--- a/etc/android-studio.profile
+++ b/etc/android-studio.profile
@@ -23,6 +23,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -32,4 +33,3 @@ private-dev
 # private-tmp
 
 noexec /tmp
-notv

--- a/etc/apktool.profile
+++ b/etc/apktool.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -27,4 +28,3 @@ private-dev
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/arduino.profile
+++ b/etc/arduino.profile
@@ -21,6 +21,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -30,4 +31,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/ark.profile
+++ b/etc/ark.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -27,4 +28,3 @@ shell none
 private-dev
 # private-etc
 private-tmp
-notv

--- a/etc/arm.profile
+++ b/etc/arm.profile
@@ -24,6 +24,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -38,4 +39,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/atom-beta.profile
+++ b/etc/atom-beta.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
@@ -25,4 +26,3 @@ shell none
 
 private-dev
 private-tmp
-notv

--- a/etc/atom.profile
+++ b/etc/atom.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
@@ -25,4 +26,3 @@ shell none
 
 private-dev
 private-tmp
-notv

--- a/etc/atool.profile
+++ b/etc/atool.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -29,4 +30,3 @@ tracelog
 private-dev
 private-etc none
 private-tmp
-notv

--- a/etc/atril.profile
+++ b/etc/atril.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -27,4 +28,3 @@ tracelog
 private-bin atril, atril-previewer, atril-thumbnailer
 private-dev
 private-tmp
-notv

--- a/etc/audacious.profile
+++ b/etc/audacious.profile
@@ -17,6 +17,7 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -25,4 +26,3 @@ tracelog
 
 private-bin audacious
 private-tmp
-notv

--- a/etc/audacity.profile
+++ b/etc/audacity.profile
@@ -18,6 +18,7 @@ no3d
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix
 seccomp
@@ -30,4 +31,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/aweather.profile
+++ b/etc/aweather.profile
@@ -22,6 +22,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -31,4 +32,3 @@ tracelog
 private-bin aweather
 private-dev
 private-tmp
-notv

--- a/etc/baloo_file.profile
+++ b/etc/baloo_file.profile
@@ -22,6 +22,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 # Baloo makes ioprio_set system calls, which are blacklisted by default.
@@ -39,4 +40,3 @@ noexec /tmp
 # read-only  ${HOME}
 # read-write ${HOME}/.local/share
 # noexec     ${HOME}/.local/share
-notv

--- a/etc/baobab.profile
+++ b/etc/baobab.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -29,4 +30,3 @@ private-tmp
 memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/bibletime.profile
+++ b/etc/bibletime.profile
@@ -28,6 +28,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
@@ -38,4 +39,3 @@ tracelog
 private-dev
 private-etc fonts,resolv.conf,sword,sword.conf,passwd
 private-tmp
-notv

--- a/etc/bitlbee.profile
+++ b/etc/bitlbee.profile
@@ -17,6 +17,7 @@ netfilter
 no3d
 nonewprivs
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -29,4 +30,3 @@ private-tmp
 read-write /var/lib/bitlbee
 
 noexec /tmp
-notv

--- a/etc/bleachbit.profile
+++ b/etc/bleachbit.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -31,4 +32,3 @@ shell none
 memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/blender.profile
+++ b/etc/blender.profile
@@ -17,6 +17,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
@@ -26,4 +27,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/bless.profile
+++ b/etc/bless.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -30,4 +31,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/brasero.profile
+++ b/etc/brasero.profile
@@ -17,6 +17,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -31,4 +32,3 @@ tracelog
 memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/brave.profile
+++ b/etc/brave.profile
@@ -30,8 +30,8 @@ include /etc/firejail/whitelist-common.inc
 netfilter
 # nonewprivs
 # noroot
+notv
 # protocol unix,inet,inet6,netlink
 # seccomp
 
 # disable-mnt
-notv

--- a/etc/caja.profile
+++ b/etc/caja.profile
@@ -22,6 +22,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix
 seccomp
 shell none
@@ -32,4 +33,3 @@ tracelog
 # private-dev
 # private-etc fonts
 # private-tmp
-notv

--- a/etc/calibre.profile
+++ b/etc/calibre.profile
@@ -20,6 +20,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -32,4 +33,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/catfish.profile
+++ b/etc/catfish.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -29,4 +30,3 @@ tracelog
 # private-bin bash,catfish,env,locate,ls,mlocate,python,python2,python2.7,python3,python3.5,python3.5m,python3m
 # private-dev
 # private-tmp
-notv

--- a/etc/cherrytree.profile
+++ b/etc/cherrytree.profile
@@ -21,6 +21,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
@@ -32,4 +33,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/chromium.profile
+++ b/etc/chromium.profile
@@ -28,6 +28,7 @@ include /etc/firejail/whitelist-common.inc
 caps.keep sys_chroot,sys_admin
 netfilter
 nogroups
+notv
 shell none
 
 private-dev
@@ -35,4 +36,3 @@ private-dev
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/claws-mail.profile
+++ b/etc/claws-mail.profile
@@ -20,10 +20,10 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
 
 private-dev
 private-tmp
-notv

--- a/etc/clementine.profile
+++ b/etc/clementine.profile
@@ -15,8 +15,8 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 # Clementine makes ioprio_set system calls, which are blacklisted by default.
 seccomp.drop mount,umount2,ptrace,kexec_load,kexec_file_load,name_to_handle_at,open_by_handle_at,create_module,init_module,finit_module,delete_module,iopl,ioperm,swapon,swapoff,syslog,process_vm_readv,process_vm_writev,sysfs,_sysctl,adjtimex,clock_adjtime,lookup_dcookie,perf_event_open,fanotify_init,kcmp,add_key,request_key,keyctl,uselib,acct,modify_ldt,pivot_root,io_setup,io_destroy,io_getevents,io_submit,io_cancel,remap_file_pages,mbind,get_mempolicy,set_mempolicy,migrate_pages,move_pages,vmsplice,chroot,tuxcall,reboot,mfsservctl,get_kernel_syms,bpf,clock_settime,personality,process_vm_writev,query_module,settimeofday,stime,umount,userfaultfd,ustat,vm86,vm86old
-notv

--- a/etc/clipit.profile
+++ b/etc/clipit.profile
@@ -20,6 +20,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -31,4 +32,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/cmus.profile
+++ b/etc/cmus.profile
@@ -16,10 +16,10 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
 
 private-bin cmus
 private-etc group
-notv

--- a/etc/conkeror.profile
+++ b/etc/conkeror.profile
@@ -27,6 +27,6 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
-notv

--- a/etc/corebird.profile
+++ b/etc/corebird.profile
@@ -14,6 +14,6 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 netfilter
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
-notv

--- a/etc/cpio.profile
+++ b/etc/cpio.profile
@@ -20,9 +20,9 @@ net none
 net none
 no3d
 nosound
+notv
 seccomp
 shell none
 tracelog
 
 private-dev
-notv

--- a/etc/curl.profile
+++ b/etc/curl.profile
@@ -21,6 +21,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -32,4 +33,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/cvlc.profile
+++ b/etc/cvlc.profile
@@ -17,6 +17,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
@@ -28,4 +29,3 @@ private-dev
 private-tmp
 
 memory-deny-write-execute
-notv

--- a/etc/cyberfox.profile
+++ b/etc/cyberfox.profile
@@ -55,6 +55,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
@@ -68,4 +69,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/darktable.profile
+++ b/etc/darktable.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -29,4 +30,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/deadbeef.profile
+++ b/etc/deadbeef.profile
@@ -18,6 +18,7 @@ no3d
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -28,4 +29,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/default.profile
+++ b/etc/default.profile
@@ -16,13 +16,13 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 # ipc-namespace
 netfilter
+# no3d
 # nogroups
 nonewprivs
 noroot
 # nosound
-# novideo
 # notv
-# no3d
+# novideo
 protocol unix,inet,inet6
 seccomp
 # shell none

--- a/etc/deluge.profile
+++ b/etc/deluge.profile
@@ -22,6 +22,7 @@ netfilter
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -31,4 +32,3 @@ shell none
 # private-bin deluge,sh,python,uname
 private-dev
 private-tmp
-notv

--- a/etc/dex2jar.profile
+++ b/etc/dex2jar.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -28,4 +29,3 @@ private-dev
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/dia.profile
+++ b/etc/dia.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -30,4 +31,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/digikam.profile
+++ b/etc/digikam.profile
@@ -19,6 +19,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 # seccomp.keep fallocate,getrusage,openat,access,arch_prctl,bind,brk,chdir,chmod,clock_getres,clone,close,connect,dup2,dup3,eventfd2,execve,fadvise64,fcntl,fdatasync,flock,fstat,fstatfs,ftruncate,futex,getcwd,getdents,getegid,geteuid,getgid,getpeername,getpgrp,getpid,getppid,getrandom,getresgid,getresuid,getrlimit,getsockname,getsockopt,gettid,getuid,inotify_add_watch,inotify_init,inotify_init1,inotify_rm_watch,ioctl,lseek,lstat,madvise,mbind,memfd_create,mkdir,mmap,mprotect,msync,munmap,nanosleep,open,pipe,pipe2,poll,ppoll,prctl,pread64,pwrite64,read,readlink,readlinkat,recvfrom,recvmsg,rename,rt_sigaction,rt_sigprocmask,rt_sigreturn,sched_getaffinity,sched_getparam,sched_get_priority_max,sched_get_priority_min,sched_getscheduler,sched_setscheduler,sched_yield,sendmsg,sendto,setgid,setresgid,setresuid,set_robust_list,setsid,setsockopt,set_tid_address,setuid,shmat,shmctl,shmdt,shmget,shutdown,socket,stat,statfs,sysinfo,timerfd_create,umask,uname,unlink,wait4,waitid,write,writev,fchmod,fchown,unshare,exit,exit_group
@@ -31,4 +32,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/dillo.profile
+++ b/etc/dillo.profile
@@ -23,7 +23,7 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 tracelog
-notv

--- a/etc/dino.profile
+++ b/etc/dino.profile
@@ -24,6 +24,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -37,4 +38,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/display.profile
+++ b/etc/display.profile
@@ -17,6 +17,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -26,4 +27,3 @@ private-bin display
 private-dev
 private-etc none
 private-tmp
-notv

--- a/etc/dnscrypt-proxy.profile
+++ b/etc/dnscrypt-proxy.profile
@@ -15,8 +15,8 @@ include /etc/firejail/disable-programs.inc
 
 no3d
 nosound
+notv
 seccomp.drop mount,umount2,ptrace,kexec_load,kexec_file_load,open_by_handle_at,init_module,finit_module,delete_module,iopl,ioperm,swapon,swapoff,syslog,process_vm_readv,process_vm_writev,sysfs,_sysctl,adjtimex,clock_adjtime,lookup_dcookie,perf_event_open,fanotify_init,kcmp,add_key,request_key,keyctl,uselib,acct,modify_ldt,pivot_root,io_setup,io_destroy,io_getevents,io_submit,io_cancel,remap_file_pages,mbind,get_mempolicy,set_mempolicy,migrate_pages,move_pages,vmsplice,perf_event_open
 
 private
 private-dev
-notv

--- a/etc/dnsmasq.profile
+++ b/etc/dnsmasq.profile
@@ -18,10 +18,10 @@ netfilter
 no3d
 nonewprivs
 nosound
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 
 disable-mnt
 private
 private-dev
-notv

--- a/etc/dolphin.profile
+++ b/etc/dolphin.profile
@@ -22,6 +22,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix
 seccomp
@@ -31,4 +32,3 @@ shell none
 # private-dev
 # private-etc
 # private-tmp
-notv

--- a/etc/dosbox.profile
+++ b/etc/dosbox.profile
@@ -17,6 +17,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -25,4 +26,3 @@ tracelog
 private-bin dosbox
 private-dev
 private-tmp
-notv

--- a/etc/dragon.profile
+++ b/etc/dragon.profile
@@ -17,6 +17,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -29,4 +30,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/dropbox.profile
+++ b/etc/dropbox.profile
@@ -30,6 +30,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -39,4 +40,3 @@ private-dev
 private-tmp
 
 noexec /tmp
-notv

--- a/etc/electron.profile
+++ b/etc/electron.profile
@@ -15,6 +15,6 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
-notv

--- a/etc/elinks.profile
+++ b/etc/elinks.profile
@@ -21,6 +21,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -31,4 +32,3 @@ tracelog
 private-dev
 # private-etc none
 private-tmp
-notv

--- a/etc/emacs.profile
+++ b/etc/emacs.profile
@@ -17,6 +17,6 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
-notv

--- a/etc/empathy.profile
+++ b/etc/empathy.profile
@@ -15,6 +15,6 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
-notv

--- a/etc/enchant.profile
+++ b/etc/enchant.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -27,4 +28,3 @@ tracelog
 # private-dev
 # private-etc fonts
 # private-tmp
-notv

--- a/etc/engrampa.profile
+++ b/etc/engrampa.profile
@@ -17,6 +17,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -27,4 +28,3 @@ tracelog
 private-dev
 # private-etc fonts
 # private-tmp
-notv

--- a/etc/eog.profile
+++ b/etc/eog.profile
@@ -22,6 +22,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -35,4 +36,3 @@ private-tmp
 memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/eom.profile
+++ b/etc/eom.profile
@@ -20,6 +20,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -32,4 +33,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/epiphany.profile
+++ b/etc/epiphany.profile
@@ -25,6 +25,6 @@ include /etc/firejail/whitelist-common.inc
 caps.drop all
 netfilter
 nonewprivs
+notv
 protocol unix,inet,inet6
 seccomp
-notv

--- a/etc/etr.profile
+++ b/etc/etr.profile
@@ -20,6 +20,7 @@ net none
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,netlink
 seccomp
 shell none
@@ -28,4 +29,3 @@ shell none
 private-dev
 # private-etc none
 private-tmp
-notv

--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -34,4 +35,3 @@ private-etc fonts
 memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/evolution.profile
+++ b/etc/evolution.profile
@@ -27,6 +27,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -36,4 +37,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/exiftool.profile
+++ b/etc/exiftool.profile
@@ -24,6 +24,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -33,4 +34,3 @@ tracelog
 private-dev
 private-etc none
 private-tmp
-notv

--- a/etc/fbreader.profile
+++ b/etc/fbreader.profile
@@ -17,6 +17,7 @@ netfilter
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -24,4 +25,3 @@ shell none
 private-bin fbreader,FBReader
 private-dev
 private-tmp
-notv

--- a/etc/feh.profile
+++ b/etc/feh.profile
@@ -17,6 +17,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -25,4 +26,3 @@ private-bin feh
 private-dev
 private-etc feh
 private-tmp
-notv

--- a/etc/file-roller.profile
+++ b/etc/file-roller.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -32,4 +33,3 @@ private-dev
 memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/file.profile
+++ b/etc/file.profile
@@ -19,6 +19,7 @@ no3d
 nogroups
 nonewprivs
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -28,4 +29,3 @@ x11 none
 private-bin file
 private-dev
 private-etc magic.mgc,magic,localtime
-notv

--- a/etc/filezilla.profile
+++ b/etc/filezilla.profile
@@ -17,6 +17,7 @@ netfilter
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -24,4 +25,3 @@ shell none
 private-bin filezilla,uname,sh,bash,dash,python,lsb_release,fzputtygen,fzsftp
 private-dev
 private-tmp
-notv

--- a/etc/firefox.profile
+++ b/etc/firefox.profile
@@ -55,6 +55,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
@@ -68,4 +69,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/flashpeak-slimjet.profile
+++ b/etc/flashpeak-slimjet.profile
@@ -32,6 +32,6 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
-notv

--- a/etc/flowblade.profile
+++ b/etc/flowblade.profile
@@ -18,6 +18,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
@@ -27,4 +28,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/fontforge.profile
+++ b/etc/fontforge.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -28,4 +29,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/fossamail.profile
+++ b/etc/fossamail.profile
@@ -17,5 +17,6 @@ whitelist ~/.fossamail
 whitelist ~/.gnupg
 include /etc/firejail/whitelist-common.inc
 
-include /etc/firejail/firefox.profile
 notv
+
+include /etc/firejail/firefox.profile

--- a/etc/franz.profile
+++ b/etc/franz.profile
@@ -27,6 +27,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
@@ -37,4 +38,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/frozen-bubble.profile
+++ b/etc/frozen-bubble.profile
@@ -20,6 +20,7 @@ net none
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,netlink
 seccomp
 shell none
@@ -28,4 +29,3 @@ shell none
 private-dev
 # private-etc none
 private-tmp
-notv

--- a/etc/gajim.profile
+++ b/etc/gajim.profile
@@ -31,6 +31,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -42,4 +43,3 @@ private-dev
 # private-tmp
 # Allow the local python 2.7 site packages, in case any plugins are using these
 read-only ${HOME}/.local/lib/python2.7/site-packages/
-notv

--- a/etc/galculator.profile
+++ b/etc/galculator.profile
@@ -22,6 +22,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -31,4 +32,3 @@ private-bin galculator
 private-dev
 private-etc fonts
 private-tmp
-notv

--- a/etc/geany.profile
+++ b/etc/geany.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -25,4 +26,3 @@ shell none
 
 private-dev
 private-tmp
-notv

--- a/etc/gedit.profile
+++ b/etc/gedit.profile
@@ -21,6 +21,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -33,4 +34,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/geeqie.profile
+++ b/etc/geeqie.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -26,4 +27,3 @@ shell none
 # private-bin geeqie
 private-dev
 # private-etc X11
-notv

--- a/etc/gimp.profile
+++ b/etc/gimp.profile
@@ -17,6 +17,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -28,4 +29,3 @@ private-tmp
 # if you are not using external plugins, you can enable noexec statement below
 # noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/git.profile
+++ b/etc/git.profile
@@ -27,9 +27,9 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
 
 private-dev
-notv

--- a/etc/gitg.profile
+++ b/etc/gitg.profile
@@ -20,6 +20,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -31,4 +32,3 @@ private-tmp
 memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/gitter.profile
+++ b/etc/gitter.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
@@ -25,4 +26,3 @@ shell none
 private-bin gitter
 private-dev
 private-tmp
-notv

--- a/etc/gjs.profile
+++ b/etc/gjs.profile
@@ -22,6 +22,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -31,4 +32,3 @@ tracelog
 private-dev
 # private-etc fonts
 private-tmp
-notv

--- a/etc/globaltime.profile
+++ b/etc/globaltime.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -30,4 +31,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/gnome-2048.profile
+++ b/etc/gnome-2048.profile
@@ -21,6 +21,7 @@ netfilter
 no3d
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -31,4 +32,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/gnome-books.profile
+++ b/etc/gnome-books.profile
@@ -21,6 +21,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -34,4 +35,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/gnome-calculator.profile
+++ b/etc/gnome-calculator.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -33,4 +34,3 @@ private-tmp
 memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/gnome-chess.profile
+++ b/etc/gnome-chess.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -32,4 +33,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/gnome-clocks.profile
+++ b/etc/gnome-clocks.profile
@@ -17,6 +17,7 @@ no3d
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -31,4 +32,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/gnome-contacts.profile
+++ b/etc/gnome-contacts.profile
@@ -18,6 +18,7 @@ no3d
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -28,4 +29,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/gnome-documents.profile
+++ b/etc/gnome-documents.profile
@@ -21,6 +21,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -32,4 +33,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/gnome-font-viewer.profile
+++ b/etc/gnome-font-viewer.profile
@@ -17,6 +17,7 @@ no3d
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -27,4 +28,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/gnome-maps.profile
+++ b/etc/gnome-maps.profile
@@ -20,6 +20,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -34,4 +35,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/gnome-music.profile
+++ b/etc/gnome-music.profile
@@ -18,6 +18,7 @@ no3d
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix
 seccomp
@@ -31,4 +32,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/gnome-photos.profile
+++ b/etc/gnome-photos.profile
@@ -20,6 +20,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -32,4 +33,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/gnome-twitch.profile
+++ b/etc/gnome-twitch.profile
@@ -23,6 +23,7 @@ caps.drop all
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -33,4 +34,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/gnome-weather.profile
+++ b/etc/gnome-weather.profile
@@ -21,6 +21,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -35,4 +36,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/goobox.profile
+++ b/etc/goobox.profile
@@ -16,6 +16,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix
 seccomp
 shell none
@@ -25,4 +26,3 @@ tracelog
 # private-dev
 # private-etc fonts
 # private-tmp
-notv

--- a/etc/google-chrome-beta.profile
+++ b/etc/google-chrome-beta.profile
@@ -26,6 +26,7 @@ include /etc/firejail/whitelist-common.inc
 caps.keep sys_chroot,sys_admin
 netfilter
 nogroups
+notv
 shell none
 
 private-dev
@@ -33,4 +34,3 @@ private-dev
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/google-chrome-unstable.profile
+++ b/etc/google-chrome-unstable.profile
@@ -26,6 +26,7 @@ include /etc/firejail/whitelist-common.inc
 caps.keep sys_chroot,sys_admin
 netfilter
 nogroups
+notv
 shell none
 
 private-dev
@@ -33,4 +34,3 @@ private-dev
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/google-chrome.profile
+++ b/etc/google-chrome.profile
@@ -26,6 +26,7 @@ include /etc/firejail/whitelist-common.inc
 caps.keep sys_chroot,sys_admin
 netfilter
 nogroups
+notv
 shell none
 
 private-dev
@@ -33,4 +34,3 @@ private-dev
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/google-play-music-desktop-player.profile
+++ b/etc/google-play-music-desktop-player.profile
@@ -23,6 +23,7 @@ no3d
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
@@ -34,4 +35,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/gpa.profile
+++ b/etc/gpa.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -25,4 +26,3 @@ tracelog
 
 # private-bin gpa,gpg
 private-dev
-notv

--- a/etc/gpg-agent.profile
+++ b/etc/gpg-agent.profile
@@ -21,6 +21,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -28,4 +29,3 @@ tracelog
 
 # private-bin gpg-agent,gpg
 private-dev
-notv

--- a/etc/gpg.profile
+++ b/etc/gpg.profile
@@ -21,6 +21,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -28,4 +29,3 @@ tracelog
 
 # private-bin gpg,gpg-agent
 private-dev
-notv

--- a/etc/gpicview.profile
+++ b/etc/gpicview.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -27,4 +28,3 @@ private-bin gpicview
 private-dev
 private-etc fonts
 private-tmp
-notv

--- a/etc/gpredict.profile
+++ b/etc/gpredict.profile
@@ -21,6 +21,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -33,4 +34,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/gthumb.profile
+++ b/etc/gthumb.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -27,4 +28,3 @@ tracelog
 private-bin gthumb
 private-dev
 private-tmp
-notv

--- a/etc/guayadeque.profile
+++ b/etc/guayadeque.profile
@@ -17,6 +17,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
@@ -27,4 +28,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/gucharmap.profile
+++ b/etc/gucharmap.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -30,4 +31,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/gwenview.profile
+++ b/etc/gwenview.profile
@@ -23,6 +23,7 @@ caps.drop all
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix
 seccomp
@@ -35,4 +36,3 @@ private-dev
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/gzip.profile
+++ b/etc/gzip.profile
@@ -12,10 +12,10 @@ ignore noroot
 net none
 no3d
 nosound
+notv
 shell none
 tracelog
 
 private-dev
 
 include /etc/firejail/default.profile
-notv

--- a/etc/handbrake.profile
+++ b/etc/handbrake.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
@@ -28,4 +29,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/hashcat.profile
+++ b/etc/hashcat.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -29,4 +30,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/hedgewars.profile
+++ b/etc/hedgewars.profile
@@ -21,10 +21,10 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 seccomp
 tracelog
 
 disable-mnt
 private-dev
 private-tmp
-notv

--- a/etc/hexchat.profile
+++ b/etc/hexchat.profile
@@ -24,6 +24,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -38,4 +39,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/highlight.profile
+++ b/etc/highlight.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -28,4 +29,3 @@ private-bin highlight
 private-dev
 # private-etc none
 private-tmp
-notv

--- a/etc/hugin.profile
+++ b/etc/hugin.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -28,4 +29,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/icecat.profile
+++ b/etc/icecat.profile
@@ -39,6 +39,7 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 tracelog
@@ -47,4 +48,3 @@ tracelog
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/idea.sh.profile
+++ b/etc/idea.sh.profile
@@ -23,6 +23,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -32,4 +33,3 @@ private-dev
 # private-tmp
 
 noexec /tmp
-notv

--- a/etc/img2txt.profile
+++ b/etc/img2txt.profile
@@ -17,6 +17,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -26,4 +27,3 @@ tracelog
 private-dev
 # private-etc none
 private-tmp
-notv

--- a/etc/inkscape.profile
+++ b/etc/inkscape.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -28,4 +29,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/jd-gui.profile
+++ b/etc/jd-gui.profile
@@ -20,6 +20,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -30,4 +31,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/jitsi.profile
+++ b/etc/jitsi.profile
@@ -16,6 +16,7 @@ caps.drop all
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -23,4 +24,3 @@ tracelog
 
 disable-mnt
 private-tmp
-notv

--- a/etc/k3b.profile
+++ b/etc/k3b.profile
@@ -19,6 +19,7 @@ no3d
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -28,4 +29,3 @@ tracelog
 # private-bin
 # private-etc
 # private-tmp
-notv

--- a/etc/kate.profile
+++ b/etc/kate.profile
@@ -23,6 +23,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -33,4 +34,3 @@ tracelog
 private-dev
 # private-etc fonts
 private-tmp
-notv

--- a/etc/kcalc.profile
+++ b/etc/kcalc.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -30,4 +31,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/keepass.profile
+++ b/etc/keepass.profile
@@ -25,6 +25,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -35,4 +36,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/keepassx.profile
+++ b/etc/keepassx.profile
@@ -23,6 +23,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -36,4 +37,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/keepassx2.profile
+++ b/etc/keepassx2.profile
@@ -22,6 +22,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -34,4 +35,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/keepassxc.profile
+++ b/etc/keepassxc.profile
@@ -22,6 +22,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -35,4 +36,3 @@ private-tmp
 memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/kino.profile
+++ b/etc/kino.profile
@@ -18,6 +18,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix
 seccomp
@@ -28,4 +29,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/kmail.profile
+++ b/etc/kmail.profile
@@ -17,10 +17,10 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 tracelog
 
 private-dev
 # private-tmp
-notv

--- a/etc/knotes.profile
+++ b/etc/knotes.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -27,4 +28,3 @@ tracelog
 private-dev
 # private-etc fonts
 private-tmp
-notv

--- a/etc/konversation.profile
+++ b/etc/konversation.profile
@@ -15,8 +15,8 @@ caps.drop all
 netfilter
 nogroups
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 
 private-tmp
-notv

--- a/etc/ktorrent.profile
+++ b/etc/ktorrent.profile
@@ -39,6 +39,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -49,4 +50,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/kwrite.profile
+++ b/etc/kwrite.profile
@@ -23,6 +23,7 @@ nogroups
 nonewprivs
 noroot
 # nosound - KWrite is using ALSA!
+notv
 novideo
 protocol unix
 seccomp
@@ -33,4 +34,3 @@ tracelog
 private-dev
 # private-etc fonts
 private-tmp
-notv

--- a/etc/leafpad.profile
+++ b/etc/leafpad.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -28,4 +29,3 @@ private-dev
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/less.profile
+++ b/etc/less.profile
@@ -12,9 +12,11 @@ ignore noroot
 net none
 no3d
 nosound
+notv
 novideo
 shell none
 tracelog
+writable-var-log
 
 # The user can have a custom coloring scritps configured in ~/.lessfilter.
 # Enable private-bin if you are not using any filter.
@@ -24,7 +26,5 @@ private-dev
 memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp
-writable-var-log
 
 include /etc/firejail/default.profile
-notv

--- a/etc/libreoffice.profile
+++ b/etc/libreoffice.profile
@@ -19,6 +19,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -28,4 +29,3 @@ private-dev
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/liferea.profile
+++ b/etc/liferea.profile
@@ -29,6 +29,7 @@ nogroups
 nonewprivs
 noroot
 # nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -40,4 +41,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/lollypop.profile
+++ b/etc/lollypop.profile
@@ -18,6 +18,7 @@ no3d
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -29,4 +30,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/luminance-hdr.profile
+++ b/etc/luminance-hdr.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -29,4 +30,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/lximage-qt.profile
+++ b/etc/lximage-qt.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -29,4 +30,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/lxmusic.profile
+++ b/etc/lxmusic.profile
@@ -19,6 +19,7 @@ no3d
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix
 seccomp
@@ -29,4 +30,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/lxterminal.profile
+++ b/etc/lxterminal.profile
@@ -13,6 +13,6 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 netfilter
 # noroot - somehow this breaks on Debian Jessie!
+notv
 protocol unix,inet,inet6
 seccomp
-notv

--- a/etc/lynx.profile
+++ b/etc/lynx.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -28,4 +29,3 @@ tracelog
 private-dev
 # private-etc none
 private-tmp
-notv

--- a/etc/mate-calc.profile
+++ b/etc/mate-calc.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -30,4 +31,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/mate-calculator.profile
+++ b/etc/mate-calculator.profile
@@ -1,9 +1,6 @@
-# Firejail profile for mate-calculator
+# Firejail profile alias for mate-calc
 # This file is overwritten after every install/update
-# Persistent local customizations
-include /etc/firejail/mate-calculator.local
-# Persistent global definitions
-include /etc/firejail/globals.local
+
 
 # Redirect
-include include /etc/firejail/mate-calc.profile
+include /etc/firejail/mate-calc.profile

--- a/etc/mate-color-select.profile
+++ b/etc/mate-color-select.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -30,4 +31,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/mate-dictionary.profile
+++ b/etc/mate-dictionary.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -30,4 +31,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/mcabber.profile
+++ b/etc/mcabber.profile
@@ -18,6 +18,7 @@ netfilter
 nonewprivs
 noroot
 nosound
+notv
 protocol inet,inet6
 seccomp
 shell none
@@ -25,4 +26,3 @@ shell none
 private-bin mcabber
 private-dev
 private-etc null
-notv

--- a/etc/mediainfo.profile
+++ b/etc/mediainfo.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -28,4 +29,3 @@ private-bin mediainfo
 private-dev
 private-etc none
 private-tmp
-notv

--- a/etc/mediathekview.profile
+++ b/etc/mediathekview.profile
@@ -23,6 +23,7 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -33,4 +34,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/meld.profile
+++ b/etc/meld.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -29,4 +30,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/midori.profile
+++ b/etc/midori.profile
@@ -37,7 +37,7 @@ caps.drop all
 netfilter
 nonewprivs
 # noroot - problems on Ubuntu 14.04
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 tracelog
-notv

--- a/etc/mousepad.profile
+++ b/etc/mousepad.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -26,4 +27,3 @@ tracelog
 private-bin mousepad
 private-dev
 private-tmp
-notv

--- a/etc/multimc5.profile
+++ b/etc/multimc5.profile
@@ -25,6 +25,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 # seccomp
@@ -36,4 +37,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/mumble.profile
+++ b/etc/mumble.profile
@@ -25,6 +25,7 @@ no3d
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -37,4 +38,3 @@ private-tmp
 memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/mupdf.profile
+++ b/etc/mupdf.profile
@@ -17,6 +17,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 # seccomp.keep access,arch_prctl,brk,clone,close,connect,execve,exit_group,fchmod,fchown,fcntl,fstat,futex,getcwd,getpeername,getrlimit,getsockname,getsockopt,lseek,lstat,mlock,mmap,mprotect,mremap,munmap,nanosleep,open,poll,prctl,read,recvfrom,recvmsg,restart_syscall,rt_sigaction,rt_sigprocmask,select,sendmsg,set_robust_list,set_tid_address,setresgid,setresuid,shmat,shmctl,shmget,shutdown,socket,stat,sysinfo,uname,unshare,wait4,write,writev
@@ -27,6 +28,6 @@ tracelog
 private-dev
 private-etc fonts
 private-tmp
+
 # mupdf will never write anything
 read-only ${HOME}
-notv

--- a/etc/mupen64plus.profile
+++ b/etc/mupen64plus.profile
@@ -24,5 +24,5 @@ caps.drop all
 net none
 nonewprivs
 noroot
-seccomp
 notv
+seccomp

--- a/etc/mutt.profile
+++ b/etc/mutt.profile
@@ -42,9 +42,9 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
 
 private-dev
-notv

--- a/etc/nautilus.profile
+++ b/etc/nautilus.profile
@@ -23,6 +23,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix
 seccomp
 shell none
@@ -33,4 +34,3 @@ tracelog
 # private-dev
 # private-etc fonts
 # private-tmp
-notv

--- a/etc/nemo.profile
+++ b/etc/nemo.profile
@@ -21,6 +21,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -28,4 +29,3 @@ shell none
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/netsurf.profile
+++ b/etc/netsurf.profile
@@ -23,7 +23,7 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 tracelog
-notv

--- a/etc/nylas.profile
+++ b/etc/nylas.profile
@@ -24,9 +24,9 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
 
 private-dev
-notv

--- a/etc/obs.profile
+++ b/etc/obs.profile
@@ -16,6 +16,7 @@ caps.drop all
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -26,4 +27,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/odt2txt.profile
+++ b/etc/odt2txt.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -29,4 +30,3 @@ private-dev
 private-etc none
 private-tmp
 read-only ${HOME}
-notv

--- a/etc/okular.profile
+++ b/etc/okular.profile
@@ -26,6 +26,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -39,4 +40,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/open-invaders.profile
+++ b/etc/open-invaders.profile
@@ -20,6 +20,7 @@ net none
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,netlink
 seccomp
 shell none
@@ -28,4 +29,3 @@ shell none
 private-dev
 # private-etc none
 private-tmp
-notv

--- a/etc/openshot.profile
+++ b/etc/openshot.profile
@@ -18,6 +18,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
@@ -27,4 +28,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/orage.profile
+++ b/etc/orage.profile
@@ -20,6 +20,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -31,4 +32,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/palemoon.profile
+++ b/etc/palemoon.profile
@@ -44,6 +44,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
@@ -54,4 +55,3 @@ tracelog
 # private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse
 # private-opt palemoon
 private-tmp
-notv

--- a/etc/parole.profile
+++ b/etc/parole.profile
@@ -15,10 +15,10 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
 
 private-bin parole,dbus-launch
 private-etc passwd,group,fonts
-notv

--- a/etc/pcmanfm.profile
+++ b/etc/pcmanfm.profile
@@ -20,9 +20,9 @@ no3d
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
 shell none
 tracelog
-notv

--- a/etc/pdfsam.profile
+++ b/etc/pdfsam.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -29,4 +30,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/pdftotext.profile
+++ b/etc/pdftotext.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -29,4 +30,3 @@ private-bin pdftotext
 private-dev
 private-etc none
 private-tmp
-notv

--- a/etc/peek.profile
+++ b/etc/peek.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -31,4 +32,3 @@ private-tmp
 memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/picard.profile
+++ b/etc/picard.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -29,4 +30,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/pidgin.profile
+++ b/etc/pidgin.profile
@@ -17,6 +17,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -25,4 +26,3 @@ tracelog
 private-bin pidgin
 private-dev
 private-tmp
-notv

--- a/etc/pingus.profile
+++ b/etc/pingus.profile
@@ -20,6 +20,7 @@ net none
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,netlink
 seccomp
 shell none
@@ -28,4 +29,3 @@ shell none
 private-dev
 # private-etc none
 private-tmp
-notv

--- a/etc/pithos.profile
+++ b/etc/pithos.profile
@@ -18,6 +18,7 @@ no3d
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -29,4 +30,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/pix.profile
+++ b/etc/pix.profile
@@ -20,6 +20,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -28,4 +29,3 @@ tracelog
 private-bin pix
 private-dev
 private-tmp
-notv

--- a/etc/pluma.profile
+++ b/etc/pluma.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 seccomp
 shell none
 tracelog
@@ -25,4 +26,3 @@ tracelog
 private-bin pluma
 private-dev
 private-tmp
-notv

--- a/etc/polari.profile
+++ b/etc/polari.profile
@@ -31,6 +31,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -42,4 +43,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/psi-plus.profile
+++ b/etc/psi-plus.profile
@@ -28,6 +28,7 @@ no3d
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -39,4 +40,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/qbittorrent.profile
+++ b/etc/qbittorrent.profile
@@ -33,6 +33,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 # shell none
@@ -41,4 +42,3 @@ seccomp
 private-dev
 # private-etc X11,fonts,xdg,resolv.conf
 private-tmp
-notv

--- a/etc/qemu-launcher.profile
+++ b/etc/qemu-launcher.profile
@@ -16,6 +16,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -24,4 +25,3 @@ tracelog
 private-tmp
 
 noexec /tmp
-notv

--- a/etc/qemu-system-x86_64.profile
+++ b/etc/qemu-system-x86_64.profile
@@ -15,6 +15,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -23,4 +24,3 @@ tracelog
 private-tmp
 
 noexec /tmp
-notv

--- a/etc/qlipper.profile
+++ b/etc/qlipper.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -30,4 +31,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/qpdfview.profile
+++ b/etc/qpdfview.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -27,4 +28,3 @@ tracelog
 private-bin qpdfview
 private-dev
 private-tmp
-notv

--- a/etc/qtox.profile
+++ b/etc/qtox.profile
@@ -25,6 +25,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -36,4 +37,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/quassel.profile
+++ b/etc/quassel.profile
@@ -14,6 +14,6 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
-notv

--- a/etc/quiterss.profile
+++ b/etc/quiterss.profile
@@ -32,6 +32,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -44,4 +45,3 @@ private-dev
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/qupzilla.profile
+++ b/etc/qupzilla.profile
@@ -21,9 +21,9 @@ include /etc/firejail/whitelist-common.inc
 caps.drop all
 netfilter
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 tracelog
 
 # private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse
-notv

--- a/etc/qutebrowser.profile
+++ b/etc/qutebrowser.profile
@@ -25,7 +25,7 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 tracelog
-notv

--- a/etc/rambox.profile
+++ b/etc/rambox.profile
@@ -24,7 +24,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 # tracelog
-notv

--- a/etc/ranger.profile
+++ b/etc/ranger.profile
@@ -22,8 +22,8 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 
 private-dev
-notv

--- a/etc/remmina.profile
+++ b/etc/remmina.profile
@@ -18,6 +18,7 @@ caps.drop all
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -28,4 +29,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/rhythmbox.profile
+++ b/etc/rhythmbox.profile
@@ -17,6 +17,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -29,4 +30,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/ristretto.profile
+++ b/etc/ristretto.profile
@@ -21,6 +21,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -31,4 +32,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/rtorrent.profile
+++ b/etc/rtorrent.profile
@@ -16,6 +16,7 @@ netfilter
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -23,4 +24,3 @@ shell none
 private-bin rtorrent
 private-dev
 private-tmp
-notv

--- a/etc/scribus.profile
+++ b/etc/scribus.profile
@@ -30,6 +30,7 @@ caps.drop all
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -37,4 +38,3 @@ tracelog
 
 private-dev
 # private-tmp
-notv

--- a/etc/sdat2img.profile
+++ b/etc/sdat2img.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -28,4 +29,3 @@ private-dev
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/seamonkey.profile
+++ b/etc/seamonkey.profile
@@ -39,9 +39,9 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 tracelog
 
 # private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse
-notv

--- a/etc/silentarmy.profile
+++ b/etc/silentarmy.profile
@@ -17,6 +17,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -30,4 +31,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/simple-scan.profile
+++ b/etc/simple-scan.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 shell none
 # seccomp
@@ -27,4 +28,3 @@ tracelog
 # private-dev
 # private-etc fonts
 # private-tmp
-notv

--- a/etc/simutrans.profile
+++ b/etc/simutrans.profile
@@ -20,6 +20,7 @@ net none
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix
 seccomp
 shell none
@@ -28,4 +29,3 @@ shell none
 private-dev
 # private-etc none
 private-tmp
-notv

--- a/etc/skanlite.profile
+++ b/etc/skanlite.profile
@@ -17,6 +17,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 # protocol unix,inet,inet6
 seccomp
 shell none
@@ -25,4 +26,3 @@ shell none
 # private-dev
 # private-etc
 # private-tmp
-notv

--- a/etc/skype.profile
+++ b/etc/skype.profile
@@ -17,6 +17,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -27,4 +28,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/skypeforlinux.profile
+++ b/etc/skypeforlinux.profile
@@ -17,6 +17,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
@@ -27,4 +28,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/slack.profile
+++ b/etc/slack.profile
@@ -27,6 +27,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
@@ -36,4 +37,3 @@ private-bin slack
 private-dev
 private-etc fonts,resolv.conf,ld.so.conf,ld.so.cache,localtime
 private-tmp
-notv

--- a/etc/soundconverter.profile
+++ b/etc/soundconverter.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -28,4 +29,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/spotify.profile
+++ b/etc/spotify.profile
@@ -36,6 +36,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
@@ -48,4 +49,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/sqlitebrowser.profile
+++ b/etc/sqlitebrowser.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -31,4 +32,3 @@ private-tmp
 memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/ssh-agent.profile
+++ b/etc/ssh-agent.profile
@@ -21,6 +21,6 @@ netfilter
 no3d
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
-notv

--- a/etc/ssh.profile
+++ b/etc/ssh.profile
@@ -22,6 +22,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -33,4 +34,3 @@ private-dev
 memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/start-tor-browser.profile
+++ b/etc/start-tor-browser.profile
@@ -16,6 +16,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -25,4 +26,3 @@ private-bin bash,dash,sh,grep,tail,env,gpg,id,readlink,dirname,test,mkdir,ln,sed
 private-dev
 private-etc fonts
 private-tmp
-notv

--- a/etc/steam.profile
+++ b/etc/steam.profile
@@ -27,6 +27,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 # novideo
 protocol unix,inet,inet6,netlink
 seccomp
@@ -36,4 +37,3 @@ shell none
 
 private-dev
 private-tmp
-notv

--- a/etc/stellarium.profile
+++ b/etc/stellarium.profile
@@ -25,6 +25,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
@@ -34,4 +35,3 @@ disable-mnt
 private-bin stellarium
 private-dev
 private-tmp
-notv

--- a/etc/strings.profile
+++ b/etc/strings.profile
@@ -12,6 +12,7 @@ ignore noroot
 net none
 no3d
 nosound
+notv
 novideo
 shell none
 tracelog
@@ -21,4 +22,3 @@ private-dev
 memory-deny-write-execute
 
 include /etc/firejail/default.profile
-notv

--- a/etc/supertux2.profile
+++ b/etc/supertux2.profile
@@ -20,6 +20,7 @@ net none
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,netlink
 seccomp
 shell none
@@ -28,4 +29,3 @@ shell none
 private-dev
 # private-etc none
 private-tmp
-notv

--- a/etc/synfigstudio.profile
+++ b/etc/synfigstudio.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -29,4 +30,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/tar.profile
+++ b/etc/tar.profile
@@ -13,6 +13,7 @@ ignore noroot
 net none
 no3d
 nosound
+notv
 shell none
 tracelog
 
@@ -22,4 +23,3 @@ private-dev
 private-etc passwd,group,localtime
 
 include /etc/firejail/default.profile
-notv

--- a/etc/telegram.profile
+++ b/etc/telegram.profile
@@ -15,6 +15,7 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 
@@ -23,4 +24,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/tracker.profile
+++ b/etc/tracker.profile
@@ -21,6 +21,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -30,4 +31,3 @@ tracelog
 # private-dev
 # private-etc fonts
 # private-tmp
-notv

--- a/etc/transmission-cli.profile
+++ b/etc/transmission-cli.profile
@@ -18,6 +18,7 @@ netfilter
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -29,4 +30,3 @@ private-etc none
 private-tmp
 
 memory-deny-write-execute
-notv

--- a/etc/transmission-gtk.profile
+++ b/etc/transmission-gtk.profile
@@ -25,6 +25,7 @@ netfilter
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -35,4 +36,3 @@ private-dev
 private-tmp
 
 memory-deny-write-execute
-notv

--- a/etc/transmission-qt.profile
+++ b/etc/transmission-qt.profile
@@ -25,6 +25,7 @@ netfilter
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -33,4 +34,3 @@ tracelog
 private-bin transmission-qt
 private-dev
 private-tmp
-notv

--- a/etc/transmission-show.profile
+++ b/etc/transmission-show.profile
@@ -18,6 +18,7 @@ net none
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -27,4 +28,3 @@ tracelog
 private-dev
 private-etc none
 private-tmp
-notv

--- a/etc/truecraft.profile
+++ b/etc/truecraft.profile
@@ -23,6 +23,7 @@ caps.drop all
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -34,4 +35,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/tuxguitar.profile
+++ b/etc/tuxguitar.profile
@@ -17,6 +17,7 @@ caps.drop all
 no3d
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -27,4 +28,3 @@ private-tmp
 
 # noexec ${HOME} - tuxguitar may fail to launch
 noexec /tmp
-notv

--- a/etc/uget-gtk.profile
+++ b/etc/uget-gtk.profile
@@ -21,6 +21,7 @@ netfilter
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -28,4 +29,3 @@ shell none
 private-bin uget-gtk
 private-dev
 private-tmp
-notv

--- a/etc/unbound.profile
+++ b/etc/unbound.profile
@@ -15,8 +15,8 @@ include /etc/firejail/disable-programs.inc
 
 no3d
 nosound
+notv
 seccomp.drop mount,umount2,ptrace,kexec_load,kexec_file_load,open_by_handle_at,init_module,finit_module,delete_module,iopl,ioperm,swapon,swapoff,syslog,process_vm_readv,process_vm_writev,sysfs,_sysctl,adjtimex,clock_adjtime,lookup_dcookie,perf_event_open,fanotify_init,kcmp,add_key,request_key,keyctl,uselib,acct,modify_ldt,pivot_root,io_setup,io_destroy,io_getevents,io_submit,io_cancel,remap_file_pages,mbind,get_mempolicy,set_mempolicy,migrate_pages,move_pages,vmsplice,perf_event_open
 
 private
 private-dev
-notv

--- a/etc/unknown-horizons.profile
+++ b/etc/unknown-horizons.profile
@@ -19,6 +19,7 @@ caps.drop all
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,netlink,inet,inet6
 seccomp
 shell none
@@ -27,4 +28,3 @@ shell none
 private-dev
 # private-etc none
 private-tmp
-notv

--- a/etc/unrar.profile
+++ b/etc/unrar.profile
@@ -13,6 +13,7 @@ ignore noroot
 net none
 no3d
 nosound
+notv
 shell none
 tracelog
 
@@ -22,4 +23,3 @@ private-etc passwd,group,localtime
 private-tmp
 
 include /etc/firejail/default.profile
-notv

--- a/etc/unzip.profile
+++ b/etc/unzip.profile
@@ -13,6 +13,7 @@ ignore noroot
 net none
 no3d
 nosound
+notv
 shell none
 tracelog
 
@@ -21,4 +22,3 @@ private-dev
 private-etc passwd,group,localtime
 
 include /etc/firejail/default.profile
-notv

--- a/etc/uudeview.profile
+++ b/etc/uudeview.profile
@@ -11,6 +11,7 @@ hostname uudeview
 ignore noroot
 net none
 nosound
+notv
 shell none
 tracelog
 
@@ -19,4 +20,3 @@ private-dev
 private-etc ld.so.preload
 
 include /etc/firejail/default.profile
-notv

--- a/etc/uzbl-browser.profile
+++ b/etc/uzbl-browser.profile
@@ -27,7 +27,7 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 tracelog
-notv

--- a/etc/viewnior.profile
+++ b/etc/viewnior.profile
@@ -23,6 +23,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -32,4 +33,3 @@ private-bin viewnior
 private-dev
 private-etc fonts
 private-tmp
-notv

--- a/etc/viking.profile
+++ b/etc/viking.profile
@@ -20,6 +20,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -29,4 +30,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/vim.profile
+++ b/etc/vim.profile
@@ -18,6 +18,6 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
-notv

--- a/etc/vivaldi.profile
+++ b/etc/vivaldi.profile
@@ -22,6 +22,7 @@ include /etc/firejail/whitelist-common.inc
 caps.keep sys_chroot,sys_admin
 netfilter
 nogroups
+notv
 shell none
 
 private-dev
@@ -29,4 +30,3 @@ private-dev
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/vym.profile
+++ b/etc/vym.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -30,4 +31,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/w3m.profile
+++ b/etc/w3m.profile
@@ -21,6 +21,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -30,4 +31,3 @@ tracelog
 private-dev
 private-etc none
 private-tmp
-notv

--- a/etc/warzone2100.profile
+++ b/etc/warzone2100.profile
@@ -23,6 +23,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
@@ -32,4 +33,3 @@ disable-mnt
 private-bin warzone2100
 private-dev
 private-tmp
-notv

--- a/etc/waterfox.profile
+++ b/etc/waterfox.profile
@@ -55,6 +55,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
@@ -68,4 +69,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/weechat.profile
+++ b/etc/weechat.profile
@@ -14,10 +14,10 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 
 # no private-bin support for various reasons:
 # Plugins loaded: alias, aspell, charset, exec, fifo, guile, irc,
 # logger, lua, perl, python, relay, ruby, script, tcl, trigger, xferloading plugins
-notv

--- a/etc/wesnoth.profile
+++ b/etc/wesnoth.profile
@@ -25,9 +25,9 @@ include /etc/firejail/whitelist-common.inc
 caps.drop all
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 
 private-dev
 private-tmp
-notv

--- a/etc/wget.profile
+++ b/etc/wget.profile
@@ -21,6 +21,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -33,4 +34,3 @@ private-dev
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/wine.profile
+++ b/etc/wine.profile
@@ -20,5 +20,5 @@ netfilter
 nogroups
 nonewprivs
 noroot
-seccomp
 notv
+seccomp

--- a/etc/wire.profile
+++ b/etc/wire.profile
@@ -21,6 +21,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
@@ -28,4 +29,3 @@ shell none
 disable-mnt
 private-dev
 private-tmp
-notv

--- a/etc/wireshark.profile
+++ b/etc/wireshark.profile
@@ -19,6 +19,7 @@ no3d
 # nonewprivs - breaks unprivileged wireshark usage
 # noroot
 nosound
+notv
 # protocol unix,inet,inet6,netlink
 # seccomp - breaks unprivileged wireshark usage
 shell none
@@ -31,4 +32,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/xchat.profile
+++ b/etc/xchat.profile
@@ -14,8 +14,8 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 
 # private-bin requires perl, python, etc.
-notv

--- a/etc/xed.profile
+++ b/etc/xed.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 seccomp
 shell none
 tracelog
@@ -25,4 +26,3 @@ tracelog
 private-bin xed
 private-dev
 private-tmp
-notv

--- a/etc/xfburn.profile
+++ b/etc/xfburn.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -27,4 +28,3 @@ tracelog
 # private-dev
 # private-etc fonts
 # private-tmp
-notv

--- a/etc/xfce4-dict.profile
+++ b/etc/xfce4-dict.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -30,4 +31,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/xfce4-notes.profile
+++ b/etc/xfce4-notes.profile
@@ -21,6 +21,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -32,4 +33,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/xiphos.profile
+++ b/etc/xiphos.profile
@@ -26,6 +26,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -35,4 +36,3 @@ private-bin xiphos
 private-dev
 private-etc fonts,resolv.conf,sword
 private-tmp
-notv

--- a/etc/xmms.profile
+++ b/etc/xmms.profile
@@ -17,10 +17,10 @@ netfilter
 no3d
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
 
 private-bin xmms
 private-dev
-notv

--- a/etc/xonotic.profile
+++ b/etc/xonotic.profile
@@ -21,6 +21,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -33,4 +34,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/xpdf.profile
+++ b/etc/xpdf.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix
 seccomp
@@ -29,4 +30,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/xplayer.profile
+++ b/etc/xplayer.profile
@@ -18,6 +18,7 @@ netfilter
 nogroups
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -26,4 +27,3 @@ tracelog
 private-bin xplayer,xplayer-audio-preview,xplayer-video-thumbnailer
 private-dev
 private-tmp
-notv

--- a/etc/xreader.profile
+++ b/etc/xreader.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -27,4 +28,3 @@ tracelog
 private-bin xreader, xreader-previewer, xreader-thumbnailer
 private-dev
 private-tmp
-notv

--- a/etc/xviewer.profile
+++ b/etc/xviewer.profile
@@ -20,6 +20,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -31,4 +32,3 @@ private-tmp
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/xzdec.profile
+++ b/etc/xzdec.profile
@@ -12,10 +12,10 @@ ignore noroot
 net none
 no3d
 nosound
+notv
 shell none
 tracelog
 
 private-dev
 
 include /etc/firejail/default.profile
-notv

--- a/etc/youtube-dl.profile
+++ b/etc/youtube-dl.profile
@@ -21,6 +21,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -31,4 +32,3 @@ private-dev
 
 noexec ${HOME}
 noexec /tmp
-notv

--- a/etc/zathura.profile
+++ b/etc/zathura.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 nosound
+notv
 protocol unix
 seccomp
 shell none
@@ -29,4 +30,3 @@ private-etc fonts
 private-tmp
 read-only ~/
 read-write ~/.local/share/zathura/
-notv

--- a/etc/zoom.profile
+++ b/etc/zoom.profile
@@ -20,8 +20,8 @@ caps.drop all
 netfilter
 nonewprivs
 noroot
+notv
 protocol unix,inet,inet6
 seccomp
 
 private-tmp
-notv


### PR DESCRIPTION
- Fix notv placement
- Fix "include include" in mate-calculator.profile a1cb05b0304c0f0fb68582a34fcfcfe1d4b505f0
- Fix "nosound\nnosound" in 7z.profile
- Fix options out of alphabetical order in default.profile