### PR TITLE
Add descriptions to profiles

### DIFF
--- a/etc/0ad.profile
+++ b/etc/0ad.profile
@@ -1,4 +1,5 @@
 # Firejail profile for 0ad
+# Description: Real-time strategy game of ancient warfare
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/0ad.local

--- a/etc/2048-qt.profile
+++ b/etc/2048-qt.profile
@@ -1,4 +1,5 @@
 # Firejail profile for 2048-qt
+# Description: mathematics based puzzle game
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/2048-qt.local

--- a/etc/2048-qt.profile
+++ b/etc/2048-qt.profile
@@ -1,5 +1,5 @@
 # Firejail profile for 2048-qt
-# Description: mathematics based puzzle game
+# Description: Mathematics based puzzle game
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/2048-qt.local

--- a/etc/Fritzing.profile
+++ b/etc/Fritzing.profile
@@ -1,4 +1,5 @@
 # Firejail profile for fritzing
+# Description: Easy-to-use electronic design software
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/Fritzing.local

--- a/etc/Thunar.profile
+++ b/etc/Thunar.profile
@@ -1,4 +1,5 @@
 # Firejail profile for Thunar
+# Description: File Manager for Xfce
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/Thunar.local

--- a/etc/VirtualBox.profile
+++ b/etc/VirtualBox.profile
@@ -1,5 +1,5 @@
 # Firejail profile alias for virtualbox
-# Description: Powerful x86 virtualization for enterprise as well as home use
+# Description: x86 virtualization solution
 # This file is overwritten after every install/update
 
 

--- a/etc/VirtualBox.profile
+++ b/etc/VirtualBox.profile
@@ -1,4 +1,5 @@
 # Firejail profile alias for virtualbox
+# Description: Powerful x86 virtualization for enterprise as well as home use
 # This file is overwritten after every install/update
 
 

--- a/etc/Xvfb.profile
+++ b/etc/Xvfb.profile
@@ -1,4 +1,5 @@
 # Firejail profile for Xvfb
+# Description: Virtual Framebuffer 'fake' X server
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/Xvfb.local

--- a/etc/akregator.profile
+++ b/etc/akregator.profile
@@ -1,4 +1,5 @@
 # Firejail profile for akregator
+# Description: RSS/Atom feed aggregator
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/akregator.local

--- a/etc/amarok.profile
+++ b/etc/amarok.profile
@@ -1,4 +1,5 @@
 # Firejail profile for amarok
+# Description: easy to use media player based on the KDE Platform
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/amarok.local

--- a/etc/amarok.profile
+++ b/etc/amarok.profile
@@ -1,5 +1,5 @@
 # Firejail profile for amarok
-# Description: easy to use media player based on the KDE Platform
+# Description: Easy to use media player based on the KDE Platform
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/amarok.local

--- a/etc/amule.profile
+++ b/etc/amule.profile
@@ -1,4 +1,5 @@
 # Firejail profile for amule
+# Description: client for the eD2k and Kad networks, like eMule
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/amule.local

--- a/etc/amule.profile
+++ b/etc/amule.profile
@@ -1,5 +1,5 @@
 # Firejail profile for amule
-# Description: client for the eD2k and Kad networks, like eMule
+# Description: Client for the eD2k and Kad networks, like eMule
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/amule.local

--- a/etc/apktool.profile
+++ b/etc/apktool.profile
@@ -1,4 +1,5 @@
 # Firejail profile for apktool
+# Description: tool for reverse engineering Android apk files
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/apktool.profile
+++ b/etc/apktool.profile
@@ -1,5 +1,5 @@
 # Firejail profile for apktool
-# Description: tool for reverse engineering Android apk files
+# Description: Tool for reverse engineering Android apk files
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/arch-audit.profile
+++ b/etc/arch-audit.profile
@@ -1,4 +1,5 @@
 # Firejail profile for arch-audit
+# Description: An utility like pkg-audit based on Arch CVE Monitoring Team data
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/arch-audit.profile
+++ b/etc/arch-audit.profile
@@ -1,5 +1,5 @@
 # Firejail profile for arch-audit
-# Description: An utility like pkg-audit based on Arch CVE Monitoring Team data
+# Description: A utility like pkg-audit based on Arch CVE Monitoring Team data
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/arduino.profile
+++ b/etc/arduino.profile
@@ -1,4 +1,5 @@
 # Firejail profile for arduino
+# Description: AVR development board IDE and built-in libraries
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/arduino.local

--- a/etc/ark.profile
+++ b/etc/ark.profile
@@ -1,4 +1,5 @@
 # Firejail profile for ark
+# Description: archive utility
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/ark.local

--- a/etc/ark.profile
+++ b/etc/ark.profile
@@ -1,5 +1,5 @@
 # Firejail profile for ark
-# Description: archive utility
+# Description: Archive utility
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/ark.local

--- a/etc/arm.profile
+++ b/etc/arm.profile
@@ -1,4 +1,5 @@
 # Firejail profile for arm
+# Description: Terminal status monitor for Tor relays
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/arm.local

--- a/etc/asunder.profile
+++ b/etc/asunder.profile
@@ -1,4 +1,5 @@
 # Firejail profile for asounder
+# Description: graphical audio CD ripper and encoder
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/asunder.local

--- a/etc/asunder.profile
+++ b/etc/asunder.profile
@@ -1,5 +1,5 @@
 # Firejail profile for asounder
-# Description: graphical audio CD ripper and encoder
+# Description: Graphical audio CD ripper and encoder
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/asunder.local

--- a/etc/atom.profile
+++ b/etc/atom.profile
@@ -1,4 +1,5 @@
 # Firejail profile for atom
+# Description: A hackable text editor for the 21st Century
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/atom.local

--- a/etc/atool.profile
+++ b/etc/atool.profile
@@ -1,4 +1,5 @@
 # Firejail profile for atool
+# Description: tool for managing file archives of various types
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/atool.local

--- a/etc/atool.profile
+++ b/etc/atool.profile
@@ -1,5 +1,5 @@
 # Firejail profile for atool
-# Description: tool for managing file archives of various types
+# Description: Tool for managing file archives of various types
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/atool.local

--- a/etc/atril.profile
+++ b/etc/atril.profile
@@ -1,4 +1,5 @@
 # Firejail profile for atril
+# Description: MATE document viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/atril.local

--- a/etc/audacious.profile
+++ b/etc/audacious.profile
@@ -1,4 +1,5 @@
 # Firejail profile for audacious
+# Description: small and fast audio player which supports lots of formats
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/audacious.local

--- a/etc/audacious.profile
+++ b/etc/audacious.profile
@@ -1,5 +1,5 @@
 # Firejail profile for audacious
-# Description: small and fast audio player which supports lots of formats
+# Description: Small and fast audio player which supports lots of formats
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/audacious.local

--- a/etc/audacity.profile
+++ b/etc/audacity.profile
@@ -1,4 +1,5 @@
 # Firejail profile for audacity
+# Description: fast, cross-platform audio editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/audacity.local

--- a/etc/audacity.profile
+++ b/etc/audacity.profile
@@ -1,5 +1,5 @@
 # Firejail profile for audacity
-# Description: fast, cross-platform audio editor
+# Description: Fast, cross-platform audio editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/audacity.local

--- a/etc/aweather.profile
+++ b/etc/aweather.profile
@@ -1,4 +1,5 @@
 # Firejail profile for aweather
+# Description: Advanced Weather Monitoring Program
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/aweather.local

--- a/etc/baobab.profile
+++ b/etc/baobab.profile
@@ -1,4 +1,5 @@
 # Firejail profile for baobab
+# Description: GNOME disk usage analyzer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/baobab.local

--- a/etc/bibletime.profile
+++ b/etc/bibletime.profile
@@ -1,4 +1,5 @@
 # Firejail profile for bibletime
+# Description: bible study tool for Qt
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/bibletime.local

--- a/etc/bibletime.profile
+++ b/etc/bibletime.profile
@@ -1,5 +1,5 @@
 # Firejail profile for bibletime
-# Description: bible study tool for Qt
+# Description: Bible study tool
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/bibletime.local

--- a/etc/bitcoin-qt.profile
+++ b/etc/bitcoin-qt.profile
@@ -1,4 +1,5 @@
 # Firejail profile for bitcoin-qt
+# Description: Bitcoin is a peer-to-peer network based digital currency - Qt
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/bitcoin-qt.local

--- a/etc/bitcoin-qt.profile
+++ b/etc/bitcoin-qt.profile
@@ -1,5 +1,5 @@
 # Firejail profile for bitcoin-qt
-# Description: Bitcoin is a peer-to-peer network based digital currency - Qt
+# Description: Bitcoin is a peer-to-peer network based digital currency
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/bitcoin-qt.local

--- a/etc/bitlbee.profile
+++ b/etc/bitlbee.profile
@@ -1,4 +1,5 @@
 # Firejail profile for bitlbee
+# Description: IRC to other chat networks gateway (default version)
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/bitlbee.local

--- a/etc/bitlbee.profile
+++ b/etc/bitlbee.profile
@@ -1,5 +1,5 @@
 # Firejail profile for bitlbee
-# Description: IRC to other chat networks gateway (default version)
+# Description: IRC to other chat networks gateway
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/bitlbee.local

--- a/etc/bleachbit.profile
+++ b/etc/bleachbit.profile
@@ -1,4 +1,5 @@
 # Firejail profile for bleachbit
+# Description: delete unnecessary files from the system
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/bleachbit.local

--- a/etc/bleachbit.profile
+++ b/etc/bleachbit.profile
@@ -1,5 +1,5 @@
 # Firejail profile for bleachbit
-# Description: delete unnecessary files from the system
+# Description: Delete unnecessary files from the system
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/bleachbit.local

--- a/etc/blender.profile
+++ b/etc/blender.profile
@@ -1,4 +1,5 @@
 # Firejail profile for blender
+# Description: Very fast and versatile 3D modeller/renderer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/blender.local

--- a/etc/bless.profile
+++ b/etc/bless.profile
@@ -1,4 +1,5 @@
 # Firejail profile for bless
+# Description: A full featured hexadecimal editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/bless.local

--- a/etc/bluefish.profile
+++ b/etc/bluefish.profile
@@ -1,4 +1,5 @@
 # Firejail profile for bluefish
+# Description: advanced Gtk+ text editor for web and software development
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/bluefish.local

--- a/etc/bluefish.profile
+++ b/etc/bluefish.profile
@@ -1,5 +1,5 @@
 # Firejail profile for bluefish
-# Description: advanced Gtk+ text editor for web and software development
+# Description: Advanced Gtk+ text editor for web and software development
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/bluefish.local

--- a/etc/brasero.profile
+++ b/etc/brasero.profile
@@ -1,4 +1,5 @@
 # Firejail profile for brasero
+# Description: CD/DVD burning application for GNOME
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/brasero.local

--- a/etc/bsdtar.profile
+++ b/etc/bsdtar.profile
@@ -1,4 +1,5 @@
 # Firejail profile for bsdtar
+# Description: transitional dummy package for moving bsdtar to libarchive-tools
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations
@@ -37,6 +38,3 @@ tracelog
 private-bin sh,bash,bsdtar,gtar,compress,gzip,lzma,xz,bzip2,lbzip2,lzip,lzop,lz4,libarchive
 private-dev
 private-etc passwd,group,localtime
-
-
-

--- a/etc/bsdtar.profile
+++ b/etc/bsdtar.profile
@@ -1,5 +1,4 @@
 # Firejail profile for bsdtar
-# Description: transitional dummy package for moving bsdtar to libarchive-tools
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/caja.profile
+++ b/etc/caja.profile
@@ -1,4 +1,5 @@
 # Firejail profile for caja
+# Description: file manager for the MATE desktop
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/caja.local

--- a/etc/caja.profile
+++ b/etc/caja.profile
@@ -1,5 +1,5 @@
 # Firejail profile for caja
-# Description: file manager for the MATE desktop
+# Description: File manager for the MATE desktop
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/caja.local

--- a/etc/calibre.profile
+++ b/etc/calibre.profile
@@ -1,4 +1,5 @@
 # Firejail profile for calibre
+# Description: powerful and easy to use e-book manager
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/calibre.local

--- a/etc/calibre.profile
+++ b/etc/calibre.profile
@@ -1,5 +1,5 @@
 # Firejail profile for calibre
-# Description: powerful and easy to use e-book manager
+# Description: Powerful and easy to use e-book manager
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/calibre.local

--- a/etc/calligra.profile
+++ b/etc/calligra.profile
@@ -1,4 +1,5 @@
 # Firejail profile for calligra
+# Description: extensive productivity and creative suite
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/calligra.local

--- a/etc/calligra.profile
+++ b/etc/calligra.profile
@@ -1,5 +1,5 @@
 # Firejail profile for calligra
