### PR TITLE
viewnior needs access to X

### DIFF
--- a/etc/viewnior.profile
+++ b/etc/viewnior.profile
@@ -6,7 +6,6 @@ include /etc/firejail/viewnior.local
 include /etc/firejail/globals.local
 
 blacklist /run/user/*/bus
-blacklist ${HOME}/.Xauthority
 blacklist ${HOME}/.bashrc
 
 noblacklist ${HOME}/.Steam


### PR DESCRIPTION
Hi all,

Viewnior needs access to X so I think it would be useful not to blacklist .Xauthority, otherwise the application cannot open properly. What do you think about this change?

Br, Joe