### PR TITLE
Allow prefixing colon to profile argument of --profile to for a profile search

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1495,7 +1495,8 @@ int main(int argc, char **argv) {
 			if (!ppath)
 				errExit("strdup");
 
-			if (access(ppath, R_OK)) {
+			if (*ppath == ':' || access(ppath, R_OK) || is_dir(ppath)) {
+				int has_colon = (*ppath == ':');
 				char *ptr = ppath;
 				while (*ptr != '/' && *ptr != '.' && *ptr != '\0')
 					ptr++;
@@ -1508,7 +1509,7 @@ int main(int argc, char **argv) {
 
 				// profile was not read in previously, try to see if
 				// we were given a profile name.
-				if (!profile_find_firejail(ppath, 1)) {
+				if (!profile_find_firejail(ppath + has_colon, 1)) {
 					// do not fall through to default profile,
 					// because the user should be notified that
 					// given profile arg could not be used.

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -2718,7 +2718,7 @@ The owner of the sandbox.
 Several command line options can be passed to the program using
 profile files. Firejail chooses the profile file as follows:
 
-1. If a profile file is provided by the user with --profile option, the profile file is loaded. If a profile name is given, it is searched for first in the ~/.config/firejail directory and if not found then in  /etc/firejail directory. Profile names do not include the .profile suffix.
+1. If a profile file is provided by the user with --profile=FILE option, the profile FILE is loaded. If a profile name is given, it is searched for first in the ~/.config/firejail directory and if not found then in  /etc/firejail directory. Profile names do not include the .profile suffix. If there is a file with the same name as the given profile name, it will be used instead of doing the profile search. To force a profile search, prefix the profile name with a colon (:), eg. --profile=:PROFILE_NAME.
 Example:
 .PP
 .RS


### PR DESCRIPTION
I ran into this while executing digikam with firejail while in the current directory there was a file named `digikam`.  So firejail was trying to read that file as a profile file.  This patch would allow me to use `--profile=:digikam` to force digikam to do a profile search instead of looking in the current directory for profiles.