### PR TITLE
Add dictionary access to Slack

### DIFF
--- a/etc/slack.profile
+++ b/etc/slack.profile
@@ -35,7 +35,7 @@ seccomp
 shell none
 
 disable-mnt
-private-bin slack
+private-bin slack,locale
 private-dev
 private-etc asound.conf,ca-certificates,fonts,group,passwd,pulse,resolv.conf,ssl,ld.so.conf,ld.so.cache,localtime,pki,crypto-policies
 private-tmp


### PR DESCRIPTION
This tiny PR adds dictionary access to Slack when launched via firejail. Helps prevent typos when quickly typing on Slack.

I tested this on Debian testing/unstable.