### PR TITLE
improve servers, harden musescore

### DIFF
--- a/README
+++ b/README
@@ -409,7 +409,7 @@ smithsohu (https://github.com/smitsohu)
 	- lots of profile hardening and fixes
 	- added MuseScore profile
 	- fixed device discovery for simple-scan
-	- add novideo support in all profiles
+	- add novideo support in many profiles
 soredake (https://github.com/soredake)
 	- fix steam startup with >=llvm-4
 SpotComms (https://github.com/SpotComms)

--- a/etc/cpio.profile
+++ b/etc/cpio.profile
@@ -17,9 +17,9 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 net none
-net none
 no3d
 nodvd
+nonewprivs
 nosound
 notv
 novideo

--- a/etc/cvlc.profile
+++ b/etc/cvlc.profile
@@ -5,7 +5,7 @@ include /etc/firejail/cvlc.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# clvc doesn't like private-bin
+# cvlc doesn't like private-bin
 ignore private-bin
 
 # Redirect

--- a/etc/dnscrypt-proxy.profile
+++ b/etc/dnscrypt-proxy.profile
@@ -24,7 +24,9 @@ notv
 novideo
 seccomp.drop mount,umount2,ptrace,kexec_load,kexec_file_load,open_by_handle_at,init_module,finit_module,delete_module,iopl,ioperm,swapon,swapoff,syslog,process_vm_readv,process_vm_writev,sysfs,_sysctl,adjtimex,clock_adjtime,lookup_dcookie,perf_event_open,fanotify_init,kcmp,add_key,request_key,keyctl,uselib,acct,modify_ldt,pivot_root,io_setup,io_destroy,io_getevents,io_submit,io_cancel,remap_file_pages,mbind,get_mempolicy,set_mempolicy,migrate_pages,move_pages,vmsplice,perf_event_open
 
+disable-mnt
 private
 private-dev
 
+# mdwe may break dnscrypt-proxy modules/plugins
 memory-deny-write-execute

--- a/etc/dnscrypt-proxy.profile
+++ b/etc/dnscrypt-proxy.profile
@@ -29,4 +29,4 @@ private
 private-dev
 
 # mdwe may break dnscrypt-proxy modules/plugins
-memory-deny-write-execute
+# memory-deny-write-execute

--- a/etc/dnscrypt-proxy.profile
+++ b/etc/dnscrypt-proxy.profile
@@ -5,6 +5,8 @@ include /etc/firejail/dnscrypt-proxy.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+blacklist /tmp/.X11-unix
+
 noblacklist /sbin
 noblacklist /usr/sbin
 
@@ -13,12 +15,17 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
+caps
 no3d
 nodvd
+nonewprivs
 nosound
 notv
 novideo
 seccomp.drop mount,umount2,ptrace,kexec_load,kexec_file_load,open_by_handle_at,init_module,finit_module,delete_module,iopl,ioperm,swapon,swapoff,syslog,process_vm_readv,process_vm_writev,sysfs,_sysctl,adjtimex,clock_adjtime,lookup_dcookie,perf_event_open,fanotify_init,kcmp,add_key,request_key,keyctl,uselib,acct,modify_ldt,pivot_root,io_setup,io_destroy,io_getevents,io_submit,io_cancel,remap_file_pages,mbind,get_mempolicy,set_mempolicy,migrate_pages,move_pages,vmsplice,perf_event_open
 
+disable-mnt
 private
 private-dev
+
+memory-deny-write-execute

--- a/etc/dnscrypt-proxy.profile
+++ b/etc/dnscrypt-proxy.profile
@@ -16,6 +16,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps
+# caps.keep ipc_lock,net_bind_service,setgid,setuid,sys_chroot,sys_resource
 no3d
 nodvd
 nonewprivs

--- a/etc/dnscrypt-proxy.profile
+++ b/etc/dnscrypt-proxy.profile
@@ -28,5 +28,5 @@ disable-mnt
 private
 private-dev
 
-# mdwe may break dnscrypt-proxy modules/plugins
+# mdwe can break modules/plugins
 # memory-deny-write-execute

--- a/etc/dnscrypt-proxy.profile
+++ b/etc/dnscrypt-proxy.profile
@@ -24,7 +24,6 @@ notv
 novideo
 seccomp.drop mount,umount2,ptrace,kexec_load,kexec_file_load,open_by_handle_at,init_module,finit_module,delete_module,iopl,ioperm,swapon,swapoff,syslog,process_vm_readv,process_vm_writev,sysfs,_sysctl,adjtimex,clock_adjtime,lookup_dcookie,perf_event_open,fanotify_init,kcmp,add_key,request_key,keyctl,uselib,acct,modify_ldt,pivot_root,io_setup,io_destroy,io_getevents,io_submit,io_cancel,remap_file_pages,mbind,get_mempolicy,set_mempolicy,migrate_pages,move_pages,vmsplice,perf_event_open
 
-disable-mnt
 private
 private-dev
 

--- a/etc/dnsmasq.profile
+++ b/etc/dnsmasq.profile
@@ -5,6 +5,8 @@ include /etc/firejail/dnsmasq.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+blacklist /tmp/.X11-unix
+
 noblacklist /sbin
 noblacklist /usr/sbin
 
@@ -14,7 +16,6 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps
-netfilter
 no3d
 nodvd
 nonewprivs

--- a/etc/file.profile
+++ b/etc/file.profile
@@ -21,6 +21,7 @@ nogroups
 nonewprivs
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none

--- a/etc/musescore.profile
+++ b/etc/musescore.profile
@@ -10,6 +10,11 @@ noblacklist ~/.config/MuseScore
 noblacklist ~/.local/share/data/MusE
 noblacklist ~/.local/share/data/MuseScore
 
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
+
 caps.drop all
 netfilter
 no3d

--- a/etc/unbound.profile
+++ b/etc/unbound.profile
@@ -29,4 +29,4 @@ private
 private-dev
 
 # mdwe may break unbound modules/plugins
-memory-deny-write-execute
+# memory-deny-write-execute

--- a/etc/unbound.profile
+++ b/etc/unbound.profile
@@ -5,6 +5,8 @@ include /etc/firejail/unbound.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+blacklist /tmp/.X11-unix
+
 noblacklist /sbin
 noblacklist /usr/sbin
 
@@ -13,12 +15,17 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
+caps
 no3d
 nodvd
+nonewprivs
 nosound
 notv
 novideo
 seccomp.drop mount,umount2,ptrace,kexec_load,kexec_file_load,open_by_handle_at,init_module,finit_module,delete_module,iopl,ioperm,swapon,swapoff,syslog,process_vm_readv,process_vm_writev,sysfs,_sysctl,adjtimex,clock_adjtime,lookup_dcookie,perf_event_open,fanotify_init,kcmp,add_key,request_key,keyctl,uselib,acct,modify_ldt,pivot_root,io_setup,io_destroy,io_getevents,io_submit,io_cancel,remap_file_pages,mbind,get_mempolicy,set_mempolicy,migrate_pages,move_pages,vmsplice,perf_event_open
 
+disable-mnt
 private
 private-dev
+
+memory-deny-write-execute

--- a/etc/unbound.profile
+++ b/etc/unbound.profile
@@ -16,6 +16,7 @@ include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
 caps
+# caps.keep ipc_lock,net_bind_service,setgid,setuid,sys_chroot,sys_resource
 no3d
 nodvd
 nonewprivs

--- a/etc/unbound.profile
+++ b/etc/unbound.profile
@@ -24,7 +24,6 @@ notv
 novideo
 seccomp.drop mount,umount2,ptrace,kexec_load,kexec_file_load,open_by_handle_at,init_module,finit_module,delete_module,iopl,ioperm,swapon,swapoff,syslog,process_vm_readv,process_vm_writev,sysfs,_sysctl,adjtimex,clock_adjtime,lookup_dcookie,perf_event_open,fanotify_init,kcmp,add_key,request_key,keyctl,uselib,acct,modify_ldt,pivot_root,io_setup,io_destroy,io_getevents,io_submit,io_cancel,remap_file_pages,mbind,get_mempolicy,set_mempolicy,migrate_pages,move_pages,vmsplice,perf_event_open
 
-disable-mnt
 private
 private-dev
 

--- a/etc/unbound.profile
+++ b/etc/unbound.profile
@@ -24,7 +24,9 @@ notv
 novideo
 seccomp.drop mount,umount2,ptrace,kexec_load,kexec_file_load,open_by_handle_at,init_module,finit_module,delete_module,iopl,ioperm,swapon,swapoff,syslog,process_vm_readv,process_vm_writev,sysfs,_sysctl,adjtimex,clock_adjtime,lookup_dcookie,perf_event_open,fanotify_init,kcmp,add_key,request_key,keyctl,uselib,acct,modify_ldt,pivot_root,io_setup,io_destroy,io_getevents,io_submit,io_cancel,remap_file_pages,mbind,get_mempolicy,set_mempolicy,migrate_pages,move_pages,vmsplice,perf_event_open
 
+disable-mnt
 private
 private-dev
 
+# mdwe may break unbound modules/plugins
 memory-deny-write-execute

--- a/etc/unbound.profile
+++ b/etc/unbound.profile
@@ -28,5 +28,5 @@ disable-mnt
 private
 private-dev
 
-# mdwe may break unbound modules/plugins
+# mdwe can break modules/plugins
 # memory-deny-write-execute


### PR DESCRIPTION
- harden server profiles
- the default `netfilter` seems to be not compatible with running a server in the sandbox, my proposal is to remove it from the dnsmasq profile
- fix copy/paste mistake in musescore profile