### PR TITLE
syscalls blacklisted twice

### DIFF
--- a/src/fseccomp/syscall.c
+++ b/src/fseccomp/syscall.c
@@ -110,7 +110,6 @@ static const SyscallGroupList sysgroups[] = {
 	{ .name = "@default", .list =
 	  "@cpu-emulation,"
 	  "@debug,"
-	  "@module,"
 	  "@obsolete,"
 	  "@privileged,"
 	  "@resources,"


### PR DESCRIPTION
Group `@module` is already included in group `@privileged`. Tiny fix for syscalls in `@module` being printed twice with `seccomp.print`