### PR TITLE
Archivers

### DIFF
--- a/etc/7z.profile
+++ b/etc/7z.profile
@@ -9,18 +9,26 @@ include 7z.local
 
 blacklist /tmp/.X11-unix
 
-ignore noroot
+apparmor
+ipc-namespace
+machine-id
 net none
 no3d
 nodbus
 nodvd
+nogroups
 nosound
 notv
 nou2f
 novideo
+protocol unix
 shell none
 tracelog
 
 private-dev
+
+memory-deny-write-execute
+noexec ${HOME}
+noexec /tmp
 
 include default.profile

--- a/etc/7z.profile
+++ b/etc/7z.profile
@@ -25,6 +25,7 @@ protocol unix
 shell none
 tracelog
 
+private-cache
 private-dev
 
 memory-deny-write-execute

--- a/etc/atool.profile
+++ b/etc/atool.profile
@@ -22,10 +22,13 @@ include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
 
+apparmor
 caps.drop all
-netfilter
+ipc-namespace
+machine-id
 net none
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs
@@ -45,3 +48,7 @@ private-dev
 # without login.defs atool complains and uses UID/GID 1000 by default
 private-etc alternatives,passwd,group,login.defs
 private-tmp
+
+memory-deny-write-execute
+noexec ${HOME}
+noexec /tmp

--- a/etc/bsdtar.profile
+++ b/etc/bsdtar.profile
@@ -14,15 +14,17 @@ include disable-programs.inc
 
 blacklist /tmp/.X11-unix
 
-hostname bsdtar
+apparmor
 caps.drop all
+hostname bsdtar
 ipc-namespace
-netfilter
+machine-id
+net none
 no3d
 nodvd
 nogroups
 nonewprivs
-# noroot
+noroot
 nosound
 notv
 nou2f
@@ -31,10 +33,14 @@ nonewprivs
 protocol unix
 seccomp
 shell none
-
 tracelog
 
 # support compressed archives
 private-bin sh,bash,bsdcat,bsdcpio,bsdtar,gtar,compress,gzip,lzma,xz,bzip2,lbzip2,lzip,lzop,lz4,libarchive
+private-cache
 private-dev
 private-etc alternatives,passwd,group,localtime
+
+memory-deny-write-execute
+noexec ${HOME}
+noexec /tmp

--- a/etc/cpio.profile
+++ b/etc/cpio.profile
@@ -16,18 +16,29 @@ include disable-common.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
 
+apparmor
 caps.drop all
+ipc-namespace
+machine-id
 net none
 no3d
 nodbus
 nodvd
+nogroups
 nonewprivs
+noroot
 nosound
 notv
 nou2f
 novideo
+protocol unix
 seccomp
 shell none
 tracelog
 
+private-cache
 private-dev
+
+memory-deny-write-execute
+noexec ${HOME}
+noexec /tmp

--- a/etc/gzip.profile
+++ b/etc/gzip.profile
@@ -10,18 +10,27 @@ include gzip.local
 
 blacklist /tmp/.X11-unix
 
-ignore noroot
+apparmor
+ipc-namespace
+machine-id
 net none
 no3d
 nodbus
 nodvd
+nogroups
 nosound
 notv
 nou2f
 novideo
+protocol unix
 shell none
 tracelog
 
+private-cache
 private-dev
+
+memory-deny-write-execute
+noexec ${HOME}
+noexec /tmp
 
 include default.profile

--- a/etc/tar.profile
+++ b/etc/tar.profile
@@ -10,24 +10,33 @@ include tar.local
 
 blacklist /tmp/.X11-unix
 
+apparmor
 hostname tar
-ignore noroot
+ipc-namespace
+machine-id
 net none
 no3d
 nodbus
 nodvd
+nogroups
 nosound
 notv
 nou2f
 novideo
+protocol unix
 shell none
 tracelog
 
 # support compressed archives
 private-bin sh,bash,tar,gtar,compress,gzip,lzma,xz,bzip2,lbzip2,lzip,lzop
+private-cache
 private-dev
 private-etc alternatives,passwd,group,localtime
 private-lib
+
+memory-deny-write-execute
+noexec ${HOME}
+noexec /tmp
 
 # Debian based distributions need this for 'dpkg --unpack' (incl. synaptic)
 writable-var


### PR DESCRIPTION
Hi all. For several months I have been testing archivers succesfully with hardened and streamlined profiles.  I noticed there were some that used `nogroups` while others didn't. All of the tested archivers currently have `ignore noroot`, yet I can't see any reason for it (which of course doesn't mean there isn't one).

Additional hardening options I've enabled in all of the tested profiles:

`apparmor`
`ipc-namespace`
`machine-id`
`net none`
`nodbus`
`nogroups`
`noroot`
`protocol unix`

`private-cache`

`memory-deny-write-execute`
`noexec ${HOME}`
`noexec /tmp`

During the test period I have not experienced any errors or other weirdness. Again, that doesn't mean there aren't any problems, I just didn't see any on my test platforms (Arch Linux/Ubuntu LTS). Which makes me pose the question if people (especially running Fedora) would be interested to test these hardened profiles and provide feed-back here.

If this looks futile, not worth the trouble or otherwise superfluous, please feel free to point that out. No harm is done, this is a draft PR made for that purpose.

Looking forward to your input.