### PR TITLE
Add 'alternatives' to all private-etc lines

### DIFF
--- a/etc-fixes/0.9.38/firefox.profile
+++ b/etc-fixes/0.9.38/firefox.profile
@@ -29,4 +29,4 @@ whitelist ~/.cache/gnome-mplayer/plugin
 include /etc/firejail/whitelist-common.inc
 
 # experimental features
-#private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse
+#private-etc alternatives,passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse

--- a/etc-fixes/0.9.52/firefox.profile
+++ b/etc-fixes/0.9.52/firefox.profile
@@ -92,7 +92,7 @@ disable-mnt
 # private-bin firefox,which,sh,dbus-launch,dbus-send,env,bash
 private-dev
 # private-etc below works fine on most distributions. There are some problems on CentOS.
-# private-etc iceweasel,ca-certificates,ssl,machine-id,dconf,selinux,passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,xdg,gtk-2.0,gtk-3.0,X11,pango,fonts,firefox,mime.types,mailcap,asound.conf,pulse
+# private-etc alternatives,iceweasel,ca-certificates,ssl,machine-id,dconf,selinux,passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,xdg,gtk-2.0,gtk-3.0,X11,pango,fonts,firefox,mime.types,mailcap,asound.conf,pulse
 private-tmp
 
 noexec ${HOME}

--- a/etc-fixes/0.9.52/gedit.profile
+++ b/etc-fixes/0.9.52/gedit.profile
@@ -36,7 +36,7 @@ tracelog
 
 # private-bin gedit
 private-dev
-# private-etc fonts
+# private-etc alternatives,fonts
 #private-lib gedit - disabled; problems when running "firejail gedit"; "firejail /usr/bin/gedit" works fine
 private-tmp
 

--- a/etc/QMediathekView.profile
+++ b/etc/QMediathekView.profile
@@ -47,7 +47,7 @@ disable-mnt
 private-bin QMediathekView,mplayer,mpv,smplayer,totem,vlc,xplayer
 private-cache
 private-dev
-# private-etc none
+# private-etc alternatives
 # private-lib
 private-tmp
 

--- a/etc/QOwnNotes.profile
+++ b/etc/QOwnNotes.profile
@@ -49,7 +49,7 @@ tracelog
 disable-mnt
 private-bin QOwnNotes,gio
 private-dev
-private-etc fonts,ld.so.cache,pulse,resolv.conf,hosts,nsswitch.conf,host.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,fonts,ld.so.cache,pulse,resolv.conf,hosts,nsswitch.conf,host.conf,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
 noexec ${HOME}

--- a/etc/Xephyr.profile
+++ b/etc/Xephyr.profile
@@ -39,5 +39,5 @@ private
 # private-bin Xephyr,sh,xkbcomp
 # private-bin Xephyr,sh,xkbcomp,strace,bash,cat,ls
 private-dev
-# private-etc ld.so.conf,ld.so.cache,resolv.conf,host.conf,nsswitch.conf,gai.conf,hosts,hostname
+# private-etc alternatives,ld.so.conf,ld.so.cache,resolv.conf,host.conf,nsswitch.conf,gai.conf,hosts,hostname
 private-tmp

--- a/etc/Xvfb.profile
+++ b/etc/Xvfb.profile
@@ -41,5 +41,5 @@ private
 # private-bin Xvfb,sh,xkbcomp
 # private-bin Xvfb,sh,xkbcomp,strace,bash,cat,ls
 private-dev
-private-etc ld.so.conf,ld.so.cache,resolv.conf,host.conf,nsswitch.conf,gai.conf,hosts,hostname
+private-etc alternatives,ld.so.conf,ld.so.cache,resolv.conf,host.conf,nsswitch.conf,gai.conf,hosts,hostname
 private-tmp

--- a/etc/abrowser.profile
+++ b/etc/abrowser.profile
@@ -14,7 +14,7 @@ whitelist ${HOME}/.cache/mozilla/abrowser
 whitelist ${HOME}/.mozilla
 
 # private-etc must first be enabled in firefox-common.profile
-#private-etc abrowser
+#private-etc abrowser, alternatives
 
 
 # Redirect

--- a/etc/abrowser.profile
+++ b/etc/abrowser.profile
@@ -14,7 +14,7 @@ whitelist ${HOME}/.cache/mozilla/abrowser
 whitelist ${HOME}/.mozilla
 
 # private-etc must first be enabled in firefox-common.profile
-#private-etc abrowser, alternatives
+#private-etc abrowser
 
 
 # Redirect

--- a/etc/amarok.profile
+++ b/etc/amarok.profile
@@ -31,5 +31,5 @@ shell none
 
 # private-bin amarok
 private-dev
-# private-etc machine-id,pulse,asound.conf,ca-certificates,ssl,pki,crypto-policies
+# private-etc alternatives,machine-id,pulse,asound.conf,ca-certificates,ssl,pki,crypto-policies
 private-tmp

--- a/etc/ardour5.profile
+++ b/etc/ardour5.profile
@@ -36,7 +36,7 @@ shell none
 #private-bin sh,ardour4,ardour5,ardour5-copy-mixer,ardour5-export,ardour5-fix_bbtppq,grep,sed,ldd,nm
 private-cache
 private-dev
-#private-etc pulse,X11,alternatives,ardour4,ardour5,fonts,machine-id,asound.conf
+#private-etc alternatives,pulse,X11,alternatives,ardour4,ardour5,fonts,machine-id,asound.conf
 private-tmp
 
 noexec ${HOME}

--- a/etc/aria2c.profile
+++ b/etc/aria2c.profile
@@ -37,7 +37,7 @@ disable-mnt
 private-bin aria2c,gzip
 private-cache
 private-dev
-private-etc ca-certificates,ssl
+private-etc alternatives,ca-certificates,ssl
 private-lib libreadline.so.*
 private-tmp
 

--- a/etc/ark.profile
+++ b/etc/ark.profile
@@ -34,7 +34,7 @@ seccomp
 shell none
 
 private-bin ark,unrar,rar,unzip,zip,zipinfo,7z,p7zip,unar,lsar,lrzip,lzop,lz4,bash,sh,tclsh
-#private-etc smb.conf,samba,mtab,fonts,drirc,kde5rc,passwd,group,xdg
+#private-etc alternatives,smb.conf,samba,mtab,fonts,drirc,kde5rc,passwd,group,xdg
 
 private-dev
 private-tmp

--- a/etc/arm.profile
+++ b/etc/arm.profile
@@ -44,7 +44,7 @@ tracelog
 disable-mnt
 private-bin arm,tor,sh,bash,python*,ps,lsof,ldconfig
 private-dev
-private-etc tor,passwd,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,tor,passwd,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
 noexec ${HOME}

--- a/etc/artha.profile
+++ b/etc/artha.profile
@@ -37,7 +37,7 @@ disable-mnt
 private-bin artha,enchant,notify-send
 private-cache
 private-dev
-private-etc fonts
+private-etc alternatives,fonts
 private-lib libnotify.so.*
 private-tmp
 

--- a/etc/atool.profile
+++ b/etc/atool.profile
@@ -43,5 +43,5 @@ private-cache
 # private-bin atool
 private-dev
 # without login.defs atool complains and uses UID/GID 1000 by default
-private-etc passwd,group,login.defs
+private-etc alternatives,passwd,group,login.defs
 private-tmp

--- a/etc/atril.profile
+++ b/etc/atril.profile
@@ -41,7 +41,7 @@ tracelog
 
 private-bin atril, atril-previewer, atril-thumbnailer
 private-dev
-private-etc fonts,ld.so.cache
+private-etc alternatives,fonts,ld.so.cache
 # atril uses webkit gtk to display epub files
 # waiting for globbing support in private-lib; for now hardcoding it to webkit2gtk-4.0
 #private-lib webkit2gtk-4.0 - problems on Arch with the new version of WebKit

--- a/etc/authenticator.profile
+++ b/etc/authenticator.profile
@@ -40,7 +40,7 @@ disable-mnt
 # private-bin authenticator
 private-cache
 private-dev
-private-etc fonts,ld.so.cache
+private-etc alternatives,fonts,ld.so.cache
 # private-lib
 private-tmp
 

--- a/etc/basilisk.profile
+++ b/etc/basilisk.profile
@@ -20,7 +20,7 @@ seccomp
 
 #private-bin basilisk
 # private-etc must first be enabled in firefox-common.profile
-#private-etc basilisk
+#private-etc alternatives,basilisk
 #private-opt basilisk
 
 # Redirect

--- a/etc/basilisk.profile
+++ b/etc/basilisk.profile
@@ -20,7 +20,7 @@ seccomp
 
 #private-bin basilisk
 # private-etc must first be enabled in firefox-common.profile
-#private-etc alternatives,basilisk
+#private-etc basilisk
 #private-opt basilisk
 
 # Redirect

--- a/etc/bibletime.profile
+++ b/etc/bibletime.profile
@@ -44,5 +44,5 @@ shell none
 
 # private-bin bibletime,qt5ct
 private-dev
-private-etc fonts,resolv.conf,sword,sword.conf,passwd,machine-id,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,fonts,resolv.conf,sword,sword.conf,passwd,machine-id,ca-certificates,ssl,pki,crypto-policies
 private-tmp