-# Description: extensive productivity and creative suite
+# Description: Extensive productivity and creative suite
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/calligra.local

--- a/etc/catfish.profile
+++ b/etc/catfish.profile
@@ -1,4 +1,5 @@
 # Firejail profile for catfish
+# Description: File searching tool which is configurable via the command line
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/catfish.local

--- a/etc/catfish.profile
+++ b/etc/catfish.profile
@@ -1,5 +1,5 @@
 # Firejail profile for catfish
-# Description: File searching tool which is configurable via the command line
+# Description: File searching tool
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/catfish.local

--- a/etc/cherrytree.profile
+++ b/etc/cherrytree.profile
@@ -1,4 +1,5 @@
 # Firejail profile for cherrytree
+# Description: hierarchical note taking application
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/cherrytree.local

--- a/etc/cherrytree.profile
+++ b/etc/cherrytree.profile
@@ -1,5 +1,5 @@
 # Firejail profile for cherrytree
-# Description: hierarchical note taking application
+# Description: Hierarchical note taking application
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/cherrytree.local

--- a/etc/chromium.profile
+++ b/etc/chromium.profile
@@ -1,4 +1,5 @@
 # Firejail profile for chromium
+# Description: A web browser built for speed, simplicity, and security
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/chromium.local

--- a/etc/clamav.profile
+++ b/etc/clamav.profile
@@ -1,4 +1,5 @@
 # Firejail profile for clamav
+# Description: anti-virus utility for Unix - command-line interface
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/clamav.profile
+++ b/etc/clamav.profile
@@ -1,5 +1,5 @@
 # Firejail profile for clamav
-# Description: anti-virus utility for Unix - command-line interface
+# Description: Anti-virus utility for Unix
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/claws-mail.profile
+++ b/etc/claws-mail.profile
@@ -1,4 +1,5 @@
 # Firejail profile for claws-mail
+# Description: Fast, lightweight and user-friendly GTK+2 based email client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/claws-mail.local

--- a/etc/clementine.profile
+++ b/etc/clementine.profile
@@ -1,4 +1,5 @@
 # Firejail profile for clementine
+# Description: modern music player and library organizer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/clementine.local

--- a/etc/clementine.profile
+++ b/etc/clementine.profile
@@ -1,5 +1,5 @@
 # Firejail profile for clementine
-# Description: modern music player and library organizer
+# Description: Modern music player and library organizer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/clementine.local

--- a/etc/clipit.profile
+++ b/etc/clipit.profile
@@ -1,4 +1,5 @@
 # Firejail profile for clipit
+# Description: lightweight GTK+ clipboard manager
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/clipit.local

--- a/etc/clipit.profile
+++ b/etc/clipit.profile
@@ -1,5 +1,5 @@
 # Firejail profile for clipit
-# Description: lightweight GTK+ clipboard manager
+# Description: Lightweight GTK+ clipboard manager
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/clipit.local

--- a/etc/cmus.profile
+++ b/etc/cmus.profile
@@ -1,4 +1,5 @@
 # Firejail profile for cmus
+# Description: lightweight ncurses audio player
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/cmus.local

--- a/etc/cmus.profile
+++ b/etc/cmus.profile
@@ -1,5 +1,5 @@
 # Firejail profile for cmus
-# Description: lightweight ncurses audio player
+# Description: Lightweight ncurses audio player
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/cmus.local

--- a/etc/conky.profile
+++ b/etc/conky.profile
@@ -1,4 +1,5 @@
 # Firejail profile for conky
+# Description: highly configurable system monitor (transitional package)
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/conky.local

--- a/etc/conky.profile
+++ b/etc/conky.profile
@@ -1,5 +1,5 @@
 # Firejail profile for conky
-# Description: highly configurable system monitor (transitional package)
+# Description: Highly configurable system monitor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/conky.local

--- a/etc/corebird.profile
+++ b/etc/corebird.profile
@@ -1,4 +1,5 @@
 # Firejail profile for corebird
+# Description: Native Gtk+ Twitter client for the Linux desktop
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/corebird.local

--- a/etc/cpio.profile
+++ b/etc/cpio.profile
@@ -1,4 +1,5 @@
 # Firejail profile for cpio
+# Description: GNU cpio -- a program to manage archives of files
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/cpio.profile
+++ b/etc/cpio.profile
@@ -1,5 +1,5 @@
 # Firejail profile for cpio
-# Description: GNU cpio -- a program to manage archives of files
+# Description: A program to manage archives of files
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/curl.profile
+++ b/etc/curl.profile
@@ -1,4 +1,5 @@
 # Firejail profile for curl
+# Description: command line tool for transferring data with URL syntax
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/curl.profile
+++ b/etc/curl.profile
@@ -1,5 +1,5 @@
 # Firejail profile for curl
-# Description: command line tool for transferring data with URL syntax
+# Description: Command line tool for transferring data with URL syntax
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/darktable.profile
+++ b/etc/darktable.profile
@@ -1,4 +1,5 @@
 # Firejail profile for darktable
+# Description: virtual lighttable and darkroom for photographers
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/darktable.local

--- a/etc/darktable.profile
+++ b/etc/darktable.profile
@@ -1,5 +1,5 @@
 # Firejail profile for darktable
-# Description: virtual lighttable and darkroom for photographers
+# Description: Virtual lighttable and darkroom for photographers
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/darktable.local

--- a/etc/deadbeef.profile
+++ b/etc/deadbeef.profile
@@ -1,4 +1,5 @@
 # Firejail profile for deadbeef
+# Description: A GTK+ audio player for GNU/Linux.
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/deadbeef.local

--- a/etc/deadbeef.profile
+++ b/etc/deadbeef.profile
@@ -1,5 +1,5 @@
 # Firejail profile for deadbeef
-# Description: A GTK+ audio player for GNU/Linux.
+# Description: A GTK+ audio player for GNU/Linux
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/deadbeef.local

--- a/etc/deluge.profile
+++ b/etc/deluge.profile
@@ -1,4 +1,5 @@
 # Firejail profile for deluge
+# Description: bittorrent client written in Python/PyGTK
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/deluge.local

--- a/etc/deluge.profile
+++ b/etc/deluge.profile
@@ -1,5 +1,5 @@
 # Firejail profile for deluge
-# Description: bittorrent client written in Python/PyGTK
+# Description: BitTorrent client written in Python/PyGTK
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/deluge.local

--- a/etc/dia.profile
+++ b/etc/dia.profile
@@ -1,4 +1,5 @@
 # Firejail profile for dia
+# Description: Diagram editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/dia.local

--- a/etc/digikam.profile
+++ b/etc/digikam.profile
@@ -1,4 +1,5 @@
 # Firejail profile for digikam
+# Description: digital photo management application for KDE
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/digikam.local

--- a/etc/digikam.profile
+++ b/etc/digikam.profile
@@ -1,5 +1,5 @@
 # Firejail profile for digikam
-# Description: digital photo management application for KDE
+# Description: Digital photo management application for KDE
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/digikam.local

--- a/etc/dillo.profile
+++ b/etc/dillo.profile
@@ -1,4 +1,5 @@
 # Firejail profile for dillo
+# Description: Small and fast web browser
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/dillo.local

--- a/etc/dnscrypt-proxy.profile
+++ b/etc/dnscrypt-proxy.profile
@@ -1,4 +1,5 @@
 # Firejail profile for dnscrypt-proxy
+# Description: Tool for securing communications between a client and a DNS resolver
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/dnscrypt-proxy.local

--- a/etc/dnsmasq.profile
+++ b/etc/dnsmasq.profile
@@ -1,4 +1,5 @@
 # Firejail profile for dnsmasq
+# Description: Small caching DNS proxy and DHCP/TFTP server
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/dnsmasq.local

--- a/etc/dolphin.profile
+++ b/etc/dolphin.profile
@@ -1,4 +1,5 @@
 # Firejail profile for dolphin
+# Description: file manager
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/dolphin.local

--- a/etc/dolphin.profile
+++ b/etc/dolphin.profile
@@ -1,5 +1,5 @@
 # Firejail profile for dolphin
-# Description: file manager
+# Description: File manager
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/dolphin.local

--- a/etc/dosbox.profile
+++ b/etc/dosbox.profile
@@ -1,4 +1,5 @@
 # Firejail profile for dosbox
+# Description: x86 emulator with Tandy/Herc/CGA/EGA/VGA/SVGA graphics, sound and DOS
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/dosbox.local

--- a/etc/dragon.profile
+++ b/etc/dragon.profile
@@ -1,4 +1,5 @@
 # Firejail profile for dragon
+# Description: A multimedia player where the focus is on simplicity, instead of features
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/dragon.local

--- a/etc/electron.profile
+++ b/etc/electron.profile
@@ -1,4 +1,5 @@
 # Firejail profile for electron
+# Description: Build cross platform desktop apps with web technologies
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/electron.local

--- a/etc/electrum.profile
+++ b/etc/electrum.profile
@@ -1,4 +1,5 @@
 # Firejail profile for electrum
+# Description: Lightweight Bitcoin wallet
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/electrum.local

--- a/etc/elinks.profile
+++ b/etc/elinks.profile
@@ -1,4 +1,5 @@
 # Firejail profile for elinks
+# Description: advanced text-mode WWW browser
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/elinks.local

--- a/etc/elinks.profile
+++ b/etc/elinks.profile
@@ -1,5 +1,5 @@
 # Firejail profile for elinks
-# Description: advanced text-mode WWW browser
+# Description: Advanced text-mode WWW browser
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/elinks.local

--- a/etc/emacs.profile
+++ b/etc/emacs.profile
@@ -1,4 +1,5 @@
 # Firejail profile for emacs
+# Description: GNU Emacs editor (metapackage)
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/emacs.local

--- a/etc/emacs.profile
+++ b/etc/emacs.profile
@@ -1,5 +1,5 @@
 # Firejail profile for emacs
-# Description: GNU Emacs editor (metapackage)
+# Description: GNU Emacs editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/emacs.local

--- a/etc/empathy.profile
+++ b/etc/empathy.profile
@@ -1,4 +1,5 @@
 # Firejail profile for empathy
+# Description: GNOME multi-protocol chat and call client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/empathy.local

--- a/etc/enchant.profile
+++ b/etc/enchant.profile
@@ -1,4 +1,5 @@
 # Firejail profile for enchant
+# Description: Wrapper for various spell checker engines (binary programs)
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/enchant.local

--- a/etc/enchant.profile
+++ b/etc/enchant.profile
@@ -1,5 +1,5 @@
 # Firejail profile for enchant
-# Description: Wrapper for various spell checker engines (binary programs)
+# Description: Wrapper for various spell checker engines
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/enchant.local

--- a/etc/engrampa.profile
+++ b/etc/engrampa.profile
@@ -1,4 +1,5 @@
 # Firejail profile for engrampa
+# Description: archive manager for MATE
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/engrampa.local

--- a/etc/engrampa.profile
+++ b/etc/engrampa.profile
@@ -1,5 +1,5 @@
 # Firejail profile for engrampa
-# Description: archive manager for MATE
+# Description: Archive manager for MATE
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/engrampa.local

--- a/etc/eog.profile
+++ b/etc/eog.profile
@@ -1,4 +1,5 @@
 # Firejail profile for eog
+# Description: Eye of GNOME graphics viewer program
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/eog.local

--- a/etc/eom.profile
+++ b/etc/eom.profile
@@ -1,4 +1,5 @@
 # Firejail profile for eom
+# Description: Eye of MATE graphics viewer program
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/eom.local

--- a/etc/epiphany.profile
+++ b/etc/epiphany.profile
@@ -1,4 +1,5 @@
 # Firejail profile for epiphany
+# Description: clone of Boulder Dash game
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/epiphany.local

--- a/etc/epiphany.profile
+++ b/etc/epiphany.profile
@@ -1,5 +1,5 @@
 # Firejail profile for epiphany
-# Description: clone of Boulder Dash game
+# Description: Clone of Boulder Dash game
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/epiphany.local

--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -1,4 +1,5 @@
 # Firejail profile for evince
+# Description: Document (PostScript, PDF) viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/evince.local

--- a/etc/evolution.profile
+++ b/etc/evolution.profile
@@ -1,4 +1,5 @@
 # Firejail profile for evolution
+# Description: groupware suite with mail client and organizer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/evolution.local

--- a/etc/evolution.profile
+++ b/etc/evolution.profile
@@ -1,5 +1,5 @@
 # Firejail profile for evolution
-# Description: groupware suite with mail client and organizer
+# Description: Groupware suite with mail client and organizer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/evolution.local

--- a/etc/falkon.profile
+++ b/etc/falkon.profile
@@ -1,4 +1,5 @@
 # Firejail profile for falkon
+# Description: lightweight web browser based on Qt WebEngine
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/falkon.local

