### PR TITLE
add disable-interpreters.inc to gnome-logs

### DIFF
--- a/etc/gnome-logs.profile
+++ b/etc/gnome-logs.profile
@@ -7,6 +7,7 @@ include /etc/firejail/globals.local
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-interpreters.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
@@ -31,8 +32,8 @@ shell none
 disable-mnt
 private-bin gnome-logs
 private-dev
-#private-etc fonts
-#private-lib gdk-pixbuf-2.0,gio,gvfs/libgvfscommon.so,libgconf-2.so.4,librsvg-2.so.2
+private-etc fonts
+private-lib gdk-pixbuf-2.0,gio,gvfs/libgvfscommon.so,libgconf-2.so.4,librsvg-2.so.2
 private-tmp
 writable-var-log
 

--- a/etc/gnome-logs.profile
+++ b/etc/gnome-logs.profile
@@ -32,7 +32,7 @@ shell none
 disable-mnt
 private-bin gnome-logs
 private-dev
-private-etc fonts
+private-etc fonts,localtime
 private-lib gdk-pixbuf-2.0,gio,gvfs/libgvfscommon.so,libgconf-2.so.4,librsvg-2.so.2
 private-tmp
 writable-var-log


### PR DESCRIPTION
Besides adding `include /etc/firejail/disable-interpreters.inc`, enabling both `private-etc` and `private-lib` (tested with systemd default storage and volatile journal).