### PR TITLE
Fix DjVu opening in Evince

### DIFF
--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -37,7 +37,7 @@ private-bin evince,evince-previewer,evince-thumbnailer
 private-dev
 private-etc fonts
 
-private-lib evince,gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libgconf-2.so.*,libpoppler-glib.so.*,librsvg-2.so.*
+private-lib evince,gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libdjvulibre.so.*,libgconf-2.so.*,libpoppler-glib.so.*,librsvg-2.so.*
 
 private-tmp
 


### PR DESCRIPTION
Access to `libdjvulibre.so.*` is required for opening DjVu documents.
Otherwise, Evince does open, but fails to load the file with the error: `Failed to load backend for 'image/vnd.djvu+multipage': libdjvulibre.so.21: cannot open shared object file: No such file or directory`