### PR TITLE
allowing local python* in mpv and youtube-dl #2262

### DIFF
--- a/etc/mpv.profile
+++ b/etc/mpv.profile
@@ -16,6 +16,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/youtube-dl.profile
+++ b/etc/youtube-dl.profile
@@ -16,6 +16,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc


### PR DESCRIPTION
allowing local python* in mpv and youtube-dl #2262 .For use with latest youtube-dl installed with pip. Having the latest is very important here.

Maybe others are using it? grep only gives these two.