### PR TITLE
enhance and fix profiles (mostly novideo additions)

### DIFF
--- a/etc/amarok.profile
+++ b/etc/amarok.profile
@@ -17,6 +17,7 @@ nogroups
 nonewprivs
 noroot
 notv
+novideo
 protocol unix,inet,inet6
 # seccomp
 shell none

--- a/etc/audacious.profile
+++ b/etc/audacious.profile
@@ -24,8 +24,10 @@ seccomp
 shell none
 tracelog
 
-private-bin audacious
+# private-bin audacious
 private-dev
 private-tmp
 
 memory-deny-write-execute
+noexec ${HOME}
+noexec /tmp

--- a/etc/caja.profile
+++ b/etc/caja.profile
@@ -24,6 +24,7 @@ nogroups
 nonewprivs
 noroot
 notv
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/claws-mail.profile
+++ b/etc/claws-mail.profile
@@ -22,6 +22,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/cmus.profile
+++ b/etc/cmus.profile
@@ -17,6 +17,7 @@ netfilter
 nonewprivs
 noroot
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/cpio.profile
+++ b/etc/cpio.profile
@@ -22,6 +22,7 @@ no3d
 nodvd
 nosound
 notv
+novideo
 seccomp
 shell none
 tracelog

--- a/etc/curl.profile
+++ b/etc/curl.profile
@@ -23,6 +23,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/cvlc.profile
+++ b/etc/cvlc.profile
@@ -5,29 +5,8 @@ include /etc/firejail/cvlc.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-noblacklist ${HOME}/.config/vlc
-
-include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-devel.inc
-include /etc/firejail/disable-passwdmgr.inc
-include /etc/firejail/disable-programs.inc
-
-caps.drop all
-netfilter
-# nogroups
-nonewprivs
-noroot
-protocol unix,inet,inet6,netlink
-seccomp
-shell none
-tracelog
-
 # clvc doesn't like private-bin
-# private-bin vlc,cvlc,nvlc,rvlc,qvlc,svlc
-private-dev
-private-tmp
+ignore private-bin
 
-# mdwe is disabled due to breaking hardware accelerated decoding
-# memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp
+# Redirect
+include /etc/firejail/vlc.profile

--- a/etc/dnscrypt-proxy.profile
+++ b/etc/dnscrypt-proxy.profile
@@ -17,6 +17,7 @@ no3d
 nodvd
 nosound
 notv
+novideo
 seccomp.drop mount,umount2,ptrace,kexec_load,kexec_file_load,open_by_handle_at,init_module,finit_module,delete_module,iopl,ioperm,swapon,swapoff,syslog,process_vm_readv,process_vm_writev,sysfs,_sysctl,adjtimex,clock_adjtime,lookup_dcookie,perf_event_open,fanotify_init,kcmp,add_key,request_key,keyctl,uselib,acct,modify_ldt,pivot_root,io_setup,io_destroy,io_getevents,io_submit,io_cancel,remap_file_pages,mbind,get_mempolicy,set_mempolicy,migrate_pages,move_pages,vmsplice,perf_event_open
 
 private

--- a/etc/dnsmasq.profile
+++ b/etc/dnsmasq.profile
@@ -20,6 +20,7 @@ nodvd
 nonewprivs
 nosound
 notv
+novideo
 protocol unix,inet,inet6,netlink
 seccomp
 

--- a/etc/dosbox.profile
+++ b/etc/dosbox.profile
@@ -19,6 +19,7 @@ nogroups
 nonewprivs
 noroot
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/enchant.profile
+++ b/etc/enchant.profile
@@ -20,6 +20,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/evolution.profile
+++ b/etc/evolution.profile
@@ -29,6 +29,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/exiftool.profile
+++ b/etc/exiftool.profile
@@ -26,6 +26,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/fbreader.profile
+++ b/etc/fbreader.profile
@@ -19,6 +19,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/feh.profile
+++ b/etc/feh.profile
@@ -13,17 +13,19 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 net none
+no3d
 nodvd
 nogroups
 nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none
 
-private-bin feh
+private-bin feh,jpegexiforient,jpegtran
 private-dev
 private-etc feh
 private-tmp

--- a/etc/file.profile
+++ b/etc/file.profile
@@ -30,3 +30,7 @@ x11 none
 private-bin file
 private-dev
 private-etc magic.mgc,magic,localtime
+
+memory-deny-write-execute
+noexec ${HOME}
+noexec /tmp

--- a/etc/filezilla.profile
+++ b/etc/filezilla.profile
@@ -19,6 +19,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/firefox.profile
+++ b/etc/firefox.profile
@@ -10,7 +10,11 @@ noblacklist ~/.config/okularpartrc
 noblacklist ~/.config/okularrc
 noblacklist ~/.config/qpdfview
 noblacklist ~/.kde/share/apps/okular
+noblacklist ~/.kde/share/config/okularpartrc
+noblacklist ~/.kde/share/config/okularrc
 noblacklist ~/.kde4/share/apps/okular
