### PR TITLE
Update quiterss.profile

### DIFF
--- a/etc/quiterss.profile
+++ b/etc/quiterss.profile
@@ -23,6 +23,7 @@ whitelist ${HOME}/.cache/QuiteRss
 whitelist ${HOME}/.config/QuiteRss/
 whitelist ${HOME}/.config/QuiteRssrc
 whitelist ${HOME}/.local/share/data/QuiteRss
+whitelist ${HOME}/.local/share/QuiteRss
 whitelist ${HOME}/quiterssfeeds.opml
 include /etc/firejail/whitelist-common.inc
 


### PR DESCRIPTION
QuiteRSS uses ${HOME}/.local/share/QuiteRss for writing to it's feeds.db file. Without it people lose all their RSS feeds as soon as the close QuiteRSS.