### PR TITLE
Update kdenlive.profile

### DIFF
--- a/etc/kdenlive.profile
+++ b/etc/kdenlive.profile
@@ -30,7 +30,7 @@ protocol unix,netlink
 seccomp
 shell none
 
-private-bin kdenlive,kdenlive_render,dbus-launch,melt,ffmpeg,ffplay,ffprobe,dvdauthor,genisoimage,vlc,xine,kdeinit5,kshell5,kdeinit5_shutdown,kdeinit5_wrapper,kdeinit4,kshell4,kdeinit4_shutdown,kdeinit4_wrapper
+private-bin kdenlive,kdenlive_render,dbus-launch,melt,ffmpeg,ffplay,ffprobe,dvdauthor,genisoimage,vlc,xine,kdeinit5,kshell5,kdeinit5_shutdown,kdeinit5_wrapper,kdeinit4,kshell4,kdeinit4_shutdown,kdeinit4_wrapper,mlt-melt
 private-dev
 # private-etc alternatives,fonts,kde4rc,kde5rc,ld.so.cache,machine-id,passwd,pulse,xdg,X11
 


### PR DESCRIPTION
Add mlt-melt to private-bin, this is needed on Fedora-systems.

The programm `melt` is needed for rendering, because there are more than one programm that is called `melt`, Fedora (and maybe some other distros) install the `melt`-programm from MLT as `mlt-melt` under `/usr/bin`.