### PR TITLE
Re-enable join-or-start

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -701,17 +701,15 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 			cfg.original_program_index = i + 1;
 		}
 
-#if 0 // todo: redo it
 		// try to join by name only
 		pid_t pid;
-		if (!name2pid(argv[i] + 16, &pid)) {
+		if (!read_pid(argv[i] + 16, &pid)) {
 			if (!cfg.shell && !arg_shell_none)
 				cfg.shell = guess_shell();
 
 			join(pid, argc, argv, i + 1);
 			exit(0);
 		}
-#endif
 		// if there no such sandbox continue argument processing
 	}
 #ifdef HAVE_NETWORK

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -161,37 +161,47 @@ static void my_handler(int s){
 	myexit(1);
 }
 
-static pid_t extract_pid(const char *name) {
+// return 1 if error, 0 if a valid pid was found
+static int extract_pid(const char *name, pid_t *pid) {
+	int retval = 0;
 	EUID_ASSERT();
 	if (!name || strlen(name) == 0) {
 		fprintf(stderr, "Error: invalid sandbox name\n");
 		exit(1);
 	}
 
-	pid_t pid;
 	EUID_ROOT();
-	if (name2pid(name, &pid)) {
+	if (name2pid(name, pid)) {
+		retval = 1;
+	}
+	EUID_USER();
+	return retval;
+}
+
+// return 1 if error, 0 if a valid pid was found
+static int read_pid(const char *name, pid_t *pid) {
+	char *endptr;
+	errno = 0;
+	long int pidtmp = strtol(name, &endptr, 10);
+	if ((errno == ERANGE && (pidtmp == LONG_MAX || pidtmp == LONG_MIN))
+		|| (errno != 0 && pidtmp == 0)) {
+		return extract_pid(name,pid);
+	}
+	// endptr points to '\0' char in name if the entire string is valid
+	if (endptr == NULL || endptr[0]!='\0') {
+		return extract_pid(name,pid);
+	}
+	*pid =(pid_t)pidtmp;
+	return 0;
+}
+
+static pid_t require_pid(const char *name) {
+	pid_t pid;
+	if (read_pid(name,&pid)) {
 		fprintf(stderr, "Error: cannot find sandbox %s\n", name);
 		exit(1);
 	}
-	EUID_USER();
 	return pid;
-}
-
-
-static pid_t read_pid(const char *str) {
-	char *endptr;
-	errno = 0;
-	long int pidtmp = strtol(str, &endptr, 10);
-	if ((errno == ERANGE && (pidtmp == LONG_MAX || pidtmp == LONG_MIN))
-		|| (errno != 0 && pidtmp == 0)) {
-		return extract_pid(str);
-	}
-	// endptr points to '\0' char in str if the entire string is valid
-	if (endptr == NULL || endptr[0]!='\0') {
-		return extract_pid(str);
-	}
-	return (pid_t)pidtmp;
 }
 
 // init configuration
@@ -411,7 +421,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 			}
 
 			// extract pid or sandbox name
-			pid_t pid = read_pid(argv[i] + 12);
+			pid_t pid = require_pid(argv[i] + 12);
 			bandwidth_pid(pid, cmd, dev, down, up);
 		}
 		else
@@ -420,13 +430,13 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 	}
 	else if (strncmp(argv[i], "--netfilter.print=", 18) == 0) {
 		// extract pid or sandbox name
-		pid_t pid = read_pid(argv[i] + 18);
+		pid_t pid = require_pid(argv[i] + 18);
 		netfilter_print(pid, 0);
 		exit(0);
 	}
 	else if (strncmp(argv[i], "--netfilter6.print=", 19) == 0) {
 		// extract pid or sandbox name
-		pid_t pid = read_pid(argv[i] + 19);
+		pid_t pid = require_pid(argv[i] + 19);
 		netfilter_print(pid, 1);
 		exit(0);
 	}
