### PR TITLE
Fixes to make Blender with AMD GPU work under firejail (#1931)

### DIFF
--- a/etc/blender.profile
+++ b/etc/blender.profile
@@ -19,6 +19,11 @@ include /etc/firejail/disable-interpreters.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
+# Allow usage of AMD GPU by OpenCL
+noblacklist /sys/module
+whitelist /sys/module/amdgpu
+read-only /sys/module/amdgpu
+
 caps.drop all
 netfilter
 nodvd

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -85,6 +85,7 @@
 #define RUN_WHITELIST_SRV_DIR   "/run/firejail/mnt/orig-srv"
 #define RUN_WHITELIST_ETC_DIR   "/run/firejail/mnt/orig-etc"
 #define RUN_WHITELIST_SHARE_DIR   "/run/firejail/mnt/orig-share"
+#define RUN_WHITELIST_MODULE_DIR   "/run/firejail/mnt/orig-module"
 
 #define RUN_XAUTHORITY_FILE	"/run/firejail/mnt/.Xauthority"
 #define RUN_XAUTHORITY_SEC_FILE	"/run/firejail/mnt/sec.Xauthority"
@@ -204,6 +205,7 @@ typedef struct profile_entry_t {
 	unsigned srv_dir:1;	// whitelist in /srv directory
 	unsigned etc_dir:1;	// whitelist in /etc directory
 	unsigned share_dir:1;	// whitelist in /usr/share directory
+	unsigned module_dir:1;	// whitelist in /sys/module directory
 }ProfileEntry;
 
 typedef struct config_t {

--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -565,12 +565,12 @@ void fs_proc_sys_dev_boot(void) {
 
 	disable_file(BLACKLIST_FILE, "/sys/firmware");
 	disable_file(BLACKLIST_FILE, "/sys/hypervisor");
-	{ // allow user access to /sys/fs if "--noblacklist=/sys/fs" is present on the command line
+	{ // allow user access to some directories in /sys/ by specifying 'noblacklist' option
 		EUID_USER();
 		profile_add("blacklist /sys/fs");
+		profile_add("blacklist /sys/module");
 		EUID_ROOT();
 	}
-	disable_file(BLACKLIST_FILE, "/sys/module");
 	disable_file(BLACKLIST_FILE, "/sys/power");
 	disable_file(BLACKLIST_FILE, "/sys/kernel/debug");
 	disable_file(BLACKLIST_FILE, "/sys/kernel/vmcoreinfo");


### PR DESCRIPTION
This pull request allows whitelisting of directories under `/sys/module`. It's necessary for Blender to work with AMD graphics cards.

`/sys/module` is blacklisted by default, to keep compatibility with the current version, but its subdirectories can now be whitelisted.

There is also a new version of `blender.profile` making use of those capabilities.
