### PR TITLE
Fix pavucontrol

### DIFF
--- a/etc/pavucontrol.profile
+++ b/etc/pavucontrol.profile
@@ -15,9 +15,6 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-xdg.inc
 
-mkfile ${HOME}/.config/pavucontrol.ini
-whitelist ${HOME}/.config/pavucontrol.ini
-include whitelist-common.inc
 include whitelist-var-common.inc
 
 apparmor


### PR DESCRIPTION
```
...
mkfile ${HOME}/.config/pavucontrol.ini
whitelist ${HOME}/.config/pavucontrol.ini
include whitelist-common.inc
...
```

pavucontrol pops an error window with the message:
Error writing config file %s/home/glitsj16/.config/pavucontrol.ini: Bad state

Taking out those options fixes things.