### PR TITLE
recalibrate dbus access, deploy nodbus option

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,12 +259,10 @@ enable/disable apparmor functionality globally. By default the flag is enabled.
 AppArmor deployment: we are starting apparmor by default for the following programs:
 - web browsers: firefox (firefox-common.profile), chromium (chromium-common.profile)
 - torrent clients: transmission-qt, transmission-gtk, qbittorrent
-- media players: vlc, mpv, audacious, totem, rhythmbox, kodi, smplayer, xplayer
-- media editing: kdenlive, audacity, handbrake, gimp, inkscape, krita, openshot
-- image viewers: eom, eog, gwenview, xviewer
+- media players: vlc, mpv, audacious, kodi, smplayer
+- media editing: kdenlive, audacity, handbrake, inkscape, krita, openshot
 - archive managers: ark, engrampa, file-roller
-- text editors: gedit, kwrite, pluma, xed
-- etc.: digikam, gnome-calculator, galculator, kcalc, okular, libreoffice, asunder
+- etc.: digikam, libreoffice, okular, gwenview, galculator, kcalc
 
 Checking apparmor status:
 `````

--- a/README.md
+++ b/README.md
@@ -259,9 +259,12 @@ enable/disable apparmor functionality globally. By default the flag is enabled.
 AppArmor deployment: we are starting apparmor by default for the following programs:
 - web browsers: firefox (firefox-common.profile), chromium (chromium-common.profile)
 - torrent clients: transmission-qt, transmission-gtk, qbittorrent
-- media players: vlc, mpv, audacious, totem, rhythmbox
+- media players: vlc, mpv, audacious, totem, rhythmbox, kodi, smplayer, xplayer
 - media editing: kdenlive, audacity, handbrake, gimp, inkscape, krita, openshot
-- etc.: atril, gnome-calculator, galculator, eom, eog
+- image viewers: eom, eog, gwenview, xviewer
+- archive managers: ark, engrampa, file-roller
+- text editors: gedit, kwrite, pluma, xed
+- etc.: digikam, gnome-calculator, galculator, kcalc, okular, libreoffice, asunder
 
 Checking apparmor status:
 `````

--- a/etc/7z.profile
+++ b/etc/7z.profile
@@ -6,12 +6,12 @@ include /etc/firejail/7z.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
 blacklist /tmp/.X11-unix
 
 ignore noroot
 net none
 no3d
+nodbus
 nodvd
 nosound
 notv

--- a/etc/apktool.profile
+++ b/etc/apktool.profile
@@ -6,8 +6,6 @@ include /etc/firejail/apktool.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
@@ -15,6 +13,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/ardour5.profile
+++ b/etc/ardour5.profile
@@ -5,8 +5,6 @@ include /etc/firejail/ardour5.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/ardour4
 noblacklist ${HOME}/.config/ardour5
 noblacklist ${HOME}/.lv2
@@ -20,6 +18,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 ipc-namespace
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/ark.profile
+++ b/etc/ark.profile
@@ -5,8 +5,6 @@ include /etc/firejail/ark.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/arkrc
 
 include /etc/firejail/disable-common.inc
@@ -20,6 +18,7 @@ apparmor
 caps.drop all
 # net none
 netfilter
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/asunder.profile
+++ b/etc/asunder.profile
@@ -20,6 +20,7 @@ include /etc/firejail/whitelist-var-common.inc
 apparmor
 caps.drop all
 netfilter
+nodbus
 # nogroups
 nonewprivs
 noroot

--- a/etc/atom.profile
+++ b/etc/atom.profile
@@ -5,8 +5,6 @@ include /etc/firejail/atom.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.atom
 noblacklist ${HOME}/.config/Atom
 

--- a/etc/atril.profile
+++ b/etc/atril.profile
@@ -17,7 +17,7 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
-apparmor
+# apparmor
 caps.drop all
 machine-id
 no3d

--- a/etc/audacious.profile
+++ b/etc/audacious.profile
@@ -18,6 +18,7 @@ include /etc/firejail/whitelist-var-common.inc
 apparmor
 caps.drop all
 netfilter
+nodbus
 nogroups
 nonewprivs
 noroot

--- a/etc/audacity.profile
+++ b/etc/audacity.profile
@@ -5,8 +5,6 @@ include /etc/firejail/audacity.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.audacity-data
 
 include /etc/firejail/disable-common.inc
@@ -18,8 +16,9 @@ include /etc/firejail/whitelist-var-common.inc
 
 apparmor
 caps.drop all
-#net none
+net none
 no3d
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/audacity.profile
+++ b/etc/audacity.profile
@@ -18,7 +18,7 @@ apparmor
 caps.drop all
 net none
 no3d
-# nodbus
+# nodbus - problems on Fedora 27
 nodvd
 nogroups
 nonewprivs

--- a/etc/baobab.profile
+++ b/etc/baobab.profile
@@ -5,8 +5,6 @@ include /etc/firejail/baobab.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
@@ -15,6 +13,7 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/bleachbit.profile
+++ b/etc/bleachbit.profile
@@ -5,8 +5,6 @@ include /etc/firejail/bleachbit.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
@@ -15,6 +13,7 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/bless.profile
+++ b/etc/bless.profile
@@ -5,8 +5,6 @@ include /etc/firejail/bless.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/bless
 
 include /etc/firejail/disable-common.inc
@@ -17,6 +15,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/bluefish.profile
+++ b/etc/bluefish.profile
@@ -5,8 +5,6 @@ include /etc/firejail/bluefish.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
@@ -17,6 +15,7 @@ include /etc/firejail/whitelist-var-common.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/calligra.profile
+++ b/etc/calligra.profile
@@ -5,8 +5,6 @@ include /etc/firejail/calligra.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
@@ -15,6 +13,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 ipc-namespace
 # net none
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/catfish.profile
+++ b/etc/catfish.profile
@@ -8,8 +8,6 @@ include /etc/firejail/globals.local
 # We can't blacklist much since catfish
 # is for finding files/content
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/catfish
 
 include /etc/firejail/disable-common.inc

