### PR TITLE
refactor private-cache and tmpfs

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -439,6 +439,8 @@ void preproc_clean_run(void);
 // fs.c
 // blacklist files or directories by mounting empty files on top of them
 void fs_blacklist(void);
+// mount a writable tmpfs
+void fs_tmpfs(const char *dir, unsigned check_owner);
 // remount a directory read-only
 void fs_rdonly(const char *dir);
 void fs_rdonly_rec(const char *dir);

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -2058,7 +2058,7 @@ Kill the sandbox automatically after the time has elapsed. The time is specified
 $ firejail \-\-timeout=01:30:00 firefox
 .TP
 \fB\-\-tmpfs=dirname
-Mount a tmpfs filesystem on directory dirname. This option is available only when running the sandbox as root.
+Mount a writable tmpfs filesystem on directory dirname. This option is available only when running the sandbox as root.
 File globbing is supported, see \fBFILE GLOBBING\fR section for more details.
 .br
 


### PR DESCRIPTION
has the immediate benefit that the result of combining `--noexec` and `--tmpfs` does not depend on the sequence of the options.