### PR TITLE
Add ffmpeg redirect profiles to firecfg

### DIFF
--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -156,6 +156,9 @@ fbreader
 feedreader
 feh
 ffmpeg
+ffmpegthumbnailer
+ffplay
+ffprobe
 file-roller
 filezilla
 firefox
@@ -395,6 +398,7 @@ qlipper
 qmmp
 qpdfview
 qtox
+qt-faststart
 quassel
 quiterss
 qupzilla


### PR DESCRIPTION
Making this a draft PR because I'm **not exactly sure about when to add to firecfg/when not**. I think I've asked this before, or it came up in some other context. In any case, I could benefit from a refresher on the topic. Thanks to @rusty-snake for bringing this to my attention in https://github.com/netblue30/firejail/pull/2532. There are several other profiles I added recently that might need to be added to firecfg. I'll await reactions here and will provide the necessary PR's if needed.