### PR TITLE
Fix incorrect --list and --tree output under certain circumstances

### DIFF
--- a/src/lib/pid.c
+++ b/src/lib/pid.c
@@ -359,7 +359,10 @@ void pid_read(pid_t mon_pid) {
 		char buf[PIDS_BUFLEN];
 		while (fgets(buf, PIDS_BUFLEN - 1, fp)) {
 			if (strncmp(buf, "Name:", 5) == 0) {
-				char *ptr = buf + 5;
+				char *ptr = strchr(buf, '\n');
+				if (ptr)
+					*ptr = '\0';
+				ptr = buf + 5;
 				while (*ptr != '\0' && (*ptr == ' ' || *ptr == '\t')) {
 					ptr++;
 				}
@@ -368,7 +371,7 @@ void pid_read(pid_t mon_pid) {
 					exit(1);
 				}
 
-				if ((strncmp(ptr, "firejail", 8) == 0) && (mon_pid == 0 || mon_pid == pid)) {
+				if ((strcmp(ptr, "firejail") == 0) && (mon_pid == 0 || mon_pid == pid)) {
 					if (pid_proc_cmdline_x11_xpra_xephyr(pid))
 						pids[pid].level = -1;
 					else


### PR DESCRIPTION
Firejail should look for processes with names exactly named "firejail" to avoid accounting for processes with a "firejail" prefix.  For example, I have a script named `firejail-bridged.sh` which forks a `firejail` child.  When it is running, `firejail --list` shows the script rather than the child firejail process and `firejail --tree` shows the process tree for the script and all its subprocesses.