### PR TITLE
git.profile: Disable blacklist for default Oh My Zsh directory

### DIFF
--- a/etc/git.profile
+++ b/etc/git.profile
@@ -13,6 +13,7 @@ noblacklist ${HOME}/.emacs
 noblacklist ${HOME}/.emacs.d
 noblacklist ${HOME}/.gitconfig
 noblacklist ${HOME}/.gnupg
+noblacklist ${HOME}/.oh-my-zsh
 noblacklist ${HOME}/.ssh
 noblacklist ${HOME}/.vim
 noblacklist ${HOME}/.viminfo


### PR DESCRIPTION
[Oh My Zsh](https://ohmyz.sh/) is installed to `${HOME}/.oh-my-zsh` by default. Installation and upgrading use `git` and will fail if it gets sandboxed (since commit 6b84a6a9e82affa460e46790da542dbf3b1b84f9):
```
$ upgrade_oh_my_zsh
Updating Oh My Zsh
error: cannot open .git/FETCH_HEAD: Read-only file system
There was an error updating. Try again later?
```
[Topgrade](https://github.com/r-darwish/topgrade) and anything or anyone else trying to upgrade Oh My Zsh using a sandboxed `git` will encounter the same error.

Disabling blacklisting of the default Oh My Zsh installation directory for the `git` profile fixes this.