### PR TITLE
WIP: Add new disable-xdg.inc

### DIFF
--- a/etc/2048-qt.profile
+++ b/etc/2048-qt.profile
@@ -14,6 +14,11 @@ include /etc/firejail/disable-interpreters.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
 
+mkdir ${HOME}/.config/2048-qt
+mkdir ${HOME}/.config/xiaoyong
+whitelist ${HOME}/.config/2048-qt
+whitelist ${HOME}/.config/xiaoyong
+include /etc/firejail/whitelist-common.inc
 include /etc/firejail/whitelist-var-common.inc
 
 caps.drop all

--- a/etc/Fritzing.profile
+++ b/etc/Fritzing.profile
@@ -6,12 +6,14 @@ include /etc/firejail/Fritzing.local
 include /etc/firejail/globals.local
 
 noblacklist ${HOME}/.config/Fritzing
+noblacklist ${DOCUMENTS}
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-interpreters.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-xdg.inc
 
 include /etc/firejail/whitelist-var-common.inc
 

--- a/etc/android-studio.profile
+++ b/etc/android-studio.profile
@@ -15,10 +15,12 @@ noblacklist ${HOME}/.java
 noblacklist ${HOME}/.local/share/JetBrains
 noblacklist ${HOME}/.ssh
 noblacklist ${HOME}/.tooling
+noblacklist ${DOCUMENTS}
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-xdg.inc
 
 caps.drop all
 netfilter

--- a/etc/aosp.profile
+++ b/etc/aosp.profile
@@ -21,6 +21,7 @@ noblacklist ${HOME}/.tooling
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-xdg.inc
 
 include /etc/firejail/whitelist-var-common.inc
 

--- a/etc/apktool.profile
+++ b/etc/apktool.profile
@@ -9,6 +9,7 @@ include /etc/firejail/globals.local
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-xdg.inc
 
 caps.drop all
 net none

--- a/etc/arch-audit.profile
+++ b/etc/arch-audit.profile
@@ -14,6 +14,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-interpreters.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-xdg.inc
 
 caps.drop all
 ipc-namespace

--- a/etc/archaudit-report.profile
+++ b/etc/archaudit-report.profile
@@ -14,6 +14,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-interpreters.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-xdg.inc
 
 include /etc/firejail/whitelist-common.inc
 

--- a/etc/disable-xdg.inc
+++ b/etc/disable-xdg.inc
@@ -4,7 +4,7 @@ include /etc/firejail/disable-xdg.local
 
 #blacklist ${DESKTOP}
 blacklist ${DOCUMENTS}
-blacklist ${DOWNLOADS}
+#blacklist ${DOWNLOADS}
 blacklist ${MUSIC}
 blacklist ${PICTURES}
 blacklist ${VIDEOS}

--- a/etc/disable-xdg.inc
+++ b/etc/disable-xdg.inc
@@ -1,0 +1,10 @@
+# This file is overwritten during software install.
+# Persistent customizations should go in a .local file.
+include /etc/firejail/disable-xdg.local
+
+#blacklist ${DESKTOP}
+blacklist ${DOCUMENTS}
+blacklist ${DOWNLOADS}
+blacklist ${MUSIC}
+blacklist ${PICTURES}
+blacklist ${VIDEOS}

--- a/etc/gnome-books.profile
+++ b/etc/gnome-books.profile
@@ -8,12 +8,14 @@ include /etc/firejail/globals.local
 # when gjs apps are started via gnome-shell, firejail is not applied because systemd will start them
 
 noblacklist ${HOME}/.cache/org.gnome.Books
+noblacklist ${DOCUMENTS}
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-interpreters.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-xdg.inc
 
 include /etc/firejail/whitelist-var-common.inc
 

--- a/etc/gnome-calculator.profile
+++ b/etc/gnome-calculator.profile
@@ -11,6 +11,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-interpreters.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-xdg.inc
 
 include /etc/firejail/whitelist-common.inc
 include /etc/firejail/whitelist-var-common.inc

--- a/etc/gnome-chess.profile
+++ b/etc/gnome-chess.profile
@@ -12,6 +12,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-interpreters.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-xdg.inc
 
 include /etc/firejail/whitelist-var-common.inc
 

--- a/etc/gnome-clocks.profile
+++ b/etc/gnome-clocks.profile
@@ -11,6 +11,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-interpreters.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-xdg.inc
 
 include /etc/firejail/whitelist-var-common.inc
 

--- a/etc/gnome-contacts.profile
+++ b/etc/gnome-contacts.profile
@@ -5,15 +5,16 @@ include /etc/firejail/gnome-contacts.local
 # Persistent global definitions
 include /etc/firejail/globals.local
 
+noblacklist ${DOCUMENTS}
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-interpreters.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-xdg.inc
 
 include /etc/firejail/whitelist-common.inc
-
 include /etc/firejail/whitelist-var-common.inc
 
 caps.drop all

--- a/etc/gnome-documents.profile
+++ b/etc/gnome-documents.profile
@@ -8,12 +8,14 @@ include /etc/firejail/globals.local
 # when gjs apps are started via gnome-shell, firejail is not applied because systemd will start them
 
 noblacklist ${HOME}/.config/libreoffice
+noblacklist ${DOCUMENTS}
 
 include /etc/firejail/disable-common.inc
 include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-interpreters.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-xdg.inc
 
 caps.drop all
 netfilter

--- a/etc/gnome-font-viewer.profile
+++ b/etc/gnome-font-viewer.profile
@@ -11,6 +11,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-interpreters.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-xdg.inc
 
 include /etc/firejail/whitelist-var-common.inc
 

--- a/etc/gnome-logs.profile
+++ b/etc/gnome-logs.profile
@@ -10,6 +10,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-interpreters.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-xdg.inc
 
 whitelist /var/log/journal
 include /etc/firejail/whitelist-var-common.inc

--- a/etc/gnome-maps.profile
+++ b/etc/gnome-maps.profile
@@ -14,6 +14,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-interpreters.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-xdg.inc
 
 include /etc/firejail/whitelist-var-common.inc
 

--- a/etc/gnome-weather.profile
+++ b/etc/gnome-weather.profile
@@ -14,6 +14,7 @@ include /etc/firejail/disable-devel.inc
 include /etc/firejail/disable-interpreters.inc
 include /etc/firejail/disable-passwdmgr.inc
 include /etc/firejail/disable-programs.inc
+include /etc/firejail/disable-xdg.inc
 
 include /etc/firejail/whitelist-var-common.inc
 


### PR DESCRIPTION
Now that @chiraag-nataraj added support for more XDG user dirs in fff306c991ff1f33ccb56313e4c166a169555656, we can blacklist these in many profiles that don't utilize whitelist.

I created a disable-xdg.inc. Downloads and Desktop are commented as they are usually a catch-all for most people.

And I included it in a small amount of profiles identified using the following command:
```
grep "disable-xdg" -RL $(grep 'whitelist \$' -RL $(grep "redirect" . -RiL))
```

there are still ~270 remaining, and strong discretion is needed, so I figured I'd get some discussion going before I went at it. Feel free to push to the branch at will.