### PR TITLE
gnome-mpv -> celluloid

### DIFF
--- a/etc/celluloid.profile
+++ b/etc/celluloid.profile
@@ -1,0 +1,51 @@
+# Firejail profile for celluloid
+# Description: Simple GTK+ frontend for mpv
+# This file is overwritten after every install/update
+# Persistent local customizations
+include celluloid.local
+# Persistent global definitions
+include globals.local
+
+noblacklist ${HOME}/.config/gnome-mpv
+noblacklist ${HOME}/.config/celluloid
+noblacklist ${MUSIC}
+noblacklist ${VIDEOS}
+
+# Allow python (blacklisted by disable-interpreters.inc)
+noblacklist ${PATH}/python2*
+noblacklist ${PATH}/python3*
+noblacklist /usr/lib/python2*
+noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
+
+include disable-common.inc
+include disable-devel.inc
+include disable-interpreters.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
+include disable-xdg.inc
+
+include whitelist-var-common.inc
+
+apparmor
+caps.drop all
+netfilter
+nodbus
+nogroups
+nonewprivs
+noroot
+nou2f
+protocol unix,inet,inet6
+seccomp
+shell none
+tracelog
+
+private-bin celluloid,gnome-mpv,youtube-dl,python*,env
+private-cache
+private-etc alternatives
+private-dev
+private-tmp
+
+noexec ${HOME}
+noexec /tmp

--- a/etc/celluloid.profile
+++ b/etc/celluloid.profile
@@ -43,7 +43,7 @@ tracelog
 
 private-bin celluloid,gnome-mpv,youtube-dl,python*,env
 private-cache
-private-etc alternatives
+private-etc alternatives,ca-certificates,ssl,pki,pkcs11,hosts,machine-id,localtime,libva.conf,drirc,fonts,gtk-3.0,dconf,crypto-policies,xdg,selinux,resolv.conf
 private-dev
 private-tmp
 

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -117,6 +117,7 @@ blacklist ${HOME}/.config/brave
 blacklist ${HOME}/.config/caja
 blacklist ${HOME}/.config/calibre
 blacklist ${HOME}/.config/catfish
+blacklist ${HOME}/.config/celluloid
 blacklist ${HOME}/.config/cherrytree
 blacklist ${HOME}/.config/chromium
 blacklist ${HOME}/.config/chromium-dev

--- a/etc/gnome-mpv.profile
+++ b/etc/gnome-mpv.profile
@@ -1,45 +1,5 @@
-# Firejail profile for gnome-mpv
-# Description: Simple GTK+ frontend for mpv
+# Firejail profile alias for celluloid (formerly GNOME MPV)
 # This file is overwritten after every install/update
-# Persistent local customizations
-include gnome-mpv.local
-# Persistent global definitions
-include globals.local
 
-noblacklist ${HOME}/.config/gnome-mpv
-noblacklist ${MUSIC}
-noblacklist ${VIDEOS}
-
-# Allow python (blacklisted by disable-interpreters.inc)
-noblacklist ${PATH}/python2*
-noblacklist ${PATH}/python3*
-noblacklist /usr/lib/python2*
-noblacklist /usr/lib/python3*
-noblacklist /usr/local/lib/python2*
-noblacklist /usr/local/lib/python3*
-
-include disable-common.inc
-include disable-devel.inc
-include disable-interpreters.inc
-include disable-passwdmgr.inc
-include disable-programs.inc
-include disable-xdg.inc
-
-include whitelist-var-common.inc
-
-caps.drop all
-nodbus
-nogroups
-nonewprivs
-noroot
-nou2f
-protocol unix,inet,inet6
-seccomp
-shell none
-
-private-bin gnome-mpv,youtube-dl,python*,env
-private-dev
-private-tmp
-
-noexec ${HOME}
-noexec /tmp
+# Redirect
+include celluloid.profile

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -76,6 +76,7 @@ calligrasheets
 calligrastage
 calligrawords
 catfish
+celluloid
 cherrytree
 chromium
 chromium-browser


### PR DESCRIPTION
gnome-mpv has renamed to celluloid. (https://www.omgubuntu.co.uk/2019/01/celluloid-new-name-for-gnome-mpv)

  * [x] move gnome-mpv.profile to celluloid.profile
  * [x] add gnome-mpv.profile alias for downward compatibility
  * [x] add celluloid to firecfg.config
  * [x] add celluloid paths to disable-programs.inc
  * [x] replace gnome-mpv by celluloid in celluloid.profile
  * [x] add `celluloid` to `private-bin`
  * [x] harden celluloid.profile
    * [x] add `private-cache`
    * [x] add `apparmor`
    * [x] add `tracelog`
    * [x] add `netfilter`
    * [x] add `private-etc`