### PR TITLE
Fix docs to more correctly list the syscalls in the @default seccomp group.

### DIFF
--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -1681,12 +1681,12 @@ Enable seccomp filter and blacklist the syscalls in the default list (@default).
 _sysctl, acct, add_key, adjtimex, afs_syscall, bdflush, bpf, break, chroot, clock_adjtime, clock_settime,
 create_module, delete_module, fanotify_init, finit_module, ftime, get_kernel_syms, getpmsg, gtty, init_module,
 io_cancel, io_destroy, io_getevents, io_setup, io_submit, ioperm, iopl, ioprio_set, kcmp, kexec_file_load,
-kexec_load, keyctl, lock, lookup_dcookie, mbind, mfsservctl, migrate_pages, modify_ldt, mount, move_pages, mpx,
-name_to_handle_at, open_by_handle_at, pciconfig_iobase, pciconfig_read, pciconfig_write, perf_event_open,
-personality, pivot_root, process_vm_readv, process_vm_writev, process_vm_writev, prof, profil, ptrace, putpmsg,
+kexec_load, keyctl, lock, lookup_dcookie, mbind, migrate_pages, modify_ldt, mount, move_pages, mpx,
+name_to_handle_at, nfsservctl, ni_syscall, open_by_handle_at, pciconfig_iobase, pciconfig_read, pciconfig_write, perf_event_open,
+personality, pivot_root, process_vm_readv, process_vm_writev, prof, profil, ptrace, putpmsg,
 query_module, reboot, remap_file_pages, request_key, rtas, s390_mmio_read, s390_mmio_write, s390_runtime_instr,
 security, set_mempolicy, setdomainname, sethostname, settimeofday, sgetmask, ssetmask, stime, stty, subpage_prot,
-swapoff, swapon, switch_endian, sysfs, syslog, tuxcall, ulimit, umount, umount2, uselib, userfaultfd, ustat, vhangup,
+swapoff, swapon, switch_endian, sys_debug_setcontext, sysfs, syslog, tuxcall, ulimit, umount, umount2, uselib, userfaultfd, ustat, vhangup,
 vm86, vm86old, vmsplice and vserver.
 
 .br


### PR DESCRIPTION
I'm not sure the list is 100% accurate now, but at least its closer to 100%.