### PR TITLE
some fixes and enhancements

### DIFF
--- a/etc/cvlc.profile
+++ b/etc/cvlc.profile
@@ -14,11 +14,9 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 netfilter
-nodvd
 nogroups
 nonewprivs
 noroot
-notv
 protocol unix,inet,inet6,netlink
 seccomp
 shell none

--- a/etc/konversation.profile
+++ b/etc/konversation.profile
@@ -15,9 +15,12 @@ caps.drop all
 netfilter
 nodvd
 nogroups
+nonewprivs
 noroot
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
+tracelog
 
 private-tmp

--- a/etc/skanlite.profile
+++ b/etc/skanlite.profile
@@ -13,6 +13,7 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 # net none
+netfilter
 nodvd
 nogroups
 nonewprivs

--- a/etc/skanlite.profile
+++ b/etc/skanlite.profile
@@ -25,7 +25,7 @@ protocol unix,netlink
 seccomp.drop @clock,@cpu-emulation,@debug,@module,@obsolete,@reboot,@resources,@swap,acct,add_key,bpf,chroot,fanotify_init,io_cancel,io_destroy,io_getevents,io_setup,io_submit,iopl,ioprio_set,kcmp,keyctl,mount,name_to_handle_at,nfsservctl,ni_syscall,open_by_handle_at,pciconfig_iobase,pciconfig_read,pciconfig_write,personality,pivot_root,process_vm_readv,ptrace,remap_file_pages,request_key,s390_mmio_read,s390_mmio_write,setdomainname,sethostname,syslog,umount,umount2,userfaultfd,vhangup,vmsplice
 shell none
 
-private-bin skanlite,kbuildsycoca4
+# private-bin skanlite,kbuildsycoca4
 # private-dev
 # private-etc
 # private-tmp

--- a/etc/skanlite.profile
+++ b/etc/skanlite.profile
@@ -12,18 +12,20 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
-netfilter
+# net none
 nodvd
 nogroups
 nonewprivs
 noroot
 nosound
 notv
-# protocol unix,inet,inet6
-seccomp
+novideo
+protocol unix,netlink
+# skanlite makes ioperm system calls, which are blacklisted by default.
+seccomp.drop @clock,@cpu-emulation,@debug,@module,@obsolete,@reboot,@resources,@swap,acct,add_key,bpf,chroot,fanotify_init,io_cancel,io_destroy,io_getevents,io_setup,io_submit,iopl,ioprio_set,kcmp,keyctl,mount,name_to_handle_at,nfsservctl,ni_syscall,open_by_handle_at,pciconfig_iobase,pciconfig_read,pciconfig_write,personality,pivot_root,process_vm_readv,ptrace,remap_file_pages,request_key,s390_mmio_read,s390_mmio_write,setdomainname,sethostname,syslog,umount,umount2,userfaultfd,vhangup,vmsplice
 shell none
 
-# private-bin skanlite
+private-bin skanlite,kbuildsycoca4
 # private-dev
 # private-etc
 # private-tmp

--- a/etc/tracker.profile
+++ b/etc/tracker.profile
@@ -23,6 +23,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/tuxguitar.profile
+++ b/etc/tuxguitar.profile
@@ -14,6 +14,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+netfilter
 no3d
 nodvd
 nonewprivs


### PR DESCRIPTION
A note regarding Skanlite: The default seccomp filter seems to break device discovery for Skanlite on Debian Stretch. Also I had mixed results with network namespaces. What worked for me on all platforms including Fedora is `protocol unix,netlink`, which is why I suggest bringing the option back.