### PR TITLE
profile fixes and enhancements

### DIFF
--- a/etc/atril.profile
+++ b/etc/atril.profile
@@ -14,6 +14,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+no3d
 nodvd
 nogroups
 nonewprivs
@@ -28,4 +29,10 @@ tracelog
 
 private-bin atril, atril-previewer, atril-thumbnailer
 private-dev
-private-tmp
+private-etc fonts
+# atril needs access to /tmp/mozilla* to work in firefox
+# private-tmp
+
+memory-deny-write-execute
+noexec ${HOME}
+noexec /tmp

--- a/etc/audacious.profile
+++ b/etc/audacious.profile
@@ -25,4 +25,7 @@ shell none
 tracelog
 
 private-bin audacious
+private-dev
 private-tmp
+
+memory-deny-write-execute

--- a/etc/audacity.profile
+++ b/etc/audacity.profile
@@ -30,5 +30,6 @@ private-bin audacity
 private-dev
 private-tmp
 
+memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp

--- a/etc/cvlc.profile
+++ b/etc/cvlc.profile
@@ -14,7 +14,7 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 netfilter
-nogroups
+# nogroups
 nonewprivs
 noroot
 protocol unix,inet,inet6,netlink
@@ -27,4 +27,7 @@ tracelog
 private-dev
 private-tmp
 
-memory-deny-write-execute
+# mdwe is disabled due to breaking hardware accelerated decoding
+# memory-deny-write-execute
+noexec ${HOME}
+noexec /tmp

--- a/etc/engrampa.profile
+++ b/etc/engrampa.profile
@@ -12,7 +12,8 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
-netfilter
+# net none - makes settings immutable
+no3d
 nodvd
 nogroups
 nonewprivs
@@ -29,3 +30,7 @@ tracelog
 private-dev
 # private-etc fonts
 # private-tmp
+
+memory-deny-write-execute
+noexec ${HOME}
+noexec /tmp

--- a/etc/eog.profile
+++ b/etc/eog.profile
@@ -16,7 +16,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
-net none
+# net none - makes settings immutable
 no3d
 nodvd
 nogroups

--- a/etc/eom.profile
+++ b/etc/eom.profile
@@ -16,6 +16,8 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+# net none - makes settings immutable
+no3d
 nodvd
 nogroups
 nonewprivs
@@ -30,7 +32,9 @@ tracelog
 
 private-bin eom
 private-dev
+private-etc fonts
 private-tmp
 
+memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp

--- a/etc/file-roller.profile
+++ b/etc/file-roller.profile
@@ -12,7 +12,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
-net none
+# net none - makes settings immutable
 no3d
 nodvd
 nogroups

--- a/etc/fossamail.profile
+++ b/etc/fossamail.profile
@@ -17,7 +17,6 @@ whitelist ~/.fossamail
 whitelist ~/.gnupg
 include /etc/firejail/whitelist-common.inc
 
-nodvd
-notv
-
+# allow browsers
+# Redirect
 include /etc/firejail/firefox.profile

--- a/etc/gedit.profile
+++ b/etc/gedit.profile
@@ -15,7 +15,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
-net none
+# net none - makes settings immutable
 no3d
 nodvd
 nogroups
@@ -23,6 +23,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/goobox.profile
+++ b/etc/goobox.profile
@@ -13,11 +13,11 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 netfilter
-nodvd
 nogroups
 nonewprivs
 noroot
 notv
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/handbrake.profile
+++ b/etc/handbrake.profile
@@ -18,7 +18,6 @@ nogroups
 nonewprivs
 noroot
 nosound
-notv
 novideo
 protocol unix,inet,inet6,netlink
 seccomp

--- a/etc/konversation.profile
+++ b/etc/konversation.profile
@@ -23,4 +23,5 @@ protocol unix,inet,inet6
 seccomp
 tracelog
 
+private-dev
 private-tmp

--- a/etc/mediathekview.profile
+++ b/etc/mediathekview.profile
@@ -9,8 +9,10 @@ noblacklist ~/.config/mpv
 noblacklist ~/.config/smplayer
 noblacklist ~/.config/totem
 noblacklist ~/.config/vlc
+noblacklist ~/.config/xplayer
 noblacklist ~/.java
 noblacklist ~/.local/share/totem
+noblacklist ~/.local/share/xplayer
 noblacklist ~/.mediathek3
 noblacklist ~/.mplayer
 
@@ -22,6 +24,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 netfilter
 nodvd
+nogroups
 nonewprivs
 noroot
 notv

--- a/etc/pluma.profile
+++ b/etc/pluma.profile
@@ -13,17 +13,24 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
-net none
+# net none - makes settings immutable
+no3d
 nodvd
 nogroups
 nonewprivs
 noroot
 nosound
 notv
+novideo
+protocol unix
 seccomp
 shell none
 tracelog
 
 private-bin pluma
 private-dev
+# private-etc fonts
 private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/qpdfview.profile
+++ b/etc/qpdfview.profile
@@ -21,6 +21,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none
@@ -29,3 +30,5 @@ tracelog
 private-bin qpdfview
 private-dev
 private-tmp
+
+memory-deny-write-execute

--- a/etc/scribus.profile
+++ b/etc/scribus.profile
@@ -28,6 +28,7 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 nodvd
+nogroups
 nonewprivs
 noroot
 nosound

--- a/etc/simple-scan.profile
+++ b/etc/simple-scan.profile
@@ -20,7 +20,7 @@ nonewprivs
 noroot
 nosound
 notv
