### PR TITLE
private-lib fix

### DIFF
--- a/etc/eog.profile
+++ b/etc/eog.profile
@@ -37,7 +37,7 @@ shell none
 private-bin eog
 private-dev
 private-etc fonts
-private-lib
+private-lib gdk-pixbuf-2.0,gio,girepository-1.0,gvfs,libgconf-2.so.4
 private-tmp
 
 #memory-deny-write-execute  - breaks on Arch


### PR DESCRIPTION
Using Arch Linux (Gnome Shell 3.26.2, Mutter WM, as in [#1711](https://github.com/netblue30/firejail/issues/1711)). After playing with several Gnome apps and `private-lib` conditions, it looks like there's progress to report. I made a few PR's today on the same topic, usually leaving things commented as to leave room for more eyes to double-check. In this case I took the liberty to throw in an uncommented one for eog. Please respond or rectify if this was uncalled for.