### PR TITLE
Fix installing skins on qmmp.profile

### DIFF
--- a/etc/qmmp.profile
+++ b/etc/qmmp.profile
@@ -26,7 +26,7 @@ seccomp
 shell none
 tracelog
 
-private-bin qmmp
+private-bin qmmp,tar,unzip,bzip2,gzip
 private-dev
 private-tmp
 


### PR DESCRIPTION
qmmp requires these unzipping programs in order to install skins, so i've added them to private-bin