--- a/etc/bitcoin-qt.profile
+++ b/etc/bitcoin-qt.profile
@@ -42,7 +42,7 @@ tracelog
 private-bin bitcoin-qt
 private-dev
 # Causes problem with loading of libGL.so
-#private-etc fonts,ca-certificates,ssl,pki,crypto-policies
+#private-etc alternatives,fonts,ca-certificates,ssl,pki,crypto-policies
 # Works, but QT complains about OpenSSL a bit.
 #private-lib
 private-tmp

--- a/etc/bless.profile
+++ b/etc/bless.profile
@@ -35,7 +35,7 @@ shell none
 # private-bin bless,sh,bash,mono
 private-cache
 private-dev
-private-etc fonts,mono
+private-etc alternatives,fonts,mono
 private-tmp
 
 noexec ${HOME}

--- a/etc/brasero.profile
+++ b/etc/brasero.profile
@@ -30,7 +30,7 @@ tracelog
 # private-bin brasero
 private-cache
 # private-dev
-# private-etc fonts
+# private-etc alternatives,fonts
 # private-tmp
 
 memory-deny-write-execute

--- a/etc/bsdtar.profile
+++ b/etc/bsdtar.profile
@@ -37,4 +37,4 @@ tracelog
 # support compressed archives
 private-bin sh,bash,bsdcat,bsdcpio,bsdtar,gtar,compress,gzip,lzma,xz,bzip2,lbzip2,lzip,lzop,lz4,libarchive
 private-dev
-private-etc passwd,group,localtime
+private-etc alternatives,passwd,group,localtime

--- a/etc/caja.profile
+++ b/etc/caja.profile
@@ -41,5 +41,5 @@ tracelog
 # caja needs to be able to start arbitrary applications so we cannot blacklist their files
 # private-bin caja
 # private-dev
-# private-etc fonts
+# private-etc alternatives,fonts
 # private-tmp

--- a/etc/clawsker.profile
+++ b/etc/clawsker.profile
@@ -44,7 +44,7 @@ shell none
 private-bin clawsker,perl
 private-cache
 private-dev
-private-etc fonts
+private-etc alternatives,fonts
 private-lib girepository-1.*,libgirepository-1.*,perl*
 private-tmp
 

--- a/etc/cliqz.profile
+++ b/etc/cliqz.profile
@@ -17,7 +17,7 @@ whitelist ${HOME}/.cliqz
 whitelist ${HOME}/.config/cliqz
 
 # private-etc must first be enabled in firefox-common.profile
-#private-etc cliqz
+#private-etc alternatives,cliqz
 
 # Redirect
 include firefox-common.profile

--- a/etc/cliqz.profile
+++ b/etc/cliqz.profile
@@ -17,7 +17,7 @@ whitelist ${HOME}/.cliqz
 whitelist ${HOME}/.config/cliqz
 
 # private-etc must first be enabled in firefox-common.profile
-#private-etc alternatives,cliqz
+#private-etc cliqz
 
 # Redirect
 include firefox-common.profile

--- a/etc/cmus.profile
+++ b/etc/cmus.profile
@@ -27,4 +27,4 @@ seccomp
 shell none
 
 private-bin cmus
-private-etc group,machine-id,pulse,asound.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,group,machine-id,pulse,asound.conf,ca-certificates,ssl,pki,crypto-policies

--- a/etc/crow.profile
+++ b/etc/crow.profile
@@ -37,7 +37,7 @@ shell none
 disable-mnt
 private-bin crow
 private-dev
-private-etc ca-certificates,ssl,machine-id,dconf,nsswitch.conf,resolv.conf,fonts,asound.conf,pulse,pki,crypto-policies
+private-etc alternatives,ca-certificates,ssl,machine-id,dconf,nsswitch.conf,resolv.conf,fonts,asound.conf,pulse,pki,crypto-policies
 private-opt none
 private-tmp
 private-srv none

--- a/etc/curl.profile
+++ b/etc/curl.profile
@@ -33,7 +33,7 @@ shell none
 # private-bin curl
 private-cache
 private-dev
-# private-etc resolv.conf,ca-certificates,ssl,pki,crypto-policies
+# private-etc alternatives,resolv.conf,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
 noexec ${HOME}

--- a/etc/cyberfox.profile
+++ b/etc/cyberfox.profile
@@ -15,7 +15,7 @@ whitelist ${HOME}/.cache/8pecxstudios
 
 # private-bin cyberfox,which,sh,dbus-launch,dbus-send,env
 # private-etc must first be enabled in firefox-common.profile
-#private-etc alternatives,cyberfox
+#private-etc cyberfox
 
 # Redirect
 include firefox-common.profile

--- a/etc/cyberfox.profile
+++ b/etc/cyberfox.profile
@@ -15,7 +15,7 @@ whitelist ${HOME}/.cache/8pecxstudios
 
 # private-bin cyberfox,which,sh,dbus-launch,dbus-send,env
 # private-etc must first be enabled in firefox-common.profile
-#private-etc cyberfox
+#private-etc alternatives,cyberfox
 
 # Redirect
 include firefox-common.profile

--- a/etc/default.profile
+++ b/etc/default.profile
@@ -37,7 +37,7 @@ seccomp
 # private-bin program
 # private-cache
 # private-dev
-# private-etc none
+# private-etc alternatives
 # private-lib
 # private-tmp
 

--- a/etc/devilspie.profile
+++ b/etc/devilspie.profile
@@ -37,7 +37,7 @@ disable-mnt
 private-bin devilspie
 private-cache
 private-dev
-private-etc none
+private-etc alternatives
 private-lib gconv
 private-tmp
 

--- a/etc/devilspie2.profile
+++ b/etc/devilspie2.profile
@@ -37,7 +37,7 @@ disable-mnt
 private-bin devilspie2
 private-cache
 private-dev
-private-etc none
+private-etc alternatives
 private-lib gconv
 private-tmp
 

--- a/etc/dig.profile
+++ b/etc/dig.profile
@@ -40,7 +40,7 @@ private
 private-bin sh,bash,dig
 private-cache
 private-dev
-# private-etc resolv.conf
+# private-etc alternatives,resolv.conf
 private-lib
 private-tmp
 

--- a/etc/digikam.profile
+++ b/etc/digikam.profile
@@ -37,7 +37,7 @@ shell none
 
 # private-bin program
 # private-dev - prevents libdc1394 loading; this lib is used to connect to a camera device
-# private-etc ca-certificates,ssl,pki,crypto-policies
+# private-etc alternatives,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
 noexec ${HOME}

--- a/etc/dino.profile
+++ b/etc/dino.profile
@@ -36,7 +36,7 @@ shell none
 disable-mnt
 private-bin dino
 private-dev
-# private-etc fonts,ca-certificates,ssl,pki,crypto-policies # breaks server connection
+# private-etc alternatives,fonts,ca-certificates,ssl,pki,crypto-policies # breaks server connection
 private-tmp
 
 noexec ${HOME}

--- a/etc/discord-common.profile
+++ b/etc/discord-common.profile
@@ -27,7 +27,7 @@ seccomp
 
 private-bin sh,xdg-mime,tr,sed,echo,head,cut,xdg-open,grep,egrep,bash,zsh
 private-dev
-private-etc fonts,machine-id,localtime,ld.so.cache,ca-certificates,ssl,pki,crypto-policies,resolv.conf
+private-etc alternatives,fonts,machine-id,localtime,ld.so.cache,ca-certificates,ssl,pki,crypto-policies,resolv.conf
 private-tmp
 
 noexec ${HOME}

--- a/etc/display.profile
+++ b/etc/display.profile
@@ -39,5 +39,6 @@ shell none
 
 private-bin display,python*
 private-dev
-# private-etc alternatives - on Debian-based systems display is a symlink in /etc/alternatives
+# On Debian-based systems, display is a symlink in /etc/alternatives
+private-etc alternatives
 private-tmp

--- a/etc/display.profile
+++ b/etc/display.profile
@@ -39,5 +39,5 @@ shell none
 
 private-bin display,python*
 private-dev
-# private-etc none - on Debian-based systems display is a symlink in /etc/alternatives
+# private-etc alternatives - on Debian-based systems display is a symlink in /etc/alternatives
 private-tmp

--- a/etc/easystroke.profile
+++ b/etc/easystroke.profile
@@ -36,7 +36,7 @@ disable-mnt
 private-bin easystroke,bash,sh
 private-cache
 private-dev
-private-etc fonts
+private-etc alternatives,fonts
 private-lib gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libgconf-2.so.*,librsvg-2.so.*
 private-tmp
 

--- a/etc/electrum.profile
+++ b/etc/electrum.profile
@@ -47,7 +47,7 @@ disable-mnt
 private-bin electrum,python*
 private-cache
 private-dev
-private-etc fonts,dconf,ca-certificates,ssl,pki,crypto-policies,machine-id
+private-etc alternatives,fonts,dconf,ca-certificates,ssl,pki,crypto-policies,machine-id
 private-tmp
 
 noexec ${HOME}

--- a/etc/elinks.profile
+++ b/etc/elinks.profile
@@ -36,5 +36,5 @@ tracelog
 # private-bin elinks
 private-cache
 private-dev
-# private-etc ca-certificates,ssl,pki,crypto-policies
+# private-etc alternatives,ca-certificates,ssl,pki,crypto-policies
 private-tmp

