### PR TITLE
Authenticator

### DIFF
--- a/etc/authenticator.profile
+++ b/etc/authenticator.profile
@@ -1,0 +1,49 @@
+# Firejail profile for authenticator
+# Description: 2FA code generator for GNOME
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/authenticator.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+# blacklisted in 'disable-programs.local'
+noblacklist ${HOME}/.config/Authenticator
+
+# Allow python 3.x (blacklisted by disable-interpreters.inc)
+noblacklist ${PATH}/python3*
+noblacklist /usr/lib/python3*
+
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-devel.inc
+include /etc/firejail/disable-interpreters.inc
+include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
+
+# apparmor
+caps.drop all
+net none
+no3d
+# nodbus - makes settings immutable
+nodvd
+nogroups
+nonewprivs
+noroot
+nosound
+notv
+# novideo
+nou2f
+protocol unix
+seccomp
+shell none
+
+disable-mnt
+# private-bin authenticator
+private-cache
+private-dev
+private-etc fonts,ld.so.cache
+# private-lib
+private-tmp
+
+# memory-deny-write-execute - breaks on Arch
+noexec ${HOME}
+noexec /tmp

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -46,6 +46,7 @@ blacklist ${HOME}/.config/0ad
 blacklist ${HOME}/.config/2048-qt
 blacklist ${HOME}/.config/Atom
 blacklist ${HOME}/.config/Audaciousrc
+blacklist ${HOME}/.config/Authenticator
 blacklist ${HOME}/.config/Beaker Browser
 blacklist ${HOME}/.config/Brackets
 blacklist ${HOME}/.config/Clementine

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -85,6 +85,7 @@ clipit
 cliqz
 cmus
 code
+com.github.bilelmoussaoui.Authenticator
 conkeror
 conky
 corebird


### PR DESCRIPTION
Not sure how/when the GNOME filenaming guru's came up with something so ugly (personal opinion), but that's the actual name of the .desktop file (https://gitlab.gnome.org/World/Authenticator/blob/master/data/com.github.bilelmoussaoui.Authenticator.desktop.in)...

Side-note: personally I don't use `firecfg`, but I assume the list entree should be pointing to the program's .desktop file... may need a double-check from someone that does use it.

Regards.