### PR TITLE
Config support fixup

### DIFF
--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -441,6 +441,7 @@ blacklist ${HOME}/.mcabberrc
 blacklist ${HOME}/.mediathek3
 blacklist ${HOME}/.minetest
 blacklist ${HOME}/.mozilla
+blacklist ${HOME}/.mpd
 blacklist ${HOME}/.mpdconf
 blacklist ${HOME}/.mplayer
 blacklist ${HOME}/.msmtprc

--- a/etc/mpd.profile
+++ b/etc/mpd.profile
@@ -5,8 +5,9 @@ include /etc/firejail/mpd.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-noblacklist ${HOME}/.mpdconf
 noblacklist ${HOME}/.config/mpd
+noblacklist ${HOME}/.mpd
+noblacklist ${HOME}/.mpdconf
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc


### PR DESCRIPTION
Support less/non-standard config dir too. On Ubuntu 16.04 mpd still looks at ` ~/.mpd` for defaults.