### PR TITLE
syntax fixup

### DIFF
--- a/etc/makepkg.profile
+++ b/etc/makepkg.profile
@@ -41,7 +41,7 @@ no3d
 nodvd
 nogroups
 nonewprivs
-# noroot is only disabled to allow the creation of kernel headers from an official pckgbuild.
+# noroot is only disabled to allow the creation of kernel headers from an official PKGBUILD.
 #noroot
 nosound
 notv


### PR DESCRIPTION
Using `PKGBUILD` instead of `pckgbuild` might be slightly more familiar for Arch users.