### PR TITLE
Add 'video' to profile options

### DIFF
--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -398,6 +398,10 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		arg_novideo = 1;
 		return 0;
 	}
+	else if (strcmp(ptr, "video") == 0) {
+		arg_novideo = 0;
+		return 0;
+	}
 	else if (strcmp(ptr, "no3d") == 0) {
 		arg_no3d = 1;
 		return 0;

--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -510,6 +510,9 @@ Disable U2F devices.
 \fBnovideo
 Disable video devices.
 .TP
+\fBvideo
+Enable video devices.
+.TP
 \fBno3d
 Disable 3D hardware acceleration.
 


### PR DESCRIPTION
The novideo can be set globally and video permissions can be whitelisted on a per-application basis