### PR TITLE
WIP: Recalibration of D-Bus access, see #1822

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -75,7 +75,7 @@ distclean: clean
 	for dir in $(APPS) $(MYLIBS); do \
 		$(MAKE) -C $$dir distclean; \
 	done
-	rm -fr Makefile autom4te.cache config.log config.status config.h uids.h
+	rm -fr Makefile autom4te.cache config.log config.status config.h uids.h dummy.o
 
 realinstall:
 	# firejail executable
@@ -195,7 +195,7 @@ uninstall:
 	rm -f $(DESTDIR)/$(datarootdir)/bash-completion/completions/firemon
 	rm -f $(DESTDIR)/$(datarootdir)/bash-completion/completions/firecfg
 
-DISTFILES = "src etc platform contrib configure configure.ac Makefile.in install.sh mkman.sh mketc.sh mkdeb.sh mkuid.sh COPYING README RELNOTES"
+DISTFILES = "src etc platform contrib configure configure.ac dummy.c Makefile.in install.sh mkman.sh mketc.sh mkdeb.sh mkuid.sh COPYING README RELNOTES"
 DISTFILES_TEST = "test/apps test/apps-x11 test/apps-x11-xorg test/root test/fcopy test/environment test/profiles test/utils test/compile test/filters test/network test/arguments test/fs test/sysutils test/chroot"
 
 dist:

