### PR TITLE
remount ~/.config/pulse with noexec

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -309,5 +309,4 @@ blacklist /initrd*
 blacklist /vmlinuz*
 
 # complement noexec ${HOME} and noexec /tmp
-noexec ${HOME}/.config/pulse
 noexec /tmp/.X11-unix

--- a/src/firejail/pulseaudio.c
+++ b/src/firejail/pulseaudio.c
@@ -195,7 +195,8 @@ void pulseaudio_init(void) {
 	if (asprintf(&homeusercfg, "%s/.config/pulse", cfg.homedir) == -1)
 		errExit("asprintf");
 	if (stat(homeusercfg, &s) == 0) {
-		if (mount(RUN_PULSE_DIR, homeusercfg, "none", MS_BIND, NULL) < 0)
+		if (mount(RUN_PULSE_DIR, homeusercfg, "none", MS_BIND, NULL) < 0 ||
+		    mount(NULL, homeusercfg, NULL, MS_NOEXEC|MS_NODEV|MS_NOSUID|MS_BIND|MS_REMOUNT, NULL) < 0)
 			errExit("mount pulseaudio");
 		fs_logger2("tmpfs", homeusercfg);
 	}


### PR DESCRIPTION
in case #1529 is favorably received.