### PR TITLE
Fix seccomp in mpd.profile

### DIFF
--- a/etc/mpd.profile
+++ b/etc/mpd.profile
@@ -28,7 +28,9 @@ notv
 nou2f
 novideo
 protocol unix,inet,inet6
-seccomp
+# blacklisting of ioprio_set system calls breaks auto-updating of
+# MPD's database when files in music_directory are changed
+seccomp.drop @cpu-emulation,@debug,@obsolete,@privileged,@resources,add_key,fanotify_init,io_cancel,io_destroy,io_getevents,io_setup,io_submit,kcmp,keyctl,name_to_handle_at,ni_syscall,open_by_handle_at,personality,process_vm_readv,ptrace,remap_file_pages,request_key,syslog,umount,userfaultfd,vmsplice
 shell none
 
 #private-bin mpd,bash


### PR DESCRIPTION
The current mpd profile breaks MPD's music database auto-updating feature. Changing the seccomp option fixes this.