-novideo
+# novideo
 protocol unix,inet,inet6,netlink
 # simple-scan makes ioperm system calls, which are blacklisted by default.
 seccomp.drop @clock,@cpu-emulation,@debug,@module,@obsolete,@reboot,@resources,@swap,acct,add_key,bpf,chroot,fanotify_init,io_cancel,io_destroy,io_getevents,io_setup,io_submit,iopl,ioprio_set,kcmp,keyctl,mount,name_to_handle_at,nfsservctl,ni_syscall,open_by_handle_at,pciconfig_iobase,pciconfig_read,pciconfig_write,personality,pivot_root,process_vm_readv,ptrace,remap_file_pages,request_key,s390_mmio_read,s390_mmio_write,setdomainname,sethostname,syslog,umount,umount2,userfaultfd,vhangup,vmsplice

--- a/etc/skanlite.profile
+++ b/etc/skanlite.profile
@@ -20,7 +20,7 @@ nonewprivs
 noroot
 nosound
 notv
-novideo
+# novideo
 protocol unix,netlink
 # skanlite makes ioperm system calls, which are blacklisted by default.
 seccomp.drop @clock,@cpu-emulation,@debug,@module,@obsolete,@reboot,@resources,@swap,acct,add_key,bpf,chroot,fanotify_init,io_cancel,io_destroy,io_getevents,io_setup,io_submit,iopl,ioprio_set,kcmp,keyctl,mount,name_to_handle_at,nfsservctl,ni_syscall,open_by_handle_at,pciconfig_iobase,pciconfig_read,pciconfig_write,personality,pivot_root,process_vm_readv,ptrace,remap_file_pages,request_key,s390_mmio_read,s390_mmio_write,setdomainname,sethostname,syslog,umount,umount2,userfaultfd,vhangup,vmsplice

--- a/etc/vlc.profile
+++ b/etc/vlc.profile
@@ -25,6 +25,7 @@ private-bin vlc,cvlc,nvlc,rvlc,qvlc,svlc
 private-dev
 private-tmp
 
+# mdwe is disabled due to breaking hardware accelerated decoding
 # memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp

--- a/etc/vlc.profile
+++ b/etc/vlc.profile
@@ -25,5 +25,6 @@ private-bin vlc,cvlc,nvlc,rvlc,qvlc,svlc
 private-dev
 private-tmp
 
+# memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp

--- a/etc/xed.profile
+++ b/etc/xed.profile
@@ -13,17 +13,24 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
-net none
+# net none - makes settings immutable
+no3d
 nodvd
 nogroups
 nonewprivs
 noroot
 nosound
 notv
+novideo
+protocol unix
 seccomp
 shell none
 tracelog
 
 private-bin xed
 private-dev
+# private-etc fonts
 private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/xfburn.profile
+++ b/etc/xfburn.profile
@@ -14,12 +14,12 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 netfilter
-nodvd
 nogroups
 nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/xplayer.profile
+++ b/etc/xplayer.profile
@@ -18,7 +18,6 @@ netfilter
 nogroups
 nonewprivs
 noroot
-notv
 protocol unix,inet,inet6
 seccomp
 shell none
@@ -26,4 +25,8 @@ tracelog
 
 private-bin xplayer,xplayer-audio-preview,xplayer-video-thumbnailer
 private-dev
+# private-etc fonts
 private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/xreader.profile
+++ b/etc/xreader.profile
@@ -30,7 +30,7 @@ tracelog
 
 private-bin xreader,xreader-previewer,xreader-thumbnailer
 private-dev
-private-etc fonts
+# private-etc fonts
 # xreader needs access to /tmp/mozilla* to work in firefox
 # private-tmp
 

--- a/etc/xreader.profile
+++ b/etc/xreader.profile
@@ -15,17 +15,25 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+no3d
 nodvd
 nogroups
 nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none
 tracelog
 
-private-bin xreader, xreader-previewer, xreader-thumbnailer
+private-bin xreader,xreader-previewer,xreader-thumbnailer
 private-dev
-private-tmp
+private-etc fonts
+# xreader needs access to /tmp/mozilla* to work in firefox
+# private-tmp
+
+memory-deny-write-execute
+noexec ${HOME}
+noexec /tmp

--- a/etc/xviewer.profile
+++ b/etc/xviewer.profile
@@ -16,12 +16,15 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all
+# net none - makes settings immutable
+no3d
 nodvd
 nogroups
 nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none
@@ -29,7 +32,9 @@ tracelog
 
 private-bin xviewer
 private-dev
+private-etc fonts
 private-tmp
 
+memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp


### PR DESCRIPTION
- an attempt to bring the forks gedit-pluma-xed, evince-atril-xreader, eog-eom-xviewer, totem-xplayer, engrampa-file-roller to the same level.
`net none` makes the settings of various programs immutable, which is both a bug and a feature (dconf isolation). This pull request would make the feature opt-in. If we instead leave it as it is now, maybe we should at least put a comment in the profiles.
- added `memory-deny-write-execute` to audacious, audacity, qpdfview. As it seems to work for some, may I also propose putting this option back (but commented) in the vlc profile?
- commented recently added `novideo` in skanlite, simple-scan profiles. Apparently these scanning tools can make snapshots with the webcam, too.
- fixed some more `nodvd`, `notv` options
- EDIT: vlc and cvlc profiles are harmonized again.