### PR TITLE
viewnior is completely broken with 'hostname viewnior'

### DIFF
--- a/etc/viewnior.profile
+++ b/etc/viewnior.profile
@@ -20,7 +20,6 @@ include disable-programs.inc
 
 apparmor
 caps.drop all
-hostname viewnior
 ipc-namespace
 net none
 no3d


### PR DESCRIPTION
error message:

> Cannot open display: 
> Run 'viewnior --help' to see a full list of available command line options.
> monitoring pid 10
> 
> Sandbox monitor: waitpid 10 retval 10 status 256
> 
> Parent is shutting down, bye...