### PR TITLE
disable tracelog in firefox-common.profile

### DIFF
--- a/etc/firefox-common.profile
+++ b/etc/firefox-common.profile
@@ -35,7 +35,7 @@ notv
 protocol unix,inet,inet6,netlink
 seccomp.drop @clock,@cpu-emulation,@debug,@module,@obsolete,@raw-io,@reboot,@resources,@swap,acct,add_key,bpf,fanotify_init,io_cancel,io_destroy,io_getevents,io_setup,io_submit,ioprio_set,kcmp,keyctl,mount,name_to_handle_at,nfsservctl,ni_syscall,open_by_handle_at,personality,pivot_root,process_vm_readv,ptrace,remap_file_pages,request_key,setdomainname,sethostname,syslog,umount,umount2,userfaultfd,vhangup,vmsplice
 shell none
-tracelog
+#tracelog
 
 disable-mnt
 private-dev

--- a/etc/firefox-common.profile
+++ b/etc/firefox-common.profile
@@ -35,6 +35,7 @@ notv
 protocol unix,inet,inet6,netlink
 seccomp.drop @clock,@cpu-emulation,@debug,@module,@obsolete,@raw-io,@reboot,@resources,@swap,acct,add_key,bpf,fanotify_init,io_cancel,io_destroy,io_getevents,io_setup,io_submit,ioprio_set,kcmp,keyctl,mount,name_to_handle_at,nfsservctl,ni_syscall,open_by_handle_at,personality,pivot_root,process_vm_readv,ptrace,remap_file_pages,request_key,setdomainname,sethostname,syslog,umount,umount2,userfaultfd,vhangup,vmsplice
 shell none
+#disable tracelog, it breaks or causes major issues with many firefox based browsers, see github issue #1930
 #tracelog
 
 disable-mnt


### PR DESCRIPTION
tracelog breaks firefox 60+ catastrophically in my testing