### PR TITLE
Enumerate root directories in apparmor profile

### DIFF
--- a/etc/firejail-default
+++ b/etc/firejail-default
@@ -23,7 +23,7 @@ profile firejail-default flags=(attach_disconnected,mediate_deleted) {
 # enough to run "top" or "ps aux".
 ##########
 / r,
-/[^proc,^sys]** mrwlk,
+/{usr,bin,dev,etc,home,lib,media,mnt,opt,srv,tmp,var}** mrwlk,
 /{,var/}run/ r,
 /{,var/}run/** r,
 /{,var/}run/user/**/dconf/ rw,


### PR DESCRIPTION
Replace opaque character class with an explicit list of root-level directories to be granted access.

The replaced line in the apparmor profile deceptively granted access to all root-level directories that did not start with the letters any of the characters `coprsy,^`, which is probably not what was intended. 

Once apparmor supports the [proposed addition](http://wiki.apparmor.net/index.php/QuickProfileLanguage#Proposed_additions), this line can be replaced with  `{**^sys,proc}`, which is what (I am guessing) was intended.

I'm currently running with this rule loaded. Other tools may need more liberal permissions. Notice that this **adds** access to `opt` and `srv`, which previously would not have been whitelisted.

