### PR TITLE
allowing youtube-dl and python in gnome-mpv

### DIFF
--- a/etc/gnome-mpv.profile
+++ b/etc/gnome-mpv.profile
@@ -10,6 +10,14 @@ noblacklist ${HOME}/.config/gnome-mpv
 noblacklist ${MUSIC}
 noblacklist ${VIDEOS}
 
+# Allow python (blacklisted by disable-interpreters.inc)
+noblacklist ${PATH}/python2*
+noblacklist ${PATH}/python3*
+noblacklist /usr/lib/python2*
+noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
+
 include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc
@@ -29,7 +37,7 @@ protocol unix,inet,inet6
 seccomp
 shell none
 
-private-bin gnome-mpv
+private-bin gnome-mpv,youtube-dl,python*,env
 private-dev
 private-tmp
 


### PR DESCRIPTION
like the title says. Allowing youtube-dl.