--- a/etc/enchant.profile
+++ b/etc/enchant.profile
@@ -35,7 +35,7 @@ tracelog
 # private-bin enchant, enchant-*
 private-cache
 private-dev
-private-etc none
+private-etc alternatives
 private-tmp
 
 # memory-deny-write-execute

--- a/etc/engrampa.profile
+++ b/etc/engrampa.profile
@@ -34,7 +34,7 @@ tracelog
 
 # private-bin engrampa
 private-dev
-# private-etc fonts
+# private-etc alternatives,fonts
 # private-tmp
 
 memory-deny-write-execute

--- a/etc/eog.profile
+++ b/etc/eog.profile
@@ -39,7 +39,7 @@ shell none
 private-bin eog
 private-cache
 private-dev
-private-etc fonts
+private-etc alternatives,fonts
 private-lib gdk-pixbuf-2.*,gio,girepository-1.*,gvfs,libgconf-2.so.*
 private-tmp
 

--- a/etc/eom.profile
+++ b/etc/eom.profile
@@ -39,7 +39,7 @@ tracelog
 
 private-bin eom
 private-dev
-private-etc fonts
+private-etc alternatives,fonts
 private-lib
 private-tmp
 

--- a/etc/etr.profile
+++ b/etc/etr.profile
@@ -31,5 +31,5 @@ shell none
 
 # private-bin etr
 private-dev
-# private-etc none
+# private-etc alternatives
 private-tmp

--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -39,7 +39,7 @@ tracelog
 
 private-bin evince,evince-previewer,evince-thumbnailer
 private-dev
-private-etc fonts,machine-id
+private-etc alternatives,fonts,machine-id
 
 private-lib evince,gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libdjvulibre.so.*,libgconf-2.so.*,libpoppler-glib.so.*,librsvg-2.so.*,gconv
 

--- a/etc/exiftool.profile
+++ b/etc/exiftool.profile
@@ -39,5 +39,5 @@ tracelog
 # private-bin exiftool,perl
 private-cache
 private-dev
-private-etc none
+private-etc alternatives
 private-tmp

--- a/etc/feh.profile
+++ b/etc/feh.profile
@@ -31,5 +31,5 @@ shell none
 private-bin feh,jpegexiforient,jpegtran
 private-cache
 private-dev
-private-etc feh
+private-etc alternatives,feh
 private-tmp

--- a/etc/file-roller.profile
+++ b/etc/file-roller.profile
@@ -34,7 +34,7 @@ tracelog
 
 # private-bin file-roller
 private-dev
-# private-etc fonts
+# private-etc alternatives,fonts
 # private-tmp
 
 #memory-deny-write-execute  - breaks on Arch

--- a/etc/file.profile
+++ b/etc/file.profile
@@ -34,7 +34,7 @@ x11 none
 #private-bin file
 private-cache
 private-dev
-private-etc magic.mgc,magic,localtime
+private-etc alternatives,magic.mgc,magic,localtime
 private-lib libarchive.so.*,libfakeroot,libmagic.so.*
 
 memory-deny-write-execute

--- a/etc/firefox-common-addons.inc
+++ b/etc/firefox-common-addons.inc
@@ -61,4 +61,4 @@ noblacklist /usr/lib/python3*
 
 # Flash plugin
 # private-etc must first be enabled in firefox-common.profile and in profiles including it.
-#private-etc adobe
+#private-etc alternatives,adobe

--- a/etc/firefox-common-addons.inc
+++ b/etc/firefox-common-addons.inc
@@ -61,4 +61,4 @@ noblacklist /usr/lib/python3*
 
 # Flash plugin
 # private-etc must first be enabled in firefox-common.profile and in profiles including it.
-#private-etc alternatives,adobe
+#private-etc adobe

--- a/etc/firefox-common.profile
+++ b/etc/firefox-common.profile
@@ -51,7 +51,7 @@ shell none
 disable-mnt
 private-dev
 # private-etc below works fine on most distributions. There are some problems on CentOS.
-#private-etc ca-certificates,ssl,machine-id,dconf,selinux,passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,xdg,gtk-2.0,gtk-3.0,X11,pango,fonts,mime.types,mailcap,asound.conf,pulse,pki,crypto-policies,ld.so.cache
+#private-etc alternatives,ca-certificates,ssl,machine-id,dconf,selinux,passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,xdg,gtk-2.0,gtk-3.0,X11,pango,fonts,mime.types,mailcap,asound.conf,pulse,pki,crypto-policies,ld.so.cache
 private-tmp
 
 # breaks DRM binaries

--- a/etc/firefox.profile
+++ b/etc/firefox.profile
@@ -17,7 +17,7 @@ whitelist ${HOME}/.mozilla
 # firefox requires a shell to launch on Arch.
 #private-bin firefox,which,sh,dbus-launch,dbus-send,env,bash
 # private-etc must first be enabled in firefox-common.profile
-#private-etc firefox
+#private-etc alternatives,firefox
 
 # Redirect
 include firefox-common.profile

--- a/etc/firefox.profile
+++ b/etc/firefox.profile
@@ -17,7 +17,7 @@ whitelist ${HOME}/.mozilla
 # firefox requires a shell to launch on Arch.
 #private-bin firefox,which,sh,dbus-launch,dbus-send,env,bash
 # private-etc must first be enabled in firefox-common.profile
-#private-etc alternatives,firefox
+#private-etc firefox
 
 # Redirect
 include firefox-common.profile

--- a/etc/flameshot.profile
+++ b/etc/flameshot.profile
@@ -35,7 +35,7 @@ shell none
 disable-mnt
 private-bin flameshot
 private-cache
-private-etc fonts,ld.so.conf,resolv.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,fonts,ld.so.conf,resolv.conf,ca-certificates,ssl,pki,crypto-policies
 private-dev
 private-tmp
 

--- a/etc/frozen-bubble.profile
+++ b/etc/frozen-bubble.profile
@@ -35,5 +35,5 @@ shell none
 disable-mnt
 # private-bin frozen-bubble
 private-dev
-# private-etc none
+# private-etc alternatives
 private-tmp

--- a/etc/gajim.profile
+++ b/etc/gajim.profile
@@ -47,7 +47,7 @@ tracelog
 disable-mnt
 private-bin python,python3,sh,gpg,gpg2,gajim,bash,zsh,paplay,gajim-history-manager
 private-dev
-private-etc alsa,asound.conf,ca-certificates,crypto-policies,fonts,group,hostname,hosts,ld.so.cache,ld.so.conf,localtime,machine-id,passwd,pki,pulse,resolv.conf,ssl
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,group,hostname,hosts,ld.so.cache,ld.so.conf,localtime,machine-id,passwd,pki,pulse,resolv.conf,ssl
 private-tmp
 
 noexec ${HOME}

--- a/etc/galculator.profile
+++ b/etc/galculator.profile
@@ -38,6 +38,6 @@ tracelog
 
 private-bin galculator
 private-dev
-private-etc fonts
+private-etc alternatives,fonts
 private-lib
 private-tmp

--- a/etc/gcloud.profile
+++ b/etc/gcloud.profile
@@ -32,7 +32,7 @@ tracelog
 
 disable-mnt
 private-dev
-private-etc ca-certificates,ssl,hosts,localtime,nsswitch.conf,resolv.conf,pki,crypto-policies,ld.so.cache
+private-etc alternatives,ca-certificates,ssl,hosts,localtime,nsswitch.conf,resolv.conf,pki,crypto-policies,ld.so.cache
 private-tmp
 
 noexec /tmp

--- a/etc/gedit.profile
+++ b/etc/gedit.profile
@@ -40,7 +40,7 @@ tracelog
 
 # private-bin gedit
 private-dev
-# private-etc fonts
+# private-etc alternatives,fonts
 private-lib /usr/bin/gedit,libtinfo.so.*,libreadline.so.*,gedit,libgspell-1.so.*,gconv,aspell
 private-tmp
 

--- a/etc/geeqie.profile
+++ b/etc/geeqie.profile
@@ -31,4 +31,4 @@ shell none
 
 # private-bin geeqie
 private-dev
-# private-etc X11
+# private-etc alternatives,X11

--- a/etc/ghostwriter.profile
+++ b/etc/ghostwriter.profile
@@ -52,7 +52,7 @@ tracelog
 #private-bin ghostwriter,pandoc
 private-cache
 private-dev
-private-etc cups,crypto-policies,localtime,drirc,fonts,gtk-3.0,dconf,machine-id
+private-etc alternatives,cups,crypto-policies,localtime,drirc,fonts,gtk-3.0,dconf,machine-id
 # Breaks Translation
 #private-lib
 private-tmp

--- a/etc/github-desktop.profile
+++ b/etc/github-desktop.profile
@@ -39,7 +39,7 @@ disable-mnt
 private-cache
 ?HAS_APPIMAGE: ignore private-dev
 private-dev
-# private-etc none
+# private-etc alternatives
 # private-lib
 private-tmp
 

--- a/etc/gitter.profile
+++ b/etc/gitter.profile
@@ -35,7 +35,7 @@ shell none
 
 disable-mnt
 private-bin bash,env,gitter
-private-etc fonts,pulse,resolv.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,fonts,pulse,resolv.conf,ca-certificates,ssl,pki,crypto-policies
 private-opt Gitter
 private-dev
 private-tmp

