### PR TITLE
Fix gnome-maps

### DIFF
--- a/etc/gnome-maps.profile
+++ b/etc/gnome-maps.profile
@@ -9,6 +9,7 @@ include globals.local
 # when gjs apps are started via gnome-shell, firejail is not applied because systemd will start them
 
 noblacklist ${HOME}/.cache/champlain
+noblacklist ${HOME}/.local/share/flatpak
 
 include disable-common.inc
 include disable-devel.inc


### PR DESCRIPTION
Without `noblacklist ${HOME}/.local/share/flatpak` gnome-maps not start on Fedora 29.