### PR TITLE
Make --join return exit code of the invoked program

### DIFF
--- a/src/firejail/join.c
+++ b/src/firejail/join.c
@@ -436,8 +436,18 @@ void join(pid_t pid, int argc, char **argv, int index) {
 		// it will never get here!!!
 	}
 
+	int status = 0;
 	// wait for the child to finish
-	waitpid(child, NULL, 0);
+	waitpid(child, &status, 0);
 	flush_stdin();
-	exit(0);
+
+	if (WIFEXITED(status)) {
+		status = WEXITSTATUS(status);
+	} else if (WIFSIGNALED(status)) {
+		status = WTERMSIG(status);
+	} else {
+		status = 0;
+	}
+
+	exit(status);
 }


### PR DESCRIPTION
This PR changes the behavior of --join command, making it return the exit code of the invoked program.

```
pawel@azath:~$ firejail --join=test exit 123
Switching to pid 10387, the first child process inside the sandbox
Warning: cleaning all supplementary groups
Child process initialized in 45.88 ms
pawel@azath:~$ echo $?
123
```