### PR TITLE
Add code-oss profile

### DIFF
--- a/etc/code-oss.profile
+++ b/etc/code-oss.profile
@@ -1,0 +1,1 @@
+include code.profile

--- a/etc/code-oss.profile
+++ b/etc/code-oss.profile
@@ -1,1 +1,5 @@
+# Firejail profile alias for Visual Studio Code
+# This file is overwritten after every install/update
+
+# Redirect
 include code.profile


### PR DESCRIPTION
Adds a profile alias for `code-oss`, which is the open-source build of Visual Studio Code from the official Arch community repository.