### PR TITLE
qtox needs libstdc++.so.6

### DIFF
--- a/etc/qtox.profile
+++ b/etc/qtox.profile
@@ -33,7 +33,7 @@ tracelog
 
 disable-mnt
 private-bin qtox
-private-etc fonts,resolv.conf
+private-etc fonts,resolv.conf,ld.so.cache
 private-dev
 private-tmp
 


### PR DESCRIPTION
`qtox: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory`
Related https://github.com/netblue30/firejail/issues/1320