### PR TITLE
Fix tar.profile on Debian based distributions

### DIFF
--- a/etc/tar.profile
+++ b/etc/tar.profile
@@ -29,4 +29,7 @@ private-dev
 private-etc passwd,group,localtime
 private-lib
 
+# Debian based distributions need this for 'dpkg --unpack' (incl. synaptic)
+writable-var
+
 include default.profile


### PR DESCRIPTION
This fixes https://github.com/netblue30/firejail/issues/2239.