### PR TITLE
Add profile for "playonlinux"

### DIFF
--- a/etc/playonlinux.profile
+++ b/etc/playonlinux.profile
@@ -1,0 +1,28 @@
+# Firejail profile for playonlinux
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/playonlinux.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+noblacklist ${HOME}/.Steam
+noblacklist ${HOME}/.local/share/Steam
+noblacklist ${HOME}/.local/share/steam
+noblacklist ${HOME}/.steam
+noblacklist ${HOME}/.PlayOnLinux
+
+# nc is needed to run playonlinux
+noblacklist ${PATH}/nc
+
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-programs.inc
+
+caps.drop all
+netfilter
+nodvd
+nogroups
+nonewprivs
+noroot
+notv
+seccomp


### PR DESCRIPTION
This profile have been successfully tested by starting a windows application through it.

"wine.profile" has been used as template for this. Only "noblacklist ${PATH}/nc" has been added because playonlinux needs it to run.

**Please note** that this is currently not tested due to security aspects, so it may need a rework later on. Because opening a unknown windows application through it could possibly be a security risk.