### PR TITLE
Potential fixes for Firefox 60

### DIFF
--- a/etc/basilisk.profile
+++ b/etc/basilisk.profile
@@ -12,26 +12,6 @@ include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 
-# These are uncommented in the Firefox profile. If you run into trouble you may
-# want to uncomment (some of) them.
-#whitelist ${HOME}/dwhelper
-#whitelist ${HOME}/.zotero
-#whitelist ${HOME}/.vimperatorrc
-#whitelist ${HOME}/.vimperator
-#whitelist ${HOME}/.pentadactylrc
-#whitelist ${HOME}/.pentadactyl
-#whitelist ${HOME}/.keysnail.js
-#whitelist ${HOME}/.config/gnome-mplayer
-#whitelist ${HOME}/.cache/gnome-mplayer/plugin
-#whitelist ${HOME}/.pki
-#whitelist ${HOME}/.lastpass
-
-# For silverlight
-#whitelist ${HOME}/.wine-pipelight
-#whitelist ${HOME}/.wine-pipelight64
-#whitelist ${HOME}/.config/pipelight-widevine
-#whitelist ${HOME}/.config/pipelight-silverlight5.1
-
 mkdir ${HOME}/.cache/moonchild productions/basilisk
 mkdir ${HOME}/.moonchild productions
 whitelist ${DOWNLOADS}
@@ -39,8 +19,12 @@ whitelist ${HOME}/.cache/moonchild productions/basilisk
 whitelist ${HOME}/.moonchild productions
 include /etc/firejail/whitelist-common.inc
 
+apparmor
 caps.drop all
+# machine-id breaks pulse audio; it should work fine in setups where sound is not required
+# machine-id
 netfilter
+nodbus
 nodvd
 nogroups
 nonewprivs
@@ -51,11 +35,12 @@ seccomp
 shell none
 tracelog
 
+disable-mnt
 # private-bin basilisk
-# private-dev (disabled for now as it will interfere with webcam use in basilisk)
+private-dev
 # private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse
 # private-opt basilisk
 private-tmp
 
-disable-mnt
+noexec ${HOME}
 

--- a/etc/basilisk.profile
+++ b/etc/basilisk.profile
@@ -1,23 +1,60 @@
-# Firejail profile for basilisk
+# Firejail profile for palemoon
 # This file is overwritten after every install/update
 # Persistent local customizations
-include /etc/firejail/basilisk.local
+include /etc/firejail/palemoon.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-noblacklist ${HOME}/.cache/moonchild productions/basilisk
-noblacklist ${HOME}/.moonchild productions/basilisk
+noblacklist ${HOME}/.cache/moonchild productions/pale moon
+noblacklist ${HOME}/.moonchild productions/pale moon
 
-mkdir ${HOME}/.cache/moonchild productions/basilisk
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-programs.inc
+
+# These are uncommented in the Firefox profile. If you run into trouble you may
+# want to uncomment (some of) them.
+#whitelist ${HOME}/dwhelper
+#whitelist ${HOME}/.zotero
+#whitelist ${HOME}/.vimperatorrc
+#whitelist ${HOME}/.vimperator
+#whitelist ${HOME}/.pentadactylrc
+#whitelist ${HOME}/.pentadactyl
+#whitelist ${HOME}/.keysnail.js
+#whitelist ${HOME}/.config/gnome-mplayer
+#whitelist ${HOME}/.cache/gnome-mplayer/plugin
+#whitelist ${HOME}/.pki
+#whitelist ${HOME}/.lastpass
+
+# For silverlight
+#whitelist ${HOME}/.wine-pipelight
+#whitelist ${HOME}/.wine-pipelight64
+#whitelist ${HOME}/.config/pipelight-widevine
+#whitelist ${HOME}/.config/pipelight-silverlight5.1
+
+mkdir ${HOME}/.cache/moonchild productions/pale moon
 mkdir ${HOME}/.moonchild productions
 whitelist ${DOWNLOADS}
-whitelist ${HOME}/.cache/moonchild productions/basilisk
+whitelist ${HOME}/.cache/moonchild productions/pale moon
 whitelist ${HOME}/.moonchild productions
+include /etc/firejail/whitelist-common.inc
 