--- a/etc/gjs.profile
+++ b/etc/gjs.profile
@@ -34,5 +34,5 @@ tracelog
 
 # private-bin gjs,gnome-books,gnome-documents,gnome-photos,gnome-maps,gnome-weather
 private-dev
-# private-etc fonts,ca-certificates,ssl,pki,crypto-policies
+# private-etc alternatives,fonts,ca-certificates,ssl,pki,crypto-policies
 private-tmp

--- a/etc/gnome-books.profile
+++ b/etc/gnome-books.profile
@@ -37,7 +37,7 @@ tracelog
 
 # private-bin gjs gnome-books
 private-dev
-# private-etc fonts
+# private-etc alternatives,fonts
 private-tmp
 
 noexec ${HOME}

--- a/etc/gnome-chess.profile
+++ b/etc/gnome-chess.profile
@@ -35,7 +35,7 @@ tracelog
 disable-mnt
 private-bin fairymax,gnome-chess,hoichess
 private-dev
-private-etc fonts,gnome-chess
+private-etc alternatives,fonts,gnome-chess
 private-tmp
 
 noexec ${HOME}

--- a/etc/gnome-clocks.profile
+++ b/etc/gnome-clocks.profile
@@ -34,7 +34,7 @@ tracelog
 disable-mnt
 # private-bin gnome-clocks
 private-dev
-# private-etc fonts,ca-certificates,ssl,pki,crypto-policies
+# private-etc alternatives,fonts,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
 noexec ${HOME}

--- a/etc/gnome-logs.profile
+++ b/etc/gnome-logs.profile
@@ -37,7 +37,7 @@ shell none
 disable-mnt
 private-bin gnome-logs
 private-dev
-private-etc fonts,localtime,machine-id
+private-etc alternatives,fonts,localtime,machine-id
 private-lib gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libgconf-2.so.*,librsvg-2.so.*
 private-tmp
 writable-var-log

--- a/etc/gnome-maps.profile
+++ b/etc/gnome-maps.profile
@@ -38,7 +38,7 @@ tracelog
 disable-mnt
 # private-bin gjs gnome-maps
 private-dev
-# private-etc fonts,ca-certificates,ssl,pki,crypto-policies
+# private-etc alternatives,fonts,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
 noexec ${HOME}

--- a/etc/gnome-music.profile
+++ b/etc/gnome-music.profile
@@ -40,7 +40,7 @@ tracelog
 
 private-bin gnome-music,python*,env,gio-launch-desktop,yelp
 private-dev
-private-etc fonts,machine-id,pulse,asound.conf
+private-etc alternatives,fonts,machine-id,pulse,asound.conf
 private-tmp
 
 noexec ${HOME}

--- a/etc/gnome-photos.profile
+++ b/etc/gnome-photos.profile
@@ -34,7 +34,7 @@ tracelog
 
 # private-bin gjs gnome-photos
 private-dev
-# private-etc fonts
+# private-etc alternatives,fonts
 private-tmp
 
 noexec ${HOME}

--- a/etc/gnome-pie.profile
+++ b/etc/gnome-pie.profile
@@ -34,7 +34,7 @@ shell none
 disable-mnt
 private-cache
 private-dev
-private-etc fonts
+private-etc alternatives,fonts
 private-lib gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libgconf-2.so.*,librsvg-2.so.*
 private-tmp
 

--- a/etc/gnome-recipes.profile
+++ b/etc/gnome-recipes.profile
@@ -38,7 +38,7 @@ shell none
 disable-mnt
 private-bin gnome-recipes,tar
 private-dev
-private-etc ca-certificates,fonts,ssl,crypto-policies,pki
+private-etc alternatives,ca-certificates,fonts,ssl,crypto-policies,pki
 # private-lib works for me with Gnome Shell 3.26.2, Mutter WM (Arch Linux)
 # not widely tested though, leaving it to devs discretion to enable it later
 #private-lib gdk-pixbuf-2.0,gio,gvfs/libgvfscommon.so,libgconf-2.so.4,libgnutls.so.30,libjpeg.so.8,libp11-kit.so.0,libproxy.so.1,librsvg-2.so.2

--- a/etc/gnome-weather.profile
+++ b/etc/gnome-weather.profile
@@ -38,7 +38,7 @@ tracelog
 disable-mnt
 # private-bin gjs gnome-weather
 private-dev
-# private-etc fonts,ca-certificates,ssl,pki,crypto-policies
+# private-etc alternatives,fonts,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
 noexec ${HOME}

--- a/etc/goobox.profile
+++ b/etc/goobox.profile
@@ -31,5 +31,5 @@ tracelog
 
 # private-bin goobox
 private-dev
-# private-etc fonts,machine-id,pulse,asound.conf,ca-certificates,ssl,pki,crypto-policies
+# private-etc alternatives,fonts,machine-id,pulse,asound.conf,ca-certificates,ssl,pki,crypto-policies
 # private-tmp

--- a/etc/gpicview.profile
+++ b/etc/gpicview.profile
@@ -34,6 +34,6 @@ tracelog
 
 private-bin gpicview
 private-dev
-private-etc fonts
+private-etc alternatives,fonts
 private-lib
 private-tmp

--- a/etc/gpredict.profile
+++ b/etc/gpredict.profile
@@ -33,7 +33,7 @@ tracelog
 
 private-bin gpredict
 private-dev
-private-etc fonts,resolv.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,fonts,resolv.conf,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
 noexec ${HOME}

--- a/etc/gradio.profile
+++ b/etc/gradio.profile
@@ -34,7 +34,7 @@ protocol unix,inet,inet6
 seccomp
 shell none
 
-private-etc asound.conf,ca-certificates,fonts,host.conf,hostname,hosts,pulse,resolv.conf,ssl,pki,crypto-policies,gtk-3.0,xdg,machine-id
+private-etc alternatives,asound.conf,ca-certificates,fonts,host.conf,hostname,hosts,pulse,resolv.conf,ssl,pki,crypto-policies,gtk-3.0,xdg,machine-id
 private-tmp
 
 noexec ${HOME}

--- a/etc/gwenview.profile
+++ b/etc/gwenview.profile
@@ -44,7 +44,7 @@ shell none
 
 private-bin gwenview,gimp*,kbuildsycoca4,kdeinit4
 private-dev
-private-etc fonts,gimp,gtk-2.0,kde4rc,kde5rc,ld.so.cache,machine-id,pulse,xdg
+private-etc alternatives,fonts,gimp,gtk-2.0,kde4rc,kde5rc,ld.so.cache,machine-id,pulse,xdg
 
 # memory-deny-write-execute
 noexec ${HOME}

--- a/etc/highlight.profile
+++ b/etc/highlight.profile
@@ -34,5 +34,5 @@ tracelog
 private-bin highlight
 private-cache
 private-dev
-# private-etc none
+# private-etc alternatives
 private-tmp

--- a/etc/icecat.profile
+++ b/etc/icecat.profile
@@ -14,7 +14,7 @@ whitelist ${HOME}/.cache/mozilla/icecat
 whitelist ${HOME}/.mozilla
 
 # private-etc must first be enabled in firefox-common.profile
-#private-etc alternatives,icecat
+#private-etc icecat
 
 # Redirect
 include firefox-common.profile

--- a/etc/icecat.profile
+++ b/etc/icecat.profile
@@ -14,7 +14,7 @@ whitelist ${HOME}/.cache/mozilla/icecat
 whitelist ${HOME}/.mozilla
 
 # private-etc must first be enabled in firefox-common.profile
-#private-etc icecat
+#private-etc alternatives,icecat
 
 # Redirect
 include firefox-common.profile

--- a/etc/iceweasel.profile
+++ b/etc/iceweasel.profile
@@ -6,7 +6,7 @@ include iceweasel.local
 include globals.local
 
 # private-etc must first be enabled in firefox-common.profile
-#private-etc alternatives,iceweasel
+#private-etc iceweasel
 
 # Redirect
 include firefox.profile

--- a/etc/iceweasel.profile
+++ b/etc/iceweasel.profile
@@ -6,7 +6,7 @@ include iceweasel.local
 include globals.local
 
 # private-etc must first be enabled in firefox-common.profile
-#private-etc iceweasel
+#private-etc alternatives,iceweasel
 
 # Redirect
 include firefox.profile

--- a/etc/img2txt.profile
+++ b/etc/img2txt.profile
@@ -34,5 +34,5 @@ tracelog
 # private-bin img2txt
 private-cache
 private-dev
-# private-etc none
+# private-etc alternatives
 private-tmp

--- a/etc/kate.profile
+++ b/etc/kate.profile
@@ -42,7 +42,7 @@ tracelog
 
 # private-bin kate,kbuildsycoca4,kdeinit4
 private-dev
-# private-etc fonts,kde4rc,kde5rc,ld.so.cache,machine-id,xdg
+# private-etc alternatives,fonts,kde4rc,kde5rc,ld.so.cache,machine-id,xdg
 private-tmp
 
 # noexec ${HOME}

--- a/etc/keepassx.profile
+++ b/etc/keepassx.profile
@@ -41,7 +41,7 @@ tracelog
 
 private-bin keepassx,keepassx2
 private-dev
