### PR TITLE
add note for 'volatile' storage support

### DIFF
--- a/etc/gnome-logs.profile
+++ b/etc/gnome-logs.profile
@@ -19,6 +19,8 @@ net none
 no3d
 nodbus
 nodvd
+# When using 'volatile' storage (https://www.freedesktop.org/software/systemd/man/journald.conf.html),
+# comment both 'nogroups' and 'noroot'
 nogroups
 nonewprivs
 noroot
@@ -32,7 +34,7 @@ shell none
 disable-mnt
 private-bin gnome-logs
 private-dev
-private-etc fonts,localtime
+private-etc fonts,localtime,machine-id
 private-lib gdk-pixbuf-2.0,gio,gvfs/libgvfscommon.so,libgconf-2.so.4,librsvg-2.so.2
 private-tmp
 writable-var-log


### PR DESCRIPTION
@Fred-Barclay @SkewedZeppelin Did some further testing, especially when using systemd's `volatile` storage (which is stored only in memory, i.e. below /run/log/journal). In that case `machine-id` needs to be added to private-etc, as well as commenting both `nogroups` and `noroot`. Realizing this is not a default setup and the release of 0.9.54 is approaching, it's probably better to not mess with nogroups/noroot now. Perhaps adding `machine-id` to private-etc is not that problematic. Adding a reminder for users who run a volatile storage setup might be doable. Thoughts? 