### PR TITLE
disable-common.inc: read-only access to ~/.ssh/authorized_keys

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -194,6 +194,9 @@ read-only ${HOME}/.zshenv
 read-only ${HOME}/.zshrc
 read-only ${HOME}/.zshrc.local
 
+# Remote access
+read-only ${HOME}/.ssh/authorized_keys
+
 # Initialization files that allow arbitrary command execution
 read-only ${HOME}/.caffrc
 read-only ${HOME}/.dotfiles


### PR DESCRIPTION
disable-common.inc blacklists whole .ssh, but some profiles (e.g. idea.sh)
unblacklists it to allow git over ssh with public key auth.

But this creates security hole, since firejailed app could modify
~/.ssh/authorized_keys and allow arbitrary code execution on the host with sshd
installed (e.g. ssh localhost and run any program) or even open backdoor for
remote attacker.

This commits disallows write access to ~/.ssh/authorized_keys even if .ssh was
unblacklisted.

Signed-off-by: Alexander GQ Gerasiov <gq@cs.msu.su>