### PR TITLE
Added a basic profile for gcloud

### DIFF
--- a/etc/gcloud.profile
+++ b/etc/gcloud.profile
@@ -1,0 +1,40 @@
+# Firejail profile for gcloud
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /usr/local/etc/firejail/gcloud.local
+# Persistent global definitions
+include /usr/local/etc/firejail/globals.local
+
+noblacklist ${HOME}/.boto
+noblacklist ${HOME}/.config/gcloud
+noblacklist /var/run/docker.sock
+
+include /usr/local/etc/firejail/disable-common.inc
+include /usr/local/etc/firejail/disable-devel.inc
+include /usr/local/etc/firejail/disable-programs.inc
+
+apparmor
+caps.drop all
+machine-id
+netfilter
+nodbus
+nodvd
+# required for sudo-free docker
+#nogroups
+nonewprivs
+noroot
+notv
+protocol unix,inet,inet6
+seccomp
+shell none
+tracelog
+
+disable-mnt
+private-dev
+private-etc ca-certificates,ssl,hosts,localtime,nsswitch.conf,resolv.conf,pki,crypto-policies,ld.so.cache
+private-tmp
+
+noexec /tmp
+
+# will break user-local installs of gcloud tooling
+# noexec ${HOME}

--- a/etc/gcloud.profile
+++ b/etc/gcloud.profile
@@ -1,17 +1,17 @@
 # Firejail profile for gcloud
 # This file is overwritten after every install/update
 # Persistent local customizations
-include /usr/local/etc/firejail/gcloud.local
+include /etc/firejail/gcloud.local
 # Persistent global definitions
-include /usr/local/etc/firejail/globals.local
+include /etc/firejail/globals.local
 
 noblacklist ${HOME}/.boto
 noblacklist ${HOME}/.config/gcloud
 noblacklist /var/run/docker.sock
 
-include /usr/local/etc/firejail/disable-common.inc
-include /usr/local/etc/firejail/disable-devel.inc
-include /usr/local/etc/firejail/disable-programs.inc
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-programs.inc
 
 apparmor
 caps.drop all


### PR DESCRIPTION
Hi, another quick one hopefully. I tested the profile out with the following workflows:
* `gcloud init`
* `gcloud docker -- push ...`
* `gcloud compute instances list`

All seemed okay; I think the docker integration is the only thing that requires any "interesting" permissions, and the rest is just speaking to an API.

gcloud is the Google Cloud Platform's cli. It understands how to interact with GCP's endpoint, and it need to read config and creds from the user's $HOME, plus it integrates with docker-cli.

