### PR TITLE
Revert private cache enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,6 @@ We also keep a list of profile fixes for previous released versions in [etc-fixe
 `````
 # Current development version: 0.9.55
 
-## Mounting a temporary filesystem on top of ~/.cache directory by default
-
-To disable it globally, set "private-cache no" in /etc/firejail/firejail.config.
-
-
 ## New commands:
 `````
       (wireless support for --net)
@@ -128,6 +123,14 @@ To disable it globally, set "private-cache no" in /etc/firejail/firejail.config.
 
               Example:
               $ firejail --nou2f
+
+      --private-cache
+               Mount an empty temporary filesystem on top of the .cache
+               directory in user home. All modifications are discarded
+               when the sandbox is closed.
+
+              Example:
+              $ firejail --private-cache
 `````
 
 ## New profiles

--- a/RELNOTES
+++ b/RELNOTES
@@ -1,9 +1,7 @@
 firejail (0.9.55) baseline; urgency=low
   * work in progress
   * modif: removed CFG_CHROOT_DESKTOP configuration option
-  * mounting a temporary filesystem on top of ~/.cache directory by default.
-    To disable it globally, set "private-cache no" in
-    /etc/firejail/firejail.config.
+  * add --private-cache to support private ~/.cache
   * support full paths in private-lib
   * globbing support in private-lib
   * new profiles: ms-excel, ms-office, ms-onenote, ms-outlook, ms-powerpoint

--- a/etc/Cryptocat.profile
+++ b/etc/Cryptocat.profile
@@ -25,5 +25,6 @@ protocol unix,inet,inet6,netlink
 seccomp
 shell none
 
+private-cache
 private-dev
 private-tmp

--- a/etc/android-studio.profile
+++ b/etc/android-studio.profile
@@ -32,6 +32,7 @@ protocol unix,inet,inet6
 seccomp
 shell none
 
+private-cache
 # private-tmp
 
 # noexec /tmp breaks 'Android Profiler'

--- a/etc/apktool.profile
+++ b/etc/apktool.profile
@@ -26,6 +26,7 @@ seccomp
 shell none
 
 private-bin apktool,bash,java,dirname,basename,expr,sh
+private-cache
 private-dev
 
 noexec ${HOME}

--- a/etc/arch-audit.profile
+++ b/etc/arch-audit.profile
@@ -32,6 +32,7 @@ shell none
 
 disable-mnt
 private
+private-cache
 private-bin arch-audit
 private-dev
 private-tmp

--- a/etc/ardour5.profile
+++ b/etc/ardour5.profile
@@ -30,6 +30,7 @@ seccomp
 shell none
 
 #private-bin sh,ardour4,ardour5,ardour5-copy-mixer,ardour5-export,ardour5-fix_bbtppq,grep,sed,ldd,nm
+private-cache
 private-dev
 #private-etc pulse,X11,alternatives,ardour4,ardour5,fonts
 private-tmp

--- a/etc/arduino.profile
+++ b/etc/arduino.profile
@@ -35,6 +35,7 @@ protocol unix,inet,inet6
 seccomp
 shell none
 
+private-cache
 private-tmp
 
 noexec ${HOME}

--- a/etc/atom.profile
+++ b/etc/atom.profile
@@ -27,6 +27,7 @@ protocol unix,inet,inet6,netlink
 seccomp
 shell none
 
+private-cache
 private-dev
 private-tmp
 

--- a/etc/atool.profile
+++ b/etc/atool.profile
@@ -36,6 +36,7 @@ seccomp
 shell none
 tracelog
 
+private-cache
 # private-bin atool
 private-dev
 private-etc passwd,group

--- a/etc/bitlbee.profile
+++ b/etc/bitlbee.profile
@@ -27,6 +27,7 @@ seccomp
 
 disable-mnt
 private
+private-cache
 private-dev
 private-tmp
 read-write /var/lib/bitlbee

--- a/etc/bless.profile
+++ b/etc/bless.profile
@@ -29,6 +29,7 @@ seccomp
 shell none
 
 # private-bin bless,sh,bash,mono
+private-cache
 private-dev
 private-etc fonts,mono
 private-tmp

--- a/etc/brackets.profile
+++ b/etc/brackets.profile
@@ -26,4 +26,5 @@ protocol unix,inet,inet6,netlink
 seccomp.drop @clock,@cpu-emulation,@debug,@module,@obsolete,@reboot,@resources,@swap,acct,add_key,bpf,fanotify_init,io_cancel,io_destroy,io_getevents,io_setup,io_submit,iopl,ioprio_set,kcmp,keyctl,mount,name_to_handle_at,nfsservctl,ni_syscall,open_by_handle_at,pciconfig_iobase,pciconfig_read,pciconfig_write,personality,pivot_root,process_vm_readv,ptrace,remap_file_pages,request_key,s390_mmio_read,s390_mmio_write,setdomainname,sethostname,syslog,umount,umount2,userfaultfd,vhangup,vmsplic
 shell none
 
+private-cache
 private-dev

--- a/etc/brasero.profile
+++ b/etc/brasero.profile
@@ -27,6 +27,7 @@ shell none
 tracelog
 
 # private-bin brasero
+private-cache
 # private-dev
 # private-etc fonts
 # private-tmp

--- a/etc/cherrytree.profile
+++ b/etc/cherrytree.profile
@@ -34,6 +34,7 @@ seccomp
 shell none
 tracelog
 
+private-cache
 private-dev
 private-tmp
 

--- a/etc/cin.profile
+++ b/etc/cin.profile
@@ -29,6 +29,7 @@ seccomp
 shell none
 
 #private-bin cin,ffmpeg
+private-cache
 private-dev
 
 noexec ${HOME}

--- a/etc/clion.profile
+++ b/etc/clion.profile
@@ -28,6 +28,7 @@ protocol unix,inet,inet6
 seccomp
 shell none
 
+private-cache
 private-dev
 # private-tmp
 

--- a/etc/clipit.profile
+++ b/etc/clipit.profile
@@ -29,6 +29,7 @@ seccomp
 shell none
 
 disable-mnt
+private-cache
 private-dev
 private-tmp
 

--- a/etc/code.profile
+++ b/etc/code.profile
@@ -26,6 +26,7 @@ protocol unix,inet,inet6,netlink
 seccomp
 shell none
 
+private-cache
 private-dev
 private-tmp
 

--- a/etc/conky.profile
+++ b/etc/conky.profile
@@ -28,6 +28,7 @@ seccomp
 shell none
 
 disable-mnt
+private-cache
 private-dev
 private-tmp
 

--- a/etc/curl.profile
+++ b/etc/curl.profile
@@ -29,6 +29,7 @@ seccomp
 shell none
 
 # private-bin curl
+private-cache
 private-dev
 # private-etc resolv.conf
 private-tmp

--- a/etc/default.profile
+++ b/etc/default.profile
@@ -33,6 +33,7 @@ seccomp
 # disable-mnt
 # private
 # private-bin program
+# private-cache
 # private-dev
 # private-etc none
 # private-lib

--- a/etc/dex2jar.profile
+++ b/etc/dex2jar.profile
@@ -34,6 +34,7 @@ seccomp
 shell none
 
 private-bin dex2jar,java,sh,bash,expr,dirname,ls,uname,grep
+private-cache
 private-dev
 
 noexec ${HOME}

--- a/etc/dia.profile
+++ b/etc/dia.profile
@@ -30,6 +30,7 @@ shell none
 
 disable-mnt
 #private-bin dia
+private-cache
 private-dev
 private-tmp
 

--- a/etc/dnscrypt-proxy.profile
+++ b/etc/dnscrypt-proxy.profile
@@ -27,6 +27,7 @@ seccomp.drop mount,umount2,ptrace,kexec_load,kexec_file_load,open_by_handle_at,i
 
 disable-mnt
 private
+private-cache
 private-dev
 
 # mdwe can break modules/plugins

--- a/etc/dnsmasq.profile
+++ b/etc/dnsmasq.profile
@@ -28,4 +28,5 @@ seccomp
 
 disable-mnt
 private
+private-cache
 private-dev

--- a/etc/elinks.profile
+++ b/etc/elinks.profile
@@ -31,6 +31,7 @@ shell none
 tracelog
 
 # private-bin elinks
+private-cache
 private-dev
 # private-etc none
 private-tmp

--- a/etc/empathy.profile
+++ b/etc/empathy.profile
@@ -20,3 +20,6 @@ noroot
 notv
 protocol unix,inet,inet6
 seccomp
+
+private-cache
+private-tmp

--- a/etc/enchant.profile
+++ b/etc/enchant.profile
@@ -30,6 +30,7 @@ shell none
 tracelog
 
 # private-bin enchant, enchant-*
+private-cache
 private-dev
 private-etc none
 private-tmp

--- a/etc/exiftool.profile
+++ b/etc/exiftool.profile
@@ -36,6 +36,7 @@ shell none
 tracelog
 
 # private-bin exiftool,perl
+private-cache
 private-dev
 private-etc none
 private-tmp

--- a/etc/feh.profile
+++ b/etc/feh.profile
@@ -27,6 +27,7 @@ seccomp
 shell none
 
 private-bin feh,jpegexiforient,jpegtran
+private-cache
 private-dev
 private-etc feh
 private-tmp

--- a/etc/firejail.config
+++ b/etc/firejail.config
@@ -56,11 +56,6 @@
 # Remove /usr/local directories from private-bin list, default disabled.
 # private-bin-no-local no
 
-# Mount  an empty temporary filesystem on top of the .cache
-# directory in user home. All  modifications  are  discarded  when
-# the sandbox is closed. Default enabled.
-# private-cache yes
-
 # Enable or disable private-home feature, default enabled
 # private-home yes
 

--- a/etc/flowblade.profile
+++ b/etc/flowblade.profile
@@ -31,6 +31,7 @@ protocol unix,inet,inet6,netlink
 seccomp
 shell none
 
+private-cache
 private-dev
 private-tmp
 

--- a/etc/fontforge.profile
+++ b/etc/fontforge.profile
@@ -32,6 +32,7 @@ protocol unix
 seccomp
 shell none
 
+private-cache
 private-dev
 private-tmp
 

--- a/etc/freecad.profile
+++ b/etc/freecad.profile
@@ -29,6 +29,7 @@ seccomp
 shell none
 
 private-bin freecad,freecadcmd
+private-cache
 private-dev
 private-tmp
 

--- a/etc/freshclam.profile
+++ b/etc/freshclam.profile
@@ -24,6 +24,7 @@ tracelog
 
 disable-mnt
 private
+private-cache
 private-dev
 private-tmp
 writable-var

--- a/etc/geany.profile
+++ b/etc/geany.profile
@@ -25,5 +25,6 @@ protocol unix,inet,inet6
 seccomp
 shell none
 
+private-cache
 private-dev
 private-tmp

--- a/etc/git.profile
+++ b/etc/git.profile
@@ -34,4 +34,5 @@ protocol unix,inet,inet6
 seccomp
 shell none
 
+private-cache
 private-dev

--- a/etc/gitg.profile
+++ b/etc/gitg.profile
@@ -29,6 +29,7 @@ seccomp
 shell none
 
 private-bin gitg,git,ssh
+private-cache
 private-dev
 private-tmp
 

--- a/etc/globaltime.profile
+++ b/etc/globaltime.profile
@@ -28,6 +28,7 @@ seccomp
 shell none
 
 disable-mnt
+private-cache
 private-dev
 private-tmp
 

--- a/etc/gnome-builder.profile
+++ b/etc/gnome-builder.profile
@@ -23,4 +23,5 @@ protocol unix,inet,inet6
 seccomp
 shell none
 
+private-cache
 private-dev

--- a/etc/gnome-documents.profile
+++ b/etc/gnome-documents.profile
@@ -30,6 +30,7 @@ seccomp
 shell none
 tracelog
 
+private-cache
 private-dev
 private-tmp
 

--- a/etc/gnome-mplayer.profile
+++ b/etc/gnome-mplayer.profile
@@ -22,6 +22,7 @@ seccomp
 shell none
 
 # private-bin gnome-mplayer,mplayer
+private-cache
 private-dev
 private-tmp
 

--- a/etc/gpg-agent.profile
+++ b/etc/gpg-agent.profile
@@ -31,4 +31,5 @@ shell none
 tracelog
 
 # private-bin gpg-agent,gpg
+private-cache
 private-dev

--- a/etc/gpg.profile
+++ b/etc/gpg.profile
@@ -31,4 +31,5 @@ shell none
 tracelog
 
 # private-bin gpg,gpg-agent
+private-cache
 private-dev

--- a/etc/gthumb.profile
+++ b/etc/gthumb.profile
@@ -29,5 +29,6 @@ shell none
 tracelog
 
 private-bin gthumb
+private-cache
 private-dev
 private-tmp

--- a/etc/gucharmap.profile
+++ b/etc/gucharmap.profile
@@ -28,6 +28,7 @@ shell none
 
 disable-mnt
 private
+private-cache
 private-dev
 private-tmp
 

--- a/etc/hashcat.profile
+++ b/etc/hashcat.profile
@@ -31,6 +31,7 @@ shell none
 
 disable-mnt
 private-bin hashcat
+private-cache
 private-dev
 private-tmp
 

--- a/etc/highlight.profile
+++ b/etc/highlight.profile
@@ -30,6 +30,7 @@ shell none
 tracelog
 
 private-bin highlight
+private-cache
 private-dev
 # private-etc none
 private-tmp

--- a/etc/hugin.profile
+++ b/etc/hugin.profile
@@ -28,6 +28,7 @@ seccomp
 shell none
 
 private-bin PTBatcherGUI,calibrate_lens_gui,hugin,hugin_stitch_project,align_image_stack,autooptimiser,celeste_standalone,checkpto,cpclean,cpfind,deghosting_mask,fulla,geocpset,hugin_executor,hugin_hdrmerge,hugin_lensdb,icpfind,linefind,nona,pano_modify,pano_trafo,pto_gen,pto_lensstack,pto_mask,pto_merge,pto_move,pto_template,pto_var,tca_correct,verdandi,vig_optimize,enblend
+private-cache
 private-dev
 private-tmp
 

--- a/etc/idea.sh.profile
+++ b/etc/idea.sh.profile
@@ -32,6 +32,7 @@ protocol unix,inet,inet6
 seccomp
 shell none
 
+private-cache
 private-dev
 # private-tmp
 

--- a/etc/img2txt.profile
+++ b/etc/img2txt.profile
@@ -27,6 +27,7 @@ shell none
 tracelog
 
 # private-bin img2txt
+private-cache
 private-dev
 # private-etc none
 private-tmp

--- a/etc/jd-gui.profile
+++ b/etc/jd-gui.profile
@@ -36,6 +36,7 @@ seccomp
 shell none
 
 private-bin jd-gui,sh,bash
+private-cache
 private-dev
 private-tmp
 

--- a/etc/jitsi.profile
+++ b/etc/jitsi.profile
@@ -31,4 +31,5 @@ shell none
 tracelog
 
 disable-mnt
+private-cache
 private-tmp

--- a/etc/keepass.profile
+++ b/etc/keepass.profile
@@ -33,6 +33,7 @@ protocol unix,inet,inet6
 seccomp
 shell none
 
+private-cache
 private-dev
 private-tmp
 

--- a/etc/kino.profile
+++ b/etc/kino.profile
@@ -25,6 +25,7 @@ protocol unix
 seccomp
 shell none
 
+private-cache
 private-dev
 private-tmp
 

--- a/etc/krita.profile
+++ b/etc/krita.profile
@@ -36,6 +36,7 @@ protocol unix
 seccomp
 shell none
 
+private-cache
 private-dev
 private-tmp
 

--- a/etc/less.profile
+++ b/etc/less.profile
@@ -24,6 +24,7 @@ writable-var-log
 # Enable private-bin and private-lib if you are not using any filter.
 # private-bin less
 # private-lib
+private-cache
 private-dev
 
 memory-deny-write-execute

--- a/etc/luminance-hdr.profile
+++ b/etc/luminance-hdr.profile
@@ -28,6 +28,7 @@ shell none
 tracelog
 
 #private-bin luminance-hdr,luminance-hdr-cli,align_image_stack
+private-cache
 private-dev
 private-tmp
 

--- a/etc/lximage-qt.profile
+++ b/etc/lximage-qt.profile
@@ -27,6 +27,7 @@ protocol unix
 seccomp
 shell none
 
+private-cache
 private-dev
 private-tmp
 

--- a/etc/lynx.profile
+++ b/etc/lynx.profile
@@ -29,6 +29,7 @@ shell none
 tracelog
 
 # private-bin lynx
+private-cache
 private-dev
 # private-etc none
 private-tmp

--- a/etc/macrofusion.profile
+++ b/etc/macrofusion.profile
@@ -35,6 +35,7 @@ seccomp
 shell none
 
 private-bin python*,macrofusion,env,enfuse,exiftool,align_image_stack
+private-cache
 private-dev
 private-tmp
 

--- a/etc/mediainfo.profile
+++ b/etc/mediainfo.profile
@@ -30,6 +30,7 @@ shell none
 tracelog
 
 private-bin mediainfo
+private-cache
 private-dev
 private-etc none
 private-tmp

--- a/etc/meld.profile
+++ b/etc/meld.profile
@@ -28,6 +28,7 @@ seccomp
 shell none
 
 private-bin meld,python*
+private-cache
 private-dev
 private-tmp
 

--- a/etc/mpd.profile
+++ b/etc/mpd.profile
@@ -28,6 +28,7 @@ seccomp
 shell none
 
 #private-bin mpd,bash
+private-cache
 private-dev
 private-tmp
 

--- a/etc/obs.profile
+++ b/etc/obs.profile
@@ -25,6 +25,7 @@ shell none
 tracelog
 
 private-bin obs
+private-cache
 private-dev
 private-tmp
 

--- a/etc/odt2txt.profile
+++ b/etc/odt2txt.profile
@@ -30,6 +30,7 @@ shell none
 tracelog
 
 private-bin odt2txt
+private-cache
 private-dev
 private-etc none
 private-tmp

--- a/etc/orage.profile
+++ b/etc/orage.profile
@@ -29,6 +29,7 @@ seccomp
 shell none
 
 disable-mnt
+private-cache
 private-dev
 private-tmp
 

--- a/etc/parole.profile
+++ b/etc/parole.profile
@@ -22,4 +22,5 @@ seccomp
 shell none
 
 private-bin parole,dbus-launch
+private-cache
 private-etc passwd,group,fonts

--- a/etc/pdfsam.profile
+++ b/etc/pdfsam.profile
@@ -37,6 +37,7 @@ seccomp
 shell none
 
 private-bin pdfsam,sh,bash,java,archlinux-java,grep,awk,dirname,uname,which,sort,find,readlink,expr,ls,java-config
+private-cache
 private-dev
 private-tmp
 

--- a/etc/pidgin.profile
+++ b/etc/pidgin.profile
@@ -26,6 +26,7 @@ shell none
 tracelog
 
 private-bin pidgin
+private-cache
 private-dev
 private-tmp
 

--- a/etc/pinta.profile
+++ b/etc/pinta.profile
@@ -29,6 +29,7 @@ seccomp
 shell none
 
 private-dev
+private-cache
 private-tmp
 
 noexec ${HOME}

--- a/etc/pix.profile
+++ b/etc/pix.profile
@@ -30,5 +30,6 @@ shell none
 tracelog
 
 private-bin pix
+private-cache
 private-dev
 private-tmp

--- a/etc/pycharm-community.profile
+++ b/etc/pycharm-community.profile
@@ -32,6 +32,7 @@ tracelog
 
 # private-etc fonts,passwd - minimal required to run but will probably break
 # program!
+private-cache
 private-dev
 private-tmp
 

--- a/etc/qemu-launcher.profile
+++ b/etc/qemu-launcher.profile
@@ -23,6 +23,7 @@ seccomp
 shell none
 tracelog
 
+private-cache
 private-tmp
 
 noexec /tmp

--- a/etc/qemu-system-x86_64.profile
+++ b/etc/qemu-system-x86_64.profile
@@ -22,6 +22,7 @@ seccomp
 shell none
 tracelog
 
+private-cache
 private-tmp
 
 noexec /tmp

--- a/etc/qlipper.profile
+++ b/etc/qlipper.profile
@@ -28,6 +28,7 @@ seccomp
 shell none
 
 disable-mnt
+private-cache
 private-dev
 private-tmp
 

--- a/etc/quassel.profile
+++ b/etc/quassel.profile
@@ -19,3 +19,6 @@ noroot
 notv
 protocol unix,inet,inet6
 seccomp
+
+private-cache
+private-tmp

--- a/etc/remmina.profile
+++ b/etc/remmina.profile
@@ -28,6 +28,7 @@ seccomp
 # seccomp.keep access,arch_prctl,brk,chmod,clock_getres,clock_gettime,clone,close,connect,dup3,eventfd2,execve,fadvise64,fallocate,fcntl,flock,fstat,fstatfs,fsync,ftruncate,futex,getdents,getegid,geteuid,getgid,getpeername,getpid,getrandom,getresgid,getresuid,getsockname,getsockopt,gettid,getuid,inotify_add_watch,inotify_init1,inotify_rm_watch,ioctl,lseek,lstat,madvise,memfd_create,mmap,mprotect,mremap,munmap,nanosleep,open,openat,pipe,pipe2,poll,prctl,prlimit64,pwrite64,read,readlink,recvfrom,recvmsg,rename,rt_sigaction,rt_sigprocmask,sendmmsg,sendmsg,sendto,set_robust_list,setsockopt,set_tid_address,shmat,shmctl,shmdt,shmget,shutdown,socket,stat,statfs,sysinfo,tgkill,uname,utimensat,write,writev
 shell none
 
+private-cache
 private-dev
 private-tmp
 

--- a/etc/ristretto.profile
+++ b/etc/ristretto.profile
@@ -29,6 +29,7 @@ protocol unix
 seccomp
 shell none
 
+private-cache
 private-dev
 private-tmp
 

--- a/etc/rtorrent.profile
+++ b/etc/rtorrent.profile
@@ -26,5 +26,6 @@ seccomp
 shell none
 
 private-bin rtorrent
+private-cache
 private-dev
 private-tmp

--- a/etc/sdat2img.profile
+++ b/etc/sdat2img.profile
@@ -34,6 +34,7 @@ seccomp
 shell none
 
 private-bin sdat2img,env,python*
+private-cache
 private-dev
 
 noexec ${HOME}

--- a/etc/shotcut.profile
+++ b/etc/shotcut.profile
@@ -26,6 +26,7 @@ seccomp
 shell none
 
 #private-bin shotcut,melt,qmelt,nice
+private-cache
 private-dev
 
 #noexec ${HOME}

--- a/etc/skype.profile
+++ b/etc/skype.profile
@@ -26,6 +26,7 @@ shell none
 
 disable-mnt
 #private-bin skype,bash
+private-cache
 private-dev
 private-tmp
 

--- a/etc/skypeforlinux.profile
+++ b/etc/skypeforlinux.profile
@@ -25,6 +25,7 @@ seccomp
 shell none
 
 disable-mnt
+private-cache
 # private-dev - needs /dev/disk
 private-tmp
 

--- a/etc/soundconverter.profile
+++ b/etc/soundconverter.profile
@@ -31,6 +31,7 @@ protocol unix
 seccomp
 shell none
 
+private-cache
 private-dev
 private-tmp
 

--- a/etc/sqlitebrowser.profile
+++ b/etc/sqlitebrowser.profile
@@ -29,6 +29,7 @@ seccomp
 shell none
 
 private-bin sqlitebrowser
+private-cache
 private-dev
 private-tmp
 

--- a/etc/ssh.profile
+++ b/etc/ssh.profile
@@ -29,6 +29,7 @@ seccomp
 shell none
 tracelog
 
+private-cache
 private-dev
 # private-tmp # Breaks when exiting
 

--- a/etc/synfigstudio.profile
+++ b/etc/synfigstudio.profile
@@ -29,6 +29,7 @@ seccomp
 shell none
 
 #private-bin synfigstudio,synfig,ffmpeg
+private-cache
 private-dev
 private-tmp
 

--- a/etc/telegram.profile
+++ b/etc/telegram.profile
@@ -23,6 +23,7 @@ protocol unix,inet,inet6
 seccomp
 
 disable-mnt
+private-cache
 private-tmp
 
 noexec ${HOME}

--- a/etc/tilp.profile
+++ b/etc/tilp.profile
@@ -28,6 +28,7 @@ tracelog
 
 disable-mnt
 private-bin tilp
+private-cache
 private-etc fonts
 private-tmp
 

--- a/etc/tor.profile
+++ b/etc/tor.profile
@@ -41,6 +41,7 @@ writable-var
 disable-mnt
 private
 private-bin tor,bash
+private-cache
 private-dev
 private-etc tor,passwd
 private-tmp

--- a/etc/totem.profile
+++ b/etc/totem.profile
@@ -28,6 +28,7 @@ seccomp
 shell none
 
 private-bin totem
+private-cache
 private-dev
 # private-etc fonts
 private-tmp

--- a/etc/uefitool.profile
+++ b/etc/uefitool.profile
@@ -27,6 +27,7 @@ protocol unix
 seccomp
 shell none
 
+private-cache
 private-dev
 private-tmp
 

--- a/etc/uudeview.profile
+++ b/etc/uudeview.profile
@@ -18,6 +18,7 @@ shell none
 tracelog
 
 private-bin uudeview
+private-cache
 private-dev
 private-etc ld.so.preload
 

--- a/etc/viewnior.profile
+++ b/etc/viewnior.profile
@@ -34,6 +34,7 @@ shell none
 tracelog
 
 private-bin viewnior
+private-cache
 private-dev
 private-etc fonts
 private-tmp

--- a/etc/w3m.profile
+++ b/etc/w3m.profile
@@ -31,6 +31,7 @@ shell none
 tracelog
 
 # private-bin w3m
+private-cache
 private-dev
 private-etc resolv.conf,ssl,pki,ca-certificates,crypto-policies
 private-tmp

--- a/etc/webstorm.profile
+++ b/etc/webstorm.profile
@@ -35,5 +35,6 @@ protocol unix,inet,inet6
 seccomp
 shell none
 
+private-cache
 private-dev
 private-tmp

--- a/etc/wire.profile
+++ b/etc/wire.profile
@@ -29,5 +29,6 @@ seccomp
 shell none
 
 disable-mnt
+private-cache
 private-dev
 private-tmp

--- a/etc/xfce4-dict.profile
+++ b/etc/xfce4-dict.profile
@@ -28,6 +28,7 @@ seccomp
 shell none
 
 disable-mnt
+private-cache
 private-dev
 private-tmp
 

--- a/etc/xfce4-notes.profile
+++ b/etc/xfce4-notes.profile
@@ -30,6 +30,7 @@ seccomp
 shell none
 
 disable-mnt
+private-cache
 private-dev
 private-tmp
 

--- a/etc/zathura.profile
+++ b/etc/zathura.profile
@@ -29,6 +29,7 @@ seccomp
 shell none
 
 private-bin zathura
+private-cache
 private-dev
 private-etc fonts,machine-id
 private-tmp

--- a/src/firejail/checkcfg.c
+++ b/src/firejail/checkcfg.c
@@ -175,15 +175,6 @@ int checkcfg(int val) {
 				else
 					goto errout;
 			}
-			// private-cache
-			else if (strncmp(ptr, "private-cache ", 14) == 0) {
-				if (strcmp(ptr + 14, "yes") == 0)
-					cfg_val[CFG_PRIVATE_CACHE] = 1;
-				else if (strcmp(ptr + 14, "no") == 0)
-					cfg_val[CFG_PRIVATE_CACHE] = 0;
-				else
-					goto errout;
-			}
 			// seccomp
 			else if (strncmp(ptr, "seccomp ", 8) == 0) {
 				if (strcmp(ptr + 8, "yes") == 0)

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -308,6 +308,7 @@ static inline int any_interface_configured(void) {
 
 extern int arg_private;		// mount private /home
 extern int arg_private_template; // private /home template
+extern int arg_private_cache;	// private home/.cache
 extern int arg_debug;		// print debug messages
 extern int arg_debug_blacklists;	// print debug messages for blacklists
 extern int arg_debug_whitelists;	// print debug messages for whitelists
@@ -753,7 +754,6 @@ enum {
 	CFG_PRIVATE_LIB,
 	CFG_APPARMOR,
 	CFG_DBUS,
-	CFG_PRIVATE_CACHE,
 	CFG_MAX // this should always be the last entry
 };
 extern char *xephyr_screen;

--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -1353,8 +1353,10 @@ void fs_private_cache(void) {
 		fwarning("user .cache is a symbolic link, tmpfs not mounted\n");
 		return;
 	}
-	if (stat(cache, &s) == -1 || !S_ISDIR(s.st_mode))
+	if (stat(cache, &s) == -1 || !S_ISDIR(s.st_mode)) {
+		fwarning("no user .cache directory found, tmpfs not mounted\n");
 		return;
+	}
 	if (s.st_uid != getuid()) {
 		fwarning("user .cache is not owned by current user, tmpfs not mounted\n");
 		return;

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -46,6 +46,7 @@ static char child_stack[STACK_SIZE];		// space for child's stack
 Config cfg;					// configuration
 int arg_private = 0;				// mount private /home and /tmp directoryu
 int arg_private_template = 0; 	// mount private /home using a template
+int arg_private_cache = 0;		// mount private home/.cache
 int arg_debug = 0;				// print debug messages
 int arg_debug_blacklists = 0;			// print debug messages for blacklists
 int arg_debug_whitelists = 0;			// print debug messages for whitelists
@@ -1680,6 +1681,9 @@ int main(int argc, char **argv) {
 		}
 		else if (strcmp(argv[i], "--private-tmp") == 0) {
 			arg_private_tmp = 1;
+		}
+		else if (strcmp(argv[i], "--private-cache") == 0) {
+			arg_private_cache = 1;
 		}
 
 		//*************************************

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -217,6 +217,10 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		arg_allusers = 1;
 		return 0;
 	}
+	else if (strcmp(ptr, "private-cache") == 0) {
+		arg_private_cache = 1;
+		return 0;
+	}
 	else if (strcmp(ptr, "private-dev") == 0) {
 		arg_private_dev = 1;
 		return 0;

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -833,9 +833,14 @@ int sandbox(void* sandbox_arg) {
 		}
 	}
 
-	// private cache directory by default
-	if (checkcfg(CFG_PRIVATE_CACHE))
-		fs_private_cache();
+	if (arg_private_cache) {
+		if (cfg.chrootdir)
+			fwarning("private-cache feature is disabled in chroot\n");
+		else if (arg_overlay)
+			fwarning("private-cache feature is disabled in overlay\n");
+		else
+			fs_private_cache();
+	}
 
 	if (arg_private_tmp) {
 		// private-tmp is implemented as a whitelist

--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -221,6 +221,10 @@ filesystem, and copy the files and directories in the list in the
 new home. All modifications are discarded when the sandbox is
 closed.
 .TP
+\fBprivate-cache
+Mount an empty temporary filesystem on top of the .cache directory in user home. All
+modifications are discarded when the sandbox is closed.
+.TP
 \fBprivate-bin file,file
 Build a new /bin in a temporary filesystem, and copy the programs in the list.
 The same directory is also bind-mounted over /sbin, /usr/bin and /usr/sbin.

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -1322,6 +1322,17 @@ Example:
 $ firejail \-\-private-home=.mozilla firefox
 
 .TP
+\fB\-\-private-cache
+Mount an empty temporary filesystem on top of the .cache directory in user home. All
+modifications are discarded when the sandbox is closed.
+.br
+
+.br
+Example:
+.br
+$ firejail \-\-private-cache openbox
+
+.TP
 \fB\-\-private-bin=file,file
 Build a new /bin in a temporary filesystem, and copy the programs in the list.
 If no listed file is found, /bin directory will be empty.


### PR DESCRIPTION
Commit caa7ad8714206a158123773ddcaca6ef219a5501 enabled private-cache by default globally.

Should this really be enabled by default? Preventing programs from having persistent cache directories overall has many negative impacts.

- Most email clients cache emails to allow various functionality and downloading them can take many minutes
- Caching makes webpages load faster
- Most music players cache album art from libraries
- Mapping programs (gnome-maps, viking) don't need to constantly redownload tiles
- Mesa shader cache improves graphics load performance
- General waste of bandwith of clients/servers
- General increase in recomputing things
- General potential increase in disk I/O

I think it'd be better if we just manually add `private-cache` only to suitable programs.

private-cache will need to be added to more programs as identified by
```
grep 'whitelist ${HOME}/.cache' -L $(grep "private-cache" -L $(grep "redirect" -RiL))
```