-private-etc fonts,machine-id
+private-etc alternatives,fonts,machine-id
 private-tmp
 
 memory-deny-write-execute

--- a/etc/keepassxc.profile
+++ b/etc/keepassxc.profile
@@ -42,7 +42,7 @@ shell none
 
 private-bin keepassxc
 private-dev
-private-etc fonts,ld.so.cache,machine-id
+private-etc alternatives,fonts,ld.so.cache,machine-id
 private-tmp
 
 # 2.2.4 crashes on database open

--- a/etc/klavaro.profile
+++ b/etc/klavaro.profile
@@ -45,7 +45,7 @@ disable-mnt
 private-bin klavaro,tclsh,tclsh*,bash
 private-cache
 private-dev
-private-etc fonts
+private-etc alternatives,fonts
 private-tmp
 private-opt none
 private-srv none

--- a/etc/kwin_x11.profile
+++ b/etc/kwin_x11.profile
@@ -37,7 +37,7 @@ tracelog
 disable-mnt
 private-bin kwin_x11
 private-dev
-private-etc drirc,fonts,kde5rc,ld.so.cache,machine-id,xdg
+private-etc alternatives,drirc,fonts,kde5rc,ld.so.cache,machine-id,xdg
 private-tmp
 
 noexec ${HOME}

--- a/etc/kwrite.profile
+++ b/etc/kwrite.profile
@@ -44,7 +44,7 @@ tracelog
 
 private-bin kwrite,kbuildsycoca4,kdeinit4
 private-dev
-private-etc fonts,kde4rc,kde5rc,ld.so.cache,machine-id,pulse,xdg
+private-etc alternatives,fonts,kde4rc,kde5rc,ld.so.cache,machine-id,pulse,xdg
 private-tmp
 
 noexec ${HOME}

--- a/etc/lollypop.profile
+++ b/etc/lollypop.profile
@@ -38,7 +38,7 @@ seccomp
 shell none
 
 private-dev
-private-etc asound.conf,ca-certificates,fonts,host.conf,hostname,hosts,pulse,resolv.conf,ssl,pki,crypto-policies,gtk-3.0,xdg,machine-id
+private-etc alternatives,asound.conf,ca-certificates,fonts,host.conf,hostname,hosts,pulse,resolv.conf,ssl,pki,crypto-policies,gtk-3.0,xdg,machine-id
 private-tmp
 
 noexec ${HOME}

--- a/etc/lynx.profile
+++ b/etc/lynx.profile
@@ -34,5 +34,5 @@ tracelog
 # private-bin lynx
 private-cache
 private-dev
-# private-etc ca-certificates,ssl,pki,crypto-policies
+# private-etc alternatives,ca-certificates,ssl,pki,crypto-policies
 private-tmp

--- a/etc/masterpdfeditor.profile
+++ b/etc/masterpdfeditor.profile
@@ -41,7 +41,7 @@ tracelog
 private-bin masterpdfeditor*
 private-cache
 private-dev
-private-etc fonts
+private-etc alternatives,fonts
 # private-lib
 private-tmp
 

--- a/etc/mate-calc.profile
+++ b/etc/mate-calc.profile
@@ -39,7 +39,7 @@ shell none
 
 disable-mnt
 private-bin mate-calc,mate-calculator
-private-etc fonts
+private-etc alternatives,fonts
 private-dev
 private-opt none
 private-tmp

--- a/etc/mate-color-select.profile
+++ b/etc/mate-color-select.profile
@@ -34,7 +34,7 @@ shell none
 
 disable-mnt
 private-bin mate-color-select
-private-etc fonts
+private-etc alternatives,fonts
 private-dev
 private-lib
 private-tmp

--- a/etc/mate-dictionary.profile
+++ b/etc/mate-dictionary.profile
@@ -36,7 +36,7 @@ shell none
 
 disable-mnt
 private-bin mate-dictionary
-private-etc fonts,resolv.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,fonts,resolv.conf,ca-certificates,ssl,pki,crypto-policies
 private-opt mate-dictionary
 private-dev
 private-tmp

--- a/etc/mcabber.profile
+++ b/etc/mcabber.profile
@@ -30,4 +30,4 @@ shell none
 
 private-bin mcabber
 private-dev
-private-etc ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,ca-certificates,ssl,pki,crypto-policies

--- a/etc/mediainfo.profile
+++ b/etc/mediainfo.profile
@@ -34,5 +34,5 @@ tracelog
 private-bin mediainfo
 private-cache
 private-dev
-private-etc none
+private-etc alternatives
 private-tmp

--- a/etc/min.profile
+++ b/etc/min.profile
@@ -46,7 +46,7 @@ disable-mnt
 private-cache
 private-dev
 # private-etc below works fine on most distributions. There are some problems on CentOS.
-private-etc ca-certificates,ssl,machine-id,dconf,selinux,passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,xdg,gtk-2.0,gtk-3.0,X11,pango,fonts,mime.types,mailcap,asound.conf,pulse,pki,crypto-policies,ld.so.cache
+private-etc alternatives,ca-certificates,ssl,machine-id,dconf,selinux,passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,xdg,gtk-2.0,gtk-3.0,X11,pango,fonts,mime.types,mailcap,asound.conf,pulse,pki,crypto-policies,ld.so.cache
 private-tmp
 
 # memory-deny-write-execute

--- a/etc/minetest.profile
+++ b/etc/minetest.profile
@@ -38,7 +38,7 @@ disable-mnt
 private-bin minetest
 private-dev
 # private-etc needs to be updated, see #1702
-#private-etc asound.conf,ca-certificates,drirc,fonts,group,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,nsswitch.conf,passwd,pulse,resolv.conf,ssl,pki,crypto-policies,machine-id
+#private-etc alternatives,asound.conf,ca-certificates,drirc,fonts,group,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,nsswitch.conf,passwd,pulse,resolv.conf,ssl,pki,crypto-policies,machine-id
 private-tmp
 
 noexec ${HOME}

--- a/etc/ms-office.profile
+++ b/etc/ms-office.profile
@@ -37,7 +37,7 @@ tracelog
 
 disable-mnt
 private-bin bash,fonts,env,jak,ms-office,python*,sh
-private-etc resolv.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,resolv.conf,ca-certificates,ssl,pki,crypto-policies
 private-dev
 private-tmp
 

--- a/etc/mupdf.profile
+++ b/etc/mupdf.profile
@@ -37,7 +37,7 @@ tracelog
 
 # private-bin mupdf,sh,tempfile,rm
 private-dev
-private-etc fonts
+private-etc alternatives,fonts
 private-tmp
 
 # mupdf will never write anything

--- a/etc/musixmatch.profile
+++ b/etc/musixmatch.profile
@@ -21,7 +21,7 @@ nodvd
 nogroups
 nonewprivs
 noroot
-nogroups 
+nogroups
 nosound
 notv
 nou2f
@@ -31,7 +31,7 @@ seccomp
 
 disable-mnt
 private-dev
-private-etc machine-id,pulse,asound.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,machine-id,pulse,asound.conf,ca-certificates,ssl,pki,crypto-policies
 
 noexec ${HOME}
 noexec /tmp

--- a/etc/mypaint.profile
+++ b/etc/mypaint.profile
@@ -41,7 +41,7 @@ tracelog
 
 private-cache
 private-dev
-private-etc fonts,gtk-3.0,dconf
+private-etc alternatives,fonts,gtk-3.0,dconf
 private-tmp
 
 noexec ${HOME}

--- a/etc/nautilus.profile
+++ b/etc/nautilus.profile
@@ -42,5 +42,5 @@ tracelog
 # nautilus needs to be able to start arbitrary applications so we cannot blacklist their files
 # private-bin nautilus
 # private-dev
-# private-etc fonts
+# private-etc alternatives,fonts
 # private-tmp

--- a/etc/nitroshare.profile
+++ b/etc/nitroshare.profile
@@ -41,7 +41,7 @@ disable-mnt
 private-bin awk,grep,nitroshare,nitroshare-cli,nitroshare-nmh,nitroshare-send,nitroshare-ui
 private-cache
 private-dev
-private-etc ca-certificates,dconf,fonts,hostname,hosts,ld.so.cache,machine-id,nsswitch.conf,ssl
+private-etc alternatives,ca-certificates,dconf,fonts,hostname,hosts,ld.so.cache,machine-id,nsswitch.conf,ssl
 # private-lib libnitroshare.so.*,libqhttpengine.so.*,libqmdnsengine.so.*,nitroshare
 private-tmp
 

--- a/etc/nyx.profile
+++ b/etc/nyx.profile
@@ -42,7 +42,7 @@ disable-mnt
 private-bin nyx,python*
 private-cache
 private-dev
-private-etc passwd,tor,fonts
+private-etc alternatives,passwd,tor,fonts
 private-opt none
 private-srv none
 private-tmp

--- a/etc/ocenaudio.profile
+++ b/etc/ocenaudio.profile
@@ -43,7 +43,7 @@ tracelog
 private-bin ocenaudio
 private-cache
 private-dev
-private-etc asound.conf,fonts,ld.so.cache,pulse
+private-etc alternatives,asound.conf,fonts,ld.so.cache,pulse
 # private-lib
 private-tmp
 

