### PR TITLE
Blacklist the monero wallets directory

### DIFF
--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -2,6 +2,7 @@
 # Persistent customizations should go in a .local file.
 include /etc/firejail/disable-programs.local
 
+blacklist ${HOME}/Monero/wallets
 blacklist ${HOME}/.*coin
 blacklist ${HOME}/.8pecxstudios
 blacklist ${HOME}/.AndroidStudio*


### PR DESCRIPTION
~/Monero/wallets is the default path suggested by the official wallet application, but it can be changed by user.