### PR TITLE
fix simple-scan

### DIFF
--- a/etc/simple-scan.profile
+++ b/etc/simple-scan.profile
@@ -20,9 +20,11 @@ nonewprivs
 noroot
 nosound
 notv
-protocol unix,inet,inet6
+novideo
+protocol unix,inet,inet6,netlink
+# simple-scan makes ioperm system calls, which are blacklisted by default.
+seccomp.drop @clock,@cpu-emulation,@debug,@module,@obsolete,@reboot,@resources,@swap,acct,add_key,bpf,chroot,fanotify_init,io_cancel,io_destroy,io_getevents,io_setup,io_submit,iopl,ioprio_set,kcmp,keyctl,mount,name_to_handle_at,nfsservctl,ni_syscall,open_by_handle_at,pciconfig_iobase,pciconfig_read,pciconfig_write,personality,pivot_root,process_vm_readv,ptrace,remap_file_pages,request_key,s390_mmio_read,s390_mmio_write,setdomainname,sethostname,syslog,umount,umount2,userfaultfd,vhangup,vmsplice
 shell none
-# seccomp
 tracelog
 
 # private-bin simple-scan


### PR DESCRIPTION
Fix for broken device discovery. 
Mirrors recent changes for skanlite (#1475), which uses the same backend (SANE).
As tested on Debian Jessie.