--- a/etc/odt2txt.profile
+++ b/etc/odt2txt.profile
@@ -37,6 +37,6 @@ tracelog
 private-bin odt2txt
 private-cache
 private-dev
-private-etc none
+private-etc alternatives
 private-tmp
 read-only ${HOME}

--- a/etc/open-invaders.profile
+++ b/etc/open-invaders.profile
@@ -33,5 +33,5 @@ shell none
 
 # private-bin open-invaders
 private-dev
-# private-etc none
+# private-etc alternatives
 private-tmp

--- a/etc/palemoon.profile
+++ b/etc/palemoon.profile
@@ -19,7 +19,7 @@ seccomp
 
 #private-bin palemoon
 # private-etc must first be enabled in firefox-common.profile
-#private-etc palemoon
+#private-etc alternatives,palemoon
 #private-opt palemoon
 
 # Redirect

--- a/etc/palemoon.profile
+++ b/etc/palemoon.profile
@@ -19,7 +19,7 @@ seccomp
 
 #private-bin palemoon
 # private-etc must first be enabled in firefox-common.profile
-#private-etc alternatives,palemoon
+#private-etc palemoon
 #private-opt palemoon
 
 # Redirect

--- a/etc/parole.profile
+++ b/etc/parole.profile
@@ -27,4 +27,4 @@ shell none
 
 private-bin parole,dbus-launch
 private-cache
-private-etc passwd,group,fonts,machine-id,pulse,asound.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,passwd,group,fonts,machine-id,pulse,asound.conf,ca-certificates,ssl,pki,crypto-policies

--- a/etc/pdfchain.profile
+++ b/etc/pdfchain.profile
@@ -34,7 +34,7 @@ shell none
 
 private-bin pdfchain,pdftk,sh
 private-dev
-private-etc dconf,fonts,gtk-3.0,xdg
+private-etc alternatives,dconf,fonts,gtk-3.0,xdg
 private-tmp
 
 memory-deny-write-execute

--- a/etc/pdftotext.profile
+++ b/etc/pdftotext.profile
@@ -38,5 +38,5 @@ tracelog
 
 private-bin pdftotext
 private-dev
-private-etc none
+private-etc alternatives
 private-tmp

--- a/etc/ping.profile
+++ b/etc/ping.profile
@@ -41,7 +41,7 @@ private
 #private-bin has mammoth problems with execvp: "No such file or directory"
 private-dev
 # /etc/hosts is required in private-etc; however, just adding it to the list doesn't solve the problem!
-#private-etc resolv.conf,hosts,ca-certificates,ssl,pki,crypto-policies
+#private-etc alternatives,resolv.conf,hosts,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
 # memory-deny-write-execute is built using seccomp; nonewprivs will kill it

--- a/etc/ping.profile
+++ b/etc/ping.profile
@@ -41,7 +41,7 @@ private
 #private-bin has mammoth problems with execvp: "No such file or directory"
 private-dev
 # /etc/hosts is required in private-etc; however, just adding it to the list doesn't solve the problem!
-#private-etc alternatives,resolv.conf,hosts,ca-certificates,ssl,pki,crypto-policies
+#private-etc resolv.conf,hosts,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
 # memory-deny-write-execute is built using seccomp; nonewprivs will kill it

--- a/etc/pingus.profile
+++ b/etc/pingus.profile
@@ -33,5 +33,5 @@ shell none
 
 # private-bin pingus
 private-dev
-# private-etc none
+# private-etc alternatives
 private-tmp

--- a/etc/pluma.profile
+++ b/etc/pluma.profile
@@ -37,7 +37,7 @@ tracelog
 
 private-bin pluma
 private-dev
-# private-etc fonts
+# private-etc alternatives,fonts
 private-lib pluma
 private-tmp
 

--- a/etc/ppsspp.profile
+++ b/etc/ppsspp.profile
@@ -37,7 +37,7 @@ shell none
 
 # private-dev is disabled to allow controller support
 #private-dev
-private-etc asound.conf,ca-certificates,drirc,fonts,group,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,nsswitch.conf,passwd,pulse,resolv.conf,ssl,pki,crypto-policies,machine-id
+private-etc alternatives,asound.conf,ca-certificates,drirc,fonts,group,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,nsswitch.conf,passwd,pulse,resolv.conf,ssl,pki,crypto-policies,machine-id
 private-opt ppsspp
 private-tmp
 

--- a/etc/pybitmessage.profile
+++ b/etc/pybitmessage.profile
@@ -42,7 +42,7 @@ shell none
 disable-mnt
 private-bin pybitmessage,python*,sh,ldconfig,env,bash,stat
 private-dev
-private-etc PyBitmessage,PyBitmessage.conf,Trolltech.conf,fonts,gtk-2.0,hosts,ld.so.cache,ld.so.preload,localtime,pki,resolv.conf,selinux,sni-qt.conf,system-fips,xdg,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,PyBitmessage,PyBitmessage.conf,Trolltech.conf,fonts,gtk-2.0,hosts,ld.so.cache,ld.so.preload,localtime,pki,resolv.conf,selinux,sni-qt.conf,system-fips,xdg,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
 noexec ${HOME}

--- a/etc/pycharm-community.profile
+++ b/etc/pycharm-community.profile
@@ -32,7 +32,7 @@ novideo
 shell none
 tracelog
 
-# private-etc fonts,passwd - minimal required to run but will probably break
+# private-etc alternatives,fonts,passwd - minimal required to run but will probably break
 # program!
 private-cache
 private-dev

--- a/etc/qbittorrent.profile
+++ b/etc/qbittorrent.profile
@@ -53,7 +53,7 @@ shell none
 
 private-bin qbittorrent,python*
 private-dev
-# private-etc X11,fonts,xdg,resolv.conf,ca-certificates,ssl,pki,crypto-policies
+# private-etc alternatives,X11,fonts,xdg,resolv.conf,ca-certificates,ssl,pki,crypto-policies
 # private-lib - problems on Arch
 private-tmp
 

--- a/etc/qtox.profile
+++ b/etc/qtox.profile
@@ -36,7 +36,7 @@ tracelog
 
 disable-mnt
 private-bin qtox
-private-etc fonts,resolv.conf,ld.so.cache,localtime,ca-certificates,ssl,pki,crypto-policies,machine-id,pulse
+private-etc alternatives,fonts,resolv.conf,ld.so.cache,localtime,ca-certificates,ssl,pki,crypto-policies,machine-id,pulse
 private-dev
 private-tmp
 

--- a/etc/quiterss.profile
+++ b/etc/quiterss.profile
@@ -47,7 +47,7 @@ tracelog
 disable-mnt
 private-bin quiterss
 private-dev
-# private-etc X11,ssl,pki,ca-certificates,crypto-policies
+# private-etc alternatives,X11,ssl,pki,ca-certificates,crypto-policies
 
 noexec ${HOME}
 noexec /tmp

--- a/etc/qupzilla.profile
+++ b/etc/qupzilla.profile
@@ -34,7 +34,7 @@ seccomp.drop @clock,@cpu-emulation,@debug,@module,@obsolete,@raw-io,@reboot,@res
 # tracelog
 
 private-dev
-# private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,adobe,mime.types,mailcap,asound.conf,pulse,machine-id,ca-certificates,ssl,pki,crypto-policies
+# private-etc alternatives,passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,adobe,mime.types,mailcap,asound.conf,pulse,machine-id,ca-certificates,ssl,pki,crypto-policies
 # private-tmp - interferes with the opening of downloaded files
 
 noexec ${HOME}

--- a/etc/ricochet.profile
+++ b/etc/ricochet.profile
@@ -36,7 +36,7 @@ shell none
 disable-mnt
 private-bin ricochet,tor
 private-dev
-#private-etc fonts,tor,X11,alternatives,ca-certificates,ssl,pki,crypto-policies
+#private-etc alternatives,fonts,tor,X11,alternatives,ca-certificates,ssl,pki,crypto-policies
 
 noexec ${HOME}
 noexec /tmp

--- a/etc/seamonkey.profile
+++ b/etc/seamonkey.profile
@@ -50,4 +50,4 @@ seccomp
 tracelog
 
 disable-mnt
-# private-etc passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse,machine-id,ca-certificates,ssl,pki,crypto-policies
+# private-etc alternatives,passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,iceweasel,firefox,adobe,mime.types,mailcap,asound.conf,pulse,machine-id,ca-certificates,ssl,pki,crypto-policies

--- a/etc/server.profile
+++ b/etc/server.profile
@@ -43,7 +43,7 @@ private
 # private-bin program
 # private-cache
 private-dev
-# private-etc none
+# private-etc alternatives
 # private-lib
 private-tmp
 

--- a/etc/simple-scan.profile
+++ b/etc/simple-scan.profile
@@ -33,5 +33,5 @@ tracelog
 
 # private-bin simple-scan
 # private-dev
-# private-etc fonts,ca-certificates,ssl,pki,crypto-policies
+# private-etc alternatives,fonts,ca-certificates,ssl,pki,crypto-policies
 # private-tmp

--- a/etc/simutrans.profile
+++ b/etc/simutrans.profile
@@ -33,5 +33,5 @@ shell none
 
 # private-bin simutrans
 private-dev
-# private-etc none
+# private-etc alternatives
 private-tmp

