### PR TITLE
Added environment variable QML_DISABLE_DISK_CACHE=1 to okular.profile.

### DIFF
--- a/etc/okular.profile
+++ b/etc/okular.profile
@@ -45,6 +45,9 @@ private-dev
 private-etc alternatives,cups,fonts,ld.so.cache,machine-id
 # private-tmp - on KDE we need access to the real /tmp for data exchange with thunderbird
 
+# disable QML disk caching as it conflicts with the noexec constraints below
+env QML_DISABLE_DISK_CACHE=1
+
 # memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp


### PR DESCRIPTION
Without it, recent okular versions (here 17.12.0-1 on Arch Linux) crash with

mprotect failed in ExecutableAllocator::makeExecutable: Permission denied

due to the noexec constraints in the firejail profile.