### PR TITLE
Update gajim.profile

### DIFF
--- a/etc/gajim.profile
+++ b/etc/gajim.profile
@@ -46,7 +46,6 @@ tracelog
 
 disable-mnt
 private-bin python,python3,sh,gpg,gpg2,gajim,bash,zsh,paplay,gajim-history-manager
-private-cache
 private-dev
 private-etc alsa,asound.conf,ca-certificates,crypto-policies,fonts,group,hostname,hosts,ld.so.cache,ld.so.conf,localtime,machine-id,passwd,pki,pulse,resolv.conf,ssl
 private-tmp


### PR DESCRIPTION
Fix plugin-update and install.

Remove `private-cache`.
Reason: I saw that on my system (F29) it break the plugin install and update. (Gajim 1.1.1)