### PR TITLE
7z redirect profiles

### DIFF
--- a/etc/7za.profile
+++ b/etc/7za.profile
@@ -1,0 +1,10 @@
+# Firejail profile for 7za
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/7za.local
+# Persistent global definitions
+# added by included profile
+#include /etc/firejail/globals.local
+
+# Redirect
+include /etc/firejail/7z.profile

--- a/etc/7zr.profile
+++ b/etc/7zr.profile
@@ -1,0 +1,10 @@
+# Firejail profile for 7zr
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/7zr.local
+# Persistent global definitions
+# added by included profile
+#include /etc/firejail/globals.local
+
+# Redirect
+include /etc/firejail/7z.profile

--- a/etc/p7zip.profile
+++ b/etc/p7zip.profile
@@ -1,0 +1,10 @@
+# Firejail profile for p7zip
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/p7zip.local
+# Persistent global definitions
+# added by included profile
+#include /etc/firejail/globals.local
+
+# Redirect
+include /etc/firejail/7z.profile


### PR DESCRIPTION
At least Debian/Ubuntu distro's (and possibly others) carry both `p7zip` and `p7zip-full` packages. Besides `7z` these offer additional commands `7za`, `7zr` and `p7zip`. The redirect profiles offered here to cover these use the same format as used in https://github.com/netblue30/firejail/commit/edfefbe194ea0ff7a8fa9939e0dece61bea9ca5b and https://github.com/netblue30/firejail/pull/2010 (avoiding inclusion of globals.local more than once). 