--- a/etc/falkon.profile
+++ b/etc/falkon.profile
@@ -1,5 +1,5 @@
 # Firejail profile for falkon
-# Description: lightweight web browser based on Qt WebEngine
+# Description: Lightweight web browser based on Qt WebEngine
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/falkon.local

--- a/etc/fbreader.profile
+++ b/etc/fbreader.profile
@@ -1,4 +1,5 @@
 # Firejail profile for fbreader
+# Description: e-book reader
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/fbreader.local

--- a/etc/fbreader.profile
+++ b/etc/fbreader.profile
@@ -1,5 +1,5 @@
 # Firejail profile for fbreader
-# Description: e-book reader
+# Description: E-book reader
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/fbreader.local

--- a/etc/feh.profile
+++ b/etc/feh.profile
@@ -1,4 +1,5 @@
 # Firejail profile for feh
+# Description: imlib2 based image viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/feh.local

--- a/etc/fetchmail.profile
+++ b/etc/fetchmail.profile
@@ -1,4 +1,5 @@
 # Firejail profile for fetchmail
+# Description: SSL enabled POP3, APOP, IMAP mail gatherer/forwarder
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/fetchmail.local

--- a/etc/ffmpeg.profile
+++ b/etc/ffmpeg.profile
@@ -1,4 +1,5 @@
 # Firejail profile for ffmpeg
+# Description: Tools for transcoding, streaming and playing of multimedia files
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/file-roller.profile
+++ b/etc/file-roller.profile
@@ -1,4 +1,5 @@
 # Firejail profile for file-roller
+# Description: archive manager for GNOME
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/file-roller.local

--- a/etc/file-roller.profile
+++ b/etc/file-roller.profile
@@ -1,5 +1,5 @@
 # Firejail profile for file-roller
-# Description: archive manager for GNOME
+# Description: Archive manager for GNOME
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/file-roller.local

--- a/etc/file.profile
+++ b/etc/file.profile
@@ -1,4 +1,5 @@
 # Firejail profile for file
+# Description: Recognize the type of data in a file using "magic" numbers
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/filezilla.profile
+++ b/etc/filezilla.profile
@@ -1,4 +1,5 @@
 # Firejail profile for filezilla
+# Description: Full-featured graphical FTP/FTPS/SFTP client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/filezilla.local

--- a/etc/firefox-developer-edition.profile
+++ b/etc/firefox-developer-edition.profile
@@ -1,4 +1,5 @@
 # Firejail profile for firefox-developer-edition
+# Description: Developer Edition of the popular Firefox web browser
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/firefox-developer-edition.local

--- a/etc/firefox.profile
+++ b/etc/firefox.profile
@@ -1,4 +1,5 @@
 # Firejail profile for firefox
+# Description: Safe and easy web browser from Mozilla
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/firefox.local

--- a/etc/flameshot.profile
+++ b/etc/flameshot.profile
@@ -1,4 +1,5 @@
 # Firejail profile for flameshot
+# Description: Powerful yet simple-to-use screenshot software
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/flameshot.local

--- a/etc/flowblade.profile
+++ b/etc/flowblade.profile
@@ -1,4 +1,5 @@
 # Firejail profile for flowblade
+# Description: non-linear video editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/flowblade.local

--- a/etc/flowblade.profile
+++ b/etc/flowblade.profile
@@ -1,5 +1,5 @@
 # Firejail profile for flowblade
-# Description: non-linear video editor
+# Description: Non-linear video editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/flowblade.local

--- a/etc/fontforge.profile
+++ b/etc/fontforge.profile
@@ -1,4 +1,5 @@
 # Firejail profile for fontforge
+# Description: font editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/fontforge.local

--- a/etc/fontforge.profile
+++ b/etc/fontforge.profile
@@ -1,5 +1,5 @@
 # Firejail profile for fontforge
-# Description: font editor
+# Description: Font editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/fontforge.local

--- a/etc/freecad.profile
+++ b/etc/freecad.profile
@@ -1,4 +1,5 @@
 # Firejail profile for freecad
+# Description: Extensible Open Source CAx program
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/freecad.local

--- a/etc/frozen-bubble.profile
+++ b/etc/frozen-bubble.profile
@@ -1,4 +1,5 @@
 # Firejail profile for frozen-bubble
+# Description: cool game where you pop out the bubbles!
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/frozen-bubble.local

--- a/etc/frozen-bubble.profile
+++ b/etc/frozen-bubble.profile
@@ -1,5 +1,5 @@
 # Firejail profile for frozen-bubble
-# Description: cool game where you pop out the bubbles!
+# Description: Cool game where you pop out the bubbles
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/frozen-bubble.local

--- a/etc/gajim.profile
+++ b/etc/gajim.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gajim
+# Description: GTK+-based Jabber client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gajim.local

--- a/etc/galculator.profile
+++ b/etc/galculator.profile
@@ -1,4 +1,5 @@
 # Firejail profile for galculator
+# Description: scientific calculator
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/galculator.local

--- a/etc/galculator.profile
+++ b/etc/galculator.profile
@@ -1,5 +1,5 @@
 # Firejail profile for galculator
-# Description: scientific calculator
+# Description: Scientific calculator
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/galculator.local

--- a/etc/geany.profile
+++ b/etc/geany.profile
@@ -1,4 +1,5 @@
 # Firejail profile for geany
+# Description: fast and lightweight IDE
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/geany.local

--- a/etc/geany.profile
+++ b/etc/geany.profile
@@ -1,5 +1,5 @@
 # Firejail profile for geany
-# Description: fast and lightweight IDE
+# Description: Fast and lightweight IDE
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/geany.local

--- a/etc/geary.profile
+++ b/etc/geary.profile
@@ -1,4 +1,5 @@
 # Firejail profile for geary
+# Description: lightweight email client designed for the GNOME desktop
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/geary.local

--- a/etc/geary.profile
+++ b/etc/geary.profile
@@ -1,5 +1,5 @@
 # Firejail profile for geary
-# Description: lightweight email client designed for the GNOME desktop
+# Description: Lightweight email client designed for the GNOME desktop
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/geary.local

--- a/etc/gedit.profile
+++ b/etc/gedit.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gedit
+# Description: official text editor of the GNOME desktop environment
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gedit.local

--- a/etc/gedit.profile
+++ b/etc/gedit.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gedit
-# Description: official text editor of the GNOME desktop environment
+# Description: Official text editor of the GNOME desktop environment
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gedit.local

--- a/etc/geeqie.profile
+++ b/etc/geeqie.profile
@@ -1,4 +1,5 @@
 # Firejail profile for geeqie
+# Description: image viewer using GTK+
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/geeqie.local

--- a/etc/geeqie.profile
+++ b/etc/geeqie.profile
@@ -1,5 +1,5 @@
 # Firejail profile for geeqie
-# Description: image viewer using GTK+
+# Description: Image viewer using GTK+
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/geeqie.local

--- a/etc/gimp.profile
+++ b/etc/gimp.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gimp
+# Description: GNU Image Manipulation Program
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gimp.local

--- a/etc/git.profile
+++ b/etc/git.profile
@@ -1,4 +1,5 @@
 # Firejail profile for git
+# Description: fast, scalable, distributed revision control system
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/git.profile
+++ b/etc/git.profile
@@ -1,5 +1,5 @@
 # Firejail profile for git
-# Description: fast, scalable, distributed revision control system
+# Description: Fast, scalable, distributed revision control system
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/gitg.profile
+++ b/etc/gitg.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gitg
+# Description: git repository viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gitg.local

--- a/etc/gitg.profile
+++ b/etc/gitg.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gitg
-# Description: git repository viewer
+# Description: Git repository viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gitg.local

--- a/etc/gjs.profile
+++ b/etc/gjs.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gjs
+# Description: Mozilla-based javascript bindings for the GNOME platform
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gjs.local

--- a/etc/gnome-2048.profile
+++ b/etc/gnome-2048.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gnome-2048
+# Description: sliding tile puzzle game
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-2048.local

--- a/etc/gnome-2048.profile
+++ b/etc/gnome-2048.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gnome-2048
-# Description: sliding tile puzzle game
+# Description: Sliding tile puzzle game
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-2048.local

--- a/etc/gnome-builder.profile
+++ b/etc/gnome-builder.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gnome-builder
+# Description: IDE for GNOME
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-builder.local

--- a/etc/gnome-calculator.profile
+++ b/etc/gnome-calculator.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gnome-calculator
+# Description: GNOME desktop calculator
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/gnome-chess.profile
+++ b/etc/gnome-chess.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gnome-chess
+# Description: simple chess game
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-chess.local

--- a/etc/gnome-chess.profile
+++ b/etc/gnome-chess.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gnome-chess
-# Description: simple chess game
+# Description: Simple chess game
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-chess.local

--- a/etc/gnome-clocks.profile
+++ b/etc/gnome-clocks.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gnome-clocks
+# Description: Simple GNOME app with stopwatch, timer, and world clock support
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-clocks.local

--- a/etc/gnome-contacts.profile
+++ b/etc/gnome-contacts.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gnome-contacts
+# Description: Contacts manager for GNOME
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-contacts.local

--- a/etc/gnome-documents.profile
+++ b/etc/gnome-documents.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gnome-documents
+# Description: Document manager for GNOME
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-documents.local

--- a/etc/gnome-font-viewer.profile
+++ b/etc/gnome-font-viewer.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gnome-font-viewer
+# Description: font viewer for GNOME
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-font-viewer.local

--- a/etc/gnome-font-viewer.profile
+++ b/etc/gnome-font-viewer.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gnome-font-viewer
-# Description: font viewer for GNOME
+# Description: Font viewer for GNOME
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-font-viewer.local

--- a/etc/gnome-logs.profile
+++ b/etc/gnome-logs.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gnome-logs
+# Description: viewer for the systemd journal.
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-logs.local

--- a/etc/gnome-logs.profile
+++ b/etc/gnome-logs.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gnome-logs
-# Description: viewer for the systemd journal.
+# Description: Viewer for the systemd journal
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-logs.local

--- a/etc/gnome-maps.profile
+++ b/etc/gnome-maps.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gnome-maps
+# Description: map application for GNOME
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-maps.local

--- a/etc/gnome-maps.profile
+++ b/etc/gnome-maps.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gnome-maps
-# Description: map application for GNOME
+# Description: Map application for GNOME
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-maps.local

--- a/etc/gnome-mplayer.profile
+++ b/etc/gnome-mplayer.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gnome-mplayer
+# Description: GTK/Gnome interface around MPlayer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-mplayer.local

--- a/etc/gnome-mpv.profile
+++ b/etc/gnome-mpv.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gnome-mpv
+# Description: simple GTK+ frontend for mpv
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-mpv.local

--- a/etc/gnome-mpv.profile
+++ b/etc/gnome-mpv.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gnome-mpv
-# Description: simple GTK+ frontend for mpv
+# Description: Simple GTK+ frontend for mpv
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-mpv.local

--- a/etc/gnome-music.profile
+++ b/etc/gnome-music.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gnome-music
+# Description: Music is the new GNOME music playing application
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-music.local

--- a/etc/gnome-music.profile
+++ b/etc/gnome-music.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gnome-music
-# Description: Music is the new GNOME music playing application
+# Description: GNOME music player
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-music.local

--- a/etc/gnome-photos.profile
+++ b/etc/gnome-photos.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gnome-photos
+# Description: application to access, organize and share your photos with GNOME
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-photos.local

--- a/etc/gnome-photos.profile
+++ b/etc/gnome-photos.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gnome-photos
-# Description: application to access, organize and share your photos with GNOME
+# Description: Access, organize and share your photos with GNOME
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-photos.local

--- a/etc/gnome-recipes.profile
+++ b/etc/gnome-recipes.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gnome-recipes
+# Description: Recipe application for GNOME
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-recipes.local

--- a/etc/gnome-twitch.profile
+++ b/etc/gnome-twitch.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gnome-twitch
+# Description: GNOME Twitch app for watching Twitch.tv streams without a browser or flash
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-twitch.local

--- a/etc/gnome-weather.profile
+++ b/etc/gnome-weather.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gnome-weather
+# Description: access current conditions and forecasts
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-weather.local

--- a/etc/gnome-weather.profile
+++ b/etc/gnome-weather.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gnome-weather
-# Description: access current conditions and forecasts
+# Description: Access current conditions and forecasts
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gnome-weather.local

--- a/etc/goobox.profile
+++ b/etc/goobox.profile
@@ -1,4 +1,5 @@
 # Firejail profile for goobox
+# Description: CD player and ripper with GNOME 3 integration
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/goobox.local

--- a/etc/gpa.profile
+++ b/etc/gpa.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gpa
+# Description: GNU Privacy Assistant (GPA)
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gpa.local

