### PR TITLE
Correctly set address length in arp frames

### DIFF
--- a/src/firejail/arp.c
+++ b/src/firejail/arp.c
@@ -78,7 +78,7 @@ void arp_announce(const char *dev, Bridge *br) {
 		errExit("if_nametoindex");
 	addr.sll_family = AF_PACKET;
 	memcpy (addr.sll_addr, ifr.ifr_hwaddr.sa_data, 6);
-	addr.sll_halen = htons(6);
+	addr.sll_halen = ETH_ALEN;
 
 	// build the arp packet header
 	ArpHdr hdr;
@@ -150,7 +150,7 @@ int arp_check(const char *dev, uint32_t destaddr) {
 		errExit("if_nametoindex");
 	addr.sll_family = AF_PACKET;
 	memcpy (addr.sll_addr, ifr.ifr_hwaddr.sa_data, 6);
-	addr.sll_halen = htons(6);
+	addr.sll_halen = ETH_ALEN;
 
 	// build the arp packet header
 	ArpHdr hdr;

--- a/src/fnet/arp.c
+++ b/src/fnet/arp.c
@@ -124,7 +124,7 @@ void arp_scan(const char *dev, uint32_t ifip, uint32_t ifmask) {
 				errExit("if_nametoindex");
 			addr.sll_family = AF_PACKET;
 			memcpy (addr.sll_addr, mac, 6);
-			addr.sll_halen = htons(6);
+			addr.sll_halen = ETH_ALEN;
 
 			// build the arp packet header
 			ArpHdr hdr;


### PR DESCRIPTION
Kernel commit [99137b7](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=99137b7888f4058087895d035d81c6b2d31015c5) introduced an additional check of the address
length. This exposed a bug in the arp code where the address length was
being set incorrectly.
Now the length is set from the `ETH_ALEN` constant declared in
`linux/if_ether.h`.

This fixes #2314