-#private-bin basilisk
-# private-etc must first be enabled in firefox-common.profile
-#private-etc basilisk
-#private-opt basilisk
+caps.drop all
+netfilter
+nodvd
+nogroups
+nonewprivs
+noroot
+notv
+protocol unix,inet,inet6,netlink
+seccomp
+shell none
+tracelog
 
-# Redirect
-include /etc/firejail/firefox-common.profile
+# private-bin palemoon
+# private-dev (disabled for now as it will interfere with webcam use in palemoon)
+# private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse
+# private-opt palemoon
+private-tmp
+
+disable-mnt

--- a/etc/basilisk.profile
+++ b/etc/basilisk.profile
@@ -1,12 +1,12 @@
-# Firejail profile for palemoon
+# Firejail profile for basilisk
 # This file is overwritten after every install/update
 # Persistent local customizations
-include /etc/firejail/palemoon.local
+include /etc/firejail/basilisk.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
-noblacklist ${HOME}/.cache/moonchild productions/pale moon
-noblacklist ${HOME}/.moonchild productions/pale moon
+noblacklist ${HOME}/.cache/moonchild productions/basilisk
+noblacklist ${HOME}/.moonchild productions/basilisk
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
@@ -32,10 +32,10 @@ include /etc/firejail/disable-programs.inc
 #whitelist ${HOME}/.config/pipelight-widevine
 #whitelist ${HOME}/.config/pipelight-silverlight5.1
 
-mkdir ${HOME}/.cache/moonchild productions/pale moon
+mkdir ${HOME}/.cache/moonchild productions/basilisk
 mkdir ${HOME}/.moonchild productions
 whitelist ${DOWNLOADS}
-whitelist ${HOME}/.cache/moonchild productions/pale moon
+whitelist ${HOME}/.cache/moonchild productions/basilisk
 whitelist ${HOME}/.moonchild productions
 include /etc/firejail/whitelist-common.inc
 
@@ -51,10 +51,11 @@ seccomp
 shell none
 tracelog
 
-# private-bin palemoon
-# private-dev (disabled for now as it will interfere with webcam use in palemoon)
+# private-bin basilisk
+# private-dev (disabled for now as it will interfere with webcam use in basilisk)
 # private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse
-# private-opt palemoon
+# private-opt basilisk
 private-tmp
 
 disable-mnt
+

--- a/etc/firefox-common.profile
+++ b/etc/firefox-common.profile
@@ -33,8 +33,9 @@ nonewprivs
 noroot
 notv
 protocol unix,inet,inet6,netlink
-seccomp
-shell none
+seccomp.drop @clock,@cpu-emulation,@debug,@module,@obsolete,@raw-io,@reboot,@resources,@swap,acct,add_key,bpf,fanotify_init,io_cancel,io_destroy,io_getevents,io_setup,io_submit,ioprio_set,kcmp,keyctl,mount,name_to_handle_at,nfsservctl,ni_syscall,open_by_handle_at,personality,process_vm_readv,ptrace,remap_file_pages,request_key,setdomainname,sethostname,syslog,umount,umount2,userfaultfd,vhangup,vmsplice
+# Shell none breaks firefox>=60, see issue #1765
+# shell none
 tracelog
 
 disable-mnt

--- a/etc/firejail-default
+++ b/etc/firejail-default
@@ -72,6 +72,7 @@ owner /run/firejail/mnt/oroot/{run,dev}/shm/** rmwk,
 ##########
 /proc/ r,
 /proc/** r,
+owner /proc/[0-9]*/{uid_map,gid_map,setgroups} w,
 # Uncomment to silence all denied write warnings
 #deny /proc/** w,
 deny /proc/@{PID}/oom_adj w,