--- a/etc/chromium-common.profile
+++ b/etc/chromium-common.profile
@@ -20,6 +20,7 @@ include /etc/firejail/whitelist-var-common.inc
 apparmor
 caps.keep sys_chroot,sys_admin
 netfilter
+nodbus
 nodvd
 nogroups
 notv
@@ -31,3 +32,6 @@ private-dev
 
 noexec ${HOME}
 noexec /tmp
+
+# the file dialog needs to work without d-bus
+env NO_CHROME_KDE_FILE_DIALOG=1

--- a/etc/cin.profile
+++ b/etc/cin.profile
@@ -5,8 +5,6 @@ include /etc/firejail/cin.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.bcast5
 
 include /etc/firejail/disable-common.inc
@@ -17,6 +15,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 ipc-namespace
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/clamav.profile
+++ b/etc/clamav.profile
@@ -6,12 +6,11 @@ include /etc/firejail/clamav.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 caps.drop all
 ipc-namespace
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/cpio.profile
+++ b/etc/cpio.profile
@@ -6,7 +6,6 @@ include /etc/firejail/cpio.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
 blacklist /tmp/.X11-unix
 
 noblacklist /sbin
@@ -19,6 +18,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nonewprivs
 nosound

--- a/etc/default.profile
+++ b/etc/default.profile
@@ -17,6 +17,7 @@ caps.drop all
 # ipc-namespace
 netfilter
 # no3d
+# nodbus
 # nodvd
 # nogroups
 nonewprivs

--- a/etc/dex2jar.profile
+++ b/etc/dex2jar.profile
@@ -6,8 +6,6 @@ include /etc/firejail/dex2jar.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
@@ -16,6 +14,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/dia.profile
+++ b/etc/dia.profile
@@ -5,8 +5,6 @@ include /etc/firejail/dia.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.dia
 
 include /etc/firejail/disable-common.inc
@@ -17,6 +15,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/digikam.profile
+++ b/etc/digikam.profile
@@ -20,6 +20,7 @@ include /etc/firejail/whitelist-var-common.inc
 apparmor
 caps.drop all
 netfilter
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/display.profile
+++ b/etc/display.profile
@@ -5,8 +5,6 @@ include /etc/firejail/display.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
@@ -16,6 +14,7 @@ include /etc/firejail/whitelist-var-common.inc
 
 caps.drop all
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/ebook-viewer.profile
+++ b/etc/ebook-viewer.profile
@@ -1,9 +1,8 @@
 # Firejail profile alias for calibre
 # This file is overwritten after every install/update
 
-blacklist /run/user/*/bus
-
 net none
+nodbus
 
 # Redirect
 include /etc/firejail/calibre.profile

--- a/etc/engrampa.profile
+++ b/etc/engrampa.profile
@@ -18,7 +18,7 @@ caps.drop all
 net none
 no3d
 # following line makes settings immutable
-nodbus
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/engrampa.profile
+++ b/etc/engrampa.profile
@@ -5,8 +5,6 @@ include /etc/firejail/engrampa.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus - makes settings immutable
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
@@ -14,9 +12,13 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
+apparmor
 caps.drop all
-# net none - makes settings immutable
+net none
 no3d
+# following line makes settings immutable
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/engrampa.profile
+++ b/etc/engrampa.profile
@@ -12,13 +12,11 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
-# following line makes settings immutable
 apparmor
 caps.drop all
 net none
 no3d
-# following line makes settings immutable
-# nodbus
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/eog.profile
+++ b/etc/eog.profile
@@ -17,13 +17,11 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
-# following line makes settings immutable
-apparmor
+# apparmor - makes settings immutable
 caps.drop all
-net none
+# net none - makes settings immutable
 no3d
-# following line makes settings immutable
-# nodbus
+# nodbus - makes settings immutable
 nodvd
 nogroups
 nonewprivs

--- a/etc/eog.profile
+++ b/etc/eog.profile
@@ -23,7 +23,7 @@ caps.drop all
 net none
 no3d
 # following line makes settings immutable
-nodbus
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/eog.profile
+++ b/etc/eog.profile
@@ -5,8 +5,6 @@ include /etc/firejail/eog.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus - makes settings immutable
-
 noblacklist ${HOME}/.Steam
 noblacklist ${HOME}/.config/eog
 noblacklist ${HOME}/.local/share/Trash
@@ -19,10 +17,13 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
 apparmor
 caps.drop all
-# net none - makes settings immutable
+net none
 no3d
+# following line makes settings immutable
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/eom.profile
+++ b/etc/eom.profile
@@ -17,13 +17,11 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
-# following line makes settings immutable
-apparmor
+# apparmor - makes settings immutable
 caps.drop all
-net none
+# net none - makes settings immutable
 no3d
-# following line makes settings immutable
-# nodbus
+# nodbus - makes settings immutable
 nodvd
 nogroups
 nonewprivs

--- a/etc/eom.profile
+++ b/etc/eom.profile
@@ -5,8 +5,6 @@ include /etc/firejail/eom.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus - makes settings immutable
-
 noblacklist ${HOME}/.Steam
 noblacklist ${HOME}/.config/mate/eom
 noblacklist ${HOME}/.local/share/Trash
@@ -19,10 +17,13 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
 apparmor
 caps.drop all
-# net none - makes settings immutable
+net none
 no3d
+# following line makes settings immutable
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/eom.profile
+++ b/etc/eom.profile
@@ -23,7 +23,7 @@ caps.drop all
 net none
 no3d
 # following line makes settings immutable
-nodbus
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/etr.profile
+++ b/etc/etr.profile
@@ -5,8 +5,6 @@ include /etc/firejail/etr.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.etr
 
 include /etc/firejail/disable-common.inc
@@ -20,6 +18,7 @@ include /etc/firejail/whitelist-var-common.inc
 
 caps.drop all
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -5,8 +5,6 @@ include /etc/firejail/evince.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/evince
 
 include /etc/firejail/disable-common.inc
@@ -21,6 +19,7 @@ machine-id
 # net none breaks AppArmor on Ubuntu systems
 netfilter
 no3d
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/exiftool.profile
+++ b/etc/exiftool.profile
@@ -6,7 +6,6 @@ include /etc/firejail/exiftool.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
 blacklist /tmp/.X11-unix
 
 noblacklist /usr/bin/perl
@@ -21,6 +20,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/feh.profile
+++ b/etc/feh.profile
@@ -5,8 +5,6 @@ include /etc/firejail/feh.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
@@ -15,6 +13,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/ffmpeg.profile
+++ b/etc/ffmpeg.profile
@@ -6,8 +6,6 @@ include /etc/firejail/ffmpeg.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
@@ -18,6 +16,7 @@ include /etc/firejail/whitelist-var-common.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nosound
 notv

--- a/etc/file-roller.profile
+++ b/etc/file-roller.profile
@@ -5,8 +5,6 @@ include /etc/firejail/file-roller.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus - makes settings immutable
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
@@ -14,9 +12,13 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
+apparmor
 caps.drop all
-# net none - makes settings immutable
+net none
 no3d
+# following line makes settings immutable
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/file-roller.profile
+++ b/etc/file-roller.profile
@@ -18,7 +18,7 @@ caps.drop all
 net none
 no3d
 # following line makes settings immutable
-nodbus
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/file-roller.profile
+++ b/etc/file-roller.profile
@@ -12,13 +12,11 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
-# following line makes settings immutable
 apparmor
 caps.drop all
 net none
 no3d
-# following line makes settings immutable
-# nodbus
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/file.profile
+++ b/etc/file.profile
@@ -6,7 +6,6 @@ include /etc/firejail/file.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
 blacklist /tmp/.X11-unix
 
 include /etc/firejail/disable-common.inc
@@ -17,6 +16,7 @@ caps.drop all
 hostname file
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/freecad.profile
+++ b/etc/freecad.profile
@@ -5,8 +5,6 @@ include /etc/firejail/freecad.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/FreeCAD
 
 include /etc/firejail/disable-common.inc
@@ -17,6 +15,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 ipc-namespace
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/frozen-bubble.profile
+++ b/etc/frozen-bubble.profile
@@ -5,8 +5,6 @@ include /etc/firejail/frozen-bubble.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.frozen-bubble
 
 include /etc/firejail/disable-common.inc
@@ -21,6 +19,7 @@ include /etc/firejail/whitelist-var-common.inc
 
 caps.drop all
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/galculator.profile
+++ b/etc/galculator.profile
@@ -5,8 +5,6 @@ include /etc/firejail/galculator.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/galculator
 
 include /etc/firejail/disable-common.inc
@@ -22,6 +20,7 @@ include /etc/firejail/whitelist-var-common.inc
 apparmor
 caps.drop all
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/gedit.profile
+++ b/etc/gedit.profile
@@ -16,14 +16,12 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
-# following line makes settings immutable
-apparmor
+# apparmor - makes settings immutable
 caps.drop all
 machine-id
-net none
+# net none - makes settings immutable
 no3d
-# following line makes settings immutable
-# nodbus
+# nodbus - makes settings immutable
 nodvd
 nogroups
 nonewprivs

--- a/etc/gedit.profile
+++ b/etc/gedit.profile
@@ -5,8 +5,6 @@ include /etc/firejail/gedit.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus - makes settings immutable
-
 noblacklist ${HOME}/.config/enchant
 noblacklist ${HOME}/.config/gedit
 noblacklist ${HOME}/.gitconfig
@@ -18,10 +16,14 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
+apparmor
 caps.drop all
-# net none - makes settings immutable
 machine-id
+net none
 no3d
+# following line makes settings immutable
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/gedit.profile
+++ b/etc/gedit.profile
@@ -23,7 +23,7 @@ machine-id
 net none
 no3d
 # following line makes settings immutable
-nodbus
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/gimp.profile
+++ b/etc/gimp.profile
@@ -13,12 +13,10 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
-# following line makes settings immutable
-apparmor
+# apparmor - makes settings immutable
 caps.drop all
-net none
-# following line makes settings immutable
-# nodbus
+# net none - makes settings immutable
+# nodbus - makes settings immutable
 nodvd
 nogroups
 nonewprivs

--- a/etc/gimp.profile
+++ b/etc/gimp.profile
@@ -13,10 +13,12 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
 apparmor
 caps.drop all
 net none
-nodbus
+# following line makes settings immutable
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/gimp.profile
+++ b/etc/gimp.profile
@@ -5,8 +5,6 @@ include /etc/firejail/gimp.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.gimp*
 
 include /etc/firejail/disable-common.inc
@@ -18,6 +16,7 @@ include /etc/firejail/whitelist-var-common.inc
 apparmor
 caps.drop all
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/gnome-calculator.profile
+++ b/etc/gnome-calculator.profile
@@ -20,7 +20,7 @@ caps.drop all
 net none
 no3d
 # following line makes settings immutable
-nodbus
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/gnome-calculator.profile
+++ b/etc/gnome-calculator.profile
@@ -14,13 +14,11 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/whitelist-common.inc
 include /etc/firejail/whitelist-var-common.inc
 
-# following line makes settings immutable
-apparmor
+# apparmor - makes settings immutable
 caps.drop all
-net none
+# net none - makes settings immutable
 no3d
-# following line makes settings immutable
-# nodbus
+# nodbus - makes settings immutable
 nodvd
 nogroups
 nonewprivs

--- a/etc/gnome-calculator.profile
+++ b/etc/gnome-calculator.profile
@@ -14,10 +14,13 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/whitelist-common.inc
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
 apparmor
 caps.drop all
-netfilter
+net none
 no3d
+# following line makes settings immutable
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/gpicview.profile
+++ b/etc/gpicview.profile
@@ -5,8 +5,6 @@ include /etc/firejail/gpicview.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/gpicview
 
 include /etc/firejail/disable-common.inc
@@ -18,6 +16,7 @@ include /etc/firejail/whitelist-var-common.inc
 
 caps.drop all
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/gwenview.profile
+++ b/etc/gwenview.profile
@@ -5,8 +5,6 @@ include /etc/firejail/gwenview.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/gwenviewrc
 noblacklist ${HOME}/.config/org.kde.gwenviewrc
 noblacklist ${HOME}/.gimp*
@@ -24,8 +22,10 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+apparmor
 caps.drop all
 # net none
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/gzip.profile
+++ b/etc/gzip.profile
@@ -6,12 +6,12 @@ include /etc/firejail/gzip.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
 blacklist /tmp/.X11-unix
 
 ignore noroot
 net none
 no3d
+nodbus
 nodvd
 nosound
 notv

--- a/etc/handbrake.profile
+++ b/etc/handbrake.profile
@@ -17,6 +17,7 @@ include /etc/firejail/whitelist-var-common.inc
 apparmor
 caps.drop all
 netfilter
+nodbus
 nogroups
 nonewprivs
 noroot

--- a/etc/hashcat.profile
+++ b/etc/hashcat.profile
@@ -6,8 +6,6 @@ include /etc/firejail/hashcat.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.hashcat
 noblacklist /usr/include
 
@@ -18,6 +16,7 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/highlight.profile
+++ b/etc/highlight.profile
@@ -5,7 +5,6 @@ include /etc/firejail/highlight.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
 blacklist /tmp/.X11-unix
 
 include /etc/firejail/disable-common.inc
@@ -16,6 +15,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/hugin.profile
+++ b/etc/hugin.profile
@@ -5,8 +5,6 @@ include /etc/firejail/hugin.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.hugin
 
 include /etc/firejail/disable-common.inc
@@ -16,6 +14,7 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/imagej.profile
+++ b/etc/imagej.profile
@@ -5,8 +5,6 @@ include /etc/firejail/imagej.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.imagej
 
 include /etc/firejail/disable-common.inc
@@ -17,6 +15,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 ipc-namespace
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/img2txt.profile
+++ b/etc/img2txt.profile
@@ -5,8 +5,6 @@ include /etc/firejail/img2txt.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
@@ -14,6 +12,7 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/inkscape.profile
+++ b/etc/inkscape.profile
@@ -18,7 +18,8 @@ include /etc/firejail/whitelist-var-common.inc
 
 apparmor
 caps.drop all
-netfilter
+net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/jd-gui.profile
+++ b/etc/jd-gui.profile
@@ -5,8 +5,6 @@ include /etc/firejail/jd-gui.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/jd-gui.cfg
 noblacklist ${HOME}/.java
 
@@ -18,6 +16,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/kate.profile
+++ b/etc/kate.profile
@@ -5,8 +5,6 @@ include /etc/firejail/kate.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/katepartrc
 noblacklist ${HOME}/.config/katerc
 noblacklist ${HOME}/.config/kateschemarc
@@ -21,9 +19,10 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
-apparmor
+# apparmor
 caps.drop all
 # net none
+# nodbus
 netfilter
 nodvd
 nogroups

--- a/etc/kcalc.profile
+++ b/etc/kcalc.profile
@@ -22,10 +22,10 @@ include /etc/firejail/whitelist-var-common.inc
 
 apparmor
 caps.drop all
-# net none
+net none
 netfilter
 no3d
-# nodbus
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/kcalc.profile
+++ b/etc/kcalc.profile
@@ -23,7 +23,6 @@ include /etc/firejail/whitelist-var-common.inc
 apparmor
 caps.drop all
 net none
-netfilter
 no3d
 nodbus
 nodvd

--- a/etc/kcalc.profile
+++ b/etc/kcalc.profile
@@ -20,9 +20,12 @@ whitelist ${HOME}/.kde4/share/config/kcalcrc
 include /etc/firejail/whitelist-common.inc
 include /etc/firejail/whitelist-var-common.inc
 
+apparmor
 caps.drop all
+# net none
 netfilter
 no3d
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/kdenlive.profile
+++ b/etc/kdenlive.profile
@@ -5,7 +5,6 @@ include /etc/firejail/kdenlive.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus
 noblacklist ${HOME}/.cache/kdenlive
 noblacklist ${HOME}/.config/kdenliverc
 noblacklist ${HOME}/.local/share/kdenlive
@@ -18,6 +17,7 @@ include /etc/firejail/disable-programs.inc
 apparmor
 caps.drop all
 # net none
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/keepassx.profile
+++ b/etc/keepassx.profile
@@ -5,8 +5,6 @@ include /etc/firejail/keepassx.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/*.kdb
 noblacklist ${HOME}/*.kdbx
 noblacklist ${HOME}/.config/keepassx

--- a/etc/keepassxc.profile
+++ b/etc/keepassxc.profile
@@ -5,8 +5,6 @@ include /etc/firejail/keepassxc.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/*.kdb
 noblacklist ${HOME}/*.kdbx
 noblacklist ${HOME}/.config/keepassxc
@@ -22,6 +20,7 @@ include /etc/firejail/disable-programs.inc
 include /etc/firejail/whitelist-var-common.inc
 
 caps.drop all
+machine-id
 net none
 no3d
 nodvd

--- a/etc/krita.profile
+++ b/etc/krita.profile
@@ -5,7 +5,6 @@ include /etc/firejail/krita.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus
 noblacklist ${HOME}/.config/kritarc
 noblacklist ${HOME}/.local/share/krita
 
@@ -18,6 +17,7 @@ apparmor
 caps.drop all
 ipc-namespace
 # net none
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/kwrite.profile
+++ b/etc/kwrite.profile
@@ -5,8 +5,6 @@ include /etc/firejail/kwrite.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/katepartrc
 noblacklist ${HOME}/.config/katerc
 noblacklist ${HOME}/.config/kateschemarc
@@ -26,6 +24,7 @@ apparmor
 caps.drop all
 # net none
 netfilter
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/less.profile
+++ b/etc/less.profile
@@ -6,12 +6,12 @@ include /etc/firejail/less.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
 blacklist /tmp/.X11-unix
 
 ignore noroot
 net none
 no3d
+nodbus
 nodvd
 nosound
 notv

--- a/etc/libreoffice.profile
+++ b/etc/libreoffice.profile
@@ -21,6 +21,7 @@ apparmor
 caps.drop all
 machine-id
 netfilter
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/lmms.profile
+++ b/etc/lmms.profile
@@ -5,8 +5,6 @@ include /etc/firejail/lmms.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.lmmsrc.xml
 
 include /etc/firejail/disable-common.inc
@@ -18,6 +16,7 @@ caps.drop all
 ipc-namespace
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/macrofusion.profile
+++ b/etc/macrofusion.profile
@@ -5,8 +5,6 @@ include /etc/firejail/macrofusion.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/mfusion
 
 include /etc/firejail/disable-common.inc
@@ -17,6 +15,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 ipc-namespace
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/mate-calc.profile
+++ b/etc/mate-calc.profile
@@ -5,8 +5,6 @@ include /etc/firejail/mate-calc.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/mate-calc
 
 include /etc/firejail/disable-common.inc
@@ -24,6 +22,7 @@ whitelist ${HOME}/.themes
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/mediainfo.profile
+++ b/etc/mediainfo.profile
@@ -5,7 +5,6 @@ include /etc/firejail/mediainfo.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
 blacklist /tmp/.X11-unix
 
 include /etc/firejail/disable-common.inc
@@ -16,6 +15,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/meld.profile
+++ b/etc/meld.profile
@@ -5,8 +5,6 @@ include /etc/firejail/meld.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.local/share/meld
 
 include /etc/firejail/disable-common.inc
@@ -17,6 +15,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/mpv.profile
+++ b/etc/mpv.profile
@@ -18,6 +18,7 @@ include /etc/firejail/whitelist-var-common.inc
 apparmor
 caps.drop all
 netfilter
+nodbus
 nogroups
 nonewprivs
 noroot

--- a/etc/mupdf.profile
+++ b/etc/mupdf.profile
@@ -5,8 +5,6 @@ include /etc/firejail/mupdf.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
@@ -17,6 +15,7 @@ include /etc/firejail/whitelist-var-common.inc
 caps.drop all
 machine-id
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/mupen64plus.profile
+++ b/etc/mupen64plus.profile
@@ -5,8 +5,6 @@ include /etc/firejail/mupen64plus.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/mupen64plus
 noblacklist ${HOME}/.local/share/mupen64plus
 
@@ -24,6 +22,7 @@ include /etc/firejail/whitelist-common.inc
 
 caps.drop all
 net none
+nodbus
 nodvd
 nonewprivs
 noroot

--- a/etc/natron.profile
+++ b/etc/natron.profile
@@ -5,8 +5,6 @@ include /etc/firejail/natron.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.Natron
 noblacklist ${HOME}/.cache/INRIA/Natron
 noblacklist ${HOME}/.config/INRIA
@@ -19,6 +17,7 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/odt2txt.profile
+++ b/etc/odt2txt.profile
@@ -5,7 +5,6 @@ include /etc/firejail/odt2txt.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
 blacklist /tmp/.X11-unix
 
 include /etc/firejail/disable-common.inc
@@ -16,6 +15,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/okular.profile
+++ b/etc/okular.profile
@@ -5,8 +5,6 @@ include /etc/firejail/okular.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.cache/okular
 noblacklist ${HOME}/.config/okularpartrc
 noblacklist ${HOME}/.config/okularrc
@@ -30,6 +28,7 @@ caps.drop all
 machine-id
 # net none
 netfilter
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/open-invaders.profile
+++ b/etc/open-invaders.profile
@@ -5,8 +5,6 @@ include /etc/firejail/open-invaders.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.openinvaders
 
 include /etc/firejail/disable-common.inc
@@ -20,6 +18,7 @@ include /etc/firejail/whitelist-common.inc
 
 caps.drop all
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/openshot.profile
+++ b/etc/openshot.profile
@@ -18,6 +18,7 @@ include /etc/firejail/whitelist-var-common.inc
 apparmor
 caps.drop all
 netfilter
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/pcmanfm.profile
+++ b/etc/pcmanfm.profile
@@ -5,8 +5,6 @@ include /etc/firejail/pcmanfm.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.local/share/Trash
 # noblacklist ${HOME}/.config/libfm - disable-programs.inc is disabled, see below
 # noblacklist ${HOME}/.config/pcmanfm
@@ -19,6 +17,7 @@ include /etc/firejail/disable-passwdmgr.inc
 caps.drop all
 # net none - see issue #1467, computer:/// location broken
 no3d
+# nodbus
 nodvd
 nonewprivs
 noroot

--- a/etc/pdfchain.profile
+++ b/etc/pdfchain.profile
@@ -5,9 +5,6 @@ include /etc/firejail/pdfchain.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-
-blacklist /run/user/*/bus
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-programs.inc
 include /etc/firejail/disable-devel.inc
@@ -19,6 +16,7 @@ caps.drop all
 ipc-namespace
 net none
 no3d
+nodbus
 nogroups
 nonewprivs
 noroot

--- a/etc/pdfmod.profile
+++ b/etc/pdfmod.profile
@@ -5,8 +5,6 @@ include /etc/firejail/pdfmod.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.cache/pdfmod
 noblacklist ${HOME}/.config/pdfmod
 
@@ -22,6 +20,7 @@ ipc-namespace
 machine-id
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/pdfsam.profile
+++ b/etc/pdfsam.profile
@@ -5,8 +5,6 @@ include /etc/firejail/pdfsam.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.java
 
 include /etc/firejail/disable-common.inc
@@ -18,6 +16,7 @@ caps.drop all
 machine-id
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/pdftotext.profile
+++ b/etc/pdftotext.profile
@@ -5,7 +5,6 @@ include /etc/firejail/pdftotext.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
 blacklist /tmp/.X11-unix
 
 include /etc/firejail/disable-common.inc
@@ -19,6 +18,7 @@ caps.drop all
 machine-id
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/peek.profile
+++ b/etc/peek.profile
@@ -5,8 +5,6 @@ include /etc/firejail/peek.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.cache/peek
 
 include /etc/firejail/disable-common.inc
@@ -17,6 +15,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/pingus.profile
+++ b/etc/pingus.profile
@@ -5,8 +5,6 @@ include /etc/firejail/pingus.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.pingus
 
 include /etc/firejail/disable-common.inc
@@ -20,6 +18,7 @@ include /etc/firejail/whitelist-common.inc
 
 caps.drop all
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/pinta.profile
+++ b/etc/pinta.profile
@@ -5,8 +5,6 @@ include /etc/firejail/pinta.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/Pinta
 
 include /etc/firejail/disable-common.inc
@@ -17,6 +15,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 ipc-namespace
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/pluma.profile
+++ b/etc/pluma.profile
@@ -5,8 +5,6 @@ include /etc/firejail/pluma.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus - makes settings immutable
-
 noblacklist ${HOME}/.config/pluma
 
 include /etc/firejail/disable-common.inc
@@ -16,10 +14,14 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
+apparmor
 caps.drop all
-# net none - makes settings immutable
 machine-id
+net none
 no3d
+# following line makes settings immutable
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/pluma.profile
+++ b/etc/pluma.profile
@@ -21,7 +21,7 @@ machine-id
 net none
 no3d
 # following line makes settings immutable
-nodbus
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/pluma.profile
+++ b/etc/pluma.profile
@@ -14,14 +14,12 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
-# following line makes settings immutable
-apparmor
+# apparmor - makes settings immutable
 caps.drop all
 machine-id
-net none
+# net none - makes settings immutable
 no3d
-# following line makes settings immutable
-# nodbus
+# nodbus - makes settings immutable
 nodvd
 nogroups
 nonewprivs

--- a/etc/qbittorrent.profile
+++ b/etc/qbittorrent.profile
@@ -30,6 +30,7 @@ apparmor
 caps.drop all
 machine-id
 netfilter
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/ranger.profile
+++ b/etc/ranger.profile
@@ -5,8 +5,6 @@ include /etc/firejail/ranger.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 # noblacklist /usr/bin/cpan*
 noblacklist /usr/bin/perl
 noblacklist /usr/lib/perl*
@@ -20,6 +18,7 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/rhythmbox.profile
+++ b/etc/rhythmbox.profile
@@ -13,10 +13,13 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
 apparmor
 caps.drop all
 netfilter
 # no3d
+# following line makes settings immutable
+nodbus
 nogroups
 nonewprivs
 noroot

--- a/etc/rhythmbox.profile
+++ b/etc/rhythmbox.profile
@@ -13,13 +13,11 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
-# following line makes settings immutable
-apparmor
+# apparmor - makes settings immutable
 caps.drop all
 netfilter
 # no3d
-# following line makes settings immutable
-# nodbus
+# nodbus - makes settings immutable
 nogroups
 nonewprivs
 noroot

--- a/etc/rhythmbox.profile
+++ b/etc/rhythmbox.profile
@@ -19,7 +19,7 @@ caps.drop all
 netfilter
 # no3d
 # following line makes settings immutable
-nodbus
+# nodbus
 nogroups
 nonewprivs
 noroot

--- a/etc/scribus.profile
+++ b/etc/scribus.profile
@@ -48,5 +48,5 @@ tracelog
 private-dev
 private-tmp
 
-# noexec ${HOME}
+noexec ${HOME}
 noexec /tmp

--- a/etc/scribus.profile
+++ b/etc/scribus.profile
@@ -5,8 +5,6 @@ include /etc/firejail/scribus.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 # Support for PDF readers comes with Scribus 1.5 and higher
 noblacklist ${HOME}/.cache/okular
 noblacklist ${HOME}/.config/okularpartrc
@@ -33,6 +31,7 @@ include /etc/firejail/whitelist-var-common.inc
 
 caps.drop all
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs
@@ -48,3 +47,6 @@ tracelog
 # private-bin scribus,gs,gimp*
 private-dev
 private-tmp
+
+# noexec ${HOME}
+noexec /tmp

--- a/etc/sdat2img.profile
+++ b/etc/sdat2img.profile
@@ -6,8 +6,6 @@ include /etc/firejail/sdat2img.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
@@ -16,6 +14,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/shotcut.profile
+++ b/etc/shotcut.profile
@@ -5,8 +5,6 @@ include /etc/firejail/shotcut.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/Meltytech
 
 include /etc/firejail/disable-common.inc
@@ -16,6 +14,7 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/simutrans.profile
+++ b/etc/simutrans.profile
@@ -5,8 +5,6 @@ include /etc/firejail/simutrans.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.simutrans
 
 include /etc/firejail/disable-common.inc
@@ -20,6 +18,7 @@ include /etc/firejail/whitelist-common.inc
 
 caps.drop all
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/skanlite.profile
+++ b/etc/skanlite.profile
@@ -5,8 +5,6 @@ include /etc/firejail/skanlite.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
@@ -15,6 +13,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 # net none
 netfilter
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/smplayer.profile
+++ b/etc/smplayer.profile
@@ -18,6 +18,7 @@ include /etc/firejail/whitelist-var-common.inc
 apparmor
 caps.drop all
 netfilter
+# nodbus
 # nogroups
 nonewprivs
 noroot

--- a/etc/sqlitebrowser.profile
+++ b/etc/sqlitebrowser.profile
@@ -5,8 +5,6 @@ include /etc/firejail/sqlitebrowser.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/sqlitebrowser
 
 include /etc/firejail/disable-common.inc
@@ -17,6 +15,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/strings.profile
+++ b/etc/strings.profile
@@ -6,12 +6,12 @@ include /etc/firejail/strings.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
 blacklist /tmp/.X11-unix
 
 ignore noroot
 net none
 no3d
+nodbus
 nodvd
 nosound
 notv

--- a/etc/supertux2.profile
+++ b/etc/supertux2.profile
@@ -5,8 +5,6 @@ include /etc/firejail/supertux2.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.local/share/supertux2
 
 include /etc/firejail/disable-common.inc
@@ -21,6 +19,7 @@ include /etc/firejail/whitelist-var-common.inc
 
 caps.drop all
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/synfigstudio.profile
+++ b/etc/synfigstudio.profile
@@ -5,8 +5,6 @@ include /etc/firejail/synfigstudio.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/synfig
 noblacklist ${HOME}/.synfig
 
@@ -17,6 +15,7 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/tar.profile
+++ b/etc/tar.profile
@@ -6,13 +6,13 @@ include /etc/firejail/tar.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
 blacklist /tmp/.X11-unix
 
 hostname tar
 ignore noroot
 net none
 no3d
+nodbus
 nodvd
 nosound
 notv

--- a/etc/terasology.profile
+++ b/etc/terasology.profile
@@ -5,8 +5,6 @@ include /etc/firejail/terasology.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.java
 noblacklist ${HOME}/.local/share/terasology
 
@@ -25,6 +23,7 @@ caps.drop all
 ipc-namespace
 net none
 netfilter
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/totem.profile
+++ b/etc/totem.profile
@@ -15,12 +15,10 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
-# following line makes settings immutable
-apparmor
+# apparmor - makes settings immutable
 caps.drop all
 netfilter
-# following line makes settings immutable
-# nodbus
+# nodbus - makes settings immutable
 nogroups
 nonewprivs
 noroot

--- a/etc/totem.profile
+++ b/etc/totem.profile
@@ -20,7 +20,7 @@ apparmor
 caps.drop all
 netfilter
 # following line makes settings immutable
-nodbus
+# nodbus
 nogroups
 nonewprivs
 noroot

--- a/etc/totem.profile
+++ b/etc/totem.profile
@@ -15,9 +15,12 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
 apparmor
 caps.drop all
 netfilter
+# following line makes settings immutable
+nodbus
 nogroups
 nonewprivs
 noroot

--- a/etc/transmission-gtk.profile
+++ b/etc/transmission-gtk.profile
@@ -25,6 +25,7 @@ apparmor
 caps.drop all
 machine-id
 netfilter
+nodbus
 nodvd
 nonewprivs
 noroot

--- a/etc/transmission-qt.profile
+++ b/etc/transmission-qt.profile
@@ -25,6 +25,7 @@ apparmor
 caps.drop all
 machine-id
 netfilter
+nodbus
 nodvd
 nonewprivs
 noroot

--- a/etc/transmission-show.profile
+++ b/etc/transmission-show.profile
@@ -5,8 +5,6 @@ include /etc/firejail/transmission-show.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.cache/transmission
 noblacklist ${HOME}/.config/transmission
 
@@ -18,6 +16,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 machine-id
 net none
+nodbus
 nodvd
 nonewprivs
 noroot

--- a/etc/uefitool.profile
+++ b/etc/uefitool.profile
@@ -5,8 +5,6 @@ include /etc/firejail/uefitool.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
@@ -16,6 +14,7 @@ caps.drop all
 ipc-namespace
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/unrar.profile
+++ b/etc/unrar.profile
@@ -6,13 +6,13 @@ include /etc/firejail/unrar.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
 blacklist /tmp/.X11-unix
 
 hostname unrar
 ignore noroot
 net none
 no3d
+nodbus
 nodvd
 nosound
 notv

--- a/etc/unzip.profile
+++ b/etc/unzip.profile
@@ -6,13 +6,13 @@ include /etc/firejail/unzip.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
 blacklist /tmp/.X11-unix
 
 hostname unzip
 ignore noroot
 net none
 no3d
+nodbus
 nodvd
 nosound
 notv

--- a/etc/uudeview.profile
+++ b/etc/uudeview.profile
@@ -6,11 +6,10 @@ include /etc/firejail/uudeview.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 hostname uudeview
 ignore noroot
 net none
+nodbus
 nodvd
 nosound
 notv

--- a/etc/viewnior.profile
+++ b/etc/viewnior.profile
@@ -5,7 +5,6 @@ include /etc/firejail/viewnior.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
 blacklist ${HOME}/.bashrc
 
 noblacklist ${HOME}/.Steam
@@ -20,6 +19,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/vlc.profile
+++ b/etc/vlc.profile
@@ -18,6 +18,7 @@ include /etc/firejail/whitelist-var-common.inc
 apparmor
 caps.drop all
 netfilter
+# nodbus
 # nogroups
 nonewprivs
 noroot

--- a/etc/x-terminal-emulator.profile
+++ b/etc/x-terminal-emulator.profile
@@ -5,12 +5,11 @@ include /etc/firejail/x-terminal-emulator.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 caps.drop all
 ipc-namespace
 net none
 netfilter
+nodbus
 nogroups
 noroot
 protocol unix

--- a/etc/xcalc.profile
+++ b/etc/xcalc.profile
@@ -5,8 +5,6 @@ include /etc/firejail/xcalc.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
@@ -18,6 +16,7 @@ caps.drop all
 net none
 netfilter
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/xed.profile
+++ b/etc/xed.profile
@@ -21,7 +21,7 @@ machine-id
 net none
 no3d
 # following line makes settings immutable
-nodbus
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/xed.profile
+++ b/etc/xed.profile
@@ -14,14 +14,12 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
-# following line makes settings immutable
-apparmor
+# apparmor - makes settings immutable
 caps.drop all
 machine-id
-net none
+# net none - makes settings immutable
 no3d
-# following line makes settings immutable
-# nodbus
+# nodbus - makes settings immutable
 nodvd
 nogroups
 nonewprivs

--- a/etc/xed.profile
+++ b/etc/xed.profile
@@ -5,8 +5,6 @@ include /etc/firejail/xed.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus - makes settings immutable
-
 noblacklist ${HOME}/.config/xed
 
 include /etc/firejail/disable-common.inc
@@ -16,10 +14,14 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
+apparmor
 caps.drop all
-# net none - makes settings immutable
 machine-id
+net none
 no3d
+# following line makes settings immutable
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/xpdf.profile
+++ b/etc/xpdf.profile
@@ -5,8 +5,6 @@ include /etc/firejail/xpdf.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.xpdfrc
 
 include /etc/firejail/disable-common.inc
@@ -20,6 +18,7 @@ caps.drop all
 machine-id
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/xplayer.profile
+++ b/etc/xplayer.profile
@@ -15,12 +15,10 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
-# following line makes settings immutable
-apparmor
+# apparmor - makes settings immutable
 caps.drop all
 netfilter
-# following line makes settings immutable
-# nodbus
+# nodbus - makes settings immutable
 nogroups
 nonewprivs
 noroot

--- a/etc/xplayer.profile
+++ b/etc/xplayer.profile
@@ -20,7 +20,7 @@ apparmor
 caps.drop all
 netfilter
 # following line makes settings immutable
-nodbus
+# nodbus
 nogroups
 nonewprivs
 noroot

--- a/etc/xplayer.profile
+++ b/etc/xplayer.profile
@@ -15,8 +15,12 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
+apparmor
 caps.drop all
 netfilter
+# following line makes settings immutable
+nodbus
 nogroups
 nonewprivs
 noroot

--- a/etc/xreader.profile
+++ b/etc/xreader.profile
@@ -16,6 +16,7 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# apparmor
 caps.drop all
 no3d
 nodvd

--- a/etc/xviewer.profile
+++ b/etc/xviewer.profile
@@ -17,13 +17,11 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
-# following line makes settings immutable
-apparmor
+# apparmor - makes settings immutable
 caps.drop all
-net none
+# net none - makes settings immutable
 no3d
-# following line makes settings immutable
-# nodbus
+# nodbus - makes settings immutable
 nodvd
 nogroups
 nonewprivs

--- a/etc/xviewer.profile
+++ b/etc/xviewer.profile
@@ -23,7 +23,7 @@ caps.drop all
 net none
 no3d
 # following line makes settings immutable
-nodbus
+# nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/xviewer.profile
+++ b/etc/xviewer.profile
@@ -5,8 +5,6 @@ include /etc/firejail/xviewer.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus - makes settings immutable
-
 noblacklist ${HOME}/.Steam
 noblacklist ${HOME}/.config/xviewer
 noblacklist ${HOME}/.local/share/Trash
@@ -19,9 +17,13 @@ include /etc/firejail/disable-programs.inc
 
 include /etc/firejail/whitelist-var-common.inc
 
+# following line makes settings immutable
+apparmor
 caps.drop all
-# net none - makes settings immutable
+net none
 no3d
+# following line makes settings immutable
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/xzdec.profile
+++ b/etc/xzdec.profile
@@ -6,12 +6,12 @@ include /etc/firejail/xzdec.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
 blacklist /tmp/.X11-unix
 
 ignore noroot
 net none
 no3d
+nodbus
 nodvd
 nosound
 notv

--- a/etc/zart.profile
+++ b/etc/zart.profile
@@ -5,8 +5,6 @@ include /etc/firejail/zart.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-blacklist /run/user/*/bus
-
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
@@ -15,6 +13,7 @@ include /etc/firejail/disable-programs.inc
 caps.drop all
 ipc-namespace
 net none
+nodbus
 nodvd
 nogroups
 nonewprivs

--- a/etc/zathura.profile
+++ b/etc/zathura.profile
@@ -5,8 +5,6 @@ include /etc/firejail/zathura.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-# blacklist /run/user/*/bus
-
 noblacklist ${HOME}/.config/zathura
 noblacklist ${HOME}/.local/share/zathura
 
@@ -17,6 +15,7 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 # net none
+# nodbus
 nodvd
 nogroups
 nonewprivs
@@ -31,5 +30,6 @@ private-bin zathura
 private-dev
 private-etc fonts
 private-tmp
+
 read-only ${HOME}/
 read-write ${HOME}/.local/share/zathura/


### PR DESCRIPTION
see #1822 and #1825.

- systematically replaces `blacklist /run/user/*/bus` with `nodbus` in all profiles
- enables `nodbus` in profiles with `apparmor` (except the app uses the KDE file dialog)
- moving forward, the "settings immutable" warning is omitted for `net none`. As less and less users are affected by the side-effects of `net none`, the hope is this helps to reduce confusion (rather than add to it).
- comments `apparmor` in the kate profile, based on the assumption that the execution restrictions break workflows relying on the embedded compiler or terminal window
- with contributions from @Fred-Barclay (001c7e62c7703e80024b00d9dab7206d1deda985)