### PR TITLE
Fix #1702 - Couldn't start 'minetest' in Debian Testing

### DIFF
--- a/etc/minetest.profile
+++ b/etc/minetest.profile
@@ -32,6 +32,8 @@ shell none
 disable-mnt
 private-bin minetest
 private-dev
+# private-etc needs to be updated, see #1702
+#private-etc asound.conf,ca-certificates,drirc,fonts,group,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,nsswitch.conf,passwd,pulse,resolv.conf,ssl
 private-tmp
 
 noexec ${HOME}

--- a/etc/minetest.profile
+++ b/etc/minetest.profile
@@ -32,7 +32,6 @@ shell none
 disable-mnt
 private-bin minetest
 private-dev
-private-etc asound.conf,ca-certificates,drirc,fonts,group,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,nsswitch.conf,passwd,pulse,resolv.conf,ssl
 private-tmp
 
 noexec ${HOME}


### PR DESCRIPTION
This removes the "private-etc" line from the "minetest"-profile for a successfully start of the game.