### PR TITLE
Fix issue #2148: Make sure firejail can find helper programs in sandbox regardless of options.

### DIFF
--- a/src/firejail/bandwidth.c
+++ b/src/firejail/bandwidth.c
@@ -406,17 +406,17 @@ void bandwidth_pid(pid_t pid, const char *command, const char *dev, int down, in
 	if (devname) {
 		if (strcmp(command, "set") == 0) {
 			if (asprintf(&cmd, "%s/firejail/fshaper.sh --%s %s %d %d",
-				LIBDIR, command, devname, down, up) == -1)
+				RUN_FIREJAIL_LIB_DIR, command, devname, down, up) == -1)
 				errExit("asprintf");
 		}
 		else {
 			if (asprintf(&cmd, "%s/firejail/fshaper.sh --%s %s",
-				LIBDIR, command, devname) == -1)
+				RUN_FIREJAIL_LIB_DIR, command, devname) == -1)
 				errExit("asprintf");
 		}
 	}
 	else {
-		if (asprintf(&cmd, "%s/firejail/fshaper.sh --%s", LIBDIR, command) == -1)
+		if (asprintf(&cmd, "%s/firejail/fshaper.sh --%s", RUN_FIREJAIL_LIB_DIR, command) == -1)
 			errExit("asprintf");
 	}
 	assert(cmd);

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -32,6 +32,7 @@
 #define RUN_FIREJAIL_DIR	"/run/firejail"
 #define RUN_FIREJAIL_APPIMAGE_DIR	"/run/firejail/appimage"
 #define RUN_FIREJAIL_NAME_DIR	"/run/firejail/name" // also used in src/lib/pid.c - todo: move it in a common place
+#define RUN_FIREJAIL_LIB_DIR		"/run/firejail/lib"
 #define RUN_FIREJAIL_X11_DIR	"/run/firejail/x11"
 #define RUN_FIREJAIL_NETWORK_DIR	"/run/firejail/network"
 #define RUN_FIREJAIL_BANDWIDTH_DIR	"/run/firejail/bandwidth"
@@ -62,11 +63,11 @@
 #define RUN_SECCOMP_MDWX	"/run/firejail/mnt/seccomp.mdwx"		// filter for memory-deny-write-execute
 #define RUN_SECCOMP_BLOCK_SECONDARY	"/run/firejail/mnt/seccomp.block_secondary"	// secondary arch blocking filter
 #define RUN_SECCOMP_POSTEXEC	"/run/firejail/mnt/seccomp.postexec"		// filter for post-exec library
-#define PATH_SECCOMP_DEFAULT (LIBDIR "/firejail/seccomp")			// default filter built during make
-#define PATH_SECCOMP_DEFAULT_DEBUG (LIBDIR "/firejail/seccomp.debug")	// default filter built during make
-#define PATH_SECCOMP_32 (LIBDIR "/firejail/seccomp.32")			// 32bit arch filter built during make
-#define PATH_SECCOMP_MDWX (LIBDIR "/firejail/seccomp.mdwx")		// filter for memory-deny-write-execute built during make
-#define PATH_SECCOMP_BLOCK_SECONDARY (LIBDIR "/firejail/seccomp.block_secondary")	// secondary arch blocking filter built during make
+#define PATH_SECCOMP_DEFAULT (RUN_FIREJAIL_LIB_DIR "/firejail/seccomp")			// default filter built during make
+#define PATH_SECCOMP_DEFAULT_DEBUG (RUN_FIREJAIL_LIB_DIR "/firejail/seccomp.debug")	// default filter built during make
+#define PATH_SECCOMP_32 (RUN_FIREJAIL_LIB_DIR "/firejail/seccomp.32")			// 32bit arch filter built during make
+#define PATH_SECCOMP_MDWX (RUN_FIREJAIL_LIB_DIR "/firejail/seccomp.mdwx")		// filter for memory-deny-write-execute built during make
+#define PATH_SECCOMP_BLOCK_SECONDARY (RUN_FIREJAIL_LIB_DIR "/firejail/seccomp.block_secondary")	// secondary arch blocking filter built during make
 
 
 #define RUN_DEV_DIR		"/run/firejail/mnt/dev"
