### PR TITLE
chore(.gitignore) ignore built packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.so
 *~
 *.swp
+*.deb
 *.rpm
 *.gcda
 *.gcno
@@ -9,6 +10,7 @@ Makefile
 autom4te.cache/
 config.log
 config.status
+firejail-*.tar.xz
 firejail-login.5
 firejail-profile.5
 firejail-config.5


### PR DESCRIPTION
- Ignore built package archive files (.tar.xz and .deb) from Git repository
- Avoid accidentally committing unneeded files in the future