### PR TITLE
Allow Telegram to use Netlink sockets

### DIFF
--- a/etc/telegram.profile
+++ b/etc/telegram.profile
@@ -19,7 +19,7 @@ nodvd
 nonewprivs
 noroot
 notv
-protocol unix,inet,inet6
+protocol unix,inet,inet6,netlink
 seccomp
 
 disable-mnt


### PR DESCRIPTION
It complains in a console when they are unavailable.