### PR TITLE
Fix #2142: Firefox appimage fails because it needs non-default seccomp

### DIFF
--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -530,14 +530,6 @@ static void enforce_filters(void) {
 #ifdef HAVE_SECCOMP
 	enforce_seccomp = 1;
 #endif
-	if (cfg.seccomp_list_drop) {
-		free(cfg.seccomp_list_drop);
-		cfg.seccomp_list_drop = NULL;
-	}
-	if (cfg.seccomp_list_keep) {
-		free(cfg.seccomp_list_keep);
-		cfg.seccomp_list_keep = NULL;
-	}
 
 	// disable all capabilities
 	if (arg_caps_default_filter || arg_caps_list)
@@ -547,8 +539,7 @@ static void enforce_filters(void) {
 	// drop all supplementary groups; /etc/group file inside chroot
 	// is controlled by a regular usr
 	arg_nogroups = 1;
-	fmessage("\n** Warning: dropping all Linux capabilities and enforcing  **\n");
-	fmessage("**                  default seccomp filter                 **\n\n");
+	fmessage("\n**     Warning: dropping all Linux capabilities     **\n");
 }
 
 int sandbox(void* sandbox_arg) {


### PR DESCRIPTION
Do not override user provided seccomp lists when in chroot/overlay/appimage, but to use the default if none is provided.  This is a more general fix.  I see no reason we are forcing users to use a default seccomp filter with those options.  There should be a default if no seccomp filter is provided, but if one is provided, it should not be ignored in favor of the default.  This allows the firefox appimage to work, because its sandboxing need chroot, which is disabled in the @default seccomp filter (see #2142).