### PR TITLE
kate: allow system-wide read access

### DIFF
--- a/etc/dolphin.profile
+++ b/etc/dolphin.profile
@@ -6,16 +6,15 @@ include /etc/firejail/dolphin.local
 include /etc/firejail/globals.local
 
 # warning: firejail is currently not effectively constraining dolphin since used services are started by kdeinit5
-# warning: full filesystem access is granted, allows system administration. Uncomment below  if you want
 
-# noblacklist ${HOME}/.local/share/Trash
+noblacklist ${HOME}/.local/share/Trash
 # noblacklist ${HOME}/.cache/dolphin - disable-programs.inc is disabled, see below
 # noblacklist ${HOME}/.config/dolphinrc
 # noblacklist ${HOME}/.local/share/dolphin
 
-# include /etc/firejail/disable-common.inc
-# include /etc/firejail/disable-devel.inc
-# include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-passwdmgr.inc
 # dolphin needs to be able to start arbitrary applications so we cannot blacklist their files
 # include /etc/firejail/disable-programs.inc
 

--- a/etc/dolphin.profile
+++ b/etc/dolphin.profile
@@ -6,15 +6,16 @@ include /etc/firejail/dolphin.local
 include /etc/firejail/globals.local
 
 # warning: firejail is currently not effectively constraining dolphin since used services are started by kdeinit5
+# warning: full filesystem access is granted, allows system administration. Uncomment below  if you want
 
-noblacklist ${HOME}/.local/share/Trash
+# noblacklist ${HOME}/.local/share/Trash
 # noblacklist ${HOME}/.cache/dolphin - disable-programs.inc is disabled, see below
 # noblacklist ${HOME}/.config/dolphinrc
 # noblacklist ${HOME}/.local/share/dolphin
 
-include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-devel.inc
-include /etc/firejail/disable-passwdmgr.inc
+# include /etc/firejail/disable-common.inc
+# include /etc/firejail/disable-devel.inc
+# include /etc/firejail/disable-passwdmgr.inc
 # dolphin needs to be able to start arbitrary applications so we cannot blacklist their files
 # include /etc/firejail/disable-programs.inc
 

--- a/etc/kate.profile
+++ b/etc/kate.profile
@@ -26,6 +26,7 @@ include /etc/firejail/globals.local
 caps.drop all
 # net none
 netfilter
+no3d
 nodvd
 nogroups
 nonewprivs
@@ -38,9 +39,12 @@ seccomp
 shell none
 tracelog
 
-# private-bin kate
+private-bin kate
 private-dev
 # private-etc fonts
 private-tmp
+
+noexec ${HOME}
+noexec /tmp
 
 join-or-start kate

--- a/etc/kate.profile
+++ b/etc/kate.profile
@@ -7,19 +7,21 @@ include /etc/firejail/globals.local
 
 # blacklist /run/user/*/bus
 
-noblacklist ${HOME}/.config/katepartrc
-noblacklist ${HOME}/.config/katerc
-noblacklist ${HOME}/.config/kateschemarc
-noblacklist ${HOME}/.config/katesyntaxhighlightingrc
-noblacklist ${HOME}/.config/katevirc
-noblacklist ${HOME}/.local/share/kate
+# warning: full filesystem access is granted, allows system administration. Uncomment below  if you want.
 
-include /etc/firejail/disable-common.inc
+# noblacklist ${HOME}/.config/katepartrc
+# noblacklist ${HOME}/.config/katerc
+# noblacklist ${HOME}/.config/kateschemarc
+# noblacklist ${HOME}/.config/katesyntaxhighlightingrc
+# noblacklist ${HOME}/.config/katevirc
+# noblacklist ${HOME}/.local/share/kate
+
+# include /etc/firejail/disable-common.inc
 # include /etc/firejail/disable-devel.inc
-include /etc/firejail/disable-passwdmgr.inc
-include /etc/firejail/disable-programs.inc
+# include /etc/firejail/disable-passwdmgr.inc
+# include /etc/firejail/disable-programs.inc
 
-include /etc/firejail/whitelist-var-common.inc
+# include /etc/firejail/whitelist-var-common.inc
 
 caps.drop all
 # net none


### PR DESCRIPTION
As discussed in https://github.com/netblue30/firejail/pull/1802 this PR will allow using dolphin file manager and kate text editor for system-wide administration while still sandboxed within firejail. I left blacklists commented out in case someone want to enable them.