### PR TITLE
Add pass to common blacklist

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -213,6 +213,7 @@ blacklist ${HOME}/.mutt/muttrc
 blacklist ${HOME}/.muttrc
 blacklist ${HOME}/.netrc
 blacklist ${HOME}/.pki
+blacklist ${HOME}/.password-store
 blacklist ${HOME}/.smbcredentials
 blacklist ${HOME}/.ssh
 blacklist /etc/group+


### PR DESCRIPTION
`pass` is a password manager that keeps files under `~/.password-store` by default.
See http://www.passwordstore.org/ for more info