### PR TITLE
Fix private-lib again

### DIFF
--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -38,6 +38,8 @@ private-etc fonts
 
 #private-lib - seems to be breaking on Gnome Shell 3.26.2, Mutter WM, issue 1711
 #private-lib evince,libpoppler-glib.so.8
+# private-lib fix slipped through the cracks of earlier, reverted commit
+private-lib evince,gdk-pixbuf-2.0,gio,gvfs/libgvfscommon.so,libgconf-2.so.4,libpoppler-glib.so.8,librsvg-2.so.2
 
 private-tmp
 

--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -37,7 +37,6 @@ private-dev
 private-etc fonts
 
 #private-lib - seems to be breaking on Gnome Shell 3.26.2, Mutter WM, issue 1711
-#private-lib evince,libpoppler-glib.so.8
 private-lib evince,gdk-pixbuf-2.0,gio,gvfs/libgvfscommon.so,libgconf-2.so.4,libpoppler-glib.so.8,librsvg-2.so.2
 
 private-tmp

--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -38,7 +38,6 @@ private-etc fonts
 
 #private-lib - seems to be breaking on Gnome Shell 3.26.2, Mutter WM, issue 1711
 #private-lib evince,libpoppler-glib.so.8
-# private-lib fix slipped through the cracks of earlier, reverted commit
 private-lib evince,gdk-pixbuf-2.0,gio,gvfs/libgvfscommon.so,libgconf-2.so.4,libpoppler-glib.so.8,librsvg-2.so.2
 
 private-tmp


### PR DESCRIPTION
During conversation on an [earlier attempt at fixing evince](https://github.com/netblue30/firejail/pull/1829) and the entailing [revert-commit](https://github.com/netblue30/firejail/pull/1829/commits/45732a22d1ea4ec0ade0775be7243e8669b7f850) this slipped through the cracks. The fix is tested on Gnome Shell 3.26.2 and 3.28.0 (on Arch).

I noticed the original issue #1711 is closed and tagged `in testing`. Feel free to postpone/close/disregard this fix untill testing is finished. Just wanted to remind people that a fix is available.