### PR TITLE
Add fakeroot support for makepkg on Arch

### DIFF
--- a/etc/patch.profile
+++ b/etc/patch.profile
@@ -36,7 +36,7 @@ shell none
 
 private-bin patch,red
 private-dev
-private-lib
+private-lib libfakeroot
 
 memory-deny-write-execute
 noexec ${HOME}

--- a/etc/strings.profile
+++ b/etc/strings.profile
@@ -25,7 +25,7 @@ private-bin strings
 private-cache
 private-dev
 private-etc alternatives
-private-lib
+private-lib libfakeroot
 
 memory-deny-write-execute
 noexec ${HOME}

--- a/etc/tar.profile
+++ b/etc/tar.profile
@@ -27,7 +27,7 @@ tracelog
 private-bin sh,bash,tar,gtar,compress,gzip,lzma,xz,bzip2,lbzip2,lzip,lzop
 private-dev
 private-etc alternatives,passwd,group,localtime
-private-lib
+private-lib libfakeroot
 
 # Debian based distributions need this for 'dpkg --unpack' (incl. synaptic)
 writable-var


### PR DESCRIPTION
As per discussion in https://github.com/netblue30/firejail/issues/2507, there are a few profiles that could benefit from adding `libfakeroot` to `private-lib` for the Arch `makepkg` routine. This PR fixes this for `patch`, `strings` and `tar` (file was already covered).