### PR TITLE
Hardening and added network functionality in sqlitebrowser.profile

### DIFF
--- a/etc/sqlitebrowser.profile
+++ b/etc/sqlitebrowser.profile
@@ -18,10 +18,11 @@ include disable-xdg.inc
 
 include whitelist-var-common.inc
 
+apparmor
 caps.drop all
-net none
-no3d
-nodbus
+ipc-namespace
+netfilter
+# nodbus - breaks proxy creation
 nodvd
 nogroups
 nonewprivs
@@ -30,15 +31,16 @@ nosound
 notv
 nou2f
 novideo
-protocol unix
+protocol unix,inet,inet6,netlink
 seccomp
 shell none
 
 private-bin sqlitebrowser
 private-cache
 private-dev
+private-etc alternatives,ca-certificates,crypto-policies,fonts,group,machine-id,passwd,pki,ssl
 private-tmp
 
-# memory-deny-write-execute - breaks on Arch
+memory-deny-write-execute
 noexec ${HOME}
 noexec /tmp


### PR DESCRIPTION
The profile crippled working (securely) with remote databases. That is now working as expected. Also, `memory-deny-write-execute` is no longer breaking on Arch, tested with recent [mdwx: block memfd_create](https://github.com/netblue30/firejail/commit/59e30614ad1cd7a8d6f3c685472fada37d1ed2d7) introduction.