### PR TITLE
Add seccomp filters for remmina, from an strace session connecting via RDP

### DIFF
--- a/etc/remmina.profile
+++ b/etc/remmina.profile
@@ -22,7 +22,8 @@ noroot
 notv
 novideo
 protocol unix,inet,inet6
-seccomp.keep access,arch_prctl,brk,chmod,clock_getres,clock_gettime,clone,close,connect,dup3,eventfd2,execve,fadvise64,fallocate,fcntl,flock,fstat,fstatfs,fsync,ftruncate,futex,getdents,getegid,geteuid,getgid,getpeername,getpid,getrandom,getresgid,getresuid,getsockname,getsockopt,gettid,getuid,inotify_add_watch,inotify_init1,inotify_rm_watch,ioctl,lseek,lstat,madvise,memfd_create,mmap,mprotect,mremap,munmap,nanosleep,open,openat,pipe,pipe2,poll,prctl,prlimit64,pwrite64,read,readlink,recvfrom,recvmsg,rename,rt_sigaction,rt_sigprocmask,sendmmsg,sendmsg,sendto,set_robust_list,setsockopt,set_tid_address,shmat,shmctl,shmdt,shmget,shutdown,socket,stat,statfs,sysinfo,tgkill,uname,utimensat,write,writev
+seccomp
+# seccomp.keep access,arch_prctl,brk,chmod,clock_getres,clock_gettime,clone,close,connect,dup3,eventfd2,execve,fadvise64,fallocate,fcntl,flock,fstat,fstatfs,fsync,ftruncate,futex,getdents,getegid,geteuid,getgid,getpeername,getpid,getrandom,getresgid,getresuid,getsockname,getsockopt,gettid,getuid,inotify_add_watch,inotify_init1,inotify_rm_watch,ioctl,lseek,lstat,madvise,memfd_create,mmap,mprotect,mremap,munmap,nanosleep,open,openat,pipe,pipe2,poll,prctl,prlimit64,pwrite64,read,readlink,recvfrom,recvmsg,rename,rt_sigaction,rt_sigprocmask,sendmmsg,sendmsg,sendto,set_robust_list,setsockopt,set_tid_address,shmat,shmctl,shmdt,shmget,shutdown,socket,stat,statfs,sysinfo,tgkill,uname,utimensat,write,writev
 shell none
 
 private-dev

--- a/etc/remmina.profile
+++ b/etc/remmina.profile
@@ -22,7 +22,7 @@ noroot
 notv
 novideo
 protocol unix,inet,inet6
-seccomp
+seccomp.keep access,arch_prctl,brk,chmod,clock_getres,clock_gettime,clone,close,connect,dup3,eventfd2,execve,fadvise64,fallocate,fcntl,flock,fstat,fstatfs,fsync,ftruncate,futex,getdents,getegid,geteuid,getgid,getpeername,getpid,getrandom,getresgid,getresuid,getsockname,getsockopt,gettid,getuid,inotify_add_watch,inotify_init1,inotify_rm_watch,ioctl,lseek,lstat,madvise,memfd_create,mmap,mprotect,mremap,munmap,nanosleep,open,openat,pipe,pipe2,poll,prctl,prlimit64,pwrite64,read,readlink,recvfrom,recvmsg,rename,rt_sigaction,rt_sigprocmask,sendmmsg,sendmsg,sendto,set_robust_list,setsockopt,set_tid_address,shmat,shmctl,shmdt,shmget,shutdown,socket,stat,statfs,sysinfo,tgkill,uname,utimensat,write,writev
 shell none
 
 private-dev


### PR DESCRIPTION
To derive the filters I ran: `strace -qcf remmina` then connected to a remote host via RDP.

The previous filter (just the default list) allowed Remmina to start, but would fail to establish the connection (it got as far as validating credentials; bad creds gave a different error).

The specific problematic sys call when I checked the audit log was `access` - but I didn't try incrementally building up from there, I just took the whole strace output.