### PR TITLE
Allow firefox to access proxychains' local config.

### DIFF
--- a/etc/firefox.profile
+++ b/etc/firefox.profile
@@ -7,11 +7,14 @@ include /etc/firejail/globals.local
 
 noblacklist ${HOME}/.cache/mozilla
 noblacklist ${HOME}/.mozilla
+noblacklist ${HOME}/.proxychains
 
 mkdir ${HOME}/.cache/mozilla/firefox
 mkdir ${HOME}/.mozilla
+mkdir ${HOME}/.proxychains
 whitelist ${HOME}/.cache/mozilla/firefox
 whitelist ${HOME}/.mozilla
+whitelist ${HOME}/.proxychains
 
 # firefox requires a shell to launch on Arch.
 #private-bin firefox,which,sh,dbus-launch,dbus-send,env,bash


### PR DESCRIPTION
This allows people to use proxychains in the firefox sandbox, e.g.:
$ firejail --profile=/etc/firejail/firefox.profile \
    proxychains /usr/bin/firefox