### PR TITLE
playonlinux: unblacklist perl usage

### DIFF
--- a/etc/playonlinux.profile
+++ b/etc/playonlinux.profile
@@ -15,7 +15,8 @@ noblacklist ${HOME}/.PlayOnLinux
 noblacklist ${PATH}/nc
 
 include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-devel.inc
+# playonlinux uses perl
+# include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 
 caps.drop all


### PR DESCRIPTION
Playonlinux uses perl internally: https://github.com/PlayOnLinux/POL-POM-4/search?utf8=%E2%9C%93&q=perl&type=