### PR TITLE
Addition of RLIMIT_AS

### DIFF
--- a/cmake-build-debug/CMakeFiles/clion-log.txt
+++ b/cmake-build-debug/CMakeFiles/clion-log.txt
@@ -1,1 +1,0 @@
-CMakeLists.txt not found in C:\Users\cwilliams\Projects\firejail

--- a/cmake-build-debug/CMakeFiles/clion-log.txt
+++ b/cmake-build-debug/CMakeFiles/clion-log.txt
@@ -1,0 +1,1 @@
+CMakeLists.txt not found in C:\Users\cwilliams\Projects\firejail

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -249,6 +249,7 @@ typedef struct config_t {
 	long long unsigned rlimit_nproc;
 	long long unsigned rlimit_fsize;
 	long long unsigned rlimit_sigpending;
+	long long unsigned rlimit_as;
 
 	// cpu affinity, nice and control groups
 	uint32_t cpus;
@@ -324,6 +325,7 @@ extern int arg_rlimit_nofile;	// rlimit nofile
 extern int arg_rlimit_nproc;	// rlimit nproc
 extern int arg_rlimit_fsize;	// rlimit fsize
 extern int arg_rlimit_sigpending;// rlimit sigpending
+extern int arg_rlimit_as;	//rlimit as
 extern int arg_nogroups;	// disable supplementary groups
 extern int arg_nonewprivs;	// set the NO_NEW_PRIVS prctl
 extern int arg_noroot;		// create a new user namespace and disable root user

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -71,6 +71,7 @@ int arg_rlimit_nofile = 0;			// rlimit nofile
 int arg_rlimit_nproc = 0;			// rlimit nproc
 int arg_rlimit_fsize = 0;				// rlimit fsize
 int arg_rlimit_sigpending = 0;			// rlimit fsize
+int arg_rlimit_as = 0;					// rlimit as
 int arg_nogroups = 0;				// disable supplementary groups
 int arg_nonewprivs = 0;			// set the NO_NEW_PRIVS prctl
 int arg_noroot = 0;				// create a new user namespace and disable root user

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -1036,6 +1036,11 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 			sscanf(ptr + 18, "%llu", &cfg.rlimit_sigpending);
 			arg_rlimit_sigpending = 1;
 		}
+		else if (strncmp(ptr, "rlimit-as ", 10) == 0) {
+			check_unsigned(ptr + 10, "Error: invalid rlimit in profile file: ");
+			sscanf(ptr + 10, "%llu", &cfg.rlimit_as);
+			arg_rlimit_as = 1;
+		}
 		else {
 			fprintf(stderr, "Invalid rlimit option on line %d\n", lineno);
 			exit(1);

--- a/src/firejail/rlimit.c
+++ b/src/firejail/rlimit.c
@@ -71,4 +71,16 @@ void set_rlimits(void) {
 		if (arg_debug)
 			printf("Config rlimit: maximum number of signals pending %llu\n", cfg.rlimit_sigpending);
 	}
+
+	if (arg_rlimit_as) {
+		rl.rlim_cur = (rlim_t) cfg.rlimit_as;
+		rl.rlim_max = (rlim_t) cfg.rlimit_as;
+#ifdef HAVE_GCOV
+		__gcov_dump();
+#endif
+        if (setrlimit(RLIMIT_AS, &rl) == -1)
+			errExit("setrlimit");
+		if (arg_debug)
+			printf("Config rlimit: maximum virtual memory %llu\n", cfg.rlimit_as);
+	}
 }


### PR DESCRIPTION
Addition of RLIMIT_AS for limiting process's virtual memory. Kept the same format as your previous rlimit implementations.