--- a/etc/palemoon.profile
+++ b/etc/palemoon.profile
@@ -8,15 +8,53 @@ include /etc/firejail/globals.local
 noblacklist ${HOME}/.cache/moonchild productions/pale moon
 noblacklist ${HOME}/.moonchild productions/pale moon
 
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-programs.inc
+
+# These are uncommented in the Firefox profile. If you run into trouble you may
+# want to uncomment (some of) them.
+#whitelist ${HOME}/dwhelper
+#whitelist ${HOME}/.zotero
+#whitelist ${HOME}/.vimperatorrc
+#whitelist ${HOME}/.vimperator
+#whitelist ${HOME}/.pentadactylrc
+#whitelist ${HOME}/.pentadactyl
+#whitelist ${HOME}/.keysnail.js
+#whitelist ${HOME}/.config/gnome-mplayer
+#whitelist ${HOME}/.cache/gnome-mplayer/plugin
+#whitelist ${HOME}/.pki
+#whitelist ${HOME}/.lastpass
+
+# For silverlight
+#whitelist ${HOME}/.wine-pipelight
+#whitelist ${HOME}/.wine-pipelight64
+#whitelist ${HOME}/.config/pipelight-widevine
+#whitelist ${HOME}/.config/pipelight-silverlight5.1
+
 mkdir ${HOME}/.cache/moonchild productions/pale moon
 mkdir ${HOME}/.moonchild productions
+whitelist ${DOWNLOADS}
 whitelist ${HOME}/.cache/moonchild productions/pale moon
 whitelist ${HOME}/.moonchild productions
+include /etc/firejail/whitelist-common.inc
 
-#private-bin palemoon
-# private-etc must first be enabled in firefox-common.profile
-#private-etc palemoon
-#private-opt palemoon
+caps.drop all
+netfilter
+nodvd
+nogroups
+nonewprivs
+noroot
+notv
+protocol unix,inet,inet6,netlink
+seccomp
+shell none
+tracelog
 
-# Redirect
-include /etc/firejail/firefox-common.profile
+# private-bin palemoon
+# private-dev (disabled for now as it will interfere with webcam use in palemoon)
+# private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse
+# private-opt palemoon
+private-tmp
+
+disable-mnt

--- a/etc/palemoon.profile
+++ b/etc/palemoon.profile
@@ -12,26 +12,6 @@ include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-programs.inc
 
-# These are uncommented in the Firefox profile. If you run into trouble you may
-# want to uncomment (some of) them.
-#whitelist ${HOME}/dwhelper
-#whitelist ${HOME}/.zotero
-#whitelist ${HOME}/.vimperatorrc
-#whitelist ${HOME}/.vimperator
-#whitelist ${HOME}/.pentadactylrc
-#whitelist ${HOME}/.pentadactyl
-#whitelist ${HOME}/.keysnail.js
-#whitelist ${HOME}/.config/gnome-mplayer
-#whitelist ${HOME}/.cache/gnome-mplayer/plugin
-#whitelist ${HOME}/.pki
-#whitelist ${HOME}/.lastpass
-
-# For silverlight
-#whitelist ${HOME}/.wine-pipelight
-#whitelist ${HOME}/.wine-pipelight64
-#whitelist ${HOME}/.config/pipelight-widevine
-#whitelist ${HOME}/.config/pipelight-silverlight5.1
-
 mkdir ${HOME}/.cache/moonchild productions/pale moon
 mkdir ${HOME}/.moonchild productions
 whitelist ${DOWNLOADS}
@@ -39,8 +19,12 @@ whitelist ${HOME}/.cache/moonchild productions/pale moon
 whitelist ${HOME}/.moonchild productions
 include /etc/firejail/whitelist-common.inc
 
+apparmor
 caps.drop all
+# machine-id breaks pulse audio; it should work fine in setups where sound is not required
+# machine-id
 netfilter
+nodbus
 nodvd
 nogroups
 nonewprivs
@@ -51,10 +35,12 @@ seccomp
 shell none
 tracelog
 
+disable-mnt
 # private-bin palemoon
-# private-dev (disabled for now as it will interfere with webcam use in palemoon)
+private-dev
 # private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse
 # private-opt palemoon
 private-tmp
 
-disable-mnt
+noexec ${HOME}
+


### PR DESCRIPTION
See #1765 and #1847 for reference.
This comments out `shell none` and replaces `seccomp` with `seccomp.drop`. Palemoon and Basilisk get their own profiles again. 

I think we may need to give firefox-esr its own profile temporarily, until it's fully based on Firefox 60 sometime between May and August (60 ESR comes out on 9th of May, but 52 ESR will stick around until 21st of August I believe).