### PR TITLE
Set `shell none` for ssh-agent configuration

### DIFF
--- a/etc/ssh-agent.profile
+++ b/etc/ssh-agent.profile
@@ -16,6 +16,7 @@ include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
+shell none
 caps.drop all
 netfilter
 no3d


### PR DESCRIPTION
It's common to invoke ssh-agent in shell login config, so if firejail launches it through a shell, that can lead to an infinite loop

