### PR TITLE
evince fixes

### DIFF
--- a/etc/evince-previewer.profile
+++ b/etc/evince-previewer.profile
@@ -1,0 +1,10 @@
+# Firejail profile for evince-previewer
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/evince-previewer.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+
+# Redirect
+include /etc/firejail/evince.profile

--- a/etc/evince-thumbnailer.profile
+++ b/etc/evince-thumbnailer.profile
@@ -1,0 +1,10 @@
+# Firejail profile for evince-thumbnailer
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/evince-thumbnailer.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+
+# Redirect
+include /etc/firejail/evince.profile

--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -14,7 +14,6 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
-include /etc/firejail/whitelist-common.inc
 include /etc/firejail/whitelist-var-common.inc
 
 caps.drop all
@@ -40,10 +39,6 @@ private-etc fonts
 
 #private-lib - seems to be breaking on Gnome Shell 3.26.2, Mutter WM, issue 1711
 #private-lib evince,libpoppler-glib.so.8
-# the below works on Arch Linux (same Gnome Shell & Mutter)
-# leaving commented as it seems private-lib is currently under development
-# offered here to (try to) help with that
-#private-lib evince,gdk-pixbuf-2.0,gio,gvfs/libgvfscommon.so,libgconf-2.so.4,libpoppler-glib.so.8,librsvg-2.so.2
 
 private-tmp
 

--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -14,6 +14,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
+include /etc/firejail/whitelist-common.inc
 include /etc/firejail/whitelist-var-common.inc
 
 caps.drop all
@@ -39,6 +40,10 @@ private-etc fonts
 
 #private-lib - seems to be breaking on Gnome Shell 3.26.2, Mutter WM, issue 1711
 #private-lib evince,libpoppler-glib.so.8
+# the below works on Arch Linux (same Gnome Shell & Mutter)
+# leaving commented as it seems private-lib is currently under development
+# offered here to (try to) help with that
+#private-lib evince,gdk-pixbuf-2.0,gio,gvfs/libgvfscommon.so,libgconf-2.so.4,libpoppler-glib.so.8,librsvg-2.so.2
 
 private-tmp
 


### PR DESCRIPTION
Seems the current evince profile has issues with dconf, user icons and themes. These can all be easily fixed by including `whitelist-common.inc`. Also adding 2 redirect profiles for evince-previewer and evince-thumbnailer, both executables are included in evince as packaged on Arch Linux (and probably other distro's too).

After seeing [#1711](https://github.com/netblue30/firejail/issues/1711), I took another crack at trying to fix the `private-lib` condition, something I had fiddled with before without succes. But this time it looks as if things are settling nicely in that regard. I added what works for me after extensive testing. Leaving commented, so other people can take a closer look.

For what it's worth, these all work, ordered from less to more granular/restrictive:

- private-lib dconf,evince,GConf,gdk-pixbuf-2.0,gio,gvfs,libgconf-2.so.4,libpoppler-glib.so.8,librsvg-2.so.2,libxml2.so.2
- private-lib evince,gdk-pixbuf-2.0,gio,gvfs,libgconf-2.so.4,libpoppler-glib.so.8,librsvg-2.so.2,libxml2.so.2
- private-lib evince,gdk-pixbuf-2.0,gio,gvfs,libgconf-2.so.4,libpoppler-glib.so.8,librsvg-2.so.2
- private-lib evince,gdk-pixbuf-2.0,gio,gvfs/libgvfscommon.so,libgconf-2.so.4,libpoppler-glib.so.8,librsvg-2.so.2