### PR TITLE
Fix bibletime.profile

### DIFF
--- a/etc/bibletime.profile
+++ b/etc/bibletime.profile
@@ -34,9 +34,11 @@ notv
 nou2f
 novideo
 protocol unix,inet,inet6,netlink
-seccomp
+# Breaks bibletime on Fedora and Arch
+#seccomp
 shell none
-tracelog
+# Breaks bibletime on Fedora and Arch
+#tracelog
 
 # private-bin bibletime,qt5ct
 private-dev

--- a/etc/bibletime.profile
+++ b/etc/bibletime.profile
@@ -34,11 +34,8 @@ notv
 nou2f
 novideo
 protocol unix,inet,inet6,netlink
-# Breaks bibletime on Fedora and Arch
-#seccomp
+seccomp.drop @clock,@cpu-emulation,@debug,@module,@obsolete,@raw-io,@reboot,@resources,@swap,acct,add_key,bpf,fanotify_init,io_cancel,io_destroy,io_getevents,io_setup,io_submit,ioprio_set,kcmp,keyctl,mount,name_to_handle_at,nfsservctl,ni_syscall,open_by_handle_at,personality,pivot_root,process_vm_readv,ptrace,remap_file_pages,request_key,setdomainname,sethostname,syslog,umount,umount2,userfaultfd,vhangup,vmsplice
 shell none
-# Breaks bibletime on Fedora and Arch
-#tracelog
 
 # private-bin bibletime,qt5ct
 private-dev


### PR DESCRIPTION
Fix: bibletime don't starts on Fedora and Arch if `seccomp` and `tracelog` are used.