### PR TITLE
Fix Deluge

### DIFF
--- a/etc/deluge.profile
+++ b/etc/deluge.profile
@@ -32,6 +32,6 @@ seccomp
 shell none
 
 # deluge is using python on Debian
-private-bin deluge,sh,python*,uname
+private-bin deluge,deluge-console,deluged,deluge-gtk,deluge-web,sh,python*,uname
 private-dev
 private-tmp


### PR DESCRIPTION
Deluge needs access to more than the deluge binary if it runs as a daemon (or if you want to access it via the web or command line)