### PR TITLE
Fix firefox common addons

### DIFF
--- a/etc/firefox-common-addons.inc
+++ b/etc/firefox-common-addons.inc
@@ -53,3 +53,12 @@ whitelist ${HOME}/.wine-pipelight
 whitelist ${HOME}/.wine-pipelight64
 whitelist ${HOME}/.zotero
 whitelist ${HOME}/dwhelper
+
+# GNOME Shell integration (chrome-gnome-shell) needs dbus and python 3 (blacklisted by disable-interpreters.inc)
+ignore nodbus
+noblacklist ${PATH}/python3*
+noblacklist /usr/lib/python3*
+
+# Flash plugin
+# private-etc below works fine on most distributions. There are some problems on CentOS.
+#private-etc ca-certificates,ssl,machine-id,dconf,selinux,passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,xdg,gtk-2.0,gtk-3.0,X11,pango,fonts,mime.types,mailcap,asound.conf,pulse,pki,crypto-policies,ld.so.cache,adobe


### PR DESCRIPTION
`GNOME Shell integration` relies on dbus and python 3. When users opt to include firefox-common-addons.inc (in firefox-common.profile), chrome-gnome-shell is currently broken. Opening its preferences shows ... 'Although GNOME Shell integration extension is running, native host connector is not detected. Refer to documentation for instructions about installing connector.'. Easily fixed by adding `ignore nodbus` and `allowing python 3` inside `firefox-common-addons.inc`, so users that don't include that file (the default) get an unchanged firejail experience.

NOTE: I suspect that chromium-based browsers would need a similar profile change when using GNOME Shell integration , but I neither use nor know these well enough to propose a PR.

Additionally, users using the `Flash` plugin could benefit from adding `adobe` to `private-etc`. I left that commented, to stay in sync with what's in firefox-common.profile.