--- a/etc/gpg-agent.profile
+++ b/etc/gpg-agent.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gpg-agent
+# Description: GNU privacy guard - cryptographic agent
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gpg-agent.local

--- a/etc/gpg.profile
+++ b/etc/gpg.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gpg
+# Description: GNU Privacy Guard -- minimalist public key operations
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gpg.local

--- a/etc/gpicview.profile
+++ b/etc/gpicview.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gpicview
+# Description: lightweight image viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gpicview.local

--- a/etc/gpicview.profile
+++ b/etc/gpicview.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gpicview
-# Description: lightweight image viewer
+# Description: Lightweight image viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gpicview.local

--- a/etc/gpredict.profile
+++ b/etc/gpredict.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gpredict
+# Description: Satellite tracking program
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gpredict.local

--- a/etc/gthumb.profile
+++ b/etc/gthumb.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gthumb
+# Description: image viewer and browser
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gthumb.local

--- a/etc/gthumb.profile
+++ b/etc/gthumb.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gthumb
-# Description: image viewer and browser
+# Description: Image viewer and browser
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gthumb.local

--- a/etc/gucharmap.profile
+++ b/etc/gucharmap.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gucharmap
+# Description: Unicode character picker and font browser
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gucharmap.local

--- a/etc/gwenview.profile
+++ b/etc/gwenview.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gwenview
+# Description: image viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gwenview.local

--- a/etc/gwenview.profile
+++ b/etc/gwenview.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gwenview
-# Description: image viewer
+# Description: Image viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/gwenview.local

--- a/etc/gzip.profile
+++ b/etc/gzip.profile
@@ -1,4 +1,5 @@
 # Firejail profile for gzip
+# Description: GNU compression utilities
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/handbrake.profile
+++ b/etc/handbrake.profile
@@ -1,4 +1,5 @@
 # Firejail profile for handbrake
+# Description: versatile DVD ripper and video transcoder (GTK+ GUI)
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/handbrake.local

--- a/etc/handbrake.profile
+++ b/etc/handbrake.profile
@@ -1,5 +1,5 @@
 # Firejail profile for handbrake
-# Description: versatile DVD ripper and video transcoder (GTK+ GUI)
+# Description: Versatile DVD ripper and video transcoder (GTK+ GUI)
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/handbrake.local

--- a/etc/hashcat.profile
+++ b/etc/hashcat.profile
@@ -1,4 +1,5 @@
 # Firejail profile for hashcat
+# Description: World's fastest and most advanced password recovery utility
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/hedgewars.profile
+++ b/etc/hedgewars.profile
@@ -1,4 +1,5 @@
 # Firejail profile for hedgewars
+# Description: Funny turn-based artillery game, featuring fighting hedgehogs!
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/hedgewars.local

--- a/etc/hedgewars.profile
+++ b/etc/hedgewars.profile
@@ -1,5 +1,5 @@
 # Firejail profile for hedgewars
-# Description: Funny turn-based artillery game, featuring fighting hedgehogs!
+# Description: Funny turn-based artillery game, featuring fighting hedgehogs
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/hedgewars.local

--- a/etc/hexchat.profile
+++ b/etc/hexchat.profile
@@ -1,4 +1,5 @@
 # Firejail profile for hexchat
+# Description: IRC client for X based on X-Chat 2
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/hexchat.local

--- a/etc/highlight.profile
+++ b/etc/highlight.profile
@@ -1,4 +1,5 @@
 # Firejail profile for highlight
+# Description: Universal source code to formatted text converter
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/highlight.local

--- a/etc/hugin.profile
+++ b/etc/hugin.profile
@@ -1,4 +1,5 @@
 # Firejail profile for hugin
+# Description: panorama photo stitcher - GUI tools
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/hugin.local

--- a/etc/hugin.profile
+++ b/etc/hugin.profile
@@ -1,5 +1,5 @@
 # Firejail profile for hugin
-# Description: panorama photo stitcher - GUI tools
+# Description: Panorama photo stitcher
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/hugin.local

--- a/etc/imagej.profile
+++ b/etc/imagej.profile
@@ -1,4 +1,5 @@
 # Firejail profile for imagej
+# Description: Image processing program with a focus on microscopy images
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/imagej.local

--- a/etc/inkscape.profile
+++ b/etc/inkscape.profile
@@ -1,4 +1,5 @@
 # Firejail profile for inkscape
+# Description: vector-based drawing program
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/inkscape.local

--- a/etc/inkscape.profile
+++ b/etc/inkscape.profile
@@ -1,5 +1,5 @@
 # Firejail profile for inkscape
-# Description: vector-based drawing program
+# Description: Vector-based drawing program
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/inkscape.local

--- a/etc/k3b.profile
+++ b/etc/k3b.profile
@@ -1,4 +1,5 @@
 # Firejail profile for k3b
+# Description: Sophisticated CD/DVD burning application
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/k3b.local

--- a/etc/kaffeine.profile
+++ b/etc/kaffeine.profile
@@ -1,4 +1,5 @@
 # Firejail profile for kaffeine
+# Description: versatile media player for KDE
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/kaffeine.local

--- a/etc/kaffeine.profile
+++ b/etc/kaffeine.profile
@@ -1,5 +1,5 @@
 # Firejail profile for kaffeine
-# Description: versatile media player for KDE
+# Description: Versatile media player for KDE
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/kaffeine.local

--- a/etc/kate.profile
+++ b/etc/kate.profile
@@ -1,4 +1,5 @@
 # Firejail profile for kate
+# Description: powerful text editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/kate.local

--- a/etc/kate.profile
+++ b/etc/kate.profile
@@ -1,5 +1,5 @@
 # Firejail profile for kate
-# Description: powerful text editor
+# Description: Powerful text editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/kate.local

--- a/etc/kcalc.profile
+++ b/etc/kcalc.profile
@@ -1,4 +1,5 @@
 # Firejail profile for kcalc
+# Description: simple and scientific calculator
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/kcalc.local

--- a/etc/kcalc.profile
+++ b/etc/kcalc.profile
@@ -1,5 +1,5 @@
 # Firejail profile for kcalc
-# Description: simple and scientific calculator
+# Description: Simple and scientific calculator
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/kcalc.local

--- a/etc/kdenlive.profile
+++ b/etc/kdenlive.profile
@@ -1,4 +1,5 @@
 # Firejail profile for kdenlive
+# Description: non-linear video editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/kdenlive.local

--- a/etc/kdenlive.profile
+++ b/etc/kdenlive.profile
@@ -1,5 +1,5 @@
 # Firejail profile for kdenlive
-# Description: non-linear video editor
+# Description: Non-linear video editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/kdenlive.local

--- a/etc/keepass.profile
+++ b/etc/keepass.profile
@@ -1,4 +1,5 @@
 # Firejail profile for keepass
+# Description: A easy-to-use password manager for Windows, Linux, Mac OS X and mobile devices.
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/keepass.local

--- a/etc/keepass.profile
+++ b/etc/keepass.profile
@@ -1,5 +1,5 @@
 # Firejail profile for keepass
-# Description: A easy-to-use password manager for Windows, Linux, Mac OS X and mobile devices.
+# Description: An easy-to-use password manager
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/keepass.local

--- a/etc/keepassx.profile
+++ b/etc/keepassx.profile
@@ -1,4 +1,5 @@
 # Firejail profile for keepassx
+# Description: Cross Platform Password Manager
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/keepassx.local

--- a/etc/keepassx2.profile
+++ b/etc/keepassx2.profile
@@ -1,4 +1,5 @@
 # Firejail profile for keepassx2
+# Description: Cross platform password manager
 # This file is overwritten after every install/update
 
 # Redirects

--- a/etc/keepassxc.profile
+++ b/etc/keepassxc.profile
@@ -1,4 +1,5 @@
 # Firejail profile for keepassxc
+# Description: Cross Platform Password Manager
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/keepassxc.local

--- a/etc/kget.profile
+++ b/etc/kget.profile
@@ -1,4 +1,5 @@
 # Firejail profile for kget
+# Description: download manager
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/kget.local

--- a/etc/kget.profile
+++ b/etc/kget.profile
@@ -1,5 +1,5 @@
 # Firejail profile for kget
-# Description: download manager
+# Description: Download manager
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/kget.local

--- a/etc/kino.profile
+++ b/etc/kino.profile
@@ -1,4 +1,5 @@
 # Firejail profile for kino
+# Description: Non-linear editor for Digital Video data
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/kino.local

--- a/etc/kmail.profile
+++ b/etc/kmail.profile
@@ -1,4 +1,5 @@
 # Firejail profile for kmail
+# Description: full featured graphical email client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/kmail.local

--- a/etc/kmail.profile
+++ b/etc/kmail.profile
@@ -1,5 +1,5 @@
 # Firejail profile for kmail
-# Description: full featured graphical email client
+# Description: Full featured graphical email client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/kmail.local

--- a/etc/knotes.profile
+++ b/etc/knotes.profile
@@ -1,4 +1,5 @@
 # Firejail profile for knotes
+# Description: sticky notes application
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/knotes.local

--- a/etc/knotes.profile
+++ b/etc/knotes.profile
@@ -1,5 +1,5 @@
 # Firejail profile for knotes
-# Description: sticky notes application
+# Description: Sticky notes application
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/knotes.local

--- a/etc/kodi.profile
+++ b/etc/kodi.profile
@@ -1,4 +1,5 @@
 # Firejail profile for kodi
+# Description: Open Source Home Theatre (executable binaries)
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/kodi.local

--- a/etc/kodi.profile
+++ b/etc/kodi.profile
@@ -1,5 +1,5 @@
 # Firejail profile for kodi
-# Description: Open Source Home Theatre (executable binaries)
+# Description: Open Source Home Theatre
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/kodi.local

--- a/etc/konversation.profile
+++ b/etc/konversation.profile
@@ -1,4 +1,5 @@
 # Firejail profile for konversation
+# Description: user friendly Internet Relay Chat (IRC) client for KDE
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/konversation.local

--- a/etc/konversation.profile
+++ b/etc/konversation.profile
@@ -1,5 +1,5 @@
 # Firejail profile for konversation
-# Description: user friendly Internet Relay Chat (IRC) client for KDE
+# Description: User friendly Internet Relay Chat (IRC) client for KDE
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/konversation.local

--- a/etc/kopete.profile
+++ b/etc/kopete.profile
@@ -1,4 +1,5 @@
 # Firejail profile for kopete
+# Description: instant messaging and chat application
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/kopete.local

--- a/etc/kopete.profile
+++ b/etc/kopete.profile
@@ -1,5 +1,5 @@
 # Firejail profile for kopete
-# Description: instant messaging and chat application
+# Description: Instant messaging and chat application
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/kopete.local

--- a/etc/krita.profile
+++ b/etc/krita.profile
@@ -1,4 +1,5 @@
 # Firejail profile for krita
+# Description: pixel-based image manipulation program
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/krita.local

--- a/etc/krita.profile
+++ b/etc/krita.profile
@@ -1,5 +1,5 @@
 # Firejail profile for krita
-# Description: pixel-based image manipulation program
+# Description: Pixel-based image manipulation program
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/krita.local

--- a/etc/krunner.profile
+++ b/etc/krunner.profile
@@ -1,4 +1,5 @@
 # Firejail profile for krunner
+# Description: Framework for providing different actions given a string query
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/krunner.local

--- a/etc/ktorrent.profile
+++ b/etc/ktorrent.profile
@@ -1,4 +1,5 @@
 # Firejail profile for ktorrent
+# Description: BitTorrent client based on the KDE platform
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/ktorrent.local

--- a/etc/kwrite.profile
+++ b/etc/kwrite.profile
@@ -1,4 +1,5 @@
 # Firejail profile for kwrite
+# Description: simple text editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/kwrite.local

--- a/etc/kwrite.profile
+++ b/etc/kwrite.profile
@@ -1,5 +1,5 @@
 # Firejail profile for kwrite
-# Description: simple text editor
+# Description: Simple text editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/kwrite.local

--- a/etc/leafpad.profile
+++ b/etc/leafpad.profile
@@ -1,4 +1,5 @@
 # Firejail profile for leafpad
+# Description: GTK+ based simple text editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/leafpad.local

--- a/etc/less.profile
+++ b/etc/less.profile
@@ -1,4 +1,5 @@
 # Firejail profile for less
+# Description: pager program similar to more
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/less.profile
+++ b/etc/less.profile
@@ -1,5 +1,5 @@
 # Firejail profile for less
-# Description: pager program similar to more
+# Description: Pager program similar to more
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/libreoffice.profile
+++ b/etc/libreoffice.profile
@@ -1,4 +1,5 @@
 # Firejail profile for libreoffice
+# Description: office productivity suite (metapackage)
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/libreoffice.local

--- a/etc/libreoffice.profile
+++ b/etc/libreoffice.profile
@@ -1,5 +1,5 @@
 # Firejail profile for libreoffice
