### PR TITLE
remove nodbus from MPRIS client profiles

### DIFF
--- a/etc/audacious.profile
+++ b/etc/audacious.profile
@@ -22,7 +22,7 @@ include whitelist-var-common.inc
 apparmor
 caps.drop all
 netfilter
-nodbus
+#nodbus - dbus needed for MPRIS
 nogroups
 nonewprivs
 noroot

--- a/etc/spotify.profile
+++ b/etc/spotify.profile
@@ -31,7 +31,7 @@ include whitelist-var-common.inc
 
 caps.drop all
 netfilter
-nodbus
+#nodbus - dbus needed for MPRIS
 nodvd
 nogroups
 nonewprivs

--- a/etc/vlc.profile
+++ b/etc/vlc.profile
@@ -24,7 +24,7 @@ include whitelist-var-common.inc
 #apparmor - on Ubuntu 18.04 it refuses to start without dbus access
 caps.drop all
 netfilter
-#nodbus
+#nodbus - dbus needed for MPRIS
 nogroups
 nonewprivs
 noroot


### PR DESCRIPTION
MPRIS is a D-Bus interface for controlling media players. The nodbus
option prevents these players from being controlled through MPRIS.
It seems that most of the other media players did not have the nodbus
option or it was already commented out.