### PR TITLE
priv tweaks

### DIFF
--- a/src/firejail/env.c
+++ b/src/firejail/env.c
@@ -101,9 +101,7 @@ void env_ibus_load(void) {
 				*ptr = '\0';
 			if (arg_debug)
 				printf("%s\n", buf);
-			EUID_USER();
 			env_store(buf, SETENV);
-			EUID_ROOT();
 		}
 
 		fclose(fp);

--- a/src/firejail/join.c
+++ b/src/firejail/join.c
@@ -292,6 +292,8 @@ void join(pid_t pid, int argc, char **argv, int index) {
 		}
 
 		prctl(PR_SET_PDEATHSIG, SIGKILL, 0, 0, 0); // kill the child in case the parent died
+
+		EUID_USER();
 		if (chdir("/") < 0)
 			errExit("chdir");
 		if (homedir) {
@@ -308,6 +310,7 @@ void join(pid_t pid, int argc, char **argv, int index) {
 			set_cpu_affinity();
 
 		// set caps filter
+		EUID_ROOT();
 		if (apply_caps == 1)	// not available for uid 0
 			caps_set(caps);
 #ifdef HAVE_SECCOMP
@@ -347,6 +350,8 @@ void join(pid_t pid, int argc, char **argv, int index) {
 		}
 
 		// set environment, add x11 display
+		EUID_USER();
+
 		env_defaults();
 		if (display) {
 			char *display_str;

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -669,7 +669,9 @@ int sandbox(void* sandbox_arg) {
 		// do nothing - there are problems with ibus version 1.5.11
 	}
 	else
+		EUID_USER();
 		env_ibus_load();
+		EUID_ROOT();
 
 	//****************************
 	// fs pre-processing:
@@ -925,6 +927,8 @@ int sandbox(void* sandbox_arg) {
 	// set application environment
 	//****************************
 	prctl(PR_SET_PDEATHSIG, SIGKILL, 0, 0, 0); // kill the child in case the parent died
+
+	EUID_USER();
 	int cwd = 0;
 	if (cfg.cwd) {
 		if (chdir(cfg.cwd) == 0)
@@ -951,7 +955,7 @@ int sandbox(void* sandbox_arg) {
 		}
 	}
 
-
+	EUID_ROOT();
 	// set nice
 	if (arg_nice) {
 		errno = 0;
@@ -980,7 +984,9 @@ int sandbox(void* sandbox_arg) {
 	// set cpu affinity
 	if (cfg.cpus) {
 		save_cpu(); // save cpu affinity mask to CPU_CFG file
+		EUID_USER();
 		set_cpu_affinity();
+		EUID_ROOT();
 	}
 
 	// save cgroup in CGROUP_CFG file


### PR DESCRIPTION
Lowering privileges for setting cpu affinity was no primary objective, it just turned out to be possible (from `man sched_setaffinity`: The caller needs an effective user ID equal to the real user ID or effective user ID of the thread identified by pid, or it must possess the CAP_SYS_NICE capability)
