### PR TITLE
Have appimage handling be the same with or with out special -- argument.

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -2244,21 +2244,18 @@ int main(int argc, char **argv) {
 				return 1;
 			}
 		}
-		else if (strcmp(argv[i], "--") == 0) {
-			// double dash - positional params to follow
-			arg_doubledash = 1;
-			i++;
-			if (i  >= argc) {
-				fprintf(stderr, "Error: program name not found\n");
-				exit(1);
-			}
-			extract_command_name(i, argv);
-			prog_index = i;
-			break;
-		}
 		else {
+			// double dash - positional params to follow
+			if (strcmp(argv[i], "--") == 0) {
+				arg_doubledash = 1;
+				i++;
+				if (i  >= argc) {
+					fprintf(stderr, "Error: program name not found\n");
+					exit(1);
+				}
+			}
 			// is this an invalid option?
-			if (*argv[i] == '-') {
+			else if (*argv[i] == '-') {
 				fprintf(stderr, "Error: invalid %s command line option\n", argv[i]);
 				return 1;
 			}


### PR DESCRIPTION
When not using `--` on the command line along with `--appimage`, `extract_command_name` is not run and instead `cfg.command_name` is set and `arg_shell_none` is set to `0`.  This is what one wants when running appimages where the `AppRun` is a shell script (eg. digikam).  However, this logic is not consistently applied when processing the `--` special option.

The effect of this is that using `--` with the digikam appimage and digikam profile fails to run digikam because the digikam profile sets `shell none`.  This can be overcome by adding `ignore=shell`, but that shouldn't be necessary.