--- a/README
+++ b/README
@@ -244,6 +244,9 @@ Gaman Gabriel (https://github.com/stelariusinfinitek)
 	- inox profile
 geg2048 (https://github.com/geg2048)
 	- kwallet profile fixes
+glitsj16 (https://github.com/glitsj16)
+	- evince-previewer, evince-thumbnailer profiles
+	- gnome-recipes profile
 graywolf (https://github.com/graywolf)
 	- spelling fix
 greigdp (https://github.com/greigdp)

--- a/README.md
+++ b/README.md
@@ -259,9 +259,11 @@ enable/disable apparmor functionality globally. By default the flag is enabled.
 AppArmor deployment: we are starting apparmor by default for the following programs:
 - web browsers: firefox (firefox-common.profile), chromium (chromium-common.profile)
 - torrent clients: transmission-qt, transmission-gtk, qbittorrent
-- media players: vlc, mpv, audacious, totem, rhythmbox
+- media players: vlc, mpv, audacious, totem, rhythmbox, smplayer, xplayer, kodi
 - media editing: kdenlive, audacity, handbrake, gimp, inkscape, krita, openshot
-- etc.: atril, gnome-calculator, galculator, eom, eog
+- archive managers: ark, engrampa, file-roller
+- text editors: gedit, kate, kwrite, pluma, xed
+- etc.: digikam, gnome-calculator, galculator, eom, eog, libreoffice, okular, xviewer
 
 Checking apparmor status:
 `````

--- a/README.md
+++ b/README.md
@@ -293,4 +293,4 @@ firefox-common-addons.inc in firefox-common.profile.
 Basilisk browser, Tor Browser language packs, PlayOnLinux, sylpheed, discord-canary,
 pycharm-community, pycharm-professional, Pitivi, OnionShare, Fritzing, Kaffeine, pdfchain,
 tilp, vivaldi-snapshot, bitcoin-qt, VS Code, falkon, gnome-builder, lobase, asunder,
-gnome-recipes, akonadi_control
+gnome-recipes, akonadi_control, evince-previewer, evince-thumbnailer

--- a/README.md
+++ b/README.md
@@ -98,6 +98,52 @@ Use this issue to request new profiles: [#1139](https://github.com/netblue30/fir
 `````
 # Current development version: 0.9.53
 
+## Spectre mitigation
+
+If your gcc compiler version supports it, -mindirect-branch=thunk is inserted into EXTRA_CFLAGS during software configuration.
+The patch was introduced in gcc version 8, and it was backported to gcc 7. You'll also find it
+on older versions, for example on Debian stable running on gcc 6.3.0.  This is how you check it:
+`````
+$ ./configure --prefix=/usr
+checking for gcc... gcc
+checking whether the C compiler works... yes
+checking for C compiler default output file name... a.out
+checking for suffix of executables...
+checking whether we are cross compiling... no
+checking for suffix of object files... o
+checking whether we are using the GNU C compiler... yes
+checking whether gcc accepts -g... yes
+checking for gcc option to accept ISO C89... none needed
+checking for a BSD-compatible install... /usr/bin/install -c
+checking for ranlib... ranlib
+checking for Spectre mitigation support in gcc compiler... yes
+[...]
+Configuration options:
+   prefix: /usr
+   sysconfdir: /etc
+   seccomp: -DHAVE_SECCOMP
+   <linux/seccomp.h>: -DHAVE_SECCOMP_H
+   apparmor:
+   global config: -DHAVE_GLOBALCFG
+   chroot: -DHAVE_CHROOT
+   bind: -DHAVE_BIND
+   network: -DHAVE_NETWORK
+   user namespace: -DHAVE_USERNS
+   X11 sandboxing support: -DHAVE_X11
+   whitelisting: -DHAVE_WHITELIST
+   private home support: -DHAVE_PRIVATE_HOME
+   file transfer support: -DHAVE_FILE_TRANSFER
+   overlayfs support: -DHAVE_OVERLAYFS
+   git install support:
+   busybox workaround: no
+   Spectre compiler patch: yes
+   EXTRA_LDFLAGS:
+   EXTRA_CFLAGS:  -mindirect-branch=thunk
+   fatal warnings:
+   Gcov instrumentation:
+   Install contrib scripts: yes
+`````
+
 ## AppImage development
 
 Support for private-bin, private-lib and shell none has been disabled while running AppImage archives.

--- a/README.md
+++ b/README.md
@@ -246,4 +246,5 @@ firefox-common-addons.inc in firefox-common.profile.
 
 Basilisk browser, Tor Browser language packs, PlayOnLinux, sylpheed, discord-canary,
 pycharm-community, pycharm-professional, Pitivi, OnionShare, Fritzing, Kaffeine, pdfchain,
-tilp, vivaldi-snapshot, bitcoin-qt, VS Code, falkon, gnome-builder, lobase, asunder
+tilp, vivaldi-snapshot, bitcoin-qt, VS Code, falkon, gnome-builder, lobase, asunder,
+gnome-recipes, akonadi_control

--- a/README.md
+++ b/README.md
@@ -293,4 +293,5 @@ firefox-common-addons.inc in firefox-common.profile.
 Basilisk browser, Tor Browser language packs, PlayOnLinux, sylpheed, discord-canary,
 pycharm-community, pycharm-professional, Pitivi, OnionShare, Fritzing, Kaffeine, pdfchain,
 tilp, vivaldi-snapshot, bitcoin-qt, VS Code, falkon, gnome-builder, lobase, asunder,
-gnome-recipes, akonadi_control, evince-previewer, evince-thumbnailer
+gnome-recipes, akonadi_control, evince-previewer, evince-thumbnailer, blender-2.8,
+thunderbird-beta

--- a/RELNOTES
+++ b/RELNOTES
@@ -29,7 +29,8 @@ firejail (0.9.53) baseline; urgency=low
   * new profiles: discord-canary, pycharm-community, pycharm-professional,
   * new profiles: pdfchain, tilp, vivaldi-snapshot, bitcoin-qt, kaffeine,
   * new profiles: falkon, gnome-builder, asunder, VS Code, gnome-recipes
-  * new profiles: akonadi_control
+  * new profiles: akonadi_controle, evince-previewer, evince-thumbnailer
+
  -- netblue30 <netblue30@yahoo.com>  Thu, 1 Mar 2018 08:00:00 -0500
 
 firejail (0.9.52) baseline; urgency=low

--- a/RELNOTES
+++ b/RELNOTES
@@ -27,7 +27,8 @@ firejail (0.9.53) baseline; urgency=low
   * new profiles: basilisk, Tor Browser language packs, PlayOnLinux, sylpheed,
   * new profiles: discord-canary, pycharm-community, pycharm-professional,
   * new profiles: pdfchain, tilp, vivaldi-snapshot, bitcoin-qt, kaffeine,
-  * new profiles: falkon, gnome-builder, asunder, VS Code,
+  * new profiles: falkon, gnome-builder, asunder, VS Code, gnome-recipes
+  * new profiles: akonadi_control
  -- netblue30 <netblue30@yahoo.com>  Thu, 1 Mar 2018 08:00:00 -0500
 
 firejail (0.9.52) baseline; urgency=low

--- a/RELNOTES
+++ b/RELNOTES
@@ -29,8 +29,8 @@ firejail (0.9.53) baseline; urgency=low
   * new profiles: discord-canary, pycharm-community, pycharm-professional,
   * new profiles: pdfchain, tilp, vivaldi-snapshot, bitcoin-qt, kaffeine,
   * new profiles: falkon, gnome-builder, asunder, VS Code, gnome-recipes
-  * new profiles: akonadi_controle, evince-previewer, evince-thumbnailer
-
+  * new profiles: akonadi_controle, evince-previewer, evince-thumbnailer,
+  * new profiles: blender-2.8, thunderbird-beta
  -- netblue30 <netblue30@yahoo.com>  Thu, 1 Mar 2018 08:00:00 -0500
 
 firejail (0.9.52) baseline; urgency=low

--- a/RELNOTES
+++ b/RELNOTES
@@ -9,6 +9,7 @@ firejail (0.9.53) baseline; urgency=low
      All users of Firefox-based browsers who use addons and plugins
      that read/write from ${HOME} will need to uncomment the includes for
      firefox-common-addons.inc in firefox-common.profile.
+  * Spectre mitigation patch for gcc compiler
   * AppArmor support for overlayfs and chroot sandboxes
   * AppArmor support for AppImages
   * Enable AppArmor by default for Firefox, Chromium, Transmission

--- a/RELNOTES
+++ b/RELNOTES
@@ -26,8 +26,8 @@ firejail (0.9.53) baseline; urgency=low
   * added sandbox name support in firemon
   * new profiles: basilisk, Tor Browser language packs, PlayOnLinux, sylpheed,
   * new profiles: discord-canary, pycharm-community, pycharm-professional,
-  * new profiles: pdfchain, tilp, vivaldi-snapshot, bitcoin-qt, kaffeine, VS Code,
-  * new profiles: falkon, gnome-builder, asunder
+  * new profiles: pdfchain, tilp, vivaldi-snapshot, bitcoin-qt, kaffeine,
+  * new profiles: falkon, gnome-builder, asunder, VS Code,
  -- netblue30 <netblue30@yahoo.com>  Thu, 1 Mar 2018 08:00:00 -0500
 
 firejail (0.9.52) baseline; urgency=low

--- a/configure
+++ b/configure
@@ -2100,7 +2100,6 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 #AC_CONFIG_HEADERS([config.h])
 
-
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -3106,7 +3105,6 @@ else
 fi
 
 
-
 HAVE_SPECTRE="no"
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Spectre mitigation support in gcc compiler" >&5
 $as_echo_n "checking for Spectre mitigation support in gcc compiler... " >&6; }
@@ -3121,7 +3119,7 @@ if test "$HAVE_SPECTRE" = "yes"; then :
 
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-	EXTRA_CFLAGS+="-mindirect-branch=thunk"
+	EXTRA_CFLAGS+=" -mindirect-branch=thunk "
 
 fi
 if test "$HAVE_SPECTRE" = "no"; then :
@@ -3130,7 +3128,6 @@ if test "$HAVE_SPECTRE" = "no"; then :
 $as_echo "... not available" >&6; }
 
 fi
-
 
 
 HAVE_APPARMOR=""
@@ -3145,7 +3142,6 @@ if test "x$enable_apparmor" = "xyes"; then :
 
 
 fi
-
 
 
 ac_ext=c
@@ -3559,7 +3555,7 @@ fi
 fi
 if test "x$enable_apparmor" = "xyes"; then :
 
-	EXTRA_LDFLAGS+="-lapparmor "
+	EXTRA_LDFLAGS+=" -lapparmor "
 
 fi
 
@@ -3753,7 +3749,7 @@ fi
 if test "x$enable_gcov" = "xyes"; then :
 
 	HAVE_GCOV="--coverage -DHAVE_GCOV "
-	EXTRA_LDFLAGS+="-lgcov --coverage "
+	EXTRA_LDFLAGS+=" -lgcov --coverage "
 
 
 fi

--- a/configure
+++ b/configure
@@ -646,6 +646,7 @@ EGREP
 GREP
 CPP
 HAVE_APPARMOR
+EXTRA_CFLAGS
 RANLIB
 INSTALL_DATA
 INSTALL_SCRIPT
@@ -3105,6 +3106,33 @@ else
 fi
 
 
+
+HAVE_SPECTRE="no"
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for Spectre mitigation support in gcc compiler" >&5
+$as_echo_n "checking for Spectre mitigation support in gcc compiler... " >&6; }
+if test "$CC" = "gcc"; then :
+
+	HAVE_SPECTRE="yes"
+	$CC -mindirect-branch=thunk -c dummy.c || HAVE_SPECTRE="no"
+	rm -f dummy.o
+
+fi
+if test "$HAVE_SPECTRE" = "yes"; then :
+
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+	EXTRA_CFLAGS+="-mindirect-branch=thunk"
+
+fi
+if test "$HAVE_SPECTRE" = "no"; then :
+
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: ... not available" >&5
+$as_echo "... not available" >&6; }
+
+fi
+
+
+
 HAVE_APPARMOR=""
 # Check whether --enable-apparmor was given.
 if test "${enable_apparmor+set}" = set; then :
@@ -5024,7 +5052,9 @@ echo "   file transfer support: $HAVE_FILE_TRANSFER"
 echo "   overlayfs support: $HAVE_OVERLAYFS"
 echo "   git install support: $HAVE_GIT_INSTALL"
 echo "   busybox workaround: $BUSYBOX_WORKAROUND"
+echo "   Spectre compiler patch: $HAVE_SPECTRE"
 echo "   EXTRA_LDFLAGS: $EXTRA_LDFLAGS"
+echo "   EXTRA_CFLAGS: $EXTRA_CFLAGS"
 echo "   fatal warnings: $HAVE_FATAL_WARNINGS"
 echo "   Gcov instrumentation: $HAVE_GCOV"
 echo "   Install contrib scripts: $HAVE_CONTRIB_INSTALL"

--- a/configure.ac
+++ b/configure.ac
@@ -3,12 +3,10 @@ AC_INIT(firejail, 0.9.53, netblue30@yahoo.com, , http://firejail.wordpress.com)
 AC_CONFIG_SRCDIR([src/firejail/main.c])
 #AC_CONFIG_HEADERS([config.h])
 
-
 AC_PROG_CC
 #AC_PROG_CXX
 AC_PROG_INSTALL
 AC_PROG_RANLIB
-
 
 HAVE_SPECTRE="no"
 AC_MSG_CHECKING(for Spectre mitigation support in gcc compiler)
@@ -19,13 +17,12 @@ AS_IF([test "$CC" = "gcc"], [
 ])
 AS_IF([test "$HAVE_SPECTRE" = "yes"], [
 	AC_MSG_RESULT(yes)
-	EXTRA_CFLAGS+="-mindirect-branch=thunk"
+	EXTRA_CFLAGS+=" -mindirect-branch=thunk "
 ])
 AS_IF([test "$HAVE_SPECTRE" = "no"], [
 	AC_MSG_RESULT(... not available)
 ])
 AC_SUBST([EXTRA_CFLAGS])
-
 
 HAVE_APPARMOR=""
 AC_ARG_ENABLE([apparmor],
@@ -35,13 +32,12 @@ AS_IF([test "x$enable_apparmor" = "xyes"], [
 	AC_SUBST(HAVE_APPARMOR)
 ])
 
-
 AS_IF([test "x$enable_apparmor" = "xyes"], [
 	AC_CHECK_HEADER(sys/apparmor.h, , [AC_MSG_ERROR(
 	[Couldn't find sys/apparmor.h... please install apparmor user space library and development files] )])
 ])
 AS_IF([test "x$enable_apparmor" = "xyes"], [
-	EXTRA_LDFLAGS+="-lapparmor "
+	EXTRA_LDFLAGS+=" -lapparmor "
 ])
 AC_SUBST([EXTRA_LDFLAGS])
 
@@ -160,7 +156,7 @@ AC_ARG_ENABLE([gcov],
     AS_HELP_STRING([--enable-gcov], [Gcov instrumentation]))
 AS_IF([test "x$enable_gcov" = "xyes"], [
 	HAVE_GCOV="--coverage -DHAVE_GCOV "
-	EXTRA_LDFLAGS+="-lgcov --coverage "
+	EXTRA_LDFLAGS+=" -lgcov --coverage "
 	AC_SUBST(HAVE_GCOV)
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,24 @@ AC_PROG_CC
 AC_PROG_INSTALL
 AC_PROG_RANLIB
 
+
+HAVE_SPECTRE="no"
+AC_MSG_CHECKING(for Spectre mitigation support in gcc compiler)
+AS_IF([test "$CC" = "gcc"], [
+	HAVE_SPECTRE="yes"
+	$CC -mindirect-branch=thunk -c dummy.c || HAVE_SPECTRE="no"
+	rm -f dummy.o
+])
+AS_IF([test "$HAVE_SPECTRE" = "yes"], [
+	AC_MSG_RESULT(yes)
+	EXTRA_CFLAGS+="-mindirect-branch=thunk"
+])
+AS_IF([test "$HAVE_SPECTRE" = "no"], [
+	AC_MSG_RESULT(... not available)
+])
+AC_SUBST([EXTRA_CFLAGS])
+
+
 HAVE_APPARMOR=""
 AC_ARG_ENABLE([apparmor],
     AS_HELP_STRING([--enable-apparmor], [enable apparmor]))
@@ -198,7 +216,9 @@ echo "   file transfer support: $HAVE_FILE_TRANSFER"
 echo "   overlayfs support: $HAVE_OVERLAYFS"
 echo "   git install support: $HAVE_GIT_INSTALL"
 echo "   busybox workaround: $BUSYBOX_WORKAROUND"
+echo "   Spectre compiler patch: $HAVE_SPECTRE"
 echo "   EXTRA_LDFLAGS: $EXTRA_LDFLAGS"
+echo "   EXTRA_CFLAGS: $EXTRA_CFLAGS"
 echo "   fatal warnings: $HAVE_FATAL_WARNINGS"
 echo "   Gcov instrumentation: $HAVE_GCOV"
 echo "   Install contrib scripts: $HAVE_CONTRIB_INSTALL"

--- a/dummy.c
+++ b/dummy.c
@@ -1,0 +1,3 @@
+int main(void) {
+	return 0;
+}

--- a/etc/0ad.profile
+++ b/etc/0ad.profile
@@ -24,6 +24,7 @@ include /etc/firejail/whitelist-common.inc
 
 caps.drop all
 netfilter
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/akonadi_control.profile
+++ b/etc/akonadi_control.profile
@@ -1,0 +1,44 @@
+# Firejail profile for akonadi_control
+# Persistent local customizations
+include /etc/firejail/akonadi_control.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+noblacklist ${HOME}/.cache/akonadi*
+noblacklist ${HOME}/.config/akonadi*
+noblacklist ${HOME}/.config/baloorc
+noblacklist ${HOME}/.local/share/akonadi/*
+noblacklist ${HOME}/.local/share/contacts
+noblacklist ${HOME}/.local/share/local-mail
+noblacklist /usr/sbin
+
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
+
+include /etc/firejail/whitelist-var-common.inc
+
+# depending on your setup it might be possible to
+# enable some of the commented options below
+
+caps.drop all
+ipc-namespace
+no3d
+netfilter
+nodvd
+nogroups
+# nonewprivs
+# noroot
+nosound
+notv
+novideo
+# protocol unix,inet,inet6
+# seccomp.drop @cpu-emulation,@debug,@obsolete,@privileged,@resources,add_key,fanotify_init,io_cancel,io_destroy,kcmp,keyctl,name_to_handle_at,ni_syscall,open_by_handle_at,personality,process_vm_readv,ptrace,remap_file_pages,request_key,syslog,umount,userfaultfd,vmsplice # we need to allow io_getevents, ioprio_set, io_setup, io_submit system calls
+tracelog
+
+private-dev
+# private-tmp - breaks programs that depend on akonadi
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/akonadi_control.profile
+++ b/etc/akonadi_control.profile
@@ -7,9 +7,13 @@ include /etc/firejail/globals.local
 noblacklist ${HOME}/.cache/akonadi*
 noblacklist ${HOME}/.config/akonadi*
 noblacklist ${HOME}/.config/baloorc
-noblacklist ${HOME}/.local/share/akonadi/*
+noblacklist ${HOME}/.config/emailidentities
+noblacklist ${HOME}/.config/kmail2rc
+noblacklist ${HOME}/.local/share/akonadi*
 noblacklist ${HOME}/.local/share/contacts
 noblacklist ${HOME}/.local/share/local-mail
+noblacklist ${HOME}/.local/share/notes
+noblacklist /tmp/akonadi-*
 noblacklist /usr/sbin
 
 include /etc/firejail/disable-common.inc
@@ -19,8 +23,8 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
-# depending on your setup it might be possible to
-# enable some of the commented options below
+# the default mysqld-akonadi apparmor profile in debian and ubuntu
+# is not compatible with the commented options below
 
 # apparmor
 caps.drop all
@@ -30,7 +34,7 @@ netfilter
 nodvd
 nogroups
 # nonewprivs
-# noroot
+noroot
 nosound
 notv
 novideo

--- a/etc/akonadi_control.profile
+++ b/etc/akonadi_control.profile
@@ -22,6 +22,7 @@ include /etc/firejail/whitelist-var-common.inc
 # depending on your setup it might be possible to
 # enable some of the commented options below
 
+# apparmor
 caps.drop all
 ipc-namespace
 no3d
@@ -34,7 +35,7 @@ nosound
 notv
 novideo
 # protocol unix,inet,inet6
-# seccomp.drop @cpu-emulation,@debug,@obsolete,@privileged,@resources,add_key,fanotify_init,io_cancel,io_destroy,kcmp,keyctl,name_to_handle_at,ni_syscall,open_by_handle_at,personality,process_vm_readv,ptrace,remap_file_pages,request_key,syslog,umount,userfaultfd,vmsplice # we need to allow io_getevents, ioprio_set, io_setup, io_submit system calls
+# seccomp.drop @cpu-emulation,@debug,@obsolete,@privileged,@resources,add_key,fanotify_init,io_cancel,io_destroy,kcmp,keyctl,name_to_handle_at,ni_syscall,open_by_handle_at,personality,process_vm_readv,ptrace,remap_file_pages,request_key,syslog,umount,userfaultfd,vmsplice
 tracelog
 
 private-dev

--- a/etc/atom.profile
+++ b/etc/atom.profile
@@ -17,6 +17,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 # net none
 netfilter
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/atril-previewer.profile
+++ b/etc/atril-previewer.profile
@@ -1,0 +1,10 @@
+# Firejail profile for atril-previewer
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/atril-previewer.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+
+# Redirect
+include /etc/firejail/atril.profile

--- a/etc/atril-thumbnailer.profile
+++ b/etc/atril-thumbnailer.profile
@@ -1,0 +1,10 @@
+# Firejail profile for atril-thumbnailer
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/atril-thumbnailer.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+
+# Redirect
+include /etc/firejail/atril.profile

--- a/etc/atril.profile
+++ b/etc/atril.profile
@@ -17,7 +17,7 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
-apparmor
+# apparmor
 caps.drop all
 machine-id
 no3d

--- a/etc/audacious.profile
+++ b/etc/audacious.profile
@@ -18,6 +18,7 @@ include /etc/firejail/whitelist-var-common.inc
 apparmor
 caps.drop all
 netfilter
+nodbus
 nogroups
 nonewprivs
 noroot

--- a/etc/audacious.profile
+++ b/etc/audacious.profile
@@ -5,6 +5,7 @@ include /etc/firejail/audacious.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+blacklist /run/user/*/bus
 noblacklist ${HOME}/.config/Audaciousrc
 noblacklist ${HOME}/.config/audacious
 

--- a/etc/bibletime.profile
+++ b/etc/bibletime.profile
@@ -21,6 +21,7 @@ include /etc/firejail/whitelist-common.inc
 
 caps.drop all
 netfilter
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/blender-2.8.profile
+++ b/etc/blender-2.8.profile
@@ -1,0 +1,6 @@
+# Firejail profile alias for blender
+# This file is overwritten after every install/update
+
+
+# Redirect
+include /etc/firejail/blender.profile

--- a/etc/catfish.profile
+++ b/etc/catfish.profile
@@ -23,6 +23,7 @@ include /etc/firejail/whitelist-var-common.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/chromium-common.profile
+++ b/etc/chromium-common.profile
@@ -5,6 +5,7 @@ include /etc/firejail/chromium-common.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+blacklist /run/user/*/bus
 noblacklist ${HOME}/.pki
 
 include /etc/firejail/disable-common.inc

--- a/etc/chromium-common.profile
+++ b/etc/chromium-common.profile
@@ -20,6 +20,7 @@ include /etc/firejail/whitelist-var-common.inc
 apparmor
 caps.keep sys_chroot,sys_admin
 netfilter
+nodbus
 nodvd
 nogroups
 notv
@@ -31,3 +32,6 @@ private-dev
 
 noexec ${HOME}
 noexec /tmp
+
+# the file dialog needs to work without d-bus
+env NO_CHROME_KDE_FILE_DIALOG=1

--- a/etc/digikam.profile
+++ b/etc/digikam.profile
@@ -5,6 +5,7 @@ include /etc/firejail/digikam.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+# blacklist /run/user/*/bus
 noblacklist ${HOME}/.config/digikam
 noblacklist ${HOME}/.config/digikamrc
 noblacklist ${HOME}/.kde/share/apps/digikam

--- a/etc/digikam.profile
+++ b/etc/digikam.profile
@@ -20,6 +20,7 @@ include /etc/firejail/whitelist-var-common.inc
 apparmor
 caps.drop all
 netfilter
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -75,6 +75,7 @@ blacklist ${HOME}/.kde4/share/config/plasma-desktop-appletsrc
 blacklist ${HOME}/.local/share/kglobalaccel
 blacklist ${HOME}/.local/share/kwin
 blacklist ${HOME}/.local/share/plasma
+blacklist ${HOME}/.local/share/plasmashell
 blacklist ${HOME}/.local/share/solid
 read-only ${HOME}/.cache/ksycoca5_*
 read-only ${HOME}/.config/*notifyrc

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -73,6 +73,7 @@ blacklist ${HOME}/.config/Slack
 blacklist ${HOME}/.config/Thunar
 blacklist ${HOME}/.config/VirtualBox
 blacklist ${HOME}/.config/Wire
+blacklist ${HOME}/.config/akonadi*
 blacklist ${HOME}/.config/akregatorrc
 blacklist ${HOME}/.config/ardour4
 blacklist ${HOME}/.config/ardour5
@@ -106,6 +107,7 @@ blacklist ${HOME}/.config/digikam
 blacklist ${HOME}/.config/digikamrc
 blacklist ${HOME}/.config/dolphinrc
 blacklist ${HOME}/.config/dragonplayerrc
+blacklist ${HOME}/.config/emailidentities
 blacklist ${HOME}/.config/enchant
 blacklist ${HOME}/.config/eog
 blacklist ${HOME}/.config/epiphany
@@ -144,6 +146,7 @@ blacklist ${HOME}/.config/katevirc
 blacklist ${HOME}/.config/kdenliverc
 blacklist ${HOME}/.config/kgetrc
 blacklist ${HOME}/.config/klipperrc
+blacklist ${HOME}/.config/kmail2rc
 blacklist ${HOME}/.config/kritarc
 blacklist ${HOME}/.config/kwriterc
 blacklist ${HOME}/.config/kdeconnect
@@ -346,12 +349,14 @@ blacklist ${HOME}/.local/share/SuperHexagon
 blacklist ${HOME}/.local/share/TelegramDesktop
 blacklist ${HOME}/.local/share/Terraria
 blacklist ${HOME}/.local/share/TpLogger
+blacklist ${HOME}/.local/share/akonadi/*
 blacklist ${HOME}/.local/share/akregator
 blacklist ${HOME}/.local/share/aspyr-media
 blacklist ${HOME}/.local/share/baloo
 blacklist ${HOME}/.local/share/caja-python
 blacklist ${HOME}/.local/share/cdprojektred
 blacklist ${HOME}/.local/share/clipit
+blacklist ${HOME}/.local/share/contacts
 blacklist ${HOME}/.local/share/data/Mumble
 blacklist ${HOME}/.local/share/data/MusE
 blacklist ${HOME}/.local/share/data/MuseScore
@@ -369,6 +374,7 @@ blacklist ${HOME}/.local/share/gnome-2048
 blacklist ${HOME}/.local/share/gnome-chess
 blacklist ${HOME}/.local/share/gnome-music
 blacklist ${HOME}/.local/share/gnome-photos
+blacklist ${HOME}/.local/share/gnome-recipes
 blacklist ${HOME}/.local/share/gnome-ring
 blacklist ${HOME}/.local/share/gnome-twitch
 blacklist ${HOME}/.local/share/gwenview
@@ -376,11 +382,13 @@ blacklist ${HOME}/.local/share/kaffeine
 blacklist ${HOME}/.local/share/kate
 blacklist ${HOME}/.local/share/kdenlive
 blacklist ${HOME}/.local/share/kget
+blacklist ${HOME}/.local/share/kmail2
 blacklist ${HOME}/.local/share/krita
 blacklist ${HOME}/.local/share/ktorrentrc
 blacklist ${HOME}/.local/share/ktorrent
 blacklist ${HOME}/.local/share/kwrite
 blacklist ${HOME}/.local/share/liferea
+blacklist ${HOME}/.local/share/local-mail
 blacklist ${HOME}/.local/share/lollypop
 blacklist ${HOME}/.local/share/maps-places.json
 blacklist ${HOME}/.local/share/meld
@@ -495,6 +503,7 @@ blacklist ${HOME}/.cache/Franz
 blacklist ${HOME}/.cache/INRIA
 blacklist ${HOME}/.cache/MusicBrainz
 blacklist ${HOME}/.cache/QuiteRss
+blacklist ${HOME}/.cache/akonadi*
 blacklist ${HOME}/.cache/attic
 blacklist ${HOME}/.cache/borg
 blacklist ${HOME}/.cache/calibre

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -363,6 +363,7 @@ blacklist ${HOME}/.local/share/data/MuseScore
 blacklist ${HOME}/.local/share/data/qBittorrent
 blacklist ${HOME}/.local/share/dino
 blacklist ${HOME}/.local/share/dolphin
+blacklist ${HOME}/.local/share/emailidentities
 blacklist ${HOME}/.local/share/epiphany
 blacklist ${HOME}/.local/share/evolution
 blacklist ${HOME}/.local/share/feral-interactive
@@ -405,6 +406,7 @@ blacklist ${HOME}/.local/share/okular
 blacklist ${HOME}/.local/share/orage
 blacklist ${HOME}/.local/share/org.kde.gwenview
 blacklist ${HOME}/.local/share/pix
+blacklist ${HOME}/.local/share/plasma_notes
 blacklist ${HOME}/.local/share/psi+
 blacklist ${HOME}/.local/share/qpdfview
 blacklist ${HOME}/.local/share/qutebrowser

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -349,7 +349,7 @@ blacklist ${HOME}/.local/share/SuperHexagon
 blacklist ${HOME}/.local/share/TelegramDesktop
 blacklist ${HOME}/.local/share/Terraria
 blacklist ${HOME}/.local/share/TpLogger
-blacklist ${HOME}/.local/share/akonadi/*
+blacklist ${HOME}/.local/share/akonadi*
 blacklist ${HOME}/.local/share/akregator
 blacklist ${HOME}/.local/share/aspyr-media
 blacklist ${HOME}/.local/share/baloo
@@ -495,6 +495,7 @@ blacklist ${HOME}/.xpdfrc
 blacklist ${HOME}/.zoom
 blacklist ${HOME}/Arduino
 blacklist ${HOME}/wallet.dat
+blacklist /tmp/akonadi-*
 blacklist /tmp/ssh-*
 
 # ~/.cache directory

--- a/etc/electron.profile
+++ b/etc/electron.profile
@@ -5,6 +5,8 @@ include /etc/firejail/electron.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+blacklist /run/user/*/bus
+
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc

--- a/etc/electron.profile
+++ b/etc/electron.profile
@@ -14,6 +14,7 @@ whitelist ${DOWNLOADS}
 apparmor
 caps.drop all
 netfilter
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/engrampa.profile
+++ b/etc/engrampa.profile
@@ -5,7 +5,8 @@ include /etc/firejail/engrampa.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus - makes settings immutable
+# following line makes settings immutable
+blacklist /run/user/*/bus
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
@@ -14,8 +15,11 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
+apparmor
 caps.drop all
-# net none - makes settings immutable
+# following line makes settings immutable
+net none
 no3d
 nodvd
 nogroups

--- a/etc/eog.profile
+++ b/etc/eog.profile
@@ -5,7 +5,8 @@ include /etc/firejail/eog.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus - makes settings immutable
+# following line makes settings immutable
+blacklist /run/user/*/bus
 
 noblacklist ${HOME}/.Steam
 noblacklist ${HOME}/.config/eog
@@ -19,9 +20,11 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
 apparmor
 caps.drop all
-# net none - makes settings immutable
+# following line makes settings immutable
+net none
 no3d
 nodvd
 nogroups

--- a/etc/eog.profile
+++ b/etc/eog.profile
@@ -37,7 +37,7 @@ shell none
 private-bin eog
 private-dev
 private-etc fonts
-private-lib
+private-lib gdk-pixbuf-2.0,gio,girepository-1.0,gvfs,libgconf-2.so.4
 private-tmp
 
 #memory-deny-write-execute  - breaks on Arch

--- a/etc/eom.profile
+++ b/etc/eom.profile
@@ -5,7 +5,8 @@ include /etc/firejail/eom.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus - makes settings immutable
+# following line makes settings immutable
+blacklist /run/user/*/bus
 
 noblacklist ${HOME}/.Steam
 noblacklist ${HOME}/.config/mate/eom
@@ -19,9 +20,11 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
 apparmor
 caps.drop all
-# net none - makes settings immutable
+# following line makes settings immutable
+net none
 no3d
 nodvd
 nogroups

--- a/etc/evince-previewer.profile
+++ b/etc/evince-previewer.profile
@@ -1,0 +1,10 @@
+# Firejail profile for evince-previewer
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/evince-previewer.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+
+# Redirect
+include /etc/firejail/evince.profile

--- a/etc/evince-thumbnailer.profile
+++ b/etc/evince-thumbnailer.profile
@@ -1,0 +1,10 @@
+# Firejail profile for evince-thumbnailer
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/evince-thumbnailer.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+
+# Redirect
+include /etc/firejail/evince.profile

--- a/etc/file-roller.profile
+++ b/etc/file-roller.profile
@@ -5,7 +5,8 @@ include /etc/firejail/file-roller.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus - makes settings immutable
+# following line makes settings immutable
+blacklist /run/user/*/bus
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
@@ -14,8 +15,11 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
+apparmor
 caps.drop all
-# net none - makes settings immutable
+# following line makes settings immutable
+net none
 no3d
 nodvd
 nogroups

--- a/etc/firefox-common.profile
+++ b/etc/firefox-common.profile
@@ -8,6 +8,7 @@ include /etc/firejail/globals.local
 # uncomment the following line to allow access to common programs/addons/plugins
 #include /etc/firejail/firefox-common-addons.inc
 
+blacklist /run/user/*/bus
 noblacklist ${HOME}/.pki
 
 include /etc/firejail/disable-common.inc

--- a/etc/firefox-common.profile
+++ b/etc/firefox-common.profile
@@ -25,6 +25,7 @@ caps.drop all
 # machine-id breaks pulse audio; it should work fine in setups where sound is not required
 #machine-id
 netfilter
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/gedit.profile
+++ b/etc/gedit.profile
@@ -5,7 +5,8 @@ include /etc/firejail/gedit.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus - makes settings immutable
+# following line makes settings immutable
+blacklist /run/user/*/bus
 
 noblacklist ${HOME}/.config/enchant
 noblacklist ${HOME}/.config/gedit
@@ -18,8 +19,11 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
+apparmor
 caps.drop all
-# net none - makes settings immutable
+# following line makes settings immutable
+net none
 machine-id
 no3d
 nodvd

--- a/etc/gnome-calculator.profile
+++ b/etc/gnome-calculator.profile
@@ -6,6 +6,7 @@ include /etc/firejail/gnome-calculator.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+blacklist /run/user/*/bus
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc

--- a/etc/gnome-calculator.profile
+++ b/etc/gnome-calculator.profile
@@ -16,8 +16,9 @@ include /etc/firejail/whitelist-var-common.inc
 
 apparmor
 caps.drop all
-netfilter
+net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/gnome-recipes.profile
+++ b/etc/gnome-recipes.profile
@@ -1,0 +1,45 @@
+# Firejail profile for gnome-recipes
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/gnome-recipes.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+
+noblacklist ${HOME}/.local/share/gnome-recipes
+
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
+
+mkdir ${HOME}/.cache/gnome-recipes
+whitelist ${HOME}/.cache/gnome-recipes
+include /etc/firejail/whitelist-common.inc
+include /etc/firejail/whitelist-var-common.inc
+
+caps.drop all
+ipc-namespace
+netfilter
+nodvd
+nogroups
+nonewprivs
+noroot
+nosound
+notv
+novideo
+protocol unix,inet,inet6
+seccomp
+shell none
+
+disable-mnt
+private-bin gnome-recipes,tar
+private-dev
+private-etc ca-certificates,fonts,ssl
+# private-lib works for me with Gnome Shell 3.26.2, Mutter WM (Arch Linux)
+# not widely tested though, leaving it to devs discretion to enable it later
+#private-lib gdk-pixbuf-2.0,gio,gvfs/libgvfscommon.so,libgconf-2.so.4,libgnutls.so.30,libjpeg.so.8,libp11-kit.so.0,libproxy.so.1,librsvg-2.so.2
+private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/handbrake.profile
+++ b/etc/handbrake.profile
@@ -5,6 +5,7 @@ include /etc/firejail/handbrake.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+blacklist /run/user/*/bus
 noblacklist ${HOME}/.config/ghb
 
 include /etc/firejail/disable-common.inc

--- a/etc/handbrake.profile
+++ b/etc/handbrake.profile
@@ -17,6 +17,7 @@ include /etc/firejail/whitelist-var-common.inc
 apparmor
 caps.drop all
 netfilter
+nodbus
 nogroups
 nonewprivs
 noroot

--- a/etc/inkscape.profile
+++ b/etc/inkscape.profile
@@ -18,7 +18,8 @@ include /etc/firejail/whitelist-var-common.inc
 
 apparmor
 caps.drop all
-netfilter
+net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/inkscape.profile
+++ b/etc/inkscape.profile
@@ -5,9 +5,9 @@ include /etc/firejail/inkscape.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+blacklist /run/user/*/bus
 noblacklist ${HOME}/.inkscape
 noblacklist ${HOME}/.config/inkscape
-
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc

--- a/etc/kate.profile
+++ b/etc/kate.profile
@@ -42,4 +42,7 @@ private-dev
 # private-etc fonts,kde4rc,kde5rc,ld.so.cache,machine-id,xdg
 private-tmp
 
+# noexec ${HOME}
+noexec /tmp
+
 join-or-start kate

--- a/etc/keepassx.profile
+++ b/etc/keepassx.profile
@@ -23,6 +23,7 @@ caps.drop all
 machine-id
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/keepassxc.profile
+++ b/etc/keepassxc.profile
@@ -25,6 +25,7 @@ caps.drop all
 net none
 no3d
 nodvd
+nodbus
 nogroups
 nonewprivs
 noroot

--- a/etc/kmail.profile
+++ b/etc/kmail.profile
@@ -5,6 +5,18 @@ include /etc/firejail/kmail.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+# akonadi with mysql backend fails to run inside this sandbox
+# and should be started in advance
+
+noblacklist ${HOME}/.cache/akonadi*
+noblacklist ${HOME}/.config/akonadi*
+noblacklist ${HOME}/.config/baloorc
+noblacklist ${HOME}/.config/emailidentities
+noblacklist ${HOME}/.config/kmail2rc
+noblacklist ${HOME}/.local/share/akonadi/*
+noblacklist ${HOME}/.local/share/contacts
+noblacklist ${HOME}/.local/share/kmail2
+noblacklist ${HOME}/.local/share/local-mail
 noblacklist ${HOME}/.gnupg
 
 include /etc/firejail/disable-common.inc
@@ -22,11 +34,14 @@ nosound
 notv
 novideo
 protocol unix,inet,inet6,netlink
-# blacklisting of chroot system calls breaks kmail
-seccomp.drop @clock,@cpu-emulation,@debug,@module,@obsolete,@raw-io,@reboot,@resources,@swap,acct,add_key,bpf,fanotify_init,io_cancel,io_destroy,io_getevents,io_setup,io_submit,ioprio_set,kcmp,keyctl,mount,name_to_handle_at,nfsservctl,ni_syscall,open_by_handle_at,personality,pivot_root,process_vm_readv,ptrace,remap_file_pages,request_key,setdomainname,sethostname,syslog,umount,umount2,userfaultfd,vhangup,vmsplice
+# we need to allow chroot and ioprio_set system calls
+seccomp.drop @clock,@cpu-emulation,@debug,@module,@obsolete,@raw-io,@reboot,@resources,@swap,acct,add_key,bpf,fanotify_init,io_cancel,io_destroy,io_getevents,io_setup,io_submit,kcmp,keyctl,mount,name_to_handle_at,nfsservctl,ni_syscall,open_by_handle_at,personality,pivot_root,process_vm_readv,ptrace,remap_file_pages,request_key,setdomainname,sethostname,syslog,umount,umount2,userfaultfd,vhangup,vmsplice
 # tracelog
 # writable-run-user is needed for signing and encrypting emails
 writable-run-user
 
 private-dev
-# private-tmp - breaks akonadi and opening of email attachments
+# private-tmp - interrupts connection to akonadi, breaks opening of email attachments
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/kmail.profile
+++ b/etc/kmail.profile
@@ -5,7 +5,7 @@ include /etc/firejail/kmail.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# if akonadi has a mysql backend, starting it inside this sandbox will fail
+# if akonadi has a mysql backend, starting it inside this sandbox will fail.
 # one solution is to have akonadi already running when kmail is launched
 
 noblacklist ${HOME}/.cache/akonadi*
@@ -15,6 +15,7 @@ noblacklist ${HOME}/.config/emailidentities
 noblacklist ${HOME}/.config/kmail2rc
 noblacklist ${HOME}/.local/share/akonadi/*
 noblacklist ${HOME}/.local/share/contacts
+noblacklist ${HOME}/.local/share/emailidentities
 noblacklist ${HOME}/.local/share/kmail2
 noblacklist ${HOME}/.local/share/local-mail
 noblacklist ${HOME}/.gnupg

--- a/etc/kmail.profile
+++ b/etc/kmail.profile
@@ -5,20 +5,22 @@ include /etc/firejail/kmail.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# if akonadi has a mysql backend, starting it inside this sandbox will fail.
-# one solution is to have akonadi already running when kmail is launched
+# kmail has problems launching akonadi in debian and ubuntu.
+# one solution is to have akonadi already running when kmail is started
 
 noblacklist ${HOME}/.cache/akonadi*
 noblacklist ${HOME}/.config/akonadi*
 noblacklist ${HOME}/.config/baloorc
 noblacklist ${HOME}/.config/emailidentities
 noblacklist ${HOME}/.config/kmail2rc
-noblacklist ${HOME}/.local/share/akonadi/*
+noblacklist ${HOME}/.gnupg
+noblacklist ${HOME}/.local/share/akonadi*
 noblacklist ${HOME}/.local/share/contacts
 noblacklist ${HOME}/.local/share/emailidentities
 noblacklist ${HOME}/.local/share/kmail2
 noblacklist ${HOME}/.local/share/local-mail
-noblacklist ${HOME}/.gnupg
+noblacklist ${HOME}/.local/share/notes
+noblacklist /tmp/akonadi-*
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
@@ -36,8 +38,8 @@ nosound
 notv
 novideo
 protocol unix,inet,inet6,netlink
-# we need to allow chroot and ioprio_set system calls
-seccomp.drop @clock,@cpu-emulation,@debug,@module,@obsolete,@raw-io,@reboot,@resources,@swap,acct,add_key,bpf,fanotify_init,io_cancel,io_destroy,io_getevents,io_setup,io_submit,kcmp,keyctl,mount,name_to_handle_at,nfsservctl,ni_syscall,open_by_handle_at,personality,pivot_root,process_vm_readv,ptrace,remap_file_pages,request_key,setdomainname,sethostname,syslog,umount,umount2,userfaultfd,vhangup,vmsplice
+# we need to allow chroot, io_getevents, ioprio_set, io_setup, io_submit system calls
+seccomp.drop @clock,@cpu-emulation,@debug,@module,@obsolete,@raw-io,@reboot,@resources,@swap,acct,add_key,bpf,fanotify_init,io_cancel,io_destroy,kcmp,keyctl,mount,name_to_handle_at,nfsservctl,ni_syscall,open_by_handle_at,personality,pivot_root,process_vm_readv,ptrace,remap_file_pages,request_key,setdomainname,sethostname,syslog,umount,umount2,userfaultfd,vhangup,vmsplice
 # tracelog
 # writable-run-user is needed for signing and encrypting emails
 writable-run-user

--- a/etc/kmail.profile
+++ b/etc/kmail.profile
@@ -5,8 +5,8 @@ include /etc/firejail/kmail.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# akonadi with mysql backend fails to run inside this sandbox
-# and should be started in advance
+# if akonadi has a mysql backend, starting it inside this sandbox will fail
+# one solution is to have akonadi already running when kmail is launched
 
 noblacklist ${HOME}/.cache/akonadi*
 noblacklist ${HOME}/.config/akonadi*
@@ -24,6 +24,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
+# apparmor
 caps.drop all
 netfilter
 nodvd

--- a/etc/knotes.profile
+++ b/etc/knotes.profile
@@ -5,10 +5,12 @@ include /etc/firejail/knotes.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+noblacklist ${HOME}/.config/akonadi*
 noblacklist ${HOME}/.config/knotesrc
+noblacklist ${HOME}/.local/share/akonadi/*
 
 include /etc/firejail/disable-common.inc
-# include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
@@ -22,10 +24,14 @@ nonewprivs
 noroot
 nosound
 notv
+novideo
 protocol unix
 seccomp
 shell none
 tracelog
 
 private-dev
-#private-tmp - problems on kubuntu 17.04
+# private-tmp - interrupts connection to akonadi
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/knotes.profile
+++ b/etc/knotes.profile
@@ -7,7 +7,8 @@ include /etc/firejail/globals.local
 
 noblacklist ${HOME}/.config/akonadi*
 noblacklist ${HOME}/.config/knotesrc
-noblacklist ${HOME}/.local/share/akonadi/*
+noblacklist ${HOME}/.local/share/akonadi*
+noblacklist /tmp/akonadi-*
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc

--- a/etc/kwrite.profile
+++ b/etc/kwrite.profile
@@ -43,4 +43,7 @@ private-dev
 private-etc fonts,kde4rc,kde5rc,ld.so.cache,machine-id,pulse,xdg
 private-tmp
 
+noexec ${HOME}
+noexec /tmp
+
 join-or-start kwrite

--- a/etc/libreoffice.profile
+++ b/etc/libreoffice.profile
@@ -21,6 +21,7 @@ apparmor
 caps.drop all
 machine-id
 netfilter
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/libreoffice.profile
+++ b/etc/libreoffice.profile
@@ -5,6 +5,7 @@ include /etc/firejail/libreoffice.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+blacklist /run/user/*/bus
 noblacklist ${HOME}/.java
 noblacklist /usr/local/sbin
 noblacklist ${HOME}/.config/libreoffice

--- a/etc/libreoffice.profile
+++ b/etc/libreoffice.profile
@@ -10,7 +10,8 @@ noblacklist /usr/local/sbin
 noblacklist ${HOME}/.config/libreoffice
 
 include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-devel.inc
+# libreoffice uses java; if you don't care about java functionality, uncomment this line;
+#include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 

--- a/etc/openbox.profile
+++ b/etc/openbox.profile
@@ -14,3 +14,6 @@ netfilter
 noroot
 protocol unix,inet,inet6
 seccomp
+
+read-only ${HOME}/.config/openbox/autostart
+read-only ${HOME}/.config/openbox/environment

--- a/etc/openshot.profile
+++ b/etc/openshot.profile
@@ -5,6 +5,7 @@ include /etc/firejail/openshot.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+blacklist /run/user/*/bus
 noblacklist ${HOME}/.openshot
 noblacklist ${HOME}/.openshot_qt
 

--- a/etc/openshot.profile
+++ b/etc/openshot.profile
@@ -18,6 +18,7 @@ include /etc/firejail/whitelist-var-common.inc
 apparmor
 caps.drop all
 netfilter
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/ping.profile
+++ b/etc/ping.profile
@@ -37,7 +37,8 @@ disable-mnt
 private
 #private-bin has mammoth problems with execvp: "No such file or directory"
 private-dev
-private-etc resolv.conf
+# /etc/hosts is required in private-etc; however, just adding it to the list doesn't solve the problem!
+#private-etc resolv.conf,hosts
 private-tmp
 
 # memory-deny-write-execute is built using seccomp; nonewprivs will kill it

--- a/etc/pluma.profile
+++ b/etc/pluma.profile
@@ -5,7 +5,8 @@ include /etc/firejail/pluma.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus - makes settings immutable
+# following line makes settings immutable
+blacklist /run/user/*/bus
 
 noblacklist ${HOME}/.config/pluma
 
@@ -16,8 +17,11 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
+apparmor
 caps.drop all
-# net none - makes settings immutable
+# following line makes settings immutable
+net none
 machine-id
 no3d
 nodvd

--- a/etc/qbittorrent.profile
+++ b/etc/qbittorrent.profile
@@ -30,6 +30,7 @@ apparmor
 caps.drop all
 machine-id
 netfilter
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/qbittorrent.profile
+++ b/etc/qbittorrent.profile
@@ -5,6 +5,7 @@ include /etc/firejail/qbittorrent.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+blacklist /run/user/*/bus
 noblacklist ${HOME}/.cache/qBittorrent
 noblacklist ${HOME}/.config/qBittorrent
 noblacklist ${HOME}/.config/qBittorrentrc

--- a/etc/rhythmbox.profile
+++ b/etc/rhythmbox.profile
@@ -5,6 +5,8 @@ include /etc/firejail/rhythmbox.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+# following line makes settings immutable
+blacklist /run/user/*/bus
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
@@ -13,6 +15,7 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
 apparmor
 caps.drop all
 netfilter

--- a/etc/smplayer.profile
+++ b/etc/smplayer.profile
@@ -18,6 +18,7 @@ include /etc/firejail/whitelist-var-common.inc
 apparmor
 caps.drop all
 netfilter
+nodbus
 # nogroups
 nonewprivs
 noroot

--- a/etc/smplayer.profile
+++ b/etc/smplayer.profile
@@ -5,6 +5,7 @@ include /etc/firejail/smplayer.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+# blacklist /run/user/*/bus
 noblacklist ${HOME}/.config/smplayer
 noblacklist ${HOME}/.mplayer
 

--- a/etc/spotify.profile
+++ b/etc/spotify.profile
@@ -31,6 +31,7 @@ include /etc/firejail/whitelist-var-common.inc
 
 caps.drop all
 netfilter
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/spotify.profile
+++ b/etc/spotify.profile
@@ -44,7 +44,7 @@ tracelog
 disable-mnt
 private-bin spotify,bash,sh,zenity
 private-dev
-private-etc fonts,group,ld.so.cache,machine-id,pulse,resolv.conf
+private-etc fonts,ld.so.cache,machine-id,pulse,resolv.conf
 private-opt spotify
 private-tmp
 

--- a/etc/thunderbird-beta.profile
+++ b/etc/thunderbird-beta.profile
@@ -1,0 +1,8 @@
+# Firejail profile alias for thunderbird-beta
+# This file is overwritten after every install/update
+
+
+whitelist /opt/thunderbird-beta
+
+# Redirect
+include /etc/firejail/thunderbird.profile

--- a/etc/totem.profile
+++ b/etc/totem.profile
@@ -5,6 +5,8 @@ include /etc/firejail/totem.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+# following line makes settings immutable
+blacklist /run/user/*/bus
 noblacklist ${HOME}/.config/totem
 noblacklist ${HOME}/.local/share/totem
 
@@ -15,6 +17,7 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
 apparmor
 caps.drop all
 netfilter

--- a/etc/transmission-gtk.profile
+++ b/etc/transmission-gtk.profile
@@ -25,6 +25,7 @@ apparmor
 caps.drop all
 machine-id
 netfilter
+nodbus
 nodvd
 nonewprivs
 noroot

--- a/etc/transmission-gtk.profile
+++ b/etc/transmission-gtk.profile
@@ -5,6 +5,7 @@ include /etc/firejail/transmission-gtk.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+blacklist /run/user/*/bus
 noblacklist ${HOME}/.cache/transmission
 noblacklist ${HOME}/.config/transmission
 

--- a/etc/transmission-qt.profile
+++ b/etc/transmission-qt.profile
@@ -5,6 +5,7 @@ include /etc/firejail/transmission-qt.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+blacklist /run/user/*/bus
 noblacklist ${HOME}/.cache/transmission
 noblacklist ${HOME}/.config/transmission
 

--- a/etc/transmission-qt.profile
+++ b/etc/transmission-qt.profile
@@ -25,6 +25,7 @@ apparmor
 caps.drop all
 machine-id
 netfilter
+nodbus
 nodvd
 nonewprivs
 noroot

--- a/etc/xed.profile
+++ b/etc/xed.profile
@@ -5,7 +5,8 @@ include /etc/firejail/xed.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus - makes settings immutable
+# following line makes settings immutable
+blacklist /run/user/*/bus
 
 noblacklist ${HOME}/.config/xed
 
@@ -16,8 +17,11 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
+apparmor
 caps.drop all
-# net none - makes settings immutable
+# following line makes settings immutable
+net none
 machine-id
 no3d
 nodvd

--- a/etc/xplayer-audio-preview.profile
+++ b/etc/xplayer-audio-preview.profile
@@ -1,0 +1,10 @@
+# Firejail profile for xplayer-audio-preview
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/xplayer-audio-preview.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+
+# Redirect
+include /etc/firejail/xplayer.profile

--- a/etc/xplayer-video-thumbnailer
+++ b/etc/xplayer-video-thumbnailer
@@ -1,0 +1,10 @@
+# Firejail profile for xplayer-video-thumbnailer
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/xplayer-video-thumbnailer.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+
+# Redirect
+include /etc/firejail/xplayer.profile

--- a/etc/xplayer.profile
+++ b/etc/xplayer.profile
@@ -5,6 +5,8 @@ include /etc/firejail/xplayer.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+# following line makes settings immutable
+blacklist /run/user/*/bus
 noblacklist ${HOME}/.config/xplayer
 noblacklist ${HOME}/.local/share/xplayer
 
@@ -15,6 +17,8 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
+apparmor
 caps.drop all
 netfilter
 nogroups

--- a/etc/xreader-previewer.profile
+++ b/etc/xreader-previewer.profile
@@ -1,0 +1,10 @@
+# Firejail profile for xreader-previewer
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/xreader-previewer.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+
+# Redirect
+include /etc/firejail/xreader.profile

--- a/etc/xreader-thumbnailer.profile
+++ b/etc/xreader-thumbnailer.profile
@@ -1,0 +1,10 @@
+# Firejail profile for xreader-thumbnailer
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/xreader-thumbnailer.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+
+# Redirect
+include /etc/firejail/xreader.profile

--- a/etc/xreader.profile
+++ b/etc/xreader.profile
@@ -16,6 +16,7 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# apparmor
 caps.drop all
 no3d
 nodvd

--- a/etc/xviewer.profile
+++ b/etc/xviewer.profile
@@ -5,7 +5,8 @@ include /etc/firejail/xviewer.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus - makes settings immutable
+# following line makes settings immutable
+blacklist /run/user/*/bus
 
 noblacklist ${HOME}/.Steam
 noblacklist ${HOME}/.config/xviewer
@@ -19,8 +20,11 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
+apparmor
 caps.drop all
-# net none - makes settings immutable
+# following line makes settings immutable
+net none
 no3d
 nodvd
 nogroups

--- a/src/fbuilder/Makefile.in
+++ b/src/fbuilder/Makefile.in
@@ -22,9 +22,9 @@ HAVE_GLOBALCFG=@HAVE_GLOBALCFG@
 HAVE_APPARMOR=@HAVE_APPARMOR@
 HAVE_OVERLAYFS=@HAVE_OVERLAYFS@
 HAVE_PRIVATE_HOME=@HAVE_PRIVATE_HOME@
-EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
 HAVE_GCOV=@HAVE_GCOV@
 EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
+EXTRA_CFLAGS +=@EXTRA_CFLAGS@
 
 H_FILE_LIST       = $(sort $(wildcard *.[h]))
 C_FILE_LIST       = $(sort $(wildcard *.c))
@@ -34,7 +34,7 @@ CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' $(HAVE_GCOV)
 LDFLAGS += -pie -Wl,-z,relro -Wl,-z,now -lpthread
 
 %.o : %.c $(H_FILE_LIST) ../include/common.h ../include/syscall.h
-	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(INCLUDE) -c $< -o $@
 
 fbuilder: $(OBJS)
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) $(LIBS) $(EXTRA_LDFLAGS)

--- a/src/fcopy/Makefile.in
+++ b/src/fcopy/Makefile.in
@@ -25,6 +25,7 @@ HAVE_PRIVATE_HOME=@HAVE_PRIVATE_HOME@
 EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
 HAVE_GCOV=@HAVE_GCOV@
 EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
+EXTRA_CFLAGS +=@EXTRA_CFLAGS@
 
 H_FILE_LIST       = $(sort $(wildcard *.[h]))
 C_FILE_LIST       = $(sort $(wildcard *.c))
@@ -34,7 +35,7 @@ CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' $(HAVE_GCOV)
 LDFLAGS += -pie -Wl,-z,relro -Wl,-z,now -lpthread
 
 %.o : %.c $(H_FILE_LIST) ../include/common.h ../include/syscall.h
-	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(INCLUDE) -c $< -o $@
 
 fcopy: $(OBJS)
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) $(LIBS) $(EXTRA_LDFLAGS)

--- a/src/firecfg/Makefile.in
+++ b/src/firecfg/Makefile.in
@@ -19,6 +19,7 @@ HAVE_X11=@HAVE_X11@
 HAVE_FILE_TRANSFER=@HAVE_FILE_TRANSFER@
 HAVE_GCOV=@HAVE_GCOV@
 EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
+EXTRA_CFLAGS +=@EXTRA_CFLAGS@
 
 
 H_FILE_LIST       = $(sort $(wildcard *.[h]))
@@ -29,7 +30,7 @@ CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' $(HAVE_GCOV)
 LDFLAGS += -pie -Wl,-z,relro -Wl,-z,now -lpthread
 
 %.o : %.c $(H_FILE_LIST) ../include/common.h ../include/euid_common.h ../include/libnetlink.h ../include/pid.h
-	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(INCLUDE) -c $< -o $@
 
 firecfg: $(OBJS) ../lib/common.o
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) ../lib/common.o $(LIBS) $(EXTRA_LDFLAGS)

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -16,6 +16,7 @@ VirtualBox
 Wire
 Xephyr
 abrowser
+# akonadi_control - enable later
 akregator
 amarok
 amule
@@ -154,6 +155,7 @@ gnome-maps
 gnome-mplayer
 gnome-music
 gnome-photos
+gnome-recipes
 gnome-twitch
 gnome-weather
 goobox

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -44,6 +44,7 @@ bibletime
 bitlbee
 bleachbit
 blender
+blender-2.8
 bless
 bluefish
 bnox
@@ -352,6 +353,7 @@ telegram
 telegram-desktop
 terasology
 thunderbird
+thunderbird-beta
 tilp
 tor-browser-ar
 tor-browser-en

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -109,6 +109,8 @@ eom
 epiphany
 etr
 evince
+evince-previewer
+evince-thumbnailer
 evolution
 exiftool
 falkon

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -16,7 +16,7 @@ VirtualBox
 Wire
 Xephyr
 abrowser
-# akonadi_control - enable later
+akonadi_control
 akregator
 amarok
 amule

--- a/src/firejail/Makefile.in
+++ b/src/firejail/Makefile.in
@@ -25,6 +25,7 @@ HAVE_PRIVATE_HOME=@HAVE_PRIVATE_HOME@
 HAVE_GCOV=@HAVE_GCOV@
 HAVE_GIT_INSTALL=@HAVE_GIT_INSTALL@
 EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
+EXTRA_CFLAGS +=@EXTRA_CFLAGS@
 
 H_FILE_LIST       = $(sort $(wildcard *.[h]))
 C_FILE_LIST       = $(sort $(wildcard *.c))
@@ -34,7 +35,7 @@ CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"'  $(HAVE_GCOV
 LDFLAGS += -pie -Wl,-z,relro -Wl,-z,now -lpthread
 
 %.o : %.c $(H_FILE_LIST) ../include/common.h ../include/euid_common.h ../include/pid.h ../include/seccomp.h ../include/syscall.h
-	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(INCLUDE) -c $< -o $@
 
 firejail: $(OBJS) ../lib/libnetlink.o ../lib/common.o ../lib/ldd_utils.o
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) ../lib/common.o ../lib/ldd_utils.o $(LIBS) $(EXTRA_LDFLAGS)

--- a/src/firejail/dbus.c
+++ b/src/firejail/dbus.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2014-2018 Firejail Authors
+ *
+ * This file is part of firejail project
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+#include "firejail.h"
+
+void dbus_session_disable(void) {
+	char *path;
+	if (asprintf(&path, "/run/user/%d/bus", getuid()) == -1)
+		errExit("asprintf");
+	char *env_var;
+	if (asprintf(&env_var, "DBUS_SESSION_BUS_ADDRESS=unix:path=%s", path) == -1)
+		errExit("asprintf");
+
+	// set a new environment variable: DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/<UID>/bus
+	if (setenv("DBUS_SESSION_BUS_ADDRESS", env_var, 1) == -1) {
+		fprintf(stderr, "Error: cannot modify DBUS_SESSION_BUS_ADDRESS required by --nodbus\n");
+		exit(1);
+	}
+
+	// blacklist the path
+	disable_file_or_dir(path);
+	free(path);
+	free(env_var);
+
+	// look for a possible abstract unix socket
+
+	// --net=none
+	if (arg_nonetwork)
+		return;
+
+	// --net=eth0
+	if (any_bridge_configured())
+		return;
+
+	// --protocol=unix
+#ifdef HAVE_SECCOMP
+	if (cfg.protocol && !strstr(cfg.protocol, "unix"))
+		return;
+#endif
+
+	fwarning("An abstract unix socket for session D-BUS might still be available. Use --net or remove unix from --protocol set.\n");
+}

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -382,6 +382,7 @@ extern int arg_noprofile;	// use default.profile if none other found/specified
 extern int arg_memory_deny_write_execute;	// block writable and executable memory
 extern int arg_notv;	// --notv
 extern int arg_nodvd;	// --nodvd
+extern int arg_nodbus; // -nodbus
 
 extern int login_shell;
 extern int parent_to_child_fds[2];
@@ -520,6 +521,8 @@ void create_empty_file_as_root(const char *dir, mode_t mode);
 int set_perms(const char *fname, uid_t uid, gid_t gid, mode_t mode);
 void mkdir_attr(const char *fname, mode_t mode, uid_t uid, gid_t gid);
 unsigned extract_timeout(const char *str);
+void disable_file_or_dir(const char *fname);
+void disable_file_path(const char *path, const char *file);
 
 // fs_var.c
 void fs_var_log(void);	// mounting /var/log
@@ -799,5 +802,8 @@ void delete_bandwidth_run_file(pid_t pid);
 void set_name_run_file(pid_t pid);
 void set_x11_run_file(pid_t pid, int display);
 void set_profile_run_file(pid_t pid, const char *fname);
+
+// dbus.c
+void dbus_session_disable(void);
 
 #endif

--- a/src/firejail/fs_dev.c
+++ b/src/firejail/fs_dev.c
@@ -297,26 +297,6 @@ void fs_private_dev(void){
 	}
 }
 
-
-
-static void disable_file_or_dir(const char *fname) {
-	if (arg_debug)
-		printf("disable %s\n", fname);
-	struct stat s;
-	if (stat(fname, &s) != -1) {
-		if (is_dir(fname)) {
-			if (mount(RUN_RO_DIR, fname, "none", MS_BIND, "mode=400,gid=0") < 0)
-				errExit("disable directory");
-		}
-		else {
-			if (mount(RUN_RO_FILE, fname, "none", MS_BIND, "mode=400,gid=0") < 0)
-				errExit("disable file");
-		}
-	}
-	fs_logger2("blacklist", fname);
-
-}
-
 void fs_dev_disable_sound(void) {
 	unsigned i = 0;
 	while (dev[i].dev_fname != NULL) {

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -120,6 +120,7 @@ int arg_noprofile = 0; // use default.profile if none other found/specified
 int arg_memory_deny_write_execute = 0;		// block writable and executable memory
 int arg_notv = 0;	// --notv
 int arg_nodvd = 0; // --nodvd
+int arg_nodbus = 0; // -nodbus
 int login_shell = 0;
 
 
@@ -1111,7 +1112,7 @@ int main(int argc, char **argv) {
 		else if (strncmp(argv[i], "--protocol=", 11) == 0) {
 			if (checkcfg(CFG_SECCOMP)) {
 				if (cfg.protocol) {
-					fwarning("a protocol list is present, the new list \"%s\" will not be installed\n", argv[i] + 11);
+					fwarning("two protocol lists are present, \"%s\" will be installed\n", cfg.protocol);
 				}
 				else {
 					// store list
@@ -1734,6 +1735,8 @@ int main(int argc, char **argv) {
 			arg_notv = 1;
 		else if (strcmp(argv[i], "--nodvd") == 0)
 			arg_nodvd = 1;
+		else if (strcmp(argv[i], "--nodbus") == 0)
+			arg_nodbus = 1;
 
 		//*************************************
 		// network

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -249,6 +249,10 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		arg_no3d = 1;
 		return 0;
 	}
+	else if (strcmp(ptr, "nodbus") == 0) {
+		arg_nodbus = 1;
+		return 0;
+	}
 	else if (strcmp(ptr, "allow-private-blacklist") == 0) {
 		fmessage("--allow-private-blacklist was deprecated\n");
 		return 0;
@@ -549,7 +553,7 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 #ifdef HAVE_SECCOMP
 		if (checkcfg(CFG_SECCOMP)) {
 			if (cfg.protocol) {
-				fwarning("a protocol list is present, the new list \"%s\" will not be installed\n", ptr + 9);
+				fwarning("two protocol lists are present, \"%s\" will be installed\n", cfg.protocol);
 				return 0;
 			}
 

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -838,6 +838,13 @@ int sandbox(void* sandbox_arg) {
 	}
 
 	//****************************
+	// Session D-BUS
+	//****************************
+	if (arg_nodbus)
+		dbus_session_disable();
+
+
+	//****************************
 	// hosts and hostname
 	//****************************
 	if (cfg.hostname)

--- a/src/firemon/Makefile.in
+++ b/src/firemon/Makefile.in
@@ -17,10 +17,11 @@ CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' -DPREFIX='"$
 LDFLAGS += -pie -Wl,-z,relro -Wl,-z,now
 HAVE_GCOV=@HAVE_GCOV@
 EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
+EXTRA_CFLAGS +=@EXTRA_CFLAGS@
 
 
 %.o : %.c $(H_FILE_LIST)
-	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(INCLUDE) -c $< -o $@
 
 firemon: $(OBJS) ../lib/common.o ../lib/pid.o
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) ../lib/common.o ../lib/pid.o $(LIBS) $(EXTRA_LDFLAGS)

--- a/src/fldd/Makefile.in
+++ b/src/fldd/Makefile.in
@@ -24,7 +24,7 @@ HAVE_OVERLAYFS=@HAVE_OVERLAYFS@
 HAVE_PRIVATE_HOME=@HAVE_PRIVATE_HOME@
 EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
 HAVE_GCOV=@HAVE_GCOV@
-EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
+EXTRA_CFLAGS +=@EXTRA_CFLAGS@
 
 H_FILE_LIST       = $(sort $(wildcard *.[h]))
 C_FILE_LIST       = $(sort $(wildcard *.c))
@@ -34,7 +34,7 @@ CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' $(HAVE_GCOV)
 LDFLAGS += -pie -Wl,-z,relro -Wl,-z,now -lpthread
 
 %.o : %.c $(H_FILE_LIST) ../include/common.h ../include/syscall.h ../include/ldd_utils.h
-	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(INCLUDE) -c $< -o $@
 
 fldd: $(OBJS) ../lib/ldd_utils.o
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) ../lib/ldd_utils.o $(LIBS) $(EXTRA_LDFLAGS)

--- a/src/fnet/Makefile.in
+++ b/src/fnet/Makefile.in
@@ -22,9 +22,9 @@ HAVE_GLOBALCFG=@HAVE_GLOBALCFG@
 HAVE_APPARMOR=@HAVE_APPARMOR@
 HAVE_OVERLAYFS=@HAVE_OVERLAYFS@
 HAVE_PRIVATE_HOME=@HAVE_PRIVATE_HOME@
-EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
 HAVE_GCOV=@HAVE_GCOV@
 EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
+EXTRA_CFLAGS +=@EXTRA_CFLAGS@
 
 H_FILE_LIST       = $(sort $(wildcard *.[h]))
 C_FILE_LIST       = $(sort $(wildcard *.c))
@@ -34,7 +34,7 @@ CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' $(HAVE_GCOV)
 LDFLAGS += -pie -Wl,-z,relro -Wl,-z,now -lpthread
 
 %.o : %.c $(H_FILE_LIST) ../include/common.h ../include/libnetlink.h
-	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(INCLUDE) -c $< -o $@
 
 fnet: $(OBJS) ../lib/libnetlink.o
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) ../lib/libnetlink.o $(LIBS) $(EXTRA_LDFLAGS)

--- a/src/fnetfilter/Makefile.in
+++ b/src/fnetfilter/Makefile.in
@@ -24,7 +24,7 @@ HAVE_OVERLAYFS=@HAVE_OVERLAYFS@
 HAVE_PRIVATE_HOME=@HAVE_PRIVATE_HOME@
 EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
 HAVE_GCOV=@HAVE_GCOV@
-EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
+EXTRA_CFLAGS +=@EXTRA_CFLAGS@
 
 H_FILE_LIST       = $(sort $(wildcard *.[h]))
 C_FILE_LIST       = $(sort $(wildcard *.c))
@@ -34,7 +34,7 @@ CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' $(HAVE_GCOV)
 LDFLAGS += -pie -Wl,-z,relro -Wl,-z,now -lpthread
 
 %.o : %.c $(H_FILE_LIST) ../include/common.h ../include/syscall.h
-	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(INCLUDE) -c $< -o $@
 
 fnetfilter: $(OBJS)
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) $(LIBS) $(EXTRA_LDFLAGS)

--- a/src/fsec-optimize/Makefile.in
+++ b/src/fsec-optimize/Makefile.in
@@ -22,9 +22,9 @@ HAVE_GLOBALCFG=@HAVE_GLOBALCFG@
 HAVE_APPARMOR=@HAVE_APPARMOR@
 HAVE_OVERLAYFS=@HAVE_OVERLAYFS@
 HAVE_PRIVATE_HOME=@HAVE_PRIVATE_HOME@
-EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
 HAVE_GCOV=@HAVE_GCOV@
 EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
+EXTRA_CFLAGS +=@EXTRA_CFLAGS@
 
 H_FILE_LIST       = $(sort $(wildcard *.[h]))
 C_FILE_LIST       = $(sort $(wildcard *.c))
@@ -34,7 +34,7 @@ CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' $(HAVE_GCOV)
 LDFLAGS += -pie -Wl,-z,relro -Wl,-z,now -lpthread
 
 %.o : %.c $(H_FILE_LIST) ../include/common.h ../include/seccomp.h ../include/syscall.h
-	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(INCLUDE) -c $< -o $@
 
 fsec-optimize: $(OBJS) ../lib/libnetlink.o
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) $(LIBS) $(EXTRA_LDFLAGS)

--- a/src/fsec-print/Makefile.in
+++ b/src/fsec-print/Makefile.in
@@ -25,6 +25,7 @@ HAVE_PRIVATE_HOME=@HAVE_PRIVATE_HOME@
 EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
 HAVE_GCOV=@HAVE_GCOV@
 EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
+EXTRA_CFLAGS +=@EXTRA_CFLAGS@
 
 H_FILE_LIST       = $(sort $(wildcard *.[h]))
 C_FILE_LIST       = $(sort $(wildcard *.c))
@@ -34,7 +35,7 @@ CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' $(HAVE_GCOV)
 LDFLAGS += -pie -Wl,-z,relro -Wl,-z,now -lpthread
 
 %.o : %.c $(H_FILE_LIST) ../include/common.h ../include/seccomp.h ../include/syscall.h
-	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(INCLUDE) -c $< -o $@
 
 fsec-print: $(OBJS) ../lib/libnetlink.o
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) $(LIBS) $(EXTRA_LDFLAGS)

--- a/src/fsec-print/print.c
+++ b/src/fsec-print/print.c
@@ -269,7 +269,7 @@ static void bpf_decode_args(const struct sock_filter *bpf, unsigned int line) {
 				 native_arch = (ARCH_NR == ARCH_64)? 1: 0;
 			}
 			else if (bpf->k == X32_SYSCALL_BIT)
-				printf("X32_ABI true:%.4x (false %.4x)",
+				printf("X32_ABI %.4x (false %.4x)",
 				       (line + 1) + bpf->jt,
 				       (line + 1) + bpf->jf);
 			else if (name)

--- a/src/fseccomp/Makefile.in
+++ b/src/fseccomp/Makefile.in
@@ -22,9 +22,9 @@ HAVE_GLOBALCFG=@HAVE_GLOBALCFG@
 HAVE_APPARMOR=@HAVE_APPARMOR@
 HAVE_OVERLAYFS=@HAVE_OVERLAYFS@
 HAVE_PRIVATE_HOME=@HAVE_PRIVATE_HOME@
-EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
 HAVE_GCOV=@HAVE_GCOV@
 EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
+EXTRA_CFLAGS +=@EXTRA_CFLAGS@
 
 H_FILE_LIST       = $(sort $(wildcard *.[h]))
 C_FILE_LIST       = $(sort $(wildcard *.c))
@@ -34,7 +34,7 @@ CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' $(HAVE_GCOV)
 LDFLAGS += -pie -Wl,-z,relro -Wl,-z,now -lpthread
 
 %.o : %.c $(H_FILE_LIST) ../include/common.h ../include/syscall.h
-	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(INCLUDE) -c $< -o $@
 
 fseccomp: $(OBJS)
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) $(LIBS) $(EXTRA_LDFLAGS)

--- a/src/ftee/Makefile.in
+++ b/src/ftee/Makefile.in
@@ -7,6 +7,7 @@ NAME=@PACKAGE_NAME@
 HAVE_FATAL_WARNINGS=@HAVE_FATAL_WARNINGS@
 HAVE_GCOV=@HAVE_GCOV@
 EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
+EXTRA_CFLAGS +=@EXTRA_CFLAGS@
 
 H_FILE_LIST       = $(sort $(wildcard *.[h]))
 C_FILE_LIST       = $(sort $(wildcard *.c))
@@ -16,7 +17,7 @@ CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' $(HAVE_GCOV)
 LDFLAGS += -pie -Wl,-z,relro -Wl,-z,now -lpthread
 
 %.o : %.c $(H_FILE_LIST)
-	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(INCLUDE) -c $< -o $@
 
 ftee: $(OBJS)
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) $(EXTRA_LDFLAGS)

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -5,6 +5,7 @@ NAME=@PACKAGE_NAME@
 HAVE_FATAL_WARNINGS=@HAVE_FATAL_WARNINGS@
 HAVE_GCOV=@HAVE_GCOV@
 EXTRA_LDFLAGS +=@EXTRA_LDFLAGS@
+EXTRA_CFLAGS +=@EXTRA_CFLAGS@
 
 H_FILE_LIST       = $(sort $(wildcard *.[h]))
 C_FILE_LIST       = $(sort $(wildcard *.c))
@@ -16,7 +17,7 @@ LDFLAGS:=-pic -Wl,-z,relro -Wl,-z,now
 all: $(OBJS)
 
 %.o : %.c $(H_FILE_LIST)
-	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(INCLUDE) -c $< -o $@
 
 clean:; rm -f $(OBJS) *.gcov *.gcda *.gcno
 

--- a/src/lib/pid.c
+++ b/src/lib/pid.c
@@ -188,10 +188,11 @@ static void print_elem(unsigned index, int nowrap) {
 	uid_t uid = pids[index].uid;
 	char *cmd = pid_proc_cmdline(index);
 	char *user = pid_get_user_name(uid);
-	char *allocated = user;
+	char *user_allocated = user;
 
 	// extract sandbox name - pid == index
 	char *sandbox_name = "";
+	char *sandbox_name_allocated = NULL;
 	char *fname;
 	if (asprintf(&fname, "%s/%d", RUN_FIREJAIL_NAME_DIR, index) == -1)
 		errExit("asprintf");
@@ -202,6 +203,7 @@ static void print_elem(unsigned index, int nowrap) {
 			sandbox_name = malloc(s.st_size + 1);
 			if (!sandbox_name)
 				errExit("malloc");
+			sandbox_name_allocated = sandbox_name;
 			char *rv = fgets(sandbox_name, s.st_size + 1, fp);
 			if (!rv)
 				*sandbox_name = '\0';
@@ -241,8 +243,10 @@ static void print_elem(unsigned index, int nowrap) {
 		else
 			printf("%s%u:\n", indent, index);
 	}
-	if (allocated)
-		free(allocated);
+	if (user_allocated)
+		free(user_allocated);
+	if (sandbox_name_allocated)
+		free(sandbox_name_allocated);
 }
 
 // recursivity!!!


### PR DESCRIPTION
A few notes:

- Atril I found broken without D-Bus, probably because it can't talk to its server process atrild anymore. Same for Xreader.
- SMPlayer uses the KDE file dialog, so we need to treat it like other KDE apps.
- Audacity, Kodi are not yet included here.

Still I am a bit unsure if we really can freeze application settings in some cases. Looking at the rich settings that gedit or rhythmbox expose (for a reason), can we make exceptions case by case?