--- a/etc/slack.profile
+++ b/etc/slack.profile
@@ -37,5 +37,5 @@ shell none
 disable-mnt
 private-bin slack,locale
 private-dev
-private-etc asound.conf,ca-certificates,fonts,group,passwd,pulse,resolv.conf,ssl,ld.so.conf,ld.so.cache,localtime,pki,crypto-policies,machine-id
+private-etc alternatives,asound.conf,ca-certificates,fonts,group,passwd,pulse,resolv.conf,ssl,ld.so.conf,ld.so.cache,localtime,pki,crypto-policies,machine-id
 private-tmp

--- a/etc/spotify.profile
+++ b/etc/spotify.profile
@@ -46,7 +46,7 @@ tracelog
 disable-mnt
 private-bin spotify,bash,sh,zenity
 private-dev
-private-etc fonts,group,ld.so.cache,machine-id,pulse,resolv.conf,hosts,nsswitch.conf,host.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,fonts,group,ld.so.cache,machine-id,pulse,resolv.conf,hosts,nsswitch.conf,host.conf,ca-certificates,ssl,pki,crypto-policies
 private-opt spotify
 private-tmp
 

--- a/etc/standardnotes-desktop.profile
+++ b/etc/standardnotes-desktop.profile
@@ -38,7 +38,7 @@ seccomp
 disable-mnt
 private-dev
 private-tmp
-private-etc ca-certificates,fonts,host.conf,hostname,hosts,resolv.conf,ssl,pki,crypto-policies,xdg
+private-etc alternatives,ca-certificates,fonts,host.conf,hostname,hosts,resolv.conf,ssl,pki,crypto-policies,xdg
 
 noexec ${HOME}
 noexec /tmp

--- a/etc/start-tor-browser.profile
+++ b/etc/start-tor-browser.profile
@@ -34,7 +34,7 @@ shell none
 disable-mnt
 private-bin bash,sh,grep,tail,env,gpg,id,readlink,dirname,test,mkdir,ln,sed,cp,rm,getconf
 private-dev
-private-etc fonts,hostname,hosts,resolv.conf,pki,ssl,ca-certificates,crypto-policies,alsa,asound.conf,pulse,machine-id,ld.so.cache
+private-etc alternatives,fonts,hostname,hosts,resolv.conf,pki,ssl,ca-certificates,crypto-policies,alsa,asound.conf,pulse,machine-id,ld.so.cache
 private-tmp
 
 noexec /tmp

--- a/etc/steam.profile
+++ b/etc/steam.profile
@@ -74,5 +74,5 @@ shell none
 # private-dev should be commented for controllers
 private-dev
 # private-etc breaks a small selection of games on some systems, comment to support those
-private-etc asound.conf,ca-certificates,dbus-1,drirc,fonts,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,ld.so.conf,ld.so.conf.d,localtime,lsb-release,machine-id,mime.types,passwd,pulse,resolv.conf,ssl,pki,services,crypto-policies,alternatives,bumblebee,nvidia,os-release
+private-etc alternatives,asound.conf,ca-certificates,dbus-1,drirc,fonts,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,ld.so.conf,ld.so.conf.d,localtime,lsb-release,machine-id,mime.types,passwd,pulse,resolv.conf,ssl,pki,services,crypto-policies,alternatives,bumblebee,nvidia,os-release
 private-tmp

--- a/etc/strings.profile
+++ b/etc/strings.profile
@@ -24,7 +24,7 @@ tracelog
 private-bin strings
 private-cache
 private-dev
-private-etc none
+private-etc alternatives
 private-lib
 
 memory-deny-write-execute

--- a/etc/supertux2.profile
+++ b/etc/supertux2.profile
@@ -34,5 +34,5 @@ shell none
 disable-mnt
 # private-bin supertux2
 private-dev
-# private-etc none
+# private-etc alternatives
 private-tmp

--- a/etc/supertuxkart.profile
+++ b/etc/supertuxkart.profile
@@ -46,7 +46,7 @@ disable-mnt
 private-bin supertuxkart
 private-cache
 private-dev
-private-etc resolv.conf,ca-certificates,ssl,hosts,machine-id,xdg,openal,crypto-policies,pki,drirc,system-fips,selinux
+private-etc alternatives,resolv.conf,ca-certificates,ssl,hosts,machine-id,xdg,openal,crypto-policies,pki,drirc,system-fips,selinux
 private-tmp
 private-opt none
 private-srv none

--- a/etc/surf.profile
+++ b/etc/surf.profile
@@ -32,7 +32,7 @@ tracelog
 disable-mnt
 private-bin ls,surf,sh,bash,curl,dmenu,printf,sed,sleep,st,stterm,xargs,xprop
 private-dev
-private-etc passwd,group,hosts,resolv.conf,fonts,ssl,pki,ca-certificates,crypto-policies
+private-etc alternatives,passwd,group,hosts,resolv.conf,fonts,ssl,pki,ca-certificates,crypto-policies
 private-tmp
 
 noexec ${HOME}

--- a/etc/tar.profile
+++ b/etc/tar.profile
@@ -26,7 +26,7 @@ tracelog
 # support compressed archives
 private-bin sh,bash,tar,gtar,compress,gzip,lzma,xz,bzip2,lbzip2,lzip,lzop
 private-dev
-private-etc passwd,group,localtime
+private-etc alternatives,passwd,group,localtime
 private-lib
 
 # Debian based distributions need this for 'dpkg --unpack' (incl. synaptic)

--- a/etc/terasology.profile
+++ b/etc/terasology.profile
@@ -44,7 +44,7 @@ shell none
 
 disable-mnt
 private-dev
-private-etc asound.conf,ca-certificates,dbus-1,drirc,fonts,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,lsb-release,machine-id,mime.types,passwd,pulse,resolv.conf,ssl,java-8-openjdk,java-7-openjdk,pki,crypto-policies
+private-etc alternatives,asound.conf,ca-certificates,dbus-1,drirc,fonts,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,lsb-release,machine-id,mime.types,passwd,pulse,resolv.conf,ssl,java-8-openjdk,java-7-openjdk,pki,crypto-policies
 private-tmp
 
 noexec ${HOME}

--- a/etc/tilp.profile
+++ b/etc/tilp.profile
@@ -29,7 +29,7 @@ tracelog
 disable-mnt
 private-bin tilp
 private-cache
-private-etc fonts
+private-etc alternatives,fonts
 private-tmp
 
 noexec ${HOME}

--- a/etc/tor.profile
+++ b/etc/tor.profile
@@ -46,7 +46,7 @@ private
 private-bin tor,bash
 private-cache
 private-dev
-private-etc tor,passwd,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,tor,passwd,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
 noexec ${HOME}

--- a/etc/torbrowser-launcher.profile
+++ b/etc/torbrowser-launcher.profile
@@ -49,7 +49,7 @@ shell none
 disable-mnt
 private-bin bash,cp,dirname,env,expr,file,getconf,gpg,grep,id,ln,mkdir,python*,readlink,rm,sed,sh,tail,tar,tclsh,test,tor-browser-en,torbrowser-launcher,xz
 private-dev
-private-etc fonts,hostname,hosts,resolv.conf,pki,ssl,ca-certificates,crypto-policies,alsa,asound.conf,pulse,machine-id,ld.so.cache
+private-etc alternatives,fonts,hostname,hosts,resolv.conf,pki,ssl,ca-certificates,crypto-policies,alsa,asound.conf,pulse,machine-id,ld.so.cache
 private-tmp
 
 noexec /tmp

--- a/etc/totem.profile
+++ b/etc/totem.profile
@@ -36,7 +36,7 @@ private-bin totem
 # totem needs access to ~/.cache/tracker or it exits
 #private-cache
 private-dev
-# private-etc fonts,machine-id,pulse,asound.conf,ca-certificates,ssl,pki,crypto-policies
+# private-etc alternatives,fonts,machine-id,pulse,asound.conf,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
 noexec ${HOME}

--- a/etc/tracker.profile
+++ b/etc/tracker.profile
@@ -33,5 +33,5 @@ tracelog
 
 # private-bin tracker
 # private-dev
-# private-etc fonts
+# private-etc alternatives,fonts
 # private-tmp

--- a/etc/transmission-cli.profile
+++ b/etc/transmission-cli.profile
@@ -33,7 +33,7 @@ tracelog
 
 # private-bin transmission-cli
 private-dev
-private-etc ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
 memory-deny-write-execute

--- a/etc/transmission-show.profile
+++ b/etc/transmission-show.profile
@@ -31,5 +31,5 @@ shell none
 tracelog
 
 private-dev
-private-etc none
+private-etc alternatives
 private-tmp

--- a/etc/unknown-horizons.profile
+++ b/etc/unknown-horizons.profile
@@ -29,5 +29,5 @@ shell none
 
 # private-bin unknown-horizons
 private-dev
-# private-etc ca-certificates,ssl,pki,crypto-policies
+# private-etc alternatives,ca-certificates,ssl,pki,crypto-policies
 private-tmp

--- a/etc/unrar.profile
+++ b/etc/unrar.profile
@@ -25,7 +25,7 @@ tracelog
 
 private-bin unrar
 private-dev
-private-etc passwd,group,localtime
+private-etc alternatives,passwd,group,localtime
 private-tmp
 
 include default.profile

