### PR TITLE
add --noautopulse arg for complex pulse setups

### DIFF
--- a/RELNOTES
+++ b/RELNOTES
@@ -1,5 +1,6 @@
 firejail (0.9.53) baseline; urgency=low
   * work in progress
+  * add --noautopulse to disable automatic ~/.config/pulse (for complex setups)
   * modif: support for private-bin, private-lib and shell none has been
      disabled while running AppImage archives in order to be able to use
      our regular profile files with AppImages.

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -357,6 +357,7 @@ extern int arg_private_lib;	// private lib directory
 extern int arg_scan;		// arp-scan all interfaces
 extern int arg_whitelist;	// whitelist commad
 extern int arg_nosound;	// disable sound
+extern int arg_noautopulse; // disable automatic ~/.config/pulse init
 extern int arg_novideo; //disable video devices in /dev
 extern int arg_no3d;		// disable 3d hardware acceleration
 extern int arg_quiet;		// no output for scripting

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -94,6 +94,7 @@ int arg_private_lib = 0;			// private lib directory
 int arg_scan = 0;				// arp-scan all interfaces
 int arg_whitelist = 0;				// whitelist commad
 int arg_nosound = 0;				// disable sound
+int arg_noautopulse = 0;			// disable automatic ~/.config/pulse init
 int arg_novideo = 0;			//disable video devices in /dev
 int arg_no3d;					// disable 3d hardware acceleration
 int arg_quiet = 0;				// no output for scripting
@@ -1727,6 +1728,8 @@ int main(int argc, char **argv) {
 			env_store(argv[i] + 8, RMENV);
 		else if (strcmp(argv[i], "--nosound") == 0)
 			arg_nosound = 1;
+		else if (strcmp(argv[i], "--noautopulse") == 0)
+			arg_noautopulse = 1;
 		else if (strcmp(argv[i], "--novideo") == 0)
 			arg_novideo = 1;
 		else if (strcmp(argv[i], "--no3d") == 0)

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -233,6 +233,10 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		arg_nosound = 1;
 		return 0;
 	}
+	else if (strcmp(ptr, "noautopulse") == 0) {
+		arg_noautopulse = 1;
+		return 0;
+	}
 	else if (strcmp(ptr, "notv") == 0) {
 		arg_notv = 1;
 		return 0;

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -889,7 +889,7 @@ int sandbox(void* sandbox_arg) {
 		// disable /dev/snd
 		fs_dev_disable_sound();
 	}
-	else
+	else if (!arg_noautopulse)
 		pulseaudio_init();
 
 	if (arg_no3d)

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -143,6 +143,7 @@ void usage(void) {
 	printf("    --noroot - install a user namespace with only the current user.\n");
 #endif
 	printf("    --nosound - disable sound system.\n");
+	printf("    --noautopulse - disable automatic ~/.config/pulse init.\n");
 	printf("    --novideo - disable video devices.\n");
 	printf("    --nowhitelist=filename - disable whitelist for file or directory .\n");
 	printf("    --output=logfile - stdout logging and log rotation.\n");

--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -451,6 +451,10 @@ Enable IPC namespace.
 \fBnosound
 Disable sound system.
 .TP
+\fBnoautopulse
+Disable automatic ~/.config/pulse init, for complex setups such as remote
+pulse servers or non-standard socket paths.
+.TP
 \fBnotv
 Disable DVB (Digital Video Broadcasting) TV devices.
 .TP

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -1199,6 +1199,17 @@ Example:
 $ firejail \-\-nosound firefox
 
 .TP
+\fB\-\-noautopulse
+Disable automatic ~/.config/pulse init, for complex setups such as remote
+pulse servers or non-standard socket paths.
+.br
+
+.br
+Example:
+.br
+$ firejail \-\-noautopulse firefox
+
+.TP
 \fB\-\-notv
 Disable DVB (Digital Video Broadcasting) TV devices.
 .br


### PR DESCRIPTION
such as remote pulse servers or non-standard socket paths

closes #1028