### PR TITLE
Allow GNOME Shell integration in unzip

### DIFF
--- a/etc/unzip.profile
+++ b/etc/unzip.profile
@@ -24,4 +24,7 @@ private-bin unzip
 private-dev
 private-etc passwd,group,localtime
 
+# GNOME Shell integration (chrome-gnome-shell)
+noblacklist ${HOME}/.local/share/gnome-shell
+
 include /etc/firejail/default.profile


### PR DESCRIPTION
Without granting access to `${HOME}/.local/share/gnome-shell` unzip fails (silently) when updating GNOME Shell extensions. As removing outdated extension(s) prior to unzipping works as expected, this leaves users with crippled extensions.