### PR TITLE
Add description to dig.profile

### DIFF
--- a/etc/dig.profile
+++ b/etc/dig.profile
@@ -1,5 +1,6 @@
-quiet
 # Firejail profile for dig
+# Description: DNS lookup utility
+quiet
 # This file is overwritten after every install/update
 # Persistent local customizations
 include dig.local


### PR DESCRIPTION
Moved `quiet` option below the newly added description for consistency.