-# Description: office productivity suite (metapackage)
+# Description: Office productivity suite
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/libreoffice.local

--- a/etc/liferea.profile
+++ b/etc/liferea.profile
@@ -1,4 +1,5 @@
 # Firejail profile for liferea
+# Description: feed/news/podcast client with plugin support
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/liferea.local

--- a/etc/liferea.profile
+++ b/etc/liferea.profile
@@ -1,5 +1,5 @@
 # Firejail profile for liferea
-# Description: feed/news/podcast client with plugin support
+# Description: Feed/news/podcast client with plugin support
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/liferea.local

--- a/etc/linphone.profile
+++ b/etc/linphone.profile
@@ -1,4 +1,5 @@
 # Firejail profile for linphone
+# Description: SIP softphone - graphical client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/linphone.local

--- a/etc/lmms.profile
+++ b/etc/lmms.profile
@@ -1,4 +1,5 @@
 # Firejail profile for lmms
+# Description: Linux Multimedia Studio
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/lmms.local

--- a/etc/lollypop.profile
+++ b/etc/lollypop.profile
@@ -1,4 +1,5 @@
 # Firejail profile for lollypop
+# Description: Music player for GNOME
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/lollypop.local

--- a/etc/luminance-hdr.profile
+++ b/etc/luminance-hdr.profile
@@ -1,4 +1,5 @@
 # Firejail profile for luminance-hdr
+# Description: graphical user interface providing a workflow for HDR imaging
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/luminance-hdr.local

--- a/etc/luminance-hdr.profile
+++ b/etc/luminance-hdr.profile
@@ -1,5 +1,5 @@
 # Firejail profile for luminance-hdr
-# Description: graphical user interface providing a workflow for HDR imaging
+# Description: Graphical user interface providing a workflow for HDR imaging
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/luminance-hdr.local

--- a/etc/lximage-qt.profile
+++ b/etc/lximage-qt.profile
@@ -1,4 +1,5 @@
 # Firejail profile for lximage-qt
+# Description: Image viewer for LXQt
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/lximage-qt.local

--- a/etc/lxmusic.profile
+++ b/etc/lxmusic.profile
@@ -1,4 +1,5 @@
 # Firejail profile for lxmusic
+# Description: LXDE music player
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/lxmusic.local

--- a/etc/lynx.profile
+++ b/etc/lynx.profile
@@ -1,4 +1,5 @@
 # Firejail profile for lynx
+# Description: classic non-graphical (text-mode) web browser
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/lynx.local

--- a/etc/lynx.profile
+++ b/etc/lynx.profile
@@ -1,5 +1,5 @@
 # Firejail profile for lynx
-# Description: classic non-graphical (text-mode) web browser
+# Description: Classic non-graphical (text-mode) web browser
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/lynx.local

--- a/etc/mate-calc.profile
+++ b/etc/mate-calc.profile
@@ -1,4 +1,5 @@
 # Firejail profile for mate-calc
+# Description: MATE desktop calculator
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mate-calc.local

--- a/etc/mcabber.profile
+++ b/etc/mcabber.profile
@@ -1,4 +1,5 @@
 # Firejail profile for mcabber
+# Description: small Jabber (XMPP) console client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mcabber.local

--- a/etc/mcabber.profile
+++ b/etc/mcabber.profile
@@ -1,5 +1,5 @@
 # Firejail profile for mcabber
-# Description: small Jabber (XMPP) console client
+# Description: Small Jabber (XMPP) console client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mcabber.local

--- a/etc/mediainfo.profile
+++ b/etc/mediainfo.profile
@@ -1,4 +1,5 @@
 # Firejail profile for mediainfo
+# Description: command-line utility for reading information from audio/video files
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mediainfo.local

--- a/etc/mediainfo.profile
+++ b/etc/mediainfo.profile
@@ -1,5 +1,5 @@
 # Firejail profile for mediainfo
-# Description: command-line utility for reading information from audio/video files
+# Description: Command-line utility for reading information from audio/video files
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mediainfo.local

--- a/etc/mediathekview.profile
+++ b/etc/mediathekview.profile
@@ -1,4 +1,5 @@
 # Firejail profile for mediathekview
+# Description: view streams from German public television stations
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mediathekview.local

--- a/etc/mediathekview.profile
+++ b/etc/mediathekview.profile
@@ -1,5 +1,5 @@
 # Firejail profile for mediathekview
-# Description: view streams from German public television stations
+# Description: View streams from German public television stations
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mediathekview.local

--- a/etc/meld.profile
+++ b/etc/meld.profile
@@ -1,4 +1,5 @@
 # Firejail profile for meld
+# Description: graphical tool to diff and merge files
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/meld.local

--- a/etc/meld.profile
+++ b/etc/meld.profile
@@ -1,5 +1,5 @@
 # Firejail profile for meld
-# Description: graphical tool to diff and merge files
+# Description: Graphical tool to diff and merge files
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/meld.local

--- a/etc/midori.profile
+++ b/etc/midori.profile
@@ -1,4 +1,5 @@
 # Firejail profile for midori
+# Description: Lightweight web browser
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/midori.local

--- a/etc/minetest.profile
+++ b/etc/minetest.profile
@@ -1,4 +1,5 @@
 # Firejail profile for minetest
+# Description: Multiplayer infinite-world block sandbox
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/minetest.local

--- a/etc/mousepad.profile
+++ b/etc/mousepad.profile
@@ -1,4 +1,5 @@
 # Firejail profile for mousepad
+# Description: simple Xfce oriented text editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mousepad.local

--- a/etc/mousepad.profile
+++ b/etc/mousepad.profile
@@ -1,5 +1,5 @@
 # Firejail profile for mousepad
-# Description: simple Xfce oriented text editor
+# Description: Simple Xfce oriented text editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mousepad.local

--- a/etc/mpd.profile
+++ b/etc/mpd.profile
@@ -1,4 +1,5 @@
 # Firejail profile for mpd
+# Description: Music Player Daemon
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mpd.local

--- a/etc/mplayer.profile
+++ b/etc/mplayer.profile
@@ -1,4 +1,5 @@
 # Firejail profile for mplayer
+# Description: movie player for Unix-like systems
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mplayer.local

--- a/etc/mplayer.profile
+++ b/etc/mplayer.profile
@@ -1,5 +1,5 @@
 # Firejail profile for mplayer
-# Description: movie player for Unix-like systems
+# Description: Movie player for Unix-like systems
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mplayer.local

--- a/etc/mpv.profile
+++ b/etc/mpv.profile
@@ -1,4 +1,5 @@
 # Firejail profile for mpv
+# Description: video player based on MPlayer/mplayer2
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mpv.local

--- a/etc/mpv.profile
+++ b/etc/mpv.profile
@@ -1,5 +1,5 @@
 # Firejail profile for mpv
-# Description: video player based on MPlayer/mplayer2
+# Description: Video player based on MPlayer/mplayer2
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mpv.local

--- a/etc/mumble.profile
+++ b/etc/mumble.profile
@@ -1,4 +1,5 @@
 # Firejail profile for mumble
+# Description: Low latency encrypted VoIP client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mumble.local

--- a/etc/mupdf.profile
+++ b/etc/mupdf.profile
@@ -1,4 +1,5 @@
 # Firejail profile for mupdf
+# Description: lightweight PDF viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mupdf.local

--- a/etc/mupdf.profile
+++ b/etc/mupdf.profile
@@ -1,5 +1,5 @@
 # Firejail profile for mupdf
-# Description: lightweight PDF viewer
+# Description: Lightweight PDF viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mupdf.local

--- a/etc/mupen64plus.profile
+++ b/etc/mupen64plus.profile
@@ -1,4 +1,5 @@
 # Firejail profile for mupen64plus
+# Description: Nintendo64 Emulator
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mupen64plus.local

--- a/etc/musescore.profile
+++ b/etc/musescore.profile
@@ -1,4 +1,5 @@
 # Firejail profile for musescore
+# Description: Free music composition and notation software
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/musescore.local

--- a/etc/mutt.profile
+++ b/etc/mutt.profile
@@ -1,4 +1,5 @@
 # Firejail profile for mutt
+# Description: text-based mailreader supporting MIME, GPG, PGP and threading
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mutt.local

--- a/etc/mutt.profile
+++ b/etc/mutt.profile
@@ -1,5 +1,5 @@
 # Firejail profile for mutt
-# Description: text-based mailreader supporting MIME, GPG, PGP and threading
+# Description: Text-based mailreader supporting MIME, GPG, PGP and threading
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/mutt.local

--- a/etc/nautilus.profile
+++ b/etc/nautilus.profile
@@ -1,4 +1,5 @@
 # Firejail profile for nautilus
+# Description: file manager and graphical shell for GNOME
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/nautilus.local

--- a/etc/nautilus.profile
+++ b/etc/nautilus.profile
@@ -1,5 +1,5 @@
 # Firejail profile for nautilus
-# Description: file manager and graphical shell for GNOME
+# Description: File manager and graphical shell for GNOME
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/nautilus.local

--- a/etc/ncdu.profile
+++ b/etc/ncdu.profile
@@ -1,4 +1,5 @@
 # Firejail profile for ncdu
+# Description: ncurses disk usage viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/ncdu.local

--- a/etc/ncdu.profile
+++ b/etc/ncdu.profile
@@ -1,5 +1,5 @@
 # Firejail profile for ncdu
-# Description: ncurses disk usage viewer
+# Description: Ncurses disk usage viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/ncdu.local

--- a/etc/nemo.profile
+++ b/etc/nemo.profile
@@ -1,4 +1,5 @@
 # Firejail profile for nemo
+# Description: File manager and graphical shell for Cinnamon
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/nemo.local

--- a/etc/netsurf.profile
+++ b/etc/netsurf.profile
@@ -1,4 +1,5 @@
 # Firejail profile for netsurf
+# Description: Lightweight and fast web browser
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/netsurf.local

--- a/etc/neverball.profile
+++ b/etc/neverball.profile
@@ -1,4 +1,5 @@
 # Firejail profile for neverball
+# Description: 3D floor-tilting game
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/neverball.local

--- a/etc/nheko.profile
+++ b/etc/nheko.profile
@@ -1,4 +1,5 @@
 # Firejail profile for nheko
+# Description: desktop IM client for the Matrix protocol
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/nheko.local

--- a/etc/nheko.profile
+++ b/etc/nheko.profile
@@ -1,5 +1,5 @@
 # Firejail profile for nheko
-# Description: desktop IM client for the Matrix protocol
+# Description: Desktop IM client for the Matrix protocol
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/nheko.local

--- a/etc/odt2txt.profile
+++ b/etc/odt2txt.profile
@@ -1,4 +1,5 @@
 # Firejail profile for odt2txt
+# Description: simple converter from OpenDocument Text to plain text
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/odt2txt.local

--- a/etc/odt2txt.profile
+++ b/etc/odt2txt.profile
@@ -1,5 +1,5 @@
 # Firejail profile for odt2txt
-# Description: simple converter from OpenDocument Text to plain text
+# Description: Simple converter from OpenDocument Text to plain text
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/odt2txt.local

--- a/etc/okular.profile
+++ b/etc/okular.profile
@@ -1,4 +1,5 @@
 # Firejail profile for okular
+# Description: universal document viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/okular.local

--- a/etc/okular.profile
+++ b/etc/okular.profile
@@ -1,5 +1,5 @@
 # Firejail profile for okular
-# Description: universal document viewer
+# Description: Universal document viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/okular.local

--- a/etc/open-invaders.profile
+++ b/etc/open-invaders.profile
@@ -1,4 +1,5 @@
 # Firejail profile for open-invaders
+# Description: Space Invaders clone
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/open-invaders.local

--- a/etc/openbox.profile
+++ b/etc/openbox.profile
@@ -1,4 +1,5 @@
 # Firejail profile for openbox
+# Description: standards-compliant, fast, light-weight and extensible window manager
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/openbox.local

--- a/etc/openbox.profile
+++ b/etc/openbox.profile
@@ -1,5 +1,5 @@
 # Firejail profile for openbox
-# Description: standards-compliant, fast, light-weight and extensible window manager
+# Description: Standards-compliant, fast, light-weight and extensible window manager
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/openbox.local

--- a/etc/openshot.profile
+++ b/etc/openshot.profile
@@ -1,4 +1,5 @@
 # Firejail profile for openshot
+# Description: create and edit videos and movies (transitional package)
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/openshot.local

--- a/etc/openshot.profile
+++ b/etc/openshot.profile
@@ -1,5 +1,5 @@
 # Firejail profile for openshot
-# Description: create and edit videos and movies (transitional package)
+# Description: Create and edit videos and movies
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/openshot.local

--- a/etc/opera.profile
+++ b/etc/opera.profile
@@ -1,4 +1,5 @@
 # Firejail profile for opera
