### PR TITLE
In Testing: (Re)add disable-mnt to common browser profiles.

### DIFF
--- a/etc/brave.profile
+++ b/etc/brave.profile
@@ -35,4 +35,4 @@ notv
 # protocol unix,inet,inet6,netlink
 # seccomp
 
-# disable-mnt
+disable-mnt

--- a/etc/chromium.profile
+++ b/etc/chromium.profile
@@ -32,6 +32,7 @@ nogroups
 notv
 shell none
 
+disable-mnt
 # private-bin chromium,chromium-browser,chromedriver
 private-dev
 # private-tmp - problems with multiple browser sessions

--- a/etc/conkeror.profile
+++ b/etc/conkeror.profile
@@ -31,3 +31,5 @@ noroot
 notv
 protocol unix,inet,inet6
 seccomp
+
+disable-mnt

--- a/etc/cyberfox.profile
+++ b/etc/cyberfox.profile
@@ -62,9 +62,10 @@ seccomp
 shell none
 tracelog
 
+disable-mnt
 # private-bin cyberfox,which,sh,dbus-launch,dbus-send,env
 private-dev
-# private-dev might prevent video calls going out
+private-dev
 # private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,xdg,gtk-2.0,gtk-3.0,X11,pango,fonts,cyberfox,mime.types,mailcap,asound.conf,pulse
 private-tmp
 

--- a/etc/flashpeak-slimjet.profile
+++ b/etc/flashpeak-slimjet.profile
@@ -35,3 +35,5 @@ noroot
 notv
 protocol unix,inet,inet6,netlink
 seccomp
+
+disable-mnt

--- a/etc/google-chrome.profile
+++ b/etc/google-chrome.profile
@@ -30,6 +30,7 @@ nogroups
 notv
 shell none
 
+disable-mnt
 private-dev
 # private-tmp - problems with multiple browser sessions
 

--- a/etc/icecat.profile
+++ b/etc/icecat.profile
@@ -45,6 +45,7 @@ protocol unix,inet,inet6,netlink
 seccomp
 tracelog
 
+disable-mnt
 # private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse
 
 noexec ${HOME}

--- a/etc/midori.profile
+++ b/etc/midori.profile
@@ -42,3 +42,5 @@ notv
 protocol unix,inet,inet6,netlink
 seccomp
 tracelog
+
+disable-mnt

--- a/etc/netsurf.profile
+++ b/etc/netsurf.profile
@@ -28,3 +28,5 @@ notv
 protocol unix,inet,inet6,netlink
 seccomp
 tracelog
+
+disable-mnt

--- a/etc/opera-beta.profile
+++ b/etc/opera-beta.profile
@@ -24,3 +24,5 @@ include /etc/firejail/whitelist-common.inc
 netfilter
 nodvd
 notv
+
+disable-mnt

--- a/etc/opera.profile
+++ b/etc/opera.profile
@@ -28,3 +28,5 @@ include /etc/firejail/whitelist-common.inc
 netfilter
 nodvd
 notv
+
+disable-mnt

--- a/etc/palemoon.profile
+++ b/etc/palemoon.profile
@@ -56,3 +56,5 @@ tracelog
 # private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse
 # private-opt palemoon
 private-tmp
+
+disable-mnt

--- a/etc/seamonkey.profile
+++ b/etc/seamonkey.profile
@@ -45,4 +45,5 @@ protocol unix,inet,inet6,netlink
 seccomp
 tracelog
 
+disable-mnt
 # private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse

--- a/etc/start-tor-browser.profile
+++ b/etc/start-tor-browser.profile
@@ -24,6 +24,7 @@ seccomp
 shell none
 tracelog
 
+disable-mnt
 private-bin bash,sh,grep,tail,env,gpg,id,readlink,dirname,test,mkdir,ln,sed,cp,rm,getconf
 private-dev
 private-etc fonts

--- a/etc/surf.profile
+++ b/etc/surf.profile
@@ -26,6 +26,7 @@ seccomp
 shell none
 tracelog
 
+disable-mnt
 private-bin ls,surf,sh,bash,curl,dmenu,printf,sed,sleep,st,stterm,xargs,xprop
 private-dev
 private-etc passwd,group,hosts,resolv.conf,fonts,ssl

--- a/etc/torbrowser-launcher.profile
+++ b/etc/torbrowser-launcher.profile
@@ -32,6 +32,7 @@ seccomp
 shell none
 tracelog
 
+disable-mnt
 private-bin bash,cp,dirname,env,expr,file,getconf,gpg,grep,id,ln,mkdir,python*,readlink,rm,sed,sh,tail,test,tor-browser-en,torbrowser-launcher
 private-dev
 private-etc fonts

--- a/etc/vivaldi.profile
+++ b/etc/vivaldi.profile
@@ -27,6 +27,7 @@ nogroups
 notv
 shell none
 
+disable-mnt
 private-dev
 # private-tmp - problems with multiple browser sessions
 

--- a/etc/yandex-browser.profile
+++ b/etc/yandex-browser.profile
@@ -35,6 +35,7 @@ nogroups
 notv
 shell none
 
+disable-mnt
 private-dev
 # private-tmp - problems with multiple browser sessions
 


### PR DESCRIPTION
Let's don't merge this just yet. 
This adds disable-mnt to most (all?) of our browser profiles as per the discussion in #1660, blocking access to mount points. This does mean some users (relatively few) will have some problems if their ${DOWNLOADS}, etc, are on external media, but I think it's an acceptable tradeoff for the increased sandbox tightness that will benefit the majority of users. 

Thoughts/comments/suggestions/"we-shouldn't-do-this-because-xyz"? :grin:
