### PR TITLE
Add a section for cloud-providers to the default block-list

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -297,6 +297,13 @@ blacklist /etc/ssh
 blacklist /home/.ecryptfs
 blacklist /var/backup
 
+# cloud provider configuration
+blacklist ${HOME}/.aws
+blacklist ${HOME}/.boto
+blacklist /etc/boto.cfg
+blacklist ${HOME}/.config/gcloud
+blacklist ${HOME}/.kube
+
 # system directories
 blacklist /sbin
 blacklist /usr/local/sbin


### PR DESCRIPTION
AWS and GCP store credentials in local directories as part of project setup.

Configuration for cloud providers is sensitive information; it should be
in the default block list. I didn't see profiles for gcloud or awscli,
so haven't added any exclusions.
    
boto and kubectl are not provider-specific, but also store credentials for
whichever platforms they happen to be being used with.
