### PR TITLE
removing vim and ranger from firecfg

### DIFF
--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -358,7 +358,6 @@ quiterss
 qupzilla
 qutebrowser
 rambox
-ranger
 redeclipse
 remmina
 rhythmbox

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -443,7 +443,6 @@ uudeview
 uzbl-browser
 viewnior
 viking
-vim
 virtualbox
 vivaldi
 vivaldi-beta


### PR DESCRIPTION
ranger is a file manager - https://github.com/netblue30/firejail/issues/1261
vim is often used to edit system files - sandboxing breaks functionality.