### PR TITLE
atool fixes

### DIFF
--- a/etc/atool.profile
+++ b/etc/atool.profile
@@ -38,5 +38,5 @@ tracelog
 
 # private-bin atool
 private-dev
-private-etc none
+private-etc passwd,group
 private-tmp

--- a/etc/bunzip2
+++ b/etc/bunzip2
@@ -1,0 +1,9 @@
+# Firejail profile for bunzip2
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/bunzip2.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+# Redirect
+include /etc/firejail/gzip.profile

--- a/etc/gunzip
+++ b/etc/gunzip
@@ -1,0 +1,9 @@
+# Firejail profile for gunzip
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/gunzip.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+# Redirect
+include /etc/firejail/gzip.profile


### PR DESCRIPTION
Adding 'private-etc' `passwd,group` to unbreak the profile, fixes [issue 1869](https://github.com/netblue30/firejail/issues/1869).
Add 2 'redirect' profiles for gzip: `bunzip2` and `gunzip` (which atool uses to handle .gz archives).