### PR TITLE
Create discord-canary.profile

### DIFF
--- a/etc/discord-canary.profile
+++ b/etc/discord-canary.profile
@@ -1,0 +1,23 @@
+# Firejail profile for discord-canary
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/discord-canary.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
+
+whitelist ${DOWNLOADS}
+whitelist ${HOME}/.config/discordcanary
+
+caps.drop all
+netfilter
+nodvd
+nogroups
+nonewprivs
+noroot
+notv
+protocol unix,inet,inet6,netlink
+seccomp


### PR DESCRIPTION
Created by adding `whitelist ${HOME}/.config/discordcanary` to `electron.profile` and replacing references to electron. Seems to work for me with light usage.