### PR TITLE
Fix clawsker for older GTK2 versions

### DIFF
--- a/etc/clawsker.profile
+++ b/etc/clawsker.profile
@@ -25,6 +25,7 @@ mkdir ${HOME}/.claws-mail
 whitelist ${HOME}/.claws-mail
 include whitelist-common.inc
 
+apparmor
 caps.drop all
 net none
 no3d
@@ -42,11 +43,11 @@ seccomp
 shell none
 
 disable-mnt
-private-bin clawsker,perl
+private-bin bash,clawsker,perl,sh,which
 private-cache
 private-dev
 private-etc alternatives,fonts
-private-lib girepository-1.*,libgirepository-1.*,perl*
+private-lib girepository-1.*,libdbus-glib-1.so.*,libetpan.so.*,libgirepository-1.*,libgtk-x11-2.0.so.*,libstartup-notification-1.so.*,perl*
 private-tmp
 
 # memory-deny-write-execute - breaks on Arch


### PR DESCRIPTION
Some distributions still ship older GTK2 versions of clawsker. Let's support those too.