### PR TITLE
avoid TESTING warning in firefox-common-addons.inc

### DIFF
--- a/etc/firefox-common-addons.inc
+++ b/etc/firefox-common-addons.inc
@@ -53,8 +53,8 @@ whitelist ${HOME}/.zotero
 whitelist ${HOME}/dwhelper
 
 # GNOME Shell integration (chrome-gnome-shell) needs dbus and python 3 (blacklisted by disable-interpreters.inc)
-noblacklist ${HOME}/.local/share/gnome-shell/extensions
-whitelist ${HOME}/.local/share/gnome-shell/extensions
+noblacklist ${HOME}/.local/share/gnome-shell
+whitelist ${HOME}/.local/share/gnome-shell
 ignore nodbus
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python3*


### PR DESCRIPTION
```
$ firejail firefox
...
TESTING warning: noblacklist /home/glitsj16/.local/share/gnome-shell/extensions not matched by a proper blacklist command in disable*.inc
...

$ grep gnome-shell /etc/firejail/disable-common.inc
blacklist ${HOME}/.local/share/gnome-shell

$ grep gnome-shell /etc/firejail/firefox-common-addons.inc
noblacklist ${HOME}/.local/share/gnome-shell/extensions
whitelist ${HOME}/.local/share/gnome-shell/extensions

```

Dropping `/extensions` in `firefox-common-addons.inc` fixes things.