### PR TITLE
Remove nogroups from audio player profiles

### DIFF
--- a/etc/audacious.profile
+++ b/etc/audacious.profile
@@ -23,7 +23,7 @@ apparmor
 caps.drop all
 netfilter
 nodbus
-nogroups
+# nogroups is unfeasible for ALSA since 660 mode is usualy set on /dev/snd/*
 nonewprivs
 noroot
 notv

--- a/etc/audacity.profile
+++ b/etc/audacity.profile
@@ -25,7 +25,7 @@ net none
 no3d
 # nodbus - problems on Fedora 27
 nodvd
-nogroups
+# nogroups is unfeasible for ALSA since 660 mode is usualy set on /dev/snd/*
 nonewprivs
 noroot
 notv

--- a/etc/deadbeef.profile
+++ b/etc/deadbeef.profile
@@ -19,7 +19,7 @@ include /etc/firejail/disable-xdg.inc
 caps.drop all
 netfilter
 no3d
-nogroups
+# nogroups is unfeasible for ALSA since 660 mode is usualy set on /dev/snd/*
 nonewprivs
 noroot
 notv

--- a/etc/mplayer.profile
+++ b/etc/mplayer.profile
@@ -21,7 +21,7 @@ include /etc/firejail/whitelist-var-common.inc
 
 caps.drop all
 netfilter
-# nogroups
+# nogroups is unfeasible for ALSA since 660 mode is usualy set on /dev/snd/*
 nonewprivs
 noroot
 protocol unix,inet,inet6,netlink

--- a/etc/mpv.profile
+++ b/etc/mpv.profile
@@ -30,8 +30,8 @@ apparmor
 caps.drop all
 netfilter
 nodbus
-# Seems to cause issues with Nvidia drivers sometimes
-nogroups
+# nogroups seems to cause issues with Nvidia drivers sometimes
+# nogroups is unfeasible for ALSA since 660 mode is usualy set on /dev/snd/*
 nonewprivs
 noroot
 protocol unix,inet,inet6


### PR DESCRIPTION
`nogroups` breaks ALSA since many distros set 660 mode and `root:audio` as owner:group on `/dev/snd/*` ALSA files.