### PR TITLE
Apparmor: blacklist /proc and /sys access from firejail

### DIFF
--- a/etc/firejail-default
+++ b/etc/firejail-default
@@ -65,52 +65,16 @@ owner /run/firejail/mnt/oroot/{run,dev}/shm/** rmwk,
 /{,var/}run/firejail/profile/@{PID} w,
 
 ##########
-# Mask /proc and /sys information leakage. The configuration here is barely
-# enough to run "top" or "ps aux".
+# Allow /proc and /sys read-only access.
+# Blacklisting is controlled from Firejail.
 ##########
 /proc/ r,
-/proc/meminfo r,
-/proc/cpuinfo r,
-/proc/filesystems r,
-/proc/uptime r,
-/proc/loadavg r,
-/proc/stat r,
-/proc/sys/kernel/pid_max r,
-/proc/sys/kernel/shmmax r,
-/proc/sys/kernel/yama/ptrace_scope r,
-/proc/sys/vm/overcommit_memory r,
-/proc/sys/vm/overcommit_ratio r,
-/proc/sys/kernel/random/uuid r,
+/proc/** r,
+deny /proc/** w,
 
 /sys/ r,
-/sys/bus/ r,
-/sys/bus/** r,
-/sys/class/ r,
-/sys/class/** r,
-/sys/devices/ r,
-/sys/devices/** r,
-
-/proc/@{PID}/ r,
-/proc/@{PID}/fd/ r,
-/proc/@{PID}/task/ r,
-/proc/@{PID}/cmdline r,
-/proc/@{PID}/comm r,
-/proc/@{PID}/stat r,
-/proc/@{PID}/statm r,
-/proc/@{PID}/status r,
-/proc/@{PID}/task/@{PID}/stat r,
-/proc/@{PID}/task/@{PID}/status r,
-/proc/@{PID}/maps r,
-/proc/@{PID}/mem r,
-/proc/@{PID}/mounts r,
-/proc/@{PID}/mountinfo r,
-deny /proc/@{PID}/oom_adj w,
-/proc/@{PID}/oom_score_adj r,
-deny /proc/@{PID}/oom_score_adj w,
-/proc/@{PID}/auxv r,
-/proc/@{PID}/net/dev r,
-/proc/@{PID}/loginuid r,
-/proc/@{PID}/environ r,
+/sys/** r,
+deny /sys/** w,
 
 # Needed by chromium crash handler. Uncomment if you need it.
 #ptrace (trace tracedby),

--- a/etc/firejail-default
+++ b/etc/firejail-default
@@ -66,17 +66,22 @@ owner /run/firejail/mnt/oroot/{run,dev}/shm/** rmwk,
 
 ##########
 # Allow /proc and /sys read-only access.
-# Blacklisting is controlled from Firejail.
+# Blacklisting is controlled from userspace Firejail.
 ##########
 /proc/ r,
 /proc/** r,
-deny /proc/** w,
+# Uncomment to silence all denied write warnings
+#deny /proc/** w,
+deny /proc/@{PID}/oom_adj w,
+deny /proc/@{PID}/oom_score_adj w,
 
 /sys/ r,
 /sys/** r,
-deny /sys/** w,
+# Uncomment to silence all denied write warnings
+#deny /sys/** w,
 
-# Needed by chromium crash handler. Uncomment if you need it.
+# Allows to attach to a running program and modify the process memory.
+# May be needed by chromium crash handler. Uncomment if you need it.
 #ptrace (trace tracedby),
 
 ##########


### PR DESCRIPTION
Firejail does blacklisting sensitive /proc and /sys files on its own: https://github.com/netblue30/firejail/blob/master/src/firejail/fs.c#L530

There is no need to duplicate this in apparmor using whitelisting approach which is much harder to do and needs never ending maintenance.

See discussion in https://github.com/netblue30/firejail/pull/1766#issuecomment-364786746
