### PR TITLE
keepassxc.profile: fix crash on gentoo because of missing machine-id …

### DIFF
--- a/etc/keepassxc.profile
+++ b/etc/keepassxc.profile
@@ -35,7 +35,7 @@ shell none
 
 private-bin keepassxc
 private-dev
-private-etc fonts,ld.so.cache
+private-etc fonts,ld.so.cache,machine-id
 private-tmp
 
 memory-deny-write-execute


### PR DESCRIPTION
…in /etc

https://github.com/netblue30/firejail/issues/1633