### PR TITLE
New profile for supertuxkart.

### DIFF
--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -233,6 +233,7 @@ blacklist ${HOME}/.config/smplayer
 blacklist ${HOME}/.config/smtube
 blacklist ${HOME}/.config/specialmailcollectionsrc
 blacklist ${HOME}/.config/spotify
+blacklist ${HOME}/.config/supertuxkart
 blacklist ${HOME}/.config/sqlitebrowser
 blacklist ${HOME}/.config/stellarium
 blacklist ${HOME}/.config/synfig
@@ -461,6 +462,7 @@ blacklist ${HOME}/.local/share/scribus
 blacklist ${HOME}/.local/share/spotify
 blacklist ${HOME}/.local/share/steam
 blacklist ${HOME}/.local/share/supertux2
+blacklist ${HOME}/.local/share/supertuxkart
 blacklist ${HOME}/.local/share/telepathy
 blacklist ${HOME}/.local/share/terasology
 blacklist ${HOME}/.local/share/torbrowser
@@ -617,6 +619,7 @@ blacklist ${HOME}/.cache/qutebrowser
 blacklist ${HOME}/.cache/simple-scan
 blacklist ${HOME}/.cache/slimjet
 blacklist ${HOME}/.cache/spotify
+blacklist ${HOME}/.cache/supertuxkart
 blacklist ${HOME}/.cache/systemsettings
 blacklist ${HOME}/.cache/telepathy
 blacklist ${HOME}/.cache/thunderbird

--- a/etc/supertuxkart.profile
+++ b/etc/supertuxkart.profile
@@ -28,7 +28,6 @@ include whitelist-var-common.inc
 
 apparmor
 caps.drop all
-ipc-namespace
 netfilter
 nodbus
 nodvd

--- a/etc/supertuxkart.profile
+++ b/etc/supertuxkart.profile
@@ -20,17 +20,17 @@ include disable-interpreters.inc
 mkdir ${HOME}/.config/supertuxkart
 mkdir ${HOME}/.cache/supertuxkart
 mkdir ${HOME}/.local/share/supertuxkart
-
 whitelist ${HOME}/.config/supertuxkart
 whitelist ${HOME}/.cache/supertuxkart
 whitelist ${HOME}/.local/share/supertuxkart
+include whitelist-common.inc
+include whitelist-var-common.inc
 
 apparmor
 caps.drop all
 ipc-namespace
 netfilter
 nodbus
-noautopulse
 nodvd
 nogroups
 nonewprivs
@@ -45,10 +45,10 @@ tracelog
 
 disable-mnt
 private-bin supertuxkart
-private-dev
-private-etc resolv.conf,ca-certificates,ssl,hosts,machine-id,xdg,openal,crypto-policies,pki,drirc,system-fips,selinux,
-private-tmp
 private-cache
+private-dev
+private-etc resolv.conf,ca-certificates,ssl,hosts,machine-id,xdg,openal,crypto-policies,pki,drirc,system-fips,selinux
+private-tmp
 private-opt none
 private-srv none
 

--- a/etc/supertuxkart.profile
+++ b/etc/supertuxkart.profile
@@ -1,0 +1,56 @@
+# Firejail profile for supertuxkart
+# Description: Free kart racing game.
+# This file is overwritten after every install/update
+# Persistent local customizations
+include supertuxkart.local
+# Persistent global definitions
+include globals.local
+
+noblacklist ${HOME}/.config/supertuxkart
+noblacklist ${HOME}/.cache/supertuxkart
+noblacklist ${HOME}/.local/share/supertuxkart
+
+include disable-common.inc
+include disable-devel.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
+include disable-xdg.inc
+include disable-interpreters.inc
+
+mkdir ${HOME}/.config/supertuxkart
+mkdir ${HOME}/.cache/supertuxkart
+mkdir ${HOME}/.local/share/supertuxkart
+
+whitelist ${HOME}/.config/supertuxkart
+whitelist ${HOME}/.cache/supertuxkart
+whitelist ${HOME}/.local/share/supertuxkart
+
+apparmor
+caps.drop all
+ipc-namespace
+netfilter
+nodbus
+noautopulse
+nodvd
+nogroups
+nonewprivs
+noroot
+notv
+nou2f
+novideo
+protocol unix,inet,inet6
+seccomp
+shell none
+tracelog
+
+disable-mnt
+private-bin supertuxkart
+private-dev
+private-etc resolv.conf,ca-certificates,ssl,hosts,machine-id,xdg,openal,crypto-policies,pki,drirc,system-fips,selinux,
+private-tmp
+private-cache
+private-opt none
+private-srv none
+
+noexec ${HOME}
+noexec /tmp

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -403,6 +403,7 @@ steam-native
 stellarium
 strings
 supertux2
+supertuxkart
 surf
 sylpheed
 synfigstudio


### PR DESCRIPTION
Add a new profile for supertuxkart (STK), add STK directories in $HOME to `disable-programms.inc` and enable STK for firecfg.

This profile is still under development and may be too strict under some distributions.

Tested:
  * [x] Fedora 29
  * [x] Ubuntu 18.04 with firejail-git