+# Description: A fast and secure web browser
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/opera.local

--- a/etc/orage.profile
+++ b/etc/orage.profile
@@ -1,4 +1,5 @@
 # Firejail profile for orage
+# Description: Calendar for Xfce Desktop Environment
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/orage.local

--- a/etc/p7zip.profile
+++ b/etc/p7zip.profile
@@ -1,4 +1,5 @@
 # Firejail profile for p7zip
+# Description: 7zr file archiver with high compression ratio
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/p7zip.local

--- a/etc/parole.profile
+++ b/etc/parole.profile
@@ -1,4 +1,5 @@
 # Firejail profile for parole
+# Description: media player based on GStreamer framework
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/parole.local

--- a/etc/parole.profile
+++ b/etc/parole.profile
@@ -1,5 +1,5 @@
 # Firejail profile for parole
-# Description: media player based on GStreamer framework
+# Description: Media player based on GStreamer framework
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/parole.local

--- a/etc/patch.profile
+++ b/etc/patch.profile
@@ -1,4 +1,5 @@
 # Firejail profile for patch
+# Description: Apply a diff file to an original
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/pcmanfm.profile
+++ b/etc/pcmanfm.profile
@@ -1,4 +1,5 @@
 # Firejail profile for pcmanfm
+# Description: extremely fast and lightweight file manager
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/pcmanfm.local

--- a/etc/pcmanfm.profile
+++ b/etc/pcmanfm.profile
@@ -1,5 +1,5 @@
 # Firejail profile for pcmanfm
-# Description: extremely fast and lightweight file manager
+# Description: Extremely fast and lightweight file manager
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/pcmanfm.local

--- a/etc/pdfmod.profile
+++ b/etc/pdfmod.profile
@@ -1,4 +1,5 @@
 # Firejail profile for pdfmod
+# Description: simple tool for modifying PDF documents
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/pdfmod.local

--- a/etc/pdfmod.profile
+++ b/etc/pdfmod.profile
@@ -1,5 +1,5 @@
 # Firejail profile for pdfmod
-# Description: simple tool for modifying PDF documents
+# Description: Simple tool for modifying PDF documents
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/pdfmod.local

--- a/etc/pdfsam.profile
+++ b/etc/pdfsam.profile
@@ -1,4 +1,5 @@
 # Firejail profile for pdfsam
+# Description: PDF Split and Merge
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/pdfsam.local

--- a/etc/picard.profile
+++ b/etc/picard.profile
@@ -1,4 +1,5 @@
 # Firejail profile for picard
+# Description: Next-Generation MusicBrainz audio files tagger
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/picard.local

--- a/etc/pidgin.profile
+++ b/etc/pidgin.profile
@@ -1,4 +1,5 @@
 # Firejail profile for pidgin
+# Description: graphical multi-protocol instant messaging client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/pidgin.local

--- a/etc/pidgin.profile
+++ b/etc/pidgin.profile
@@ -1,5 +1,5 @@
 # Firejail profile for pidgin
-# Description: graphical multi-protocol instant messaging client
+# Description: Graphical multi-protocol instant messaging client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/pidgin.local

--- a/etc/pingus.profile
+++ b/etc/pingus.profile
@@ -1,4 +1,5 @@
 # Firejail profile for pingus
+# Description: Free Lemmings(TM) clone
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/pingus.local

--- a/etc/pinta.profile
+++ b/etc/pinta.profile
@@ -1,4 +1,5 @@
 # Firejail profile for pinta
+# Description: Simple drawing/painting program
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/pinta.local

--- a/etc/pithos.profile
+++ b/etc/pithos.profile
@@ -1,4 +1,5 @@
 # Firejail profile for pithos
+# Description: Pandora Radio client for the GNOME desktop
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/pithos.local

--- a/etc/pitivi.profile
+++ b/etc/pitivi.profile
@@ -1,4 +1,5 @@
 # Firejail profile for pitivi
+# Description: non-linear audio/video editor using GStreamer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/pitivi.local

--- a/etc/pitivi.profile
+++ b/etc/pitivi.profile
@@ -1,5 +1,5 @@
 # Firejail profile for pitivi
-# Description: non-linear audio/video editor using GStreamer
+# Description: Non-linear audio/video editor using GStreamer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/pitivi.local

--- a/etc/playonlinux.profile
+++ b/etc/playonlinux.profile
@@ -1,4 +1,5 @@
 # Firejail profile for playonlinux
+# Description: front-end for Wine
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/playonlinux.local

--- a/etc/playonlinux.profile
+++ b/etc/playonlinux.profile
@@ -1,5 +1,5 @@
 # Firejail profile for playonlinux
-# Description: front-end for Wine
+# Description: Front-end for Wine
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/playonlinux.local

--- a/etc/pluma.profile
+++ b/etc/pluma.profile
@@ -1,4 +1,5 @@
 # Firejail profile for pluma
+# Description: official text editor of the MATE desktop environment
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/pluma.local

--- a/etc/pluma.profile
+++ b/etc/pluma.profile
@@ -1,5 +1,5 @@
 # Firejail profile for pluma
-# Description: official text editor of the MATE desktop environment
+# Description: Official text editor of the MATE desktop environment
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/pluma.local

--- a/etc/polari.profile
+++ b/etc/polari.profile
@@ -1,4 +1,5 @@
 # Firejail profile for polari
+# Description: Internet Relay Chat (IRC) client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/polari.local

--- a/etc/ppsspp.profile
+++ b/etc/ppsspp.profile
@@ -1,4 +1,5 @@
 # Firejail profile for ppsspp
+# Description: A PSP emulator written in C++
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/ppsspp.local

--- a/etc/psi-plus.profile
+++ b/etc/psi-plus.profile
@@ -1,4 +1,5 @@
 # Firejail profile for psi-plus
+# Description: Qt-based XMPP/Jabber client (basic version)
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/psi-plus.local

--- a/etc/psi-plus.profile
+++ b/etc/psi-plus.profile
@@ -1,5 +1,5 @@
 # Firejail profile for psi-plus
-# Description: Qt-based XMPP/Jabber client (basic version)
+# Description: Qt-based XMPP/Jabber client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/psi-plus.local

--- a/etc/qbittorrent.profile
+++ b/etc/qbittorrent.profile
@@ -1,4 +1,5 @@
 # Firejail profile for qbittorrent
+# Description: bittorrent client based on libtorrent-rasterbar with a Qt5 GUI
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/qbittorrent.local

--- a/etc/qbittorrent.profile
+++ b/etc/qbittorrent.profile
@@ -1,5 +1,5 @@
 # Firejail profile for qbittorrent
-# Description: bittorrent client based on libtorrent-rasterbar with a Qt5 GUI
+# Description: BitTorrent client based on libtorrent-rasterbar with a Qt5 GUI
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/qbittorrent.local

--- a/etc/qlipper.profile
+++ b/etc/qlipper.profile
@@ -1,4 +1,5 @@
 # Firejail profile for qlipper
+# Description: Lightweight and cross-platform clipboard history applet
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/qlipper.local

--- a/etc/qmmp.profile
+++ b/etc/qmmp.profile
@@ -1,4 +1,5 @@
 # Firejail profile for qmmp
+# Description: feature-rich audio player with support of many formats
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/qmmp.local

--- a/etc/qmmp.profile
+++ b/etc/qmmp.profile
@@ -1,5 +1,5 @@
 # Firejail profile for qmmp
-# Description: feature-rich audio player with support of many formats
+# Description: Feature-rich audio player with support of many formats
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/qmmp.local

--- a/etc/qpdfview.profile
+++ b/etc/qpdfview.profile
@@ -1,4 +1,5 @@
 # Firejail profile for qpdfview
+# Description: tabbed document viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/qpdfview.local

--- a/etc/qpdfview.profile
+++ b/etc/qpdfview.profile
@@ -1,5 +1,5 @@
 # Firejail profile for qpdfview
-# Description: tabbed document viewer
+# Description: Tabbed document viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/qpdfview.local

--- a/etc/qtox.profile
+++ b/etc/qtox.profile
@@ -1,4 +1,5 @@
 # Firejail profile for qtox
+# Description: Powerful Tox client written in C++/Qt that follows the Tox design guidelines
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/qtox.local

--- a/etc/quassel.profile
+++ b/etc/quassel.profile
@@ -1,4 +1,5 @@
 # Firejail profile for quassel
+# Description: distributed IRC client - monolithic core+client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/quassel.local

--- a/etc/quassel.profile
+++ b/etc/quassel.profile
@@ -1,5 +1,5 @@
 # Firejail profile for quassel
-# Description: distributed IRC client - monolithic core+client
+# Description: Distributed IRC client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/quassel.local

--- a/etc/quiterss.profile
+++ b/etc/quiterss.profile
@@ -1,4 +1,5 @@
 # Firejail profile for quiterss
+# Description: RSS/Atom news feeds reader
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/quiterss.local

--- a/etc/qupzilla.profile
+++ b/etc/qupzilla.profile
@@ -1,4 +1,5 @@
 # Firejail profile for qupzilla
+# Description: transitional package for qupzilla
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/qupzilla.local

--- a/etc/qupzilla.profile
+++ b/etc/qupzilla.profile
@@ -1,5 +1,4 @@
 # Firejail profile for qupzilla
-# Description: transitional package for qupzilla
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/qupzilla.local

--- a/etc/qutebrowser.profile
+++ b/etc/qutebrowser.profile
@@ -1,4 +1,5 @@
 # Firejail profile for qutebrowser
+# Description: Keyboard-driven, vim-like browser based on PyQt5
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/qutebrowser.local

--- a/etc/ranger.profile
+++ b/etc/ranger.profile
@@ -1,4 +1,5 @@
 # Firejail profile for ranger
+# Description: File manager with an ncurses frontend written in Python
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/ranger.local

--- a/etc/redeclipse.profile
+++ b/etc/redeclipse.profile
@@ -1,4 +1,5 @@
 # Firejail profile for redeclipse
+# Description: free, casual arena shooter
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/redeclipse.local

--- a/etc/redeclipse.profile
+++ b/etc/redeclipse.profile
@@ -1,5 +1,5 @@
 # Firejail profile for redeclipse
-# Description: free, casual arena shooter
+# Description: Free, casual arena shooter
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/redeclipse.local

--- a/etc/remmina.profile
+++ b/etc/remmina.profile
@@ -1,4 +1,5 @@
 # Firejail profile for remmina
+# Description: GTK+ Remote Desktop Client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/remmina.local

--- a/etc/rhythmbox.profile
+++ b/etc/rhythmbox.profile
@@ -1,4 +1,5 @@
 # Firejail profile for rhythmbox
+# Description: music player and organizer for GNOME
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/rhythmbox.local

--- a/etc/rhythmbox.profile
+++ b/etc/rhythmbox.profile
@@ -1,5 +1,5 @@
 # Firejail profile for rhythmbox
-# Description: music player and organizer for GNOME
+# Description: Music player and organizer for GNOME
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/rhythmbox.local

--- a/etc/ricochet.profile
+++ b/etc/ricochet.profile
@@ -1,4 +1,5 @@
 # Firejail profile for ricochet
+# Description: multi-user networked version of the Ricochet Robots game
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/ricochet.local

--- a/etc/ricochet.profile
+++ b/etc/ricochet.profile
@@ -1,5 +1,4 @@
 # Firejail profile for ricochet
-# Description: multi-user networked version of the Ricochet Robots game
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/ricochet.local

--- a/etc/riot-desktop.profile
+++ b/etc/riot-desktop.profile
@@ -1,4 +1,5 @@
 # Firejail profile for riot-desktop
+# Description: A glossy Matrix collaboration client for the desktop.
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/riot-desktop.local

--- a/etc/riot-desktop.profile
+++ b/etc/riot-desktop.profile
@@ -1,5 +1,5 @@
 # Firejail profile for riot-desktop
-# Description: A glossy Matrix collaboration client for the desktop.
+# Description: A glossy Matrix collaboration client for the desktop
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/riot-desktop.local

--- a/etc/riot-web.profile
+++ b/etc/riot-web.profile
@@ -1,4 +1,5 @@
 # Firejail profile for riot-web
+# Description: A glossy Matrix collaboration client for the web.
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/riot-web.local

--- a/etc/riot-web.profile
+++ b/etc/riot-web.profile
@@ -1,5 +1,5 @@
 # Firejail profile for riot-web
-# Description: A glossy Matrix collaboration client for the web.
+# Description: A glossy Matrix collaboration client for the web
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/riot-web.local

--- a/etc/ristretto.profile
+++ b/etc/ristretto.profile
@@ -1,4 +1,5 @@
 # Firejail profile for ristretto
+# Description: lightweight picture-viewer for the Xfce desktop environment
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/ristretto.local

--- a/etc/ristretto.profile
+++ b/etc/ristretto.profile
@@ -1,5 +1,5 @@
 # Firejail profile for ristretto
-# Description: lightweight picture-viewer for the Xfce desktop environment
+# Description: Lightweight picture-viewer for the Xfce desktop environment
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/ristretto.local

--- a/etc/rtorrent.profile
+++ b/etc/rtorrent.profile
@@ -1,4 +1,5 @@
 # Firejail profile for rtorrent
+# Description: ncurses BitTorrent client based on LibTorrent from rakshasa
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/rtorrent.local

--- a/etc/rtorrent.profile
+++ b/etc/rtorrent.profile
@@ -1,5 +1,5 @@
 # Firejail profile for rtorrent
-# Description: ncurses BitTorrent client based on LibTorrent from rakshasa
+# Description: Ncurses BitTorrent client based on LibTorrent from rakshasa
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/rtorrent.local

--- a/etc/scribus.profile
+++ b/etc/scribus.profile
@@ -1,4 +1,5 @@
 # Firejail profile for scribus
+# Description: Open Source Desktop Page Layout - stable branch
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/scribus.local

--- a/etc/scribus.profile
+++ b/etc/scribus.profile
@@ -1,5 +1,5 @@
 # Firejail profile for scribus
-# Description: Open Source Desktop Page Layout - stable branch
+# Description: Open Source Desktop Page Layout
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/scribus.local

--- a/etc/seamonkey.profile
+++ b/etc/seamonkey.profile
@@ -1,4 +1,5 @@
 # Firejail profile for seamonkey
+# Description: SeaMonkey internet suite
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/seamonkey.local

--- a/etc/shellcheck.profile
+++ b/etc/shellcheck.profile
@@ -1,4 +1,5 @@
 # Firejail profile for shellcheck
+# Description: lint tool for shell scripts
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/shellcheck.profile
+++ b/etc/shellcheck.profile
@@ -1,5 +1,5 @@
 # Firejail profile for shellcheck
-# Description: lint tool for shell scripts
+# Description: Lint tool for shell scripts
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/simple-scan.profile
+++ b/etc/simple-scan.profile
@@ -1,4 +1,5 @@
 # Firejail profile for simple-scan
+# Description: Simple Scanning Utility
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/simple-scan.local

--- a/etc/simutrans.profile
+++ b/etc/simutrans.profile
@@ -1,4 +1,5 @@
 # Firejail profile for simutrans
+# Description: transportation simulator
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/simutrans.local

--- a/etc/simutrans.profile
+++ b/etc/simutrans.profile
@@ -1,5 +1,5 @@
 # Firejail profile for simutrans
-# Description: transportation simulator
+# Description: Transportation simulator
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/simutrans.local

--- a/etc/skanlite.profile
+++ b/etc/skanlite.profile
@@ -1,4 +1,5 @@
 # Firejail profile for skanlite
+# Description: image scanner based on the KSane backend
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/skanlite.local

--- a/etc/skanlite.profile
+++ b/etc/skanlite.profile
@@ -1,5 +1,5 @@
 # Firejail profile for skanlite
-# Description: image scanner based on the KSane backend
+# Description: Image scanner based on the KSane backend
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/skanlite.local

--- a/etc/slack.profile
+++ b/etc/slack.profile
@@ -1,4 +1,5 @@
 # Firejail profile for slack
+# Description: configuration management program for lazy admins
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/slack.local

--- a/etc/slack.profile
+++ b/etc/slack.profile
@@ -1,5 +1,4 @@
 # Firejail profile for slack
-# Description: configuration management program for lazy admins
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/slack.local

--- a/etc/smplayer.profile
+++ b/etc/smplayer.profile
@@ -1,4 +1,5 @@
 # Firejail profile for smplayer
+# Description: Complete front-end for MPlayer and mpv
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/smplayer.local

--- a/etc/smtube.profile
+++ b/etc/smtube.profile
@@ -1,4 +1,5 @@
 # Firejail profile for smtube
+# Description: YouTube videos browser
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/smtube.local

--- a/etc/snap.profile
+++ b/etc/snap.profile
@@ -1,4 +1,5 @@
 # Firejail profile for snap
+# Description: location of genes from DNA sequence with hidden markov model
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/snap.local

--- a/etc/snap.profile
+++ b/etc/snap.profile
@@ -1,5 +1,5 @@
 # Firejail profile for snap
-# Description: location of genes from DNA sequence with hidden markov model
+# Description: Location of genes from DNA sequence with hidden markov model
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/snap.local

--- a/etc/soundconverter.profile
+++ b/etc/soundconverter.profile
@@ -1,4 +1,5 @@
 # Firejail profile for soundconverter
+# Description: GNOME application to convert audio files into other formats
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/soundconverter.local

--- a/etc/sqlitebrowser.profile
+++ b/etc/sqlitebrowser.profile
@@ -1,4 +1,5 @@
 # Firejail profile for sqlitebrowser
+# Description: GUI editor for SQLite databases
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/sqlitebrowser.local

--- a/etc/ssh.profile
+++ b/etc/ssh.profile
@@ -1,4 +1,5 @@
 # Firejail profile for ssh
+# Description: secure shell client and server (metapackage)
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations
@@ -37,4 +38,3 @@ memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp
 writable-run-user
-

--- a/etc/ssh.profile
+++ b/etc/ssh.profile
@@ -1,5 +1,5 @@
 # Firejail profile for ssh
-# Description: secure shell client and server (metapackage)
+# Description: Secure shell client and server
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/steam.profile
+++ b/etc/steam.profile
@@ -1,4 +1,5 @@
 # Firejail profile for steam
+# Description: Valve's Steam digital software delivery system
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/steam.local

--- a/etc/stellarium.profile
+++ b/etc/stellarium.profile
@@ -1,4 +1,5 @@
 # Firejail profile for stellarium
+# Description: real-time photo-realistic sky generator
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/stellarium.local

--- a/etc/stellarium.profile
+++ b/etc/stellarium.profile
@@ -1,5 +1,5 @@
 # Firejail profile for stellarium
-# Description: real-time photo-realistic sky generator
+# Description: Real-time photo-realistic sky generator
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/stellarium.local

--- a/etc/surf.profile
+++ b/etc/surf.profile
@@ -1,4 +1,5 @@
 # Firejail profile for surf
+# Description: Simple web browser by suckless community
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/surf.local

--- a/etc/sylpheed.profile
+++ b/etc/sylpheed.profile
@@ -1,4 +1,5 @@
 # Firejail profile for sylpheed
+# Description: Light weight e-mail client with GTK+
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/sylpheed.local

--- a/etc/synfigstudio.profile
+++ b/etc/synfigstudio.profile
@@ -1,4 +1,5 @@
 # Firejail profile for synfigstudio
+# Description: vector-based 2D animation package (graphical user interface)
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/synfigstudio.local

--- a/etc/synfigstudio.profile
+++ b/etc/synfigstudio.profile
@@ -1,5 +1,5 @@
 # Firejail profile for synfigstudio
-# Description: vector-based 2D animation package (graphical user interface)
+# Description: Vector-based 2D animation package
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/synfigstudio.local

--- a/etc/tar.profile
+++ b/etc/tar.profile
@@ -1,4 +1,5 @@
 # Firejail profile for tar
+# Description: GNU version of the tar archiving utility
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/teamspeak3.profile
+++ b/etc/teamspeak3.profile
@@ -1,4 +1,5 @@
 # Firejail profile for teamspeak3
+# Description: TeamSpeak is software for quality voice communication via the Internet
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/teamspeak3.local

--- a/etc/telegram-desktop.profile
+++ b/etc/telegram-desktop.profile
@@ -1,4 +1,5 @@
 # Firejail profile alias for telegram
+# Description: Official Telegram Desktop client
 # This file is overwritten after every install/update
 
 

--- a/etc/thunar.profile
+++ b/etc/thunar.profile
@@ -1,4 +1,5 @@
 # Firejail profile alias for Thunar
+# Description: Modern file manager for Xfce
 # This file is overwritten after every install/update
 
 

--- a/etc/thunderbird.profile
+++ b/etc/thunderbird.profile
@@ -1,4 +1,5 @@
 # Firejail profile for thunderbird
+# Description: Email, RSS and newsgroup client with integrated spam filter
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/thunderbird.local

--- a/etc/tor.profile
+++ b/etc/tor.profile
@@ -1,4 +1,5 @@
 # Firejail profile for tor
+# Description: anonymizing overlay network for TCP
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/tor.local

--- a/etc/tor.profile
+++ b/etc/tor.profile
@@ -1,5 +1,5 @@
 # Firejail profile for tor
-# Description: anonymizing overlay network for TCP
+# Description: Anonymizing overlay network for TCP
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/tor.local

--- a/etc/torbrowser-launcher.profile
+++ b/etc/torbrowser-launcher.profile
@@ -1,4 +1,5 @@
 # Firejail profile for torbrowser-launcher
+# Description: helps download and run the Tor Browser Bundle
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/torbrowser-launcher.local

--- a/etc/torbrowser-launcher.profile
+++ b/etc/torbrowser-launcher.profile
@@ -1,5 +1,5 @@
 # Firejail profile for torbrowser-launcher
-# Description: helps download and run the Tor Browser Bundle
+# Description: Helps download and run the Tor Browser Bundle
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/torbrowser-launcher.local

--- a/etc/totem.profile
+++ b/etc/totem.profile
@@ -1,4 +1,5 @@
 # Firejail profile for totem
+# Description: Simple media player for the GNOME desktop based on GStreamer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/totem.local

--- a/etc/tracker.profile
+++ b/etc/tracker.profile
@@ -1,4 +1,5 @@
 # Firejail profile for tracker
+# Description: metadata database, indexer and search tool
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/tracker.local

--- a/etc/tracker.profile
+++ b/etc/tracker.profile
@@ -1,5 +1,5 @@
 # Firejail profile for tracker
-# Description: metadata database, indexer and search tool
+# Description: Metadata database, indexer and search tool
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/tracker.local

--- a/etc/transmission-cli.profile
+++ b/etc/transmission-cli.profile
@@ -1,4 +1,5 @@
 # Firejail profile for transmission-cli
+# Description: lightweight BitTorrent client (command line programs)
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/transmission-cli.local

--- a/etc/transmission-cli.profile
+++ b/etc/transmission-cli.profile
@@ -1,5 +1,5 @@
 # Firejail profile for transmission-cli
-# Description: lightweight BitTorrent client (command line programs)
+# Description: Lightweight BitTorrent client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/transmission-cli.local

--- a/etc/transmission-gtk.profile
+++ b/etc/transmission-gtk.profile
@@ -1,4 +1,5 @@
 # Firejail profile for transmission-gtk
+# Description: lightweight BitTorrent client (GTK+ interface)
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/transmission-gtk.local

--- a/etc/transmission-gtk.profile
+++ b/etc/transmission-gtk.profile
@@ -1,5 +1,5 @@
 # Firejail profile for transmission-gtk
-# Description: lightweight BitTorrent client (GTK+ interface)
+# Description: Lightweight BitTorrent client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/transmission-gtk.local

--- a/etc/transmission-qt.profile
+++ b/etc/transmission-qt.profile
@@ -1,4 +1,5 @@
 # Firejail profile for transmission-qt
+# Description: lightweight BitTorrent client (Qt interface)
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/transmission-qt.local

--- a/etc/transmission-qt.profile
+++ b/etc/transmission-qt.profile
@@ -1,5 +1,5 @@
 # Firejail profile for transmission-qt
-# Description: lightweight BitTorrent client (Qt interface)
+# Description: Lightweight BitTorrent client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/transmission-qt.local

--- a/etc/tuxguitar.profile
+++ b/etc/tuxguitar.profile
@@ -1,4 +1,5 @@
 # Firejail profile for tuxguitar
+# Description: Multitrack guitar tablature editor and player (gp3 to gp5)
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/tuxguitar.local

--- a/etc/unbound.profile
+++ b/etc/unbound.profile
@@ -1,4 +1,5 @@
 # Firejail profile for unbound
+# Description: validating, recursive, caching DNS resolver
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/unbound.local

--- a/etc/unbound.profile
+++ b/etc/unbound.profile
@@ -1,5 +1,5 @@
 # Firejail profile for unbound
-# Description: validating, recursive, caching DNS resolver
+# Description: Validating, recursive, caching DNS resolver
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/unbound.local

--- a/etc/unknown-horizons.profile
+++ b/etc/unknown-horizons.profile
@@ -1,4 +1,5 @@
 # Firejail profile for unknown-horizons
+# Description: 2D realtime strategy simulation
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/unknown-horizons.local

--- a/etc/unrar.profile
+++ b/etc/unrar.profile
@@ -1,4 +1,5 @@
 # Firejail profile for unrar
+# Description: Unarchiver for .rar files (non-free version)
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/unrar.profile
+++ b/etc/unrar.profile
@@ -1,5 +1,5 @@
 # Firejail profile for unrar
-# Description: Unarchiver for .rar files (non-free version)
+# Description: Unarchiver for .rar files
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/unzip.profile
+++ b/etc/unzip.profile
@@ -1,4 +1,5 @@
 # Firejail profile for unzip
+# Description: De-archiver for .zip files
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/uudeview.profile
+++ b/etc/uudeview.profile
@@ -1,4 +1,5 @@
 # Firejail profile for uudeview
+# Description: Smart multi-file multi-part decoder (command line)
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/uudeview.profile
+++ b/etc/uudeview.profile
@@ -1,5 +1,5 @@
 # Firejail profile for uudeview
-# Description: Smart multi-file multi-part decoder (command line)
+# Description: Smart multi-file multi-part decoder
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/viewnior.profile
+++ b/etc/viewnior.profile
@@ -1,4 +1,5 @@
 # Firejail profile for viewnior
+# Description: simple, fast and elegant image viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/viewnior.local

--- a/etc/viewnior.profile
+++ b/etc/viewnior.profile
@@ -1,5 +1,5 @@
 # Firejail profile for viewnior
-# Description: simple, fast and elegant image viewer
+# Description: Simple, fast and elegant image viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/viewnior.local

--- a/etc/viking.profile
+++ b/etc/viking.profile
@@ -1,4 +1,5 @@
 # Firejail profile for viking
+# Description: GPS data editor, analyzer and viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/viking.local

--- a/etc/vim.profile
+++ b/etc/vim.profile
@@ -1,4 +1,5 @@
 # Firejail profile for vim
+# Description: Vi IMproved - enhanced vi editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/vim.local

--- a/etc/vimpager.profile
+++ b/etc/vimpager.profile
@@ -1,4 +1,5 @@
 # Firejail profile for vimpager
+# Description: A vim-based script to use as a PAGER.
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/vimpager.local

--- a/etc/vimpager.profile
+++ b/etc/vimpager.profile
@@ -1,5 +1,5 @@
 # Firejail profile for vimpager
-# Description: A vim-based script to use as a PAGER.
+# Description: A vim-based script to use as a PAGER
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/vimpager.local

--- a/etc/virtualbox.profile
+++ b/etc/virtualbox.profile
@@ -1,4 +1,5 @@
 # Firejail profile for virtualbox
+# Description: x86 virtualization solution - base binaries
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/virtualbox.local

--- a/etc/virtualbox.profile
+++ b/etc/virtualbox.profile
@@ -1,5 +1,5 @@
 # Firejail profile for virtualbox
-# Description: x86 virtualization solution - base binaries
+# Description: x86 virtualization solution
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/virtualbox.local

--- a/etc/vlc.profile
+++ b/etc/vlc.profile
@@ -1,4 +1,5 @@
 # Firejail profile for vlc
+# Description: multimedia player and streamer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/vlc.local

--- a/etc/vlc.profile
+++ b/etc/vlc.profile
@@ -1,5 +1,5 @@
 # Firejail profile for vlc
-# Description: multimedia player and streamer
+# Description: Multimedia player and streamer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/vlc.local

--- a/etc/vym.profile
+++ b/etc/vym.profile
@@ -1,4 +1,5 @@
 # Firejail profile for vym
+# Description: mindmapping tool
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/vym.local

--- a/etc/vym.profile
+++ b/etc/vym.profile
@@ -1,5 +1,5 @@
 # Firejail profile for vym
-# Description: mindmapping tool
+# Description: Mindmapping tool
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/vym.local

--- a/etc/w3m.profile
+++ b/etc/w3m.profile
@@ -1,4 +1,5 @@
 # Firejail profile for w3m
+# Description: WWW browsable pager with excellent tables/frames support
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/w3m.local

--- a/etc/warzone2100.profile
+++ b/etc/warzone2100.profile
@@ -1,4 +1,5 @@
 # Firejail profile for warzone2100
+# Description: 3D real time strategy game
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/warzone2100.local

--- a/etc/weechat.profile
+++ b/etc/weechat.profile
@@ -1,4 +1,5 @@
 # Firejail profile for weechat
+# Description: Fast, light and extensible chat client (metapackage)
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/weechat.local

--- a/etc/weechat.profile
+++ b/etc/weechat.profile
@@ -1,5 +1,5 @@
 # Firejail profile for weechat
-# Description: Fast, light and extensible chat client (metapackage)
+# Description: Fast, light and extensible chat client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/weechat.local

--- a/etc/wesnoth.profile
+++ b/etc/wesnoth.profile
@@ -1,4 +1,5 @@
 # Firejail profile for wesnoth
+# Description: fantasy turn-based strategy game - complete suite (metapackage)
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/wesnoth.local

--- a/etc/wesnoth.profile
+++ b/etc/wesnoth.profile
@@ -1,5 +1,5 @@
 # Firejail profile for wesnoth
-# Description: fantasy turn-based strategy game - complete suite (metapackage)
+# Description: Fantasy turn-based strategy game
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/wesnoth.local

--- a/etc/wget.profile
+++ b/etc/wget.profile
@@ -1,4 +1,5 @@
 # Firejail profile for wget
+# Description: retrieves files from the web
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/wget.profile
+++ b/etc/wget.profile
@@ -1,5 +1,5 @@
 # Firejail profile for wget
-# Description: retrieves files from the web
+# Description: Retrieves files from the web
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/wine.profile
+++ b/etc/wine.profile
@@ -1,4 +1,5 @@
 # Firejail profile for wine
+# Description: A compatibility layer for running Windows programs
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/wine.local

--- a/etc/wireshark-gtk.profile
+++ b/etc/wireshark-gtk.profile
@@ -1,5 +1,5 @@
 # Firejail profile alias for wireshark
-# Description: a free network protocol analyzer for Unix/Linux and Windows - GTK frontend
+# Description: Network protocol analyzer
 # This file is overwritten after every install/update
 
 

--- a/etc/wireshark-gtk.profile
+++ b/etc/wireshark-gtk.profile
@@ -1,4 +1,5 @@
 # Firejail profile alias for wireshark
+# Description: a free network protocol analyzer for Unix/Linux and Windows - GTK frontend
 # This file is overwritten after every install/update
 
 

--- a/etc/wireshark-qt.profile
+++ b/etc/wireshark-qt.profile
@@ -1,4 +1,5 @@
 # Firejail profile alias for wireshark
+# Description: a free network protocol analyzer for Unix/Linux and Windows - Qt frontend
 # This file is overwritten after every install/update
 
 

--- a/etc/wireshark-qt.profile
+++ b/etc/wireshark-qt.profile
@@ -1,5 +1,5 @@
 # Firejail profile alias for wireshark
-# Description: a free network protocol analyzer for Unix/Linux and Windows - Qt frontend
+# Description: Network protocol analyzer
 # This file is overwritten after every install/update
 
 

--- a/etc/wireshark.profile
+++ b/etc/wireshark.profile
@@ -1,4 +1,5 @@
 # Firejail profile for wireshark
+# Description: network traffic analyzer - meta-package
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/wireshark.local

--- a/etc/wireshark.profile
+++ b/etc/wireshark.profile
@@ -1,5 +1,5 @@
 # Firejail profile for wireshark
-# Description: network traffic analyzer - meta-package
+# Description: Network traffic analyzer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/wireshark.local

--- a/etc/xchat.profile
+++ b/etc/xchat.profile
@@ -1,4 +1,5 @@
 # Firejail profile for xchat
+# Description: IRC client for X similar to AmIRC
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/xchat.local

--- a/etc/xfburn.profile
+++ b/etc/xfburn.profile
@@ -1,4 +1,5 @@
 # Firejail profile for xfburn
+# Description: CD-burner application for Xfce Desktop Environment
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/xfburn.local

--- a/etc/xfce4-dict.profile
+++ b/etc/xfce4-dict.profile
@@ -1,4 +1,5 @@
 # Firejail profile for xfce4-dict
+# Description: Dictionary plugin for Xfce4 panel
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/xfce4-dict.local

--- a/etc/xfce4-notes.profile
+++ b/etc/xfce4-notes.profile
@@ -1,4 +1,5 @@
 # Firejail profile for xfce4-notes
+# Description: Notes application for the Xfce4 desktop
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/xfce4-notes.local

--- a/etc/xiphos.profile
+++ b/etc/xiphos.profile
@@ -1,4 +1,5 @@
 # Firejail profile for xiphos
+# Description: environment for Bible reading, study, and research
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/xiphos.local

--- a/etc/xiphos.profile
+++ b/etc/xiphos.profile
@@ -1,5 +1,5 @@
 # Firejail profile for xiphos
-# Description: environment for Bible reading, study, and research
+# Description: Environment for Bible reading, study, and research
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/xiphos.local

--- a/etc/xonotic.profile
+++ b/etc/xonotic.profile
@@ -1,4 +1,5 @@
 # Firejail profile for xonotic
+# Description: A free, fast-paced crossplatform first-person shooter
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/xonotic.local

--- a/etc/xpdf.profile
+++ b/etc/xpdf.profile
@@ -1,4 +1,5 @@
 # Firejail profile for xpdf
+# Description: Portable Document Format (PDF) reader
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/xpdf.local

--- a/etc/xpra.profile
+++ b/etc/xpra.profile
@@ -1,4 +1,5 @@
 # Firejail profile for xpra
+# Description: tool to detach/reattach running X programs
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/xpra.local

--- a/etc/xpra.profile
+++ b/etc/xpra.profile
@@ -1,5 +1,5 @@
 # Firejail profile for xpra
-# Description: tool to detach/reattach running X programs
+# Description: Tool to detach/reattach running X programs
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/xpra.local

--- a/etc/xreader.profile
+++ b/etc/xreader.profile
@@ -1,4 +1,5 @@
 # Firejail profile for xreader
+# Description: Document viewer for files like PDF and Postscript. X-Apps Project.
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/xreader.local

--- a/etc/xxd.profile
+++ b/etc/xxd.profile
@@ -1,4 +1,5 @@
 # Firejail profile for xxd
+# Description: tool to make (or reverse) a hex dump
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/xxd.local

--- a/etc/xxd.profile
+++ b/etc/xxd.profile
@@ -1,5 +1,5 @@
 # Firejail profile for xxd
-# Description: tool to make (or reverse) a hex dump
+# Description: Tool to make (or reverse) a hex dump
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/xxd.local

--- a/etc/xz.profile
+++ b/etc/xz.profile
@@ -1,4 +1,5 @@
 # Firejail profile alias for cpio
+# Description: Library and command line tools for XZ and LZMA compressed files
 # This file is overwritten after every install/update
 
 

--- a/etc/xzdec.profile
+++ b/etc/xzdec.profile
@@ -1,4 +1,5 @@
 # Firejail profile for xzdec
+# Description: XZ-format compression utilities - tiny decompressors
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/youtube-dl.profile
+++ b/etc/youtube-dl.profile
@@ -1,4 +1,5 @@
 # Firejail profile for youtube-dl
+# Description: downloader of videos from YouTube and other sites
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/youtube-dl.profile
+++ b/etc/youtube-dl.profile
@@ -1,5 +1,5 @@
 # Firejail profile for youtube-dl
-# Description: downloader of videos from YouTube and other sites
+# Description: Downloader of videos from YouTube and other sites
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/zaproxy.profile
+++ b/etc/zaproxy.profile
@@ -1,4 +1,5 @@
 # Firejail profile for zaproxy
+# Description: Integrated penetration testing tool for finding vulnerabilities in web applications
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/zaproxy.local

--- a/etc/zart.profile
+++ b/etc/zart.profile
@@ -1,4 +1,5 @@
 # Firejail profile for zart
+# Description: A GUI for G'MIC real-time manipulations on the output of a webcam
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/zart.local

--- a/etc/zathura.profile
+++ b/etc/zathura.profile
@@ -1,4 +1,5 @@
 # Firejail profile for zathura
+# Description: document viewer with a minimalistic interface
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/zathura.local

--- a/etc/zathura.profile
+++ b/etc/zathura.profile
@@ -1,5 +1,5 @@
 # Firejail profile for zathura
-# Description: document viewer with a minimalistic interface
+# Description: Document viewer with a minimalistic interface
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/zathura.local


### PR DESCRIPTION
This adds descriptions to ~290 profiles.
The descriptions were automatically pulled from the output of `apt show $package` and `pacman -Si $package`.

This will help when doing mass changes to profiles so we don't have to go searching for a package we don't know.

Opening this as a PR for discussion:
- license of the descriptions?
- format ok?
- placement ok?
- require all new profiles to have a description?

Program here: https://gist.github.com/SkewedZeppelin/ce7dd57140bbbd35c876f240a6850ba7