@@ -455,7 +465,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 	else if (strncmp(argv[i], "--seccomp.print=", 16) == 0) {
 		if (checkcfg(CFG_SECCOMP)) {
 			// print seccomp filter for a sandbox specified by pid or by name
-			pid_t pid = read_pid(argv[i] + 16);
+			pid_t pid = require_pid(argv[i] + 16);
 			seccomp_print_filter(pid);
 		}
 		else
@@ -469,7 +479,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 	else if (strncmp(argv[i], "--protocol.print=", 17) == 0) {
 		if (checkcfg(CFG_SECCOMP)) {
 			// print seccomp filter for a sandbox specified by pid or by name
-			pid_t pid = read_pid(argv[i] + 17);
+			pid_t pid = require_pid(argv[i] + 17);
 			protocol_print_filter(pid);
 		}
 		else
@@ -478,7 +488,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 	}
 #endif
 	else if (strncmp(argv[i], "--profile.print=", 16) == 0) {
-		pid_t pid = read_pid(argv[i] + 16);
+		pid_t pid = require_pid(argv[i] + 16);
 
 		// print /run/firejail/profile/<PID> file
 		char *fname;
@@ -499,13 +509,13 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 	}
 	else if (strncmp(argv[i], "--cpu.print=", 12) == 0) {
 		// join sandbox by pid or by name
-		pid_t pid = read_pid(argv[i] + 12);
+		pid_t pid = require_pid(argv[i] + 12);
 		cpu_print_filter(pid);
 		exit(0);
 	}
 	else if (strncmp(argv[i], "--apparmor.print=", 12) == 0) {
 		// join sandbox by pid or by name
-		pid_t pid = read_pid(argv[i] + 17);
+		pid_t pid = require_pid(argv[i] + 17);
 		char *pidstr;
 		if (asprintf(&pidstr, "%u", pid) == -1)
 			errExit("asprintf");
@@ -515,19 +525,19 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 	}
 	else if (strncmp(argv[i], "--caps.print=", 13) == 0) {
 		// join sandbox by pid or by name
-		pid_t pid = read_pid(argv[i] + 13);
+		pid_t pid = require_pid(argv[i] + 13);
 		caps_print_filter(pid);
 		exit(0);
 	}
 	else if (strncmp(argv[i], "--fs.print=", 11) == 0) {
 		// join sandbox by pid or by name
-		pid_t pid = read_pid(argv[i] + 11);
+		pid_t pid = require_pid(argv[i] + 11);
 		fs_logger_print_log(pid);
 		exit(0);
 	}
 	else if (strncmp(argv[i], "--dns.print=", 12) == 0) {
 		// join sandbox by pid or by name
-		pid_t pid = read_pid(argv[i] + 12);
+		pid_t pid = require_pid(argv[i] + 12);
 		net_dns_print(pid);
 		exit(0);
 	}
@@ -592,7 +602,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 			 }
 
 			// get file
-			pid_t pid = read_pid(argv[i] + 6);
+			pid_t pid = require_pid(argv[i] + 6);
 			sandboxfs(SANDBOX_FS_GET, pid, path, NULL);
 			exit(0);
 		}
@@ -622,7 +632,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 			 }
 
 			// get file
-			pid_t pid = read_pid(argv[i] + 6);
+			pid_t pid = require_pid(argv[i] + 6);
 			sandboxfs(SANDBOX_FS_PUT, pid, path1, path2);
 			exit(0);
 		}
@@ -646,7 +656,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 			 }
 
 			// list directory contents
-			pid_t pid = read_pid(argv[i] + 5);
+			pid_t pid = require_pid(argv[i] + 5);
 			sandboxfs(SANDBOX_FS_LS, pid, path, NULL);
 			exit(0);
 		}
@@ -670,7 +680,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 				cfg.shell = guess_shell();
 
 			// join sandbox by pid or by name
-			pid_t pid = read_pid(argv[i] + 7);
+			pid_t pid = require_pid(argv[i] + 7);
 			join(pid, argc, argv, i + 1);
 			exit(0);
 		}
@@ -718,7 +728,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 				cfg.shell = guess_shell();
 
 			// join sandbox by pid or by name
-			pid_t pid = read_pid(argv[i] + 15);
+			pid_t pid = require_pid(argv[i] + 15);
 			join(pid, argc, argv, i + 1);
 		}
 		else
@@ -738,7 +748,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 			cfg.shell = guess_shell();
 
 		// join sandbox by pid or by name
-		pid_t pid = read_pid(argv[i] + 18);
+		pid_t pid = require_pid(argv[i] + 18);
 		join(pid, argc, argv, i + 1);
 		exit(0);
 	}
@@ -746,7 +756,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 		logargs(argc, argv);
 
 		// shutdown sandbox by pid or by name
-		pid_t pid = read_pid(argv[i] + 11);
+		pid_t pid = require_pid(argv[i] + 11);
 		shut(pid);
 		exit(0);
 	}


### PR DESCRIPTION
The `join-or-start` option has been broken since 3374e24eb, when that code got out of sync with the new `read_pid` approach to handling sandbox names.

This pair of patches
1. Separates the validation of the existence of a named sandbox out of `read_pid` into `require_pid`
2. Updates all old `read_pid` calls to the new `require_pid` function.
3. Re-enables the `join-or-start` option, using the non-validating `read_pid` function.