### PR TITLE
added keep-dev-shm so firefox-sync works

### DIFF
--- a/etc/firefox-common.profile
+++ b/etc/firefox-common.profile
@@ -43,6 +43,7 @@ shell none
 
 disable-mnt
 private-dev
+keep-dev-shm # for use with firefox-sync
 # private-etc below works fine on most distributions. There are some problems on CentOS.
 #private-etc ca-certificates,ssl,machine-id,dconf,selinux,passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,xdg,gtk-2.0,gtk-3.0,X11,pango,fonts,mime.types,mailcap,asound.conf,pulse,pki,crypto-policies,ld.so.cache
 private-tmp


### PR DESCRIPTION
keep-dev-shm allows [firefox-sync](https://wiki.archlinux.org/index.php/Firefox/Profile_on_RAM#The_script) to work