### PR TITLE
Update manpages to use HTTPS links

### DIFF
--- a/src/man/firecfg.txt
+++ b/src/man/firecfg.txt
@@ -96,7 +96,7 @@ $ sudo firecfg --clean
 .SH LICENSE
 This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
 .PP
-Homepage: http://firejail.wordpress.com
+Homepage: https://firejail.wordpress.com
 .SH SEE ALSO
 \&\flfirejail\fR\|(1),
 \&\flfiremon\fR\|(1),

--- a/src/man/firejail-login.txt
+++ b/src/man/firejail-login.txt
@@ -32,7 +32,7 @@ usermod \-\-shell /usr/bin/firejail username
 .SH LICENSE
 Firejail is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
 .PP
-Homepage: http://firejail.wordpress.com
+Homepage: https://firejail.wordpress.com
 .SH SEE ALSO
 \&\flfirejail\fR\|(1),
 \&\flfiremon\fR\|(1),

--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -622,7 +622,7 @@ $ firejail --profile-path=~/myprofiles
 .SH LICENSE
 Firejail is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
 .PP
-Homepage: http://firejail.wordpress.com
+Homepage: https://firejail.wordpress.com
 .SH SEE ALSO
 \&\flfirejail\fR\|(1),
 \&\flfiremon\fR\|(1),

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -109,7 +109,7 @@ $ firejail --allusers
 Enable AppArmor confinement. For more information, please see \fBAPPARMOR\fR section below.
 .TP
 \fB\-\-appimage
-Sandbox an AppImage (http://appimage.org/) application.
+Sandbox an AppImage (https://appimage.org/) application.
 .br
 
 .br
@@ -2082,7 +2082,7 @@ $ firejail \-\-x11=xorg firefox
 
 .TP
 \fB\-\-x11=xpra
-Start Xpra (http://xpra.org) and attach the sandbox to this server.
+Start Xpra (https://xpra.org) and attach the sandbox to this server.
 Xpra is a persistent remote display server and client for forwarding X11 applications and desktop screens.
 A network namespace needs to be instantiated in order to deny access to X11 abstract Unix domain socket.
 .br
@@ -2536,7 +2536,7 @@ List all sandboxed processes.
 .SH LICENSE
 This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
 .PP
-Homepage: http://firejail.wordpress.com
+Homepage: https://firejail.wordpress.com
 .SH SEE ALSO
 \&\flfiremon\fR\|(1),
 \&\flfirecfg\fR\|(1),


### PR DESCRIPTION
All of these websites support HTTPS, and nearly all of them redirect
to it anyways.