### PR TITLE
enforce nonewprivs instead of seccomp for chroot sandboxes

### DIFF
--- a/src/firejail/seccomp.c
+++ b/src/firejail/seccomp.c
@@ -31,7 +31,6 @@ typedef struct filter_list {
 
 static FilterList *filter_list_head = NULL;
 static int err_printed = 0;
-extern int enforce_seccomp;
 
 char *seccomp_check_list(const char *str) {
 	assert(str);
@@ -73,11 +72,6 @@ int seccomp_install_filters(void) {
 				printf("Installing %s seccomp filter\n", fl->fname);
 
 			if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &fl->prog)) {
-
-				if (enforce_seccomp) {
-					fprintf(stderr, "Error: a seccomp-enabled Linux kernel is required, exiting...\n");
-					exit(1);
-				}
 
 				if (!err_printed)
 					fwarning("seccomp disabled, it requires a Linux kernel version 3.5 or newer.\n");

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -100,8 +100,8 @@ $ firejail --allusers
 Enable AppArmor confinement. For more information, please see \fBAPPARMOR\fR section below.
 .TP
 \fB\-\-appimage
-Sandbox an AppImage (https://appimage.org/) application. If the sandbox is started as a
-regular user, default seccomp and capabilities filters are enabled.
+Sandbox an AppImage (https://appimage.org/) application. If the sandbox is started
+as a regular user, nonewprivs and a default capabilities filter are enabled.
 .br
 
 .br
@@ -275,7 +275,7 @@ Example:
 \fB\-\-chroot=dirname
 Chroot the sandbox into a root filesystem. Unlike the regular filesystem container,
 the system directories are mounted read-write. If the sandbox is started as a
-regular user, default seccomp and capabilities filters are enabled.
+regular user, nonewprivs and a default capabilities filter are enabled.
 .br
 
 .br
@@ -1287,7 +1287,7 @@ Similar to \-\-output, but stderr is also stored.
 Mount a filesystem overlay on top of the current filesystem.  Unlike the regular filesystem container,
 the system directories are mounted read-write. All filesystem modifications go into the overlay.
 Directories /run, /tmp and /dev are not covered by the overlay. The overlay is stored in $HOME/.firejail/<PID> directory.
-If the sandbox is started as a regular user, default seccomp and capabilities filters are enabled.
+If the sandbox is started as a regular user, nonewprivs and a default capabilities filter are enabled.
 .br
 
 .br
@@ -1307,7 +1307,7 @@ Mount a filesystem overlay on top of the current filesystem.  Unlike the regular
 the system directories are mounted read-write. All filesystem modifications go into the overlay.
 Directories /run, /tmp and /dev are not covered by the overlay. The overlay is stored in $HOME/.firejail/<NAME> directory.
 The created overlay can be reused between multiple sessions.
-If the sandbox is started as a regular user, default seccomp and capabilities filters are enabled.
+If the sandbox is started as a regular user, nonewprivs and a default capabilities filter are enabled.
 .br
 
 .br
@@ -1325,7 +1325,7 @@ $ firejail \-\-overlay-named=jail1 firefox
 \fB\-\-overlay-tmpfs
 Mount a filesystem overlay on top of the current filesystem. All filesystem modifications
 are discarded when the sandbox is closed. Directories /run, /tmp and /dev are not covered by the overlay.
-If the sandbox is started as a regular user, default seccomp and capabilities filters are enabled.
+If the sandbox is started as a regular user, nonewprivs and a default capabilities filter are enabled.
 .br
 
 .br


### PR DESCRIPTION
Currently users are always able to specify a seccomp filter of their choosing, including for chroot, appimage and overlay sandboxes. For example, Firejail allows me to do something like:

`firejail --noprofile --chroot=/somedir --seccomp.drop=merry,christmas`

Since the requirement for seccomp looks more or less obsolete now, this PR proposes to remove it entirely and replace it with an explicit nonewprivs enforcement.

There is no security benefit (or harm, AFAICT) in this. It is only about the streamlining of requirements and keeping things easy to explain. While I would regard the patch as ready for merging, I was also hoping to inspire an exchange if it is actually heading in the right direction.

Cheers!