### PR TITLE
Fix private-lib in regextester profile

### DIFF
--- a/etc/pavucontrol.profile
+++ b/etc/pavucontrol.profile
@@ -21,7 +21,6 @@ include whitelist-var-common.inc
 apparmor
 caps.drop all
 ipc-namespace
-machine-id
 net none
 no3d
 nodbus
@@ -41,7 +40,7 @@ disable-mnt
 private-bin pavucontrol
 private-cache
 private-dev
-private-etc alternatives,asound.conf,fonts,pulse
+private-etc alternatives,asound.conf,fonts,machine-id,pulse
 private-lib
 private-tmp
 

--- a/etc/pavucontrol.profile
+++ b/etc/pavucontrol.profile
@@ -21,6 +21,7 @@ include whitelist-var-common.inc
 apparmor
 caps.drop all
 ipc-namespace
+machine-id
 net none
 no3d
 nodbus
@@ -40,7 +41,7 @@ disable-mnt
 private-bin pavucontrol
 private-cache
 private-dev
-private-etc alternatives,asound.conf,fonts,machine-id,pulse
+private-etc alternatives,asound.conf,fonts,pulse
 private-lib
 private-tmp
 

--- a/etc/regextester.profile
+++ b/etc/regextester.profile
@@ -40,7 +40,7 @@ private-bin regextester
 private-cache
 private-dev
 private-etc alternatives,fonts
-private-lib /usr/lib/libgranite.so.*
+private-lib libgranite.so.*
 private-tmp
 
 memory-deny-write-execute


### PR DESCRIPTION
No need to use /usr/lib prefix in private-lib.