### PR TITLE
Drop ipc-namespace from viewnior.profile

### DIFF
--- a/etc/viewnior.profile
+++ b/etc/viewnior.profile
@@ -20,7 +20,6 @@ include disable-programs.inc
 
 apparmor
 caps.drop all
-ipc-namespace
 net none
 no3d
 nodbus


### PR DESCRIPTION
After some more back-and-forth with @veloute in https://github.com/netblue30/firejail/pull/2573, the viewnior profile needed to loose ipc-namespace.