### PR TITLE
Fix incorrect whitelist-path handling

### DIFF
--- a/src/firejail/fs_whitelist.c
+++ b/src/firejail/fs_whitelist.c
@@ -507,7 +507,7 @@ void fs_whitelist(void) {
 			// both path and absolute path are under /home
 			if (strncmp(fname, cfg.homedir, strlen(cfg.homedir)) == 0) {
 				// entire home directory is not allowed
-				if (*(fname + strlen(cfg.homedir)) != '/') {
+				if (strlen(fname) == strlen(cfg.homedir)) {
 					free(fname);
 					goto errexit;
 				}


### PR DESCRIPTION
Fixed so that the check if whitelist-path is entire home directory is correctly handled.
Previously the check also matched all subdirectories and files under homedir, which basically broke all profiles whitelisting anything in homedir.

### Examples:
From "firefox.profile"
`whitelist ${HOME}/.cache/mozilla/firefox`
