### PR TITLE
Fix gitg diff not showing

### DIFF
--- a/etc/gitg.profile
+++ b/etc/gitg.profile
@@ -31,6 +31,7 @@ private-bin gitg,git,ssh
 private-dev
 private-tmp
 
-memory-deny-write-execute
+# mdwe breaks diff in older versions
+#memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp


### PR DESCRIPTION
Fixes #1537. This should probably be backported to 0.9.50-bugfixes.

Old versions of gitg fail to display git diffs when mdwe is enabled.