### PR TITLE
mpd config modernizing

### DIFF
--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -168,6 +168,7 @@ blacklist ${HOME}/.config/mate/mate-dictionary
 blacklist ${HOME}/.config/mfusion
 blacklist ${HOME}/.config/midori
 blacklist ${HOME}/.config/mono
+blacklist ${HOME}/.config/mpd
 blacklist ${HOME}/.config/mpv
 blacklist ${HOME}/.config/mupen64plus
 blacklist ${HOME}/.config/nautilus

--- a/etc/mpd.profile
+++ b/etc/mpd.profile
@@ -5,8 +5,8 @@ include /etc/firejail/mpd.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-
 noblacklist ${HOME}/.mpdconf
+noblacklist ${HOME}/.config/mpd
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc


### PR DESCRIPTION
Current mpd profile uses outdated ${HOME}/.mpdconf noblacklist location. Not sure that was ever actually used (I remember ~/.mpd). Bring in support for freedesktop location `${HOME}/.config/mpd`, as per [official documentation](https://www.musicpd.org/doc/user/config.html#config_file).