### PR TITLE
The path in ld.so.preload should point to RUN_FIREJAIL_LIB_DIR, as LIBDIR may not exist.

### DIFF
--- a/src/firejail/fs_trace.c
+++ b/src/firejail/fs_trace.c
@@ -51,7 +51,7 @@ void fs_trace(void) {
 	FILE *fp = fopen(RUN_LDPRELOAD_FILE, "w");
 	if (!fp)
 		errExit("fopen");
-	const char *prefix = LIBDIR "/firejail";
+	const char *prefix = RUN_FIREJAIL_LIB_DIR;
 
 	if (arg_trace) {
 		fprintf(fp, "%s/libtrace.so\n", prefix);


### PR DESCRIPTION
This got broken in pq #2190, which partially reverted #2186.