+noblacklist ~/.kde4/share/config/okularpartrc
+noblacklist ~/.kde4/share/config/okularrc
 noblacklist ~/.local/share/gnome-shell/extensions
 noblacklist ~/.local/share/okular
 noblacklist ~/.local/share/qpdfview
@@ -34,7 +38,11 @@ whitelist ~/.config/pipelight-silverlight5.1
 whitelist ~/.config/pipelight-widevine
 whitelist ~/.config/qpdfview
 whitelist ~/.kde/share/apps/okular
+whitelist ~/.kde/share/config/okularpartrc
+whitelist ~/.kde/share/config/okularrc
 whitelist ~/.kde4/share/apps/okular
+whitelist ~/.kde4/share/config/okularpartrc
+whitelist ~/.kde4/share/config/okularrc
 whitelist ~/.keysnail.js
 whitelist ~/.lastpass
 whitelist ~/.local/share/gnome-shell/extensions
@@ -66,7 +74,6 @@ tracelog
 
 # private-bin firefox,which,sh,dbus-launch,dbus-send,env
 private-dev
-# private-dev might prevent video calls going out
 # private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,xdg,gtk-2.0,gtk-3.0,X11,pango,fonts,firefox,mime.types,mailcap,asound.conf,pulse
 private-tmp
 

--- a/etc/galculator.profile
+++ b/etc/galculator.profile
@@ -24,6 +24,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/geeqie.profile
+++ b/etc/geeqie.profile
@@ -21,6 +21,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/git.profile
+++ b/etc/git.profile
@@ -29,6 +29,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/gnome-calculator.profile
+++ b/etc/gnome-calculator.profile
@@ -21,6 +21,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/gpa.profile
+++ b/etc/gpa.profile
@@ -20,6 +20,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/gpg-agent.profile
+++ b/etc/gpg-agent.profile
@@ -23,6 +23,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/gpg.profile
+++ b/etc/gpg.profile
@@ -23,6 +23,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/gpicview.profile
+++ b/etc/gpicview.profile
@@ -20,6 +20,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/gthumb.profile
+++ b/etc/gthumb.profile
@@ -21,6 +21,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/guayadeque.profile
+++ b/etc/guayadeque.profile
@@ -18,6 +18,7 @@ nogroups
 nonewprivs
 noroot
 notv
+novideo
 protocol unix,inet,inet6,netlink
 seccomp
 shell none

--- a/etc/gzip.profile
+++ b/etc/gzip.profile
@@ -14,6 +14,7 @@ no3d
 nodvd
 nosound
 notv
+novideo
 shell none
 tracelog
 

--- a/etc/highlight.profile
+++ b/etc/highlight.profile
@@ -21,6 +21,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/img2txt.profile
+++ b/etc/img2txt.profile
@@ -19,6 +19,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/lynx.profile
+++ b/etc/lynx.profile
@@ -21,6 +21,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/mcabber.profile
+++ b/etc/mcabber.profile
@@ -20,6 +20,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol inet,inet6
 seccomp
 shell none

--- a/etc/mediainfo.profile
+++ b/etc/mediainfo.profile
@@ -21,6 +21,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/mupdf.profile
+++ b/etc/mupdf.profile
@@ -19,6 +19,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 # seccomp.keep access,arch_prctl,brk,clone,close,connect,execve,exit_group,fchmod,fchown,fcntl,fstat,futex,getcwd,getpeername,getrlimit,getsockname,getsockopt,lseek,lstat,mlock,mmap,mprotect,mremap,munmap,nanosleep,open,poll,prctl,read,recvfrom,recvmsg,restart_syscall,rt_sigaction,rt_sigprocmask,select,sendmsg,set_robust_list,set_tid_address,setresgid,setresuid,shmat,shmctl,shmget,shutdown,socket,stat,sysinfo,uname,unshare,wait4,write,writev

--- a/etc/mupen64plus.profile
+++ b/etc/mupen64plus.profile
@@ -26,4 +26,5 @@ nodvd
 nonewprivs
 noroot
 notv
+novideo
 seccomp

--- a/etc/mutt.profile
+++ b/etc/mutt.profile
@@ -44,6 +44,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/nautilus.profile
+++ b/etc/nautilus.profile
@@ -25,6 +25,7 @@ nogroups
 nonewprivs
 noroot
 notv
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/nylas.profile
+++ b/etc/nylas.profile
@@ -26,6 +26,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6,netlink
 seccomp
 shell none

--- a/etc/odt2txt.profile
+++ b/etc/odt2txt.profile
@@ -21,6 +21,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/parole.profile
+++ b/etc/parole.profile
@@ -13,7 +13,6 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 netfilter
-nodvd
 nonewprivs
 noroot
 notv

--- a/etc/pix.profile
+++ b/etc/pix.profile
@@ -22,6 +22,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/qbittorrent.profile
+++ b/etc/qbittorrent.profile
@@ -35,6 +35,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6,netlink
 seccomp
 # shell none

