### PR TITLE
goobox enhancements

### DIFF
--- a/etc/goobox.profile
+++ b/etc/goobox.profile
@@ -13,17 +13,18 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 netfilter
+no3d
 nogroups
 nonewprivs
 noroot
 notv
 novideo
-protocol unix
+protocol unix,inet,inet6
 seccomp
 shell none
 tracelog
 
 # private-bin goobox
-# private-dev
+private-dev
 # private-etc fonts
 # private-tmp


### PR DESCRIPTION
1) Permitting internet access fixes broken metadata retrieval (relevant for the rip functionality)
2) We can safely enable private-dev after the introduction of nodvd