### PR TITLE
fix immutable settings

### DIFF
--- a/etc/gimp.profile
+++ b/etc/gimp.profile
@@ -5,7 +5,7 @@ include /etc/firejail/gimp.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
+# blacklist /run/user/*/bus - makes settings immutable
 
 noblacklist ${HOME}/.gimp*
 


### PR DESCRIPTION
On Arch Linux I'm seeing the below with latest firejail from git:

$ firejail gimp
Reading profile /home/glitsj16/.config/firejail/gimp.profile
Reading profile /etc/firejail/gimp.profile
Reading profile /etc/firejail/globals.local
Reading profile /etc/firejail/disable-common.inc
Reading profile /etc/firejail/disable-passwdmgr.inc
Reading profile /etc/firejail/disable-passwdmgr.local
Reading profile /etc/firejail/disable-programs.inc
Reading profile /etc/firejail/whitelist-var-common.inc
Parent pid 22315, child pid 22316

Child process initialized in 317.16 ms
Could not connect: Permission denied
Failed to connect to socket /run/user/1001/bus: Permission denied