--- a/etc/qpdfview.profile
+++ b/etc/qpdfview.profile
@@ -32,3 +32,5 @@ private-dev
 private-tmp
 
 memory-deny-write-execute
+noexec ${HOME}
+noexec /tmp

--- a/etc/quiterss.profile
+++ b/etc/quiterss.profile
@@ -34,6 +34,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/ranger.profile
+++ b/etc/ranger.profile
@@ -24,6 +24,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 

--- a/etc/rtorrent.profile
+++ b/etc/rtorrent.profile
@@ -18,6 +18,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/tar.profile
+++ b/etc/tar.profile
@@ -15,6 +15,7 @@ no3d
 nodvd
 nosound
 notv
+novideo
 shell none
 tracelog
 

--- a/etc/transmission-cli.profile
+++ b/etc/transmission-cli.profile
@@ -20,6 +20,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/transmission-gtk.profile
+++ b/etc/transmission-gtk.profile
@@ -27,6 +27,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/transmission-qt.profile
+++ b/etc/transmission-qt.profile
@@ -27,6 +27,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/transmission-show.profile
+++ b/etc/transmission-show.profile
@@ -20,6 +20,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/uget-gtk.profile
+++ b/etc/uget-gtk.profile
@@ -23,6 +23,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/unbound.profile
+++ b/etc/unbound.profile
@@ -17,6 +17,7 @@ no3d
 nodvd
 nosound
 notv
+novideo
 seccomp.drop mount,umount2,ptrace,kexec_load,kexec_file_load,open_by_handle_at,init_module,finit_module,delete_module,iopl,ioperm,swapon,swapoff,syslog,process_vm_readv,process_vm_writev,sysfs,_sysctl,adjtimex,clock_adjtime,lookup_dcookie,perf_event_open,fanotify_init,kcmp,add_key,request_key,keyctl,uselib,acct,modify_ldt,pivot_root,io_setup,io_destroy,io_getevents,io_submit,io_cancel,remap_file_pages,mbind,get_mempolicy,set_mempolicy,migrate_pages,move_pages,vmsplice,perf_event_open
 
 private

--- a/etc/unrar.profile
+++ b/etc/unrar.profile
@@ -15,6 +15,7 @@ no3d
 nodvd
 nosound
 notv
+novideo
 shell none
 tracelog
 

--- a/etc/unzip.profile
+++ b/etc/unzip.profile
@@ -15,6 +15,7 @@ no3d
 nodvd
 nosound
 notv
+novideo
 shell none
 tracelog
 

--- a/etc/uudeview.profile
+++ b/etc/uudeview.profile
@@ -13,6 +13,7 @@ net none
 nodvd
 nosound
 notv
+novideo
 shell none
 tracelog
 

--- a/etc/viewnior.profile
+++ b/etc/viewnior.profile
@@ -19,12 +19,14 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 net none
+no3d
 nodvd
 nogroups
 nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none
@@ -34,3 +36,7 @@ private-bin viewnior
 private-dev
 private-etc fonts
 private-tmp
+
+memory-deny-write-execute
+noexec ${HOME}
+noexec /tmp

--- a/etc/vim.profile
+++ b/etc/vim.profile
@@ -20,5 +20,6 @@ nogroups
 nonewprivs
 noroot
 notv
+novideo
 protocol unix,inet,inet6
 seccomp

--- a/etc/w3m.profile
+++ b/etc/w3m.profile
@@ -23,6 +23,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/xiphos.profile
+++ b/etc/xiphos.profile
@@ -28,6 +28,7 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/xmms.profile
+++ b/etc/xmms.profile
@@ -18,6 +18,7 @@ no3d
 nonewprivs
 noroot
 notv
+novideo
 protocol unix,inet,inet6
 seccomp
 shell none

--- a/etc/xreader.profile
+++ b/etc/xreader.profile
@@ -30,7 +30,7 @@ tracelog
 
 private-bin xreader,xreader-previewer,xreader-thumbnailer
 private-dev
-# private-etc fonts
+# private-etc fonts,ld.so.cache
 # xreader needs access to /tmp/mozilla* to work in firefox
 # private-tmp
 

--- a/etc/xzdec.profile
+++ b/etc/xzdec.profile
@@ -14,6 +14,7 @@ no3d
 nodvd
 nosound
 notv
+novideo
 shell none
 tracelog
 


### PR DESCRIPTION
- a bunch of `novideo` additions.
- audacious fails to launch due to `private-bin`, and interestingly it is not always reproducible. I was not successful in debugging this further. Maybe we disable it for the time being? This is the error message:
```
ERROR plugin-init.cc:147 [start_required]: No output plugin found.
(Did you forget to install audacious-plugins?)

Parent is shutting down, bye...
```
- feh uses jpegexiforient and jpegtran for rotating images.
- Firefox supported KF5 Okular better than KDE4 Okular. This pull request brings both to the same level.