### PR TITLE
Fix Evince profile

### DIFF
--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -39,7 +39,7 @@ tracelog
 
 private-bin evince,evince-previewer,evince-thumbnailer
 private-dev
-private-etc fonts
+private-etc fonts,machine-id
 
 private-lib evince,gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libdjvulibre.so.*,libgconf-2.so.*,libpoppler-glib.so.*,librsvg-2.so.*,gconv
 


### PR DESCRIPTION
Evince 3.30.1 on Ubuntu 18.10 fails to open with the following error unless `private-etc machine-id` is allowed:
```
dbus[194]: D-Bus library appears to be incorrectly set up: see the manual page for dbus-uuidgen to correct this issue. (Failed to open "/var/lib/dbus/machine-id": No such file or directory; Failed to open "/etc/machine-id": No such file or directory)
  D-Bus not built with -rdynamic so unable to print a backtrace
```