### PR TITLE
Expanded the comment about nodbus breaking stuff

### DIFF
--- a/etc/firefox-common.profile
+++ b/etc/firefox-common.profile
@@ -27,8 +27,10 @@ caps.drop all
 # machine-id breaks pulse audio; it should work fine in setups where sound is not required
 #machine-id
 netfilter
-# Breaks Gnome connector - disable if you use that
+# Breaks Gnome connector and KDE Connect
 # Also seems to break Ubuntu titlebar menu
+# During a stream on Plasma it prevents the mechanism to temporarily bypass the power management, i.e. to keep the screen on
+# Therefore disable if you use that
 nodbus
 nodvd
 nogroups


### PR DESCRIPTION
As I figured out nodbus may break the streaming experience with Firefox 63.0 on Plasma 5.14.2, Framework 5.51.0

* KDE Connect: Users won't be able to control a stream with KDE Connect anymore
* power management: During a stream the screen may dim or turn off