### PR TITLE
whitelist-common.inc fixes for several profiles

### DIFF
--- a/etc/claws-mail.profile
+++ b/etc/claws-mail.profile
@@ -13,6 +13,7 @@ include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/whitelist-common.inc
 
 caps.drop all
 netfilter

--- a/etc/eog.profile
+++ b/etc/eog.profile
@@ -16,6 +16,7 @@ include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/whitelist-common.inc
 
 include /etc/firejail/whitelist-var-common.inc
 

--- a/etc/gimp.profile
+++ b/etc/gimp.profile
@@ -12,6 +12,7 @@ noblacklist ${HOME}/.gimp*
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/whitelist-common.inc
 
 include /etc/firejail/whitelist-var-common.inc
 

--- a/etc/gnome-clocks.profile
+++ b/etc/gnome-clocks.profile
@@ -10,6 +10,7 @@ include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/whitelist-common.inc
 
 include /etc/firejail/whitelist-var-common.inc
 


### PR DESCRIPTION
Some apps I use regularly are showing user icon, theme-related and dconf settings issues. Had things fixed in local profiles (gathering dust), time to clean those out and make a contribution. These apps were all lacking the generic `whitelist-common.inc` file.