### PR TITLE
Add code-oss config directory

### DIFF
--- a/etc/code.profile
+++ b/etc/code.profile
@@ -8,6 +8,7 @@ include globals.local
 noblacklist ${HOME}/.vscode
 noblacklist ${HOME}/.vscode-oss
 noblacklist ${HOME}/.config/Code
+noblacklist ${HOME}/.config/Code - OSS
 
 include disable-common.inc
 include disable-passwdmgr.inc


### PR DESCRIPTION
Adds the `code-oss` config directory to the `noblacklist` list. I'm guessing this makes sense to add here since `${HOME}/.vscode-oss` has already been added. Sorry I missed this in #2539