### PR TITLE
hardening evince, dbus not needed

### DIFF
--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -23,7 +23,7 @@ machine-id
 # net none breaks AppArmor on Ubuntu systems
 netfilter
 no3d
-# nodbus
+nodbus
 nodvd
 nogroups
 nonewprivs


### PR DESCRIPTION
Upon testing evince, I figured out dbus may not be needed and my printer is still working.
In the initial commit 7a37dc31ab907d55eb88f2fa259f37046952a0c5 or issue #1843 
there is reasoning, however the profile still works for me.
The current apparmor profile does use dbus.

Upon use I found no side effects crashing the app when dbus was disabled.