--- a/etc/unzip.profile
+++ b/etc/unzip.profile
@@ -25,7 +25,7 @@ tracelog
 
 private-bin unzip
 private-dev
-private-etc passwd,group,localtime
+private-etc alternatives,passwd,group,localtime
 
 # GNOME Shell integration (chrome-gnome-shell)
 noblacklist ${HOME}/.local/share/gnome-shell

--- a/etc/uudeview.profile
+++ b/etc/uudeview.profile
@@ -23,6 +23,6 @@ tracelog
 private-bin uudeview
 private-cache
 private-dev
-private-etc ld.so.preload
+private-etc alternatives,ld.so.preload
 
 include default.profile

--- a/etc/viewnior.profile
+++ b/etc/viewnior.profile
@@ -38,7 +38,7 @@ tracelog
 private-bin viewnior
 private-cache
 private-dev
-private-etc fonts
+private-etc alternatives,fonts
 private-tmp
 
 # memory-deny-write-executes breaks on Arch - see issue #1808

--- a/etc/w3m.profile
+++ b/etc/w3m.profile
@@ -36,5 +36,5 @@ tracelog
 # private-bin w3m
 private-cache
 private-dev
-private-etc resolv.conf,ssl,pki,ca-certificates,crypto-policies
+private-etc alternatives,resolv.conf,ssl,pki,ca-certificates,crypto-policies
 private-tmp

--- a/etc/waterfox.profile
+++ b/etc/waterfox.profile
@@ -22,7 +22,7 @@ whitelist ${HOME}/.waterfox
 # waterfox requires a shell to launch on Arch. We can possibly remove sh though.
 #private-bin waterfox,which,sh,dbus-launch,dbus-send,env,bash
 # private-etc must first be enabled in firefox-common.profile
-#private-etc waterfox
+#private-etc alternatives,waterfox
 
 # Redirect
 include firefox-common.profile

--- a/etc/waterfox.profile
+++ b/etc/waterfox.profile
@@ -22,7 +22,7 @@ whitelist ${HOME}/.waterfox
 # waterfox requires a shell to launch on Arch. We can possibly remove sh though.
 #private-bin waterfox,which,sh,dbus-launch,dbus-send,env,bash
 # private-etc must first be enabled in firefox-common.profile
-#private-etc alternatives,waterfox
+#private-etc waterfox
 
 # Redirect
 include firefox-common.profile

--- a/etc/wget.profile
+++ b/etc/wget.profile
@@ -35,7 +35,7 @@ shell none
 
 # private-bin wget
 private-dev
-# private-etc resolv.conf,ca-certificates,ssl,pki,crypto-policies
+# private-etc alternatives,resolv.conf,ca-certificates,ssl,pki,crypto-policies
 # private-tmp
 
 noexec ${HOME}

--- a/etc/whois.profile
+++ b/etc/whois.profile
@@ -38,7 +38,7 @@ private
 private-bin sh,bash,whois
 private-cache
 private-dev
-# private-etc hosts,services,whois.conf
+# private-etc alternatives,hosts,services,whois.conf
 private-lib
 private-tmp
 

--- a/etc/wire-desktop.profile
+++ b/etc/wire-desktop.profile
@@ -37,5 +37,5 @@ shell none
 disable-mnt
 private-bin wire-desktop
 private-dev
-private-etc fonts,machine-id,resolv.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,fonts,machine-id,resolv.conf,ca-certificates,ssl,pki,crypto-policies
 private-tmp

--- a/etc/wireshark.profile
+++ b/etc/wireshark.profile
@@ -45,7 +45,7 @@ tracelog
 
 # private-bin wireshark
 private-dev
-# private-etc fonts,group,hosts,machine-id,passwd,ca-certificates,ssl,pki,crypto-policies
+# private-etc alternatives,fonts,group,hosts,machine-id,passwd,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
 noexec ${HOME}

--- a/etc/xed.profile
+++ b/etc/xed.profile
@@ -42,7 +42,7 @@ tracelog
 
 private-bin xed
 private-dev
-# private-etc fonts
+# private-etc alternatives,fonts
 private-tmp
 
 # xed uses python plugins, memory-deny-write-execute breaks python

--- a/etc/xfburn.profile
+++ b/etc/xfburn.profile
@@ -29,5 +29,5 @@ tracelog
 
 # private-bin xfburn
 # private-dev
-# private-etc fonts
+# private-etc alternatives,fonts
 # private-tmp

--- a/etc/xiphos.profile
+++ b/etc/xiphos.profile
@@ -38,5 +38,5 @@ tracelog
 
 private-bin xiphos
 private-dev
-private-etc fonts,resolv.conf,sword,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,fonts,resolv.conf,sword,ca-certificates,ssl,pki,crypto-policies
 private-tmp

--- a/etc/xmr-stak.profile
+++ b/etc/xmr-stak.profile
@@ -37,7 +37,7 @@ disable-mnt
 private ${HOME}/.xmr-stak
 private-bin xmr-stak
 private-dev
-private-etc ca-certificates,crypto-policies,nsswitch.conf,pki,resolv.conf,ssl
+private-etc alternatives,ca-certificates,crypto-policies,nsswitch.conf,pki,resolv.conf,ssl
 #private-lib libxmrstak_opencl_backend,libxmrstak_cuda_backend
 private-opt cuda
 private-tmp

--- a/etc/xonotic.profile
+++ b/etc/xonotic.profile
@@ -36,7 +36,7 @@ shell none
 disable-mnt
 private-bin bash,blind-id,darkplaces-glx,darkplaces-sdl,dirname,grep,ldd,netstat,ps,readlink,sh,uname,xonotic,xonotic-glx,xonotic-linux32-dedicated,xonotic-linux32-glx,xonotic-linux32-sdl,xonotic-linux64-dedicated,xonotic-linux64-glx,xonotic-linux64-sdl,xonotic-sdl
 private-dev
-private-etc asound.conf,ca-certificates,drirc,fonts,group,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,nsswitch.conf,passwd,pulse,resolv.conf,ssl,pki,crypto-policies,machine-id
+private-etc alternatives,asound.conf,ca-certificates,drirc,fonts,group,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,nsswitch.conf,passwd,pulse,resolv.conf,ssl,pki,crypto-policies,machine-id
 private-tmp
 
 noexec ${HOME}

--- a/etc/xplayer.profile
+++ b/etc/xplayer.profile
@@ -40,7 +40,7 @@ tracelog
 
 private-bin xplayer,xplayer-audio-preview,xplayer-video-thumbnailer
 private-dev
-# private-etc fonts,machine-id,pulse,asound.conf,ca-certificates,ssl,pki,crypto-policies
+# private-etc alternatives,fonts,machine-id,pulse,asound.conf,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
 noexec ${HOME}

--- a/etc/xpra.profile
+++ b/etc/xpra.profile
@@ -52,5 +52,5 @@ shell none
 # older Xpra versions also use Xvfb
 # private-bin xpra,python*,Xvfb,Xorg,sh,xkbcomp,xauth,dbus-launch,pactl,ldconfig,which,strace,bash,cat,ls
 private-dev
-# private-etc ld.so.conf,ld.so.cache,resolv.conf,host.conf,nsswitch.conf,gai.conf,hosts,hostname,machine-id,xpra,X11
+# private-etc alternatives,ld.so.conf,ld.so.cache,resolv.conf,host.conf,nsswitch.conf,gai.conf,hosts,hostname,machine-id,xpra,X11
 private-tmp

--- a/etc/xreader.profile
+++ b/etc/xreader.profile
@@ -38,7 +38,7 @@ tracelog
 
 private-bin xreader,xreader-previewer,xreader-thumbnailer
 private-dev
-private-etc fonts,ld.so.cache
+private-etc alternatives,fonts,ld.so.cache
 private-tmp
 
 memory-deny-write-execute

--- a/etc/xviewer.profile
+++ b/etc/xviewer.profile
@@ -38,7 +38,7 @@ tracelog
 
 private-bin xviewer
 private-dev
-#private-etc fonts
+#private-etc alternatives,fonts
 private-lib
 private-tmp
 

--- a/etc/zathura.profile
+++ b/etc/zathura.profile
@@ -35,7 +35,7 @@ shell none
 private-bin zathura
 private-cache
 private-dev
-private-etc fonts,machine-id
+private-etc alternatives,fonts,machine-id
 private-tmp
 
 read-only ${HOME}/


### PR DESCRIPTION
See #2399 for context/discussion. @chiraag-nataraj suggested that we make sure we add `alternatives` to all profiles with private-etc. In particular this should help avoid the error `<some program>: error while loading shared libraries: libGL.so.1: cannot open shared object file:` for systems with multiple versions of libGL.so.

For profiles with only `private-etc none` (see list below), none was replaced with alternatives. 
1. default
2. devilspie
3. devilspie2
4. display
5. enchant
6. etr
7. exiftool
8. frozen-bubble
9. github-desktop
10. highlight
11. mediainfo
12. odt2txt
13. open-invaders
14. pdf2txt
15. pingus
16. QMediathekView
17. server
18. simutrans
19. strings
20. supertux2
21. transmission-show

Also I added it to all firefox-based profiles, but it might be better to just add it to Firefox's profile and then let `include firefox-common` do its magic. Thoughts?

Cheers!
Fred

(Also I'm planning on alphabetising the private-etc lines.... but that's another commit for another day!)