### PR TITLE
Update enchant profile

### DIFF
--- a/etc/enchant-2.profile
+++ b/etc/enchant-2.profile
@@ -1,0 +1,9 @@
+# Firejail profile for enchant-2
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/enchant-2.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+# Redirect
+include /etc/firejail/enchant.profile

--- a/etc/enchant-lsmod-2.profile
+++ b/etc/enchant-lsmod-2.profile
@@ -1,0 +1,9 @@
+# Firejail profile for enchant-lsmod-2
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/enchant-lsmod-2.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+# Redirect
+include /etc/firejail/enchant.profile

--- a/etc/enchant-lsmod.profile
+++ b/etc/enchant-lsmod.profile
@@ -1,0 +1,9 @@
+# Firejail profile for enchant-lsmod
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/enchant-lsmod.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+# Redirect
+include /etc/firejail/enchant.profile

--- a/etc/enchant.profile
+++ b/etc/enchant.profile
@@ -15,6 +15,8 @@ include /etc/firejail/disable-programs.inc
 
 caps.drop all
 netfilter
+no3d
+nodbus
 nodvd
 nogroups
 nonewprivs
@@ -27,7 +29,11 @@ seccomp
 shell none
 tracelog
 
-# private-bin enchant
-# private-dev
-# private-etc fonts
-# private-tmp
+# private-bin enchant, enchant-*
+private-dev
+private-etc none
+private-tmp
+
+# memory-deny-write-execute
+noexec ${HOME}
+noexec /tmp


### PR DESCRIPTION
Added `nodbus` and brushed-up the profile some more. Arch uses `enchant-2` & `enchant-lsmod-2` executables, while Debian/Ubuntu have `enchant` & `enchant-lsmod`. Introduced new redirect files to cope with those differences.