### PR TITLE
don't include globals.local twice (take two)

### DIFF
--- a/etc/7z.profile
+++ b/etc/7z.profile
@@ -4,7 +4,8 @@ quiet
 # Persistent local customizations
 include /etc/firejail/7z.local
 # Persistent global definitions
-include /etc/firejail/globals.local
+# added by included default.profile
+#include /etc/firejail/globals.local
 
 blacklist /tmp/.X11-unix
 

--- a/etc/gzip.profile
+++ b/etc/gzip.profile
@@ -4,7 +4,8 @@ quiet
 # Persistent local customizations
 include /etc/firejail/gzip.local
 # Persistent global definitions
-include /etc/firejail/globals.local
+# added by included default.profile
+#include /etc/firejail/globals.local
 
 blacklist /tmp/.X11-unix
 

--- a/etc/less.profile
+++ b/etc/less.profile
@@ -4,7 +4,8 @@ quiet
 # Persistent local customizations
 include /etc/firejail/less.local
 # Persistent global definitions
-include /etc/firejail/globals.local
+# added by included default.profile
+#include /etc/firejail/globals.local
 
 blacklist /tmp/.X11-unix
 

--- a/etc/strings.profile
+++ b/etc/strings.profile
@@ -4,7 +4,8 @@ quiet
 # Persistent local customizations
 include /etc/firejail/strings.local
 # Persistent global definitions
-include /etc/firejail/globals.local
+# added by included default.profile
+#include /etc/firejail/globals.local
 
 blacklist /tmp/.X11-unix
 

--- a/etc/tar.profile
+++ b/etc/tar.profile
@@ -4,7 +4,8 @@ quiet
 # Persistent local customizations
 include /etc/firejail/tar.local
 # Persistent global definitions
-include /etc/firejail/globals.local
+# added by included default.profile
+#include /etc/firejail/globals.local
 
 blacklist /tmp/.X11-unix
 

--- a/etc/unrar.profile
+++ b/etc/unrar.profile
@@ -4,7 +4,8 @@ quiet
 # Persistent local customizations
 include /etc/firejail/unrar.local
 # Persistent global definitions
-include /etc/firejail/globals.local
+# added by included default.profile
+#include /etc/firejail/globals.local
 
 blacklist /tmp/.X11-unix
 

--- a/etc/unzip.profile
+++ b/etc/unzip.profile
@@ -4,7 +4,8 @@ quiet
 # Persistent local customizations
 include /etc/firejail/unzip.local
 # Persistent global definitions
-include /etc/firejail/globals.local
+# added by included default.profile
+#include /etc/firejail/globals.local
 
 blacklist /tmp/.X11-unix
 

--- a/etc/uudeview.profile
+++ b/etc/uudeview.profile
@@ -4,7 +4,8 @@ quiet
 # Persistent local customizations
 include /etc/firejail/uudeview.local
 # Persistent global definitions
-include /etc/firejail/globals.local
+# added by included default.profile
+#include /etc/firejail/globals.local
 
 hostname uudeview
 ignore noroot

--- a/etc/xzdec.profile
+++ b/etc/xzdec.profile
@@ -4,7 +4,8 @@ quiet
 # Persistent local customizations
 include /etc/firejail/xzdec.local
 # Persistent global definitions
-include /etc/firejail/globals.local
+# added by included default.profile
+#include /etc/firejail/globals.local
 
 blacklist /tmp/.X11-unix
 


### PR DESCRIPTION
Similar to https://github.com/netblue30/firejail/issues/2006. This time we avoid including globals.local twice in profiles that include default.profile.