@@ -790,16 +791,16 @@ void build_appimage_cmdline(char **command_line, char **window_title, int argc, 
 
 // sbox.c
 // programs
-#define PATH_FNET (LIBDIR "/firejail/fnet")
-#define PATH_FNETFILTER (LIBDIR "/firejail/fnetfilter")
+#define PATH_FNET (RUN_FIREJAIL_LIB_DIR "/firejail/fnet")
+#define PATH_FNETFILTER (RUN_FIREJAIL_LIB_DIR "/firejail/fnetfilter")
 #define PATH_FIREMON (PREFIX "/bin/firemon")
 #define PATH_FIREJAIL (PREFIX "/bin/firejail")
-#define PATH_FSECCOMP (LIBDIR "/firejail/fseccomp")
-#define PATH_FSEC_PRINT (LIBDIR "/firejail/fsec-print")
-#define PATH_FSEC_OPTIMIZE (LIBDIR "/firejail/fsec-optimize")
-#define PATH_FCOPY (LIBDIR "/firejail/fcopy")
-#define SBOX_STDIN_FILE "/run/firejail/mnt/sbox_stdin"
-#define PATH_FLDD (LIBDIR "/firejail/fldd")
+#define PATH_FSECCOMP (RUN_FIREJAIL_LIB_DIR "/firejail/fseccomp")
+#define PATH_FSEC_PRINT (RUN_FIREJAIL_LIB_DIR "/firejail/fsec-print")
+#define PATH_FSEC_OPTIMIZE (RUN_FIREJAIL_LIB_DIR "/firejail/fsec-optimize")
+#define PATH_FCOPY (RUN_FIREJAIL_LIB_DIR "/firejail/fcopy")
+#define SBOX_STDIN_FILE (RUN_MNT_DIR "/sbox_stdin")
+#define PATH_FLDD (RUN_FIREJAIL_LIB_DIR "/firejail/fldd")
 
 // bitmapped filters for sbox_run
 #define SBOX_ROOT (1 << 0)			// run the sandbox as root

--- a/src/firejail/fs_trace.c
+++ b/src/firejail/fs_trace.c
@@ -51,7 +51,7 @@ void fs_trace(void) {
 	FILE *fp = fopen(RUN_LDPRELOAD_FILE, "w");
 	if (!fp)
 		errExit("fopen");
-	const char *prefix = LIBDIR "/firejail";
+	const char *prefix = RUN_FIREJAIL_LIB_DIR "/firejail";
 
 	if (arg_trace) {
 		fprintf(fp, "%s/libtrace.so\n", prefix);

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -838,7 +838,7 @@ static void run_builder(int argc, char **argv) {
 	assert(getenv("LD_PRELOAD") == NULL);
 	umask(orig_umask);
 
-	argv[0] = LIBDIR "/firejail/fbuilder";
+	argv[0] = RUN_FIREJAIL_LIB_DIR "/firejail/fbuilder";
 	execvp(argv[0], argv);
 
 	perror("execvp");
@@ -877,6 +877,13 @@ int main(int argc, char **argv) {
 	// cleanup at exit
 	EUID_ROOT();
 	atexit(clear_atexit);
+
+	// make private copy of mount namespace so that mounts in firejail do not
+	// propagate up to host
+	if (unshare(CLONE_NEWNS) != 0)
+		errExit("unshare");
+	if (mount(NULL, "/", NULL, MS_PRIVATE | MS_REC, NULL) != 0)
+		errExit("mount: make all mounts private");
 
 	// build /run/firejail directory structure
 	preproc_build_firejail_dir();
@@ -2116,7 +2123,7 @@ int main(int argc, char **argv) {
 		else if (strncmp(argv[i], "--timeout=", 10) == 0)
 			cfg.timeout = extract_timeout(argv[i] + 10);
 		else if (strcmp(argv[i], "--audit") == 0) {
-			arg_audit_prog = LIBDIR "/firejail/faudit";
+			arg_audit_prog = RUN_FIREJAIL_LIB_DIR "/firejail/faudit";
 			arg_audit = 1;
 		}
 		else if (strncmp(argv[i], "--audit=", 8) == 0) {

--- a/src/firejail/output.c
+++ b/src/firejail/output.c
@@ -76,7 +76,7 @@ void check_output(int argc, char **argv) {
 	for (i = 0; i < argc; i++) {
 		len += strlen(argv[i]) + 1; // + ' '
 	}
-	len += 100 + strlen(LIBDIR) + strlen(outfile); // tee command
+	len += 100 + strlen(RUN_FIREJAIL_LIB_DIR) + strlen(outfile); // tee command
 
 	char *cmd = malloc(len + 1); // + '\0'
 	if (!cmd)
@@ -92,9 +92,9 @@ void check_output(int argc, char **argv) {
 	}
 
 	if (enable_stderr)
-		sprintf(ptr, "2>&1 | %s/firejail/ftee %s", LIBDIR, outfile);
+		sprintf(ptr, "2>&1 | %s/firejail/ftee %s", RUN_FIREJAIL_LIB_DIR, outfile);
 	else
-		sprintf(ptr, " | %s/firejail/ftee %s", LIBDIR, outfile);
+		sprintf(ptr, " | %s/firejail/ftee %s", RUN_FIREJAIL_LIB_DIR, outfile);
 
 	// run command
 	char *a[4];

--- a/src/firejail/preproc.c
+++ b/src/firejail/preproc.c
@@ -62,12 +62,20 @@ void preproc_build_firejail_dir(void) {
 		create_empty_dir_as_root(RUN_FIREJAIL_APPIMAGE_DIR, 0755);
 	}
 
+	if (stat(RUN_FIREJAIL_LIB_DIR, &s)) {
+		create_empty_dir_as_root(RUN_FIREJAIL_LIB_DIR, 0755);
+	}
+
 	if (stat(RUN_MNT_DIR, &s)) {
 		create_empty_dir_as_root(RUN_MNT_DIR, 0755);
 	}
 
 	create_empty_file_as_root(RUN_RO_FILE, S_IRUSR);
 	create_empty_dir_as_root(RUN_RO_DIR, S_IRUSR);
+
+	// bind-mount firejail binaries and helper programs
+	if (mount(LIBDIR, RUN_FIREJAIL_LIB_DIR, "none", MS_BIND, NULL) < 0)
+		errExit("mounting " RUN_FIREJAIL_LIB_DIR);
 }
 
 // build /run/firejail/mnt directory


### PR DESCRIPTION
These changes allow firejail to always be able to find and run its helper libraries even when they are installed in a location that would otherwise be inaccessible in the sandbox (eg. under `${HOME}` or `/media` when `disable-mnt` is enabled), which fixes #2148.  The basic idea behind the implementation is to first unshare firejail's mount namespace and make all mounts private.  Then early on we bind-mount `LIBDIR`, where the helpers programs are actually stored, to `/run/firejail/lib` and have all the helpers be run from there.

Despite there being a fair amount of lines to the changeset, the magic really happens in only a few lines.  The unsharing of the mount namespace and making mounts private happens in `src/firejail/main.c` line 883-886, and the bind-mount of `LIBDIR` in `src/firejail/preproc.c` lines 77-78.
