### PR TITLE
Don't enable profiles which may be used for system administrtion

### DIFF
--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -91,7 +91,7 @@ display
 dnox
 dnscrypt-proxy
 dnsmasq
-dolphin
+# dolphin - may be used for system administration
 dooble
 dooble-qt4
 dosbox
@@ -192,7 +192,7 @@ jitsi
 k3b
 kaffeine
 karbon
-kate
+# kate - may be used for editing system files
 kcalc
 # kdeinit4
 kdenlive
@@ -214,7 +214,7 @@ ktorrent
 # kwin_x11
 kwrite
 leafpad
-less
+# less - may be used for system administration
 libreoffice
 liferea
 linphone
@@ -390,7 +390,7 @@ waterfox
 weechat
 weechat-curses
 wesnoth
-wget
+# wget - may be used in package management (Arch, Gentoo)
 wine
 wire
 wireshark


### PR DESCRIPTION
Enabling those may break system update services on Arch and Gentoo. Also those tools are very often used for general system administration which means they shouldn't be enabled by default.

See https://github.com/netblue30/firejail/issues/1800 and https://github.com/netblue30/firejail/issues/1801 (possibly more)