### PR TITLE
libtrace/libtrace.c: add missing limits.h include

### DIFF
--- a/src/libtrace/libtrace.c
+++ b/src/libtrace/libtrace.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <dlfcn.h>
 #include <sys/types.h>
+#include <limits.h>
 #include <unistd.h>
 #include <sys/socket.h>
 #include <netinet/in.h>


### PR DESCRIPTION
Fix build on Musl systems, tested on x86_64-musl Void Linux

Build error

```
libtrace.c: In function 'log_exec':
libtrace.c:683:18: error: 'PATH_MAX' undeclared (first use in this function); did you mean 'AF_MAX'?
  static char buf[PATH_MAX + 1];
                  ^~~~~~~~
                  AF_MAX
libtrace.c:683:18: note: each undeclared identifier is reported only once for each function it appears in
```