### PR TITLE
add disable-exec.inc to all profiles with apparmor

### DIFF
--- a/etc/akonadi_control.profile
+++ b/etc/akonadi_control.profile
@@ -22,6 +22,7 @@ noblacklist /usr/sbin
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -51,5 +52,3 @@ tracelog
 private-dev
 # private-tmp - breaks programs that depend on akonadi
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/arch-audit.profile
+++ b/etc/arch-audit.profile
@@ -12,6 +12,7 @@ noblacklist /var/lib/pacman
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -44,5 +45,3 @@ private-dev
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/ark.profile
+++ b/etc/ark.profile
@@ -10,6 +10,7 @@ noblacklist ${HOME}/.config/arkrc
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -39,5 +40,3 @@ private-bin ark,unrar,rar,unzip,zip,zipinfo,7z,p7zip,unar,lsar,lrzip,lzop,lz4,ba
 private-dev
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/artha.profile
+++ b/etc/artha.profile
@@ -11,6 +11,7 @@ noblacklist ${HOME}/.config/enchant
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -42,5 +43,3 @@ private-lib libnotify.so.*
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/assogiate.profile
+++ b/etc/assogiate.profile
@@ -10,6 +10,7 @@ noblacklist ${PICTURES}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -45,5 +46,3 @@ private-lib gnome-vfs-2.0,libattr.so.*,libacl.so.*,libfam.so.*
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/asunder.profile
+++ b/etc/asunder.profile
@@ -14,6 +14,7 @@ noblacklist ${MUSIC}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -39,5 +40,3 @@ private-tmp
 
 # mdwe is disabled due to breaking hardware accelerated decoding
 # memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/atril.profile
+++ b/etc/atril.profile
@@ -15,6 +15,7 @@ noblacklist ${DOCUMENTS}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -49,5 +50,3 @@ private-tmp
 
 # webkit gtk killed by memory-deny-write-execute
 #memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/audacious.profile
+++ b/etc/audacious.profile
@@ -12,6 +12,7 @@ noblacklist ${MUSIC}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -40,5 +41,3 @@ private-dev
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/audacity.profile
+++ b/etc/audacity.profile
@@ -12,6 +12,7 @@ noblacklist ${MUSIC}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -41,5 +42,3 @@ private-dev
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/authenticator.profile
+++ b/etc/authenticator.profile
@@ -14,6 +14,7 @@ noblacklist /usr/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -43,5 +44,3 @@ private-etc alternatives,fonts,ld.so.cache
 private-tmp
 
 # memory-deny-write-execute - breaks on Arch
-noexec ${HOME}
-noexec /tmp

--- a/etc/celluloid.profile
+++ b/etc/celluloid.profile
@@ -21,6 +21,7 @@ noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -47,5 +48,3 @@ private-etc alternatives,ca-certificates,ssl,pki,pkcs11,hosts,machine-id,localti
 private-dev
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/checkbashisms.profile
+++ b/etc/checkbashisms.profile
@@ -18,6 +18,7 @@ noblacklist /usr/share/perl*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -50,5 +51,3 @@ private-lib perl*
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/chromium-common.profile
+++ b/etc/chromium-common.profile
@@ -6,11 +6,15 @@ include chromium-common.local
 # already included by caller profile
 #include globals.local
 
+# noexec ${HOME} breaks DRM binaries.
+ignore noexec ${HOME}
+
 noblacklist ${HOME}/.pki
 noblacklist ${HOME}/.local/share/pki
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 
@@ -36,10 +40,6 @@ shell none
 disable-mnt
 private-dev
 # private-tmp - problems with multiple browser sessions
-
-# breaks DRM binaries
-#noexec ${HOME}
-noexec /tmp
 
 # the file dialog needs to work without d-bus
 env NO_CHROME_KDE_FILE_DIALOG=1

--- a/etc/clawsker.profile
+++ b/etc/clawsker.profile
@@ -17,6 +17,7 @@ noblacklist /usr/share/perl*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -51,5 +52,3 @@ private-lib girepository-1.*,libdbus-glib-1.so.*,libetpan.so.*,libgirepository-1
 private-tmp
 
 # memory-deny-write-execute - breaks on Arch
-noexec ${HOME}
-noexec /tmp

--- a/etc/clipit.profile
+++ b/etc/clipit.profile
@@ -11,6 +11,7 @@ noblacklist ${HOME}/.local/share/clipit
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -39,5 +40,3 @@ private-cache
 private-dev
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/d-feet.profile
+++ b/etc/d-feet.profile
@@ -16,6 +16,7 @@ noblacklist /usr/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -51,5 +52,3 @@ private-etc alternatives,dbus-1,fonts,machine-id
 private-tmp
 
 # memory-deny-write-execute - Breaks on Arch
-noexec ${HOME}
-noexec /tmp

--- a/etc/dconf-editor.profile
+++ b/etc/dconf-editor.profile
@@ -8,6 +8,7 @@ include globals.local
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -41,5 +42,3 @@ private-lib
 private-tmp
 
 # memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/dconf.profile
+++ b/etc/dconf.profile
@@ -8,6 +8,7 @@ include globals.local
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -44,5 +45,3 @@ private-lib
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/devhelp.profile
+++ b/etc/devhelp.profile
@@ -9,6 +9,7 @@ include globals.local
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -41,7 +42,5 @@ private-etc alternatives,dconf,fonts,ld.so.cache,machine-id,ssl
 private-tmp
 
 # memory-deny-write-execute - Breaks on Arch
-noexec ${HOME}
-noexec /tmp
 
 read-only ${HOME}

--- a/etc/devilspie.profile
+++ b/etc/devilspie.profile
@@ -10,6 +10,7 @@ noblacklist ${HOME}/.devilspie
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -44,7 +45,5 @@ private-lib gconv
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp
 
 read-only ${HOME}

--- a/etc/devilspie2.profile
+++ b/etc/devilspie2.profile
@@ -10,6 +10,7 @@ noblacklist ${HOME}/.config/devilspie2
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -44,7 +45,5 @@ private-lib gconv
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp
 
 read-only ${HOME}

--- a/etc/digikam.profile
+++ b/etc/digikam.profile
@@ -14,6 +14,7 @@ noblacklist ${PICTURES}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -40,5 +41,3 @@ shell none
 # private-etc alternatives,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/disable-exec.inc
+++ b/etc/disable-exec.inc
@@ -6,5 +6,6 @@ noexec ${HOME}
 noexec ${RUNUSER}
 noexec /dev/shm
 noexec /tmp
-# /var/tmp is noexec by default; just in case there is a keep-var-tmp option
+# /var/tmp is noexec by default
+# just in case there is a keep-var-tmp option:
 noexec /var/tmp

--- a/etc/disable-exec.inc
+++ b/etc/disable-exec.inc
@@ -1,0 +1,10 @@
+# This file is overwritten during software install.
+# Persistent customizations should go in a .local file.
+include disable-exec.local
+
+noexec ${HOME}
+noexec ${RUNUSER}
+noexec /dev/shm
+noexec /tmp
+# /var/tmp is noexec by default; just in case there is a keep-var-tmp option
+noexec /var/tmp

--- a/etc/electron.profile
+++ b/etc/electron.profile
@@ -7,6 +7,7 @@ include electron.local
 include globals.local
 
 include disable-common.inc
+include disable-exec.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
 

--- a/etc/electron.profile
+++ b/etc/electron.profile
@@ -7,7 +7,6 @@ include electron.local
 include globals.local
 
 include disable-common.inc
-include disable-exec.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
 

--- a/etc/enchant.profile
+++ b/etc/enchant.profile
@@ -10,6 +10,7 @@ noblacklist ${HOME}/.config/enchant
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -43,5 +44,3 @@ private-lib
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/engrampa.profile
+++ b/etc/engrampa.profile
@@ -8,6 +8,7 @@ include globals.local
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -38,5 +39,3 @@ private-dev
 # private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/eog.profile
+++ b/etc/eog.profile
@@ -13,6 +13,7 @@ noblacklist ${HOME}/.steam
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -47,5 +48,3 @@ private-lib eog,gdk-pixbuf-2.*,gio,girepository-1.*,gvfs,libgconf-2.so.*
 private-tmp
 
 # memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/exiftool.profile
+++ b/etc/exiftool.profile
@@ -15,6 +15,7 @@ noblacklist /usr/share/perl*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -46,5 +47,3 @@ private-etc alternatives
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/ffmpeg.profile
+++ b/etc/ffmpeg.profile
@@ -12,6 +12,7 @@ noblacklist ${VIDEOS}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -48,5 +49,3 @@ private-etc alternatives,pki,pkcs11,hosts,ssl,ca-certificates,resolv.conf
 private-tmp
 
 # memory-deny-write-execute - it breaks old versions of ffmpeg
-noexec ${HOME}
-noexec /tmp

--- a/etc/file-roller.profile
+++ b/etc/file-roller.profile
@@ -8,6 +8,7 @@ include globals.local
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -41,5 +42,3 @@ private-dev
 # private-tmp
 
 # memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/file.profile
+++ b/etc/file.profile
@@ -10,6 +10,7 @@ include globals.local
 blacklist /tmp/.X11-unix
 
 include disable-common.inc
+include disable-exec.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
 
@@ -41,5 +42,3 @@ private-etc alternatives,magic.mgc,magic,localtime
 private-lib libarchive.so.*,libfakeroot,libmagic.so.*
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/firefox-common.profile
+++ b/etc/firefox-common.profile
@@ -6,6 +6,9 @@ include firefox-common.local
 # already included by caller profile
 #include globals.local
 
+# noexec ${HOME} breaks DRM binaries.
+ignore noexec ${HOME}
+
 # Uncomment the following line to allow access to common programs/addons/plugins.
 #include firefox-common-addons.inc
 
@@ -14,6 +17,7 @@ noblacklist ${HOME}/.local/share/pki
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 
@@ -55,7 +59,3 @@ private-dev
 # private-etc below works fine on most distributions. There are some problems on CentOS.
 #private-etc alternatives,ca-certificates,ssl,machine-id,dconf,selinux,passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,xdg,gtk-2.0,gtk-3.0,X11,pango,fonts,mime.types,mailcap,asound.conf,pulse,pki,crypto-policies,ld.so.cache
 private-tmp
-
-# Breaks DRM binaries.
-#noexec ${HOME}
-noexec /tmp

--- a/etc/font-manager.profile
+++ b/etc/font-manager.profile
@@ -17,6 +17,7 @@ noblacklist /usr/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -52,5 +53,3 @@ private-dev
 private-tmp
 
 #memory-deny-write-execute - Breaks on Arch
-noexec ${HOME}
-noexec /tmp

--- a/etc/galculator.profile
+++ b/etc/galculator.profile
@@ -10,6 +10,7 @@ noblacklist ${HOME}/.config/galculator
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -47,5 +48,3 @@ private-lib
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/gcloud.profile
+++ b/etc/gcloud.profile
@@ -5,12 +5,16 @@ include gcloud.local
 # Persistent global definitions
 include globals.local
 
+# noexec ${HOME} will break user-local installs of gcloud tooling
+ignore noexec ${HOME}
+
 noblacklist ${HOME}/.boto
 noblacklist ${HOME}/.config/gcloud
 noblacklist /var/run/docker.sock
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-programs.inc
 
 apparmor
@@ -34,8 +38,3 @@ disable-mnt
 private-dev
 private-etc alternatives,ca-certificates,ssl,hosts,localtime,nsswitch.conf,resolv.conf,pki,crypto-policies,ld.so.cache
 private-tmp
-
-noexec /tmp
-
-# will break user-local installs of gcloud tooling
-# noexec ${HOME}

--- a/etc/gconf.profile
+++ b/etc/gconf.profile
@@ -16,6 +16,7 @@ noblacklist /usr/lib/python2*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -53,5 +54,3 @@ private-lib libpython*,python2*
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/gedit.profile
+++ b/etc/gedit.profile
@@ -13,6 +13,7 @@ noblacklist ${HOME}/.python-history
 
 include disable-common.inc
 # include disable-devel.inc
+include disable-exec.inc
 # include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -44,5 +45,3 @@ private-dev
 private-lib /usr/bin/gedit,libtinfo.so.*,libreadline.so.*,gedit,libgspell-1.so.*,gconv,aspell
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/geekbench.profile
+++ b/etc/geekbench.profile
@@ -8,6 +8,7 @@ include globals.local
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -46,7 +47,5 @@ private-opt none
 private-tmp
 
 # memory-deny-write-execute - Breaks on Arch
-noexec ${HOME}
-noexec /tmp
 
 read-only ${HOME}

--- a/etc/ghostwriter.profile
+++ b/etc/ghostwriter.profile
@@ -12,6 +12,7 @@ noblacklist ${PICTURES}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -53,5 +54,3 @@ private-etc alternatives,cups,crypto-policies,localtime,drirc,fonts,gtk-3.0,dcon
 #private-lib
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/gimp.profile
+++ b/etc/gimp.profile
@@ -6,12 +6,17 @@ include gimp.local
 # Persistent global definitions
 include globals.local
 
+# gimp plugins are installed by the user in ${HOME}/.gimp-2.8/plug-ins/ directory
+# if you are not using external plugins, you can disable ignore noexec statement below
+ignore noexec ${HOME}
+
 noblacklist ${HOME}/.config/GIMP
 noblacklist ${HOME}/.gimp*
 noblacklist ${DOCUMENTS}
 noblacklist ${PICTURES}
 
 include disable-common.inc
+include disable-exec.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-xdg.inc
@@ -35,8 +40,3 @@ shell none
 
 private-dev
 private-tmp
-
-# gimp plugins are installed by the user in ${HOME}/.gimp-2.8/plug-ins/ directory
-# if you are not using external plugins, you can enable noexec statement below
-# noexec ${HOME}
-noexec /tmp

--- a/etc/git.profile
+++ b/etc/git.profile
@@ -21,6 +21,7 @@ noblacklist ${HOME}/.vim
 noblacklist ${HOME}/.viminfo
 
 include disable-common.inc
+include disable-exec.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
 
@@ -46,5 +47,3 @@ private-cache
 private-dev
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/gnome-calculator.profile
+++ b/etc/gnome-calculator.profile
@@ -9,6 +9,7 @@ include globals.local
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-passwdmgr.inc
 include disable-interpreters.inc
 include disable-programs.inc
@@ -45,5 +46,3 @@ private-dev
 private-tmp
 
 # memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/gnome-clocks.profile
+++ b/etc/gnome-clocks.profile
@@ -8,6 +8,7 @@ include globals.local
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -39,5 +40,3 @@ private-dev
 private-etc alternatives,fonts,ca-certificates,ssl,pki,crypto-policies,machine-id,hosts,pkcs11,localtime,gtk-3.0,dconf
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/gnome-keyring.profile
+++ b/etc/gnome-keyring.profile
@@ -11,6 +11,7 @@ noblacklist ${HOME}/.gnupg
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-passwdmgr.inc
 include disable-interpreters.inc
 include disable-programs.inc
@@ -47,5 +48,3 @@ private-dev
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/gnome-logs.profile
+++ b/etc/gnome-logs.profile
@@ -8,6 +8,7 @@ include globals.local
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -46,8 +47,6 @@ private-tmp
 writable-var-log
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp
 
 # comment this if you export logs to a file in your ${HOME}
 read-only ${HOME}

--- a/etc/gnome-maps.profile
+++ b/etc/gnome-maps.profile
@@ -13,6 +13,7 @@ noblacklist ${HOME}/.local/share/flatpak
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -43,5 +44,3 @@ private-dev
 # private-etc alternatives,fonts,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/gnome-schedule.profile
+++ b/etc/gnome-schedule.profile
@@ -43,6 +43,7 @@ noblacklist /usr/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -73,5 +74,3 @@ private-dev
 # private-etc alternatives
 writable-var
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/gnome-system-log.profile
+++ b/etc/gnome-system-log.profile
@@ -10,6 +10,7 @@ noblacklist /var/log
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -49,8 +50,6 @@ private-tmp
 writable-var-log
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp
 
 # uncomment this if you never export logs to a file in your ${HOME}
 #read-only ${HOME}

--- a/etc/gpicview.profile
+++ b/etc/gpicview.profile
@@ -10,6 +10,7 @@ noblacklist ${HOME}/.config/gpicview
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -43,5 +44,3 @@ private-lib
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/gucharmap.profile
+++ b/etc/gucharmap.profile
@@ -9,6 +9,7 @@ include globals.local
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -44,7 +45,5 @@ private-lib
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp
 
 read-only ${HOME}

--- a/etc/gwenview.profile
+++ b/etc/gwenview.profile
@@ -19,6 +19,7 @@ noblacklist ${HOME}/.local/share/org.kde.gwenview
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -47,5 +48,3 @@ private-dev
 private-etc alternatives,fonts,gimp,gtk-2.0,kde4rc,kde5rc,ld.so.cache,machine-id,pulse,xdg
 
 # memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/handbrake.profile
+++ b/etc/handbrake.profile
@@ -12,6 +12,7 @@ noblacklist ${VIDEOS}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -35,5 +36,3 @@ shell none
 private-dev
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/img2txt.profile
+++ b/etc/img2txt.profile
@@ -10,6 +10,7 @@ noblacklist ${PICTURES}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -41,5 +42,3 @@ private-dev
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/inkscape.profile
+++ b/etc/inkscape.profile
@@ -20,6 +20,7 @@ noblacklist /usr/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -50,5 +51,3 @@ private-dev
 private-tmp
 
 # memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/kate.profile
+++ b/etc/kate.profile
@@ -6,6 +6,8 @@ include kate.local
 # Persistent global definitions
 include globals.local
 
+ignore noexec ${HOME}
+
 noblacklist ${HOME}/.config/katemetainfos
 noblacklist ${HOME}/.config/katepartrc
 noblacklist ${HOME}/.config/katerc
@@ -16,6 +18,7 @@ noblacklist ${HOME}/.local/share/kate
 
 include disable-common.inc
 # include disable-devel.inc
+include disable-exec.inc
 # include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -44,8 +47,5 @@ tracelog
 private-dev
 # private-etc alternatives,fonts,kde4rc,kde5rc,ld.so.cache,machine-id,xdg
 private-tmp
-
-# noexec ${HOME}
-noexec /tmp
 
 join-or-start kate

--- a/etc/kcalc.profile
+++ b/etc/kcalc.profile
@@ -9,6 +9,7 @@ include globals.local
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -45,5 +46,3 @@ private-dev
 # private-lib - problems on Arch
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/kdenlive.profile
+++ b/etc/kdenlive.profile
@@ -6,12 +6,15 @@ include kdenlive.local
 # Persistent global definitions
 include globals.local
 
+ignore noexec ${HOME}
+
 noblacklist ${HOME}/.cache/kdenlive
 noblacklist ${HOME}/.config/kdenliverc
 noblacklist ${HOME}/.local/share/kdenlive
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -33,6 +36,3 @@ shell none
 private-bin kdenlive,kdenlive_render,dbus-launch,melt,ffmpeg,ffplay,ffprobe,dvdauthor,genisoimage,vlc,xine,kdeinit5,kshell5,kdeinit5_shutdown,kdeinit5_wrapper,kdeinit4,kshell4,kdeinit4_shutdown,kdeinit4_wrapper,mlt-melt
 private-dev
 # private-etc alternatives,fonts,kde4rc,kde5rc,ld.so.cache,machine-id,passwd,pulse,xdg,X11
-
-# noexec ${HOME}
-noexec /tmp

--- a/etc/klavaro.profile
+++ b/etc/klavaro.profile
@@ -11,6 +11,7 @@ noblacklist ${HOME}/.local/share/klavaro
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -51,5 +52,3 @@ private-opt none
 private-srv none
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/kmail.profile
+++ b/etc/kmail.profile
@@ -31,6 +31,7 @@ noblacklist /tmp/akonadi-*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -58,5 +59,3 @@ writable-run-user
 private-dev
 # private-tmp - interrupts connection to akonadi, breaks opening of email attachments
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/kodi.profile
+++ b/etc/kodi.profile
@@ -6,6 +6,9 @@ include kodi.local
 # Persistent global definitions
 include globals.local
 
+# noexec ${HOME} breaks plugins
+ignore noexec ${HOME}
+
 noblacklist ${HOME}/.kodi
 noblacklist ${MUSIC}
 noblacklist ${PICTURES}
@@ -19,6 +22,7 @@ noblacklist /usr/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -40,7 +44,3 @@ tracelog
 
 private-dev
 private-tmp
-
-# breaks plugins
-#noexec ${HOME}
-noexec /tmp

--- a/etc/krita.profile
+++ b/etc/krita.profile
@@ -6,6 +6,9 @@ include krita.local
 # Persistent global definitions
 include globals.local
 
+# noexec ${HOME} may break krita, see issue #1953
+ignore noexec ${HOME}
+
 noblacklist ${HOME}/.config/kritarc
 noblacklist ${HOME}/.local/share/krita
 noblacklist ${DOCUMENTS}
@@ -19,6 +22,7 @@ noblacklist /usr/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -45,7 +49,3 @@ shell none
 private-cache
 private-dev
 private-tmp
-
-# noexec ${HOME} may break krita, see issue #1953
-# noexec ${HOME}
-noexec /tmp

--- a/etc/kwrite.profile
+++ b/etc/kwrite.profile
@@ -17,6 +17,7 @@ noblacklist ${DOCUMENTS}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -47,7 +48,5 @@ private-dev
 private-etc alternatives,fonts,kde4rc,kde5rc,ld.so.cache,machine-id,pulse,xdg
 private-tmp
 
-noexec ${HOME}
-noexec /tmp
 
 join-or-start kwrite

--- a/etc/libreoffice.profile
+++ b/etc/libreoffice.profile
@@ -19,6 +19,7 @@ noblacklist /usr/share/java
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
 
@@ -49,7 +50,5 @@ tracelog
 private-dev
 private-tmp
 
-noexec ${HOME}
-noexec /tmp
 
 join-or-start libreoffice

--- a/etc/masterpdfeditor.profile
+++ b/etc/masterpdfeditor.profile
@@ -11,6 +11,7 @@ noblacklist ${HOME}/.masterpdfeditor
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -41,5 +42,3 @@ private-dev
 private-etc alternatives,fonts
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/mediainfo.profile
+++ b/etc/mediainfo.profile
@@ -10,6 +10,7 @@ blacklist /tmp/.X11-unix
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -41,5 +42,3 @@ private-etc alternatives
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/meld.profile
+++ b/etc/meld.profile
@@ -10,6 +10,7 @@ noblacklist ${HOME}/.local/share/meld
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
 
@@ -37,5 +38,3 @@ private-cache
 private-dev
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/mpsyt.profile
+++ b/etc/mpsyt.profile
@@ -24,6 +24,7 @@ noblacklist ${VIDEOS}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -57,5 +58,3 @@ private-bin mpsyt,mplayer,mpv,youtube-dl,python*,env,ffmpeg
 private-dev
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/mpv.profile
+++ b/etc/mpv.profile
@@ -21,6 +21,7 @@ noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc

--- a/etc/mypaint.profile
+++ b/etc/mypaint.profile
@@ -15,6 +15,7 @@ noblacklist ${PICTURES}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -44,5 +45,3 @@ private-dev
 private-etc alternatives,fonts,gtk-3.0,dconf
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/nano.profile
+++ b/etc/nano.profile
@@ -11,6 +11,7 @@ noblacklist ${HOME}/.nanorc
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -43,5 +44,3 @@ private-dev
 private-etc alternatives,nanorc
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/netactview.profile
+++ b/etc/netactview.profile
@@ -10,6 +10,7 @@ noblacklist ${HOME}/.netactview
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -47,5 +48,3 @@ private-lib
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/ocenaudio.profile
+++ b/etc/ocenaudio.profile
@@ -12,6 +12,7 @@ noblacklist ${MUSIC}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -47,5 +48,3 @@ private-etc alternatives,asound.conf,fonts,ld.so.cache,pulse
 private-tmp
 
 # memory-deny-write-execute - breaks on Arch
-noexec ${HOME}
-noexec /tmp

--- a/etc/okular.profile
+++ b/etc/okular.profile
@@ -20,6 +20,7 @@ noblacklist ${DOCUMENTS}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -52,7 +53,5 @@ private-etc alternatives,cups,fonts,kde4rc,kde5rc,ld.so.cache,machine-id,xdg
 # private-tmp - on KDE we need access to the real /tmp for data exchange with email clients
 
 # memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp
 
 join-or-start okular

--- a/etc/openshot.profile
+++ b/etc/openshot.profile
@@ -17,6 +17,7 @@ noblacklist /usr/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -40,5 +41,3 @@ shell none
 private-dev
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/pavucontrol.profile
+++ b/etc/pavucontrol.profile
@@ -10,6 +10,7 @@ noblacklist ${HOME}/.config/pavucontrol.ini
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -43,5 +44,3 @@ private-lib
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/pluma.profile
+++ b/etc/pluma.profile
@@ -10,6 +10,7 @@ noblacklist ${HOME}/.config/pluma
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -42,7 +43,5 @@ private-lib pluma
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp
 
 join-or-start pluma

--- a/etc/qbittorrent.profile
+++ b/etc/qbittorrent.profile
@@ -19,6 +19,7 @@ noblacklist /usr/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -59,5 +60,3 @@ private-dev
 private-tmp
 
 # memory-deny-write-execute - problems on  Arch, see #1690 on GitHub repo
-noexec ${HOME}
-noexec /tmp

--- a/etc/redshift.profile
+++ b/etc/redshift.profile
@@ -12,6 +12,7 @@ noblacklist ${HOME}/.config/redshift.conf
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-passwdmgr.inc
 include disable-interpreters.inc
 include disable-programs.inc
@@ -45,5 +46,3 @@ private-dev
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/regextester.profile
+++ b/etc/regextester.profile
@@ -8,6 +8,7 @@ include globals.local
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-passwdmgr.inc
 include disable-interpreters.inc
 include disable-programs.inc
@@ -45,8 +46,6 @@ private-lib libgranite.so.*
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp
 
 # never write anything
 read-only ${HOME}

--- a/etc/rhythmbox.profile
+++ b/etc/rhythmbox.profile
@@ -12,6 +12,7 @@ noblacklist ${HOME}/.local/share/rhythmbox
 include disable-common.inc
 include disable-devel.inc
 # rhythmbox is using Python
+include disable-exec.inc
 #include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -39,5 +40,3 @@ private-bin rhythmbox
 private-dev
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/seahorse-tool.profile
+++ b/etc/seahorse-tool.profile
@@ -11,6 +11,7 @@ include seahorse-tool.local
 mkdir ${HOME}/.config/dconf
 whitelist ${HOME}/.config/dconf
 
+include disable-exec.inc
 include disable-xdg.inc
 include whitelist-var-common.inc
 
@@ -21,8 +22,6 @@ disable-mnt
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp
 
 # Redirect
 include gpg.profile

--- a/etc/seahorse.profile
+++ b/etc/seahorse.profile
@@ -16,6 +16,7 @@ noblacklist /etc/ssh
 noblacklist /tmp/ssh-*
 noblacklist ${HOME}/.ssh
 
+include disable-exec.inc
 include whitelist-var-common.inc
 
 apparmor

--- a/etc/simplescreenrecorder.profile
+++ b/etc/simplescreenrecorder.profile
@@ -10,6 +10,7 @@ noblacklist ${VIDEOS}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -34,5 +35,3 @@ private-dev
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/smplayer.profile
+++ b/etc/smplayer.profile
@@ -13,6 +13,7 @@ noblacklist ${VIDEOS}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -36,5 +37,3 @@ private-bin smplayer,smtube,mplayer,mpv
 private-dev
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/soundconverter.profile
+++ b/etc/soundconverter.profile
@@ -16,6 +16,7 @@ noblacklist /usr/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -44,5 +45,3 @@ private-cache
 private-dev
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/sqlitebrowser.profile
+++ b/etc/sqlitebrowser.profile
@@ -11,6 +11,7 @@ noblacklist ${DOCUMENTS}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -42,5 +43,3 @@ private-etc alternatives,ca-certificates,crypto-policies,fonts,group,machine-id,
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/standardnotes-desktop.profile
+++ b/etc/standardnotes-desktop.profile
@@ -10,6 +10,7 @@ noblacklist ${HOME}/.config/Standard Notes
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -40,5 +41,3 @@ private-dev
 private-tmp
 private-etc alternatives,ca-certificates,fonts,host.conf,hostname,hosts,resolv.conf,ssl,pki,crypto-policies,xdg
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/subdownloader.profile
+++ b/etc/subdownloader.profile
@@ -17,6 +17,7 @@ noblacklist /usr/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -42,5 +43,3 @@ private-etc alternatives,fonts
 private-tmp
 
 # memory-deny-write-execute - Breaks on Arch
-noexec ${HOME}
-noexec /tmp

--- a/etc/supertuxkart.profile
+++ b/etc/supertuxkart.profile
@@ -12,6 +12,7 @@ noblacklist ${HOME}/.local/share/supertuxkart
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-xdg.inc
@@ -51,5 +52,3 @@ private-tmp
 private-opt none
 private-srv none
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/sysprof.profile
+++ b/etc/sysprof.profile
@@ -8,6 +8,7 @@ include globals.local
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -43,5 +44,3 @@ private-etc alternatives,fonts,ld.so.cache,machine-id,ssl
 private-tmp
 
 # memory-deny-write-execute - Breaks GUI on Arch
-noexec ${HOME}
-noexec /tmp

--- a/etc/totem.profile
+++ b/etc/totem.profile
@@ -13,6 +13,7 @@ noblacklist ${VIDEOS}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -39,5 +40,3 @@ private-dev
 # private-etc alternatives,fonts,machine-id,pulse,asound.conf,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/transgui.profile
+++ b/etc/transgui.profile
@@ -10,6 +10,7 @@ noblacklist ${HOME}/.config/transgui
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -48,5 +49,3 @@ private-lib libgdk_pixbuf-2.0.so.*,libGeoIP.so*,libgthread-2.0.so.*,libgtk-x11-2
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/transmission-cli.profile
+++ b/etc/transmission-cli.profile
@@ -12,6 +12,7 @@ noblacklist ${HOME}/.config/transmission
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -40,5 +41,3 @@ private-lib
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/transmission-daemon.profile
+++ b/etc/transmission-daemon.profile
@@ -12,6 +12,7 @@ noblacklist ${HOME}/.config/transmission
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -41,5 +42,3 @@ private-lib
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/transmission-gtk.profile
+++ b/etc/transmission-gtk.profile
@@ -11,6 +11,7 @@ noblacklist ${HOME}/.config/transmission
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -47,5 +48,3 @@ private-tmp
 
 # Causes freeze during opening file dialog in Archlinux, see issue #1855
 # memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/transmission-qt.profile
+++ b/etc/transmission-qt.profile
@@ -11,6 +11,7 @@ noblacklist ${HOME}/.config/transmission
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -46,5 +47,3 @@ private-dev
 private-tmp
 
 # memory-deny-write-execute - problems on Qt 5.10.0, KDE Frameworks 5.41.0
-noexec ${HOME}
-noexec /tmp

--- a/etc/transmission-remote.profile
+++ b/etc/transmission-remote.profile
@@ -12,6 +12,7 @@ noblacklist ${HOME}/.config/transmission
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -40,5 +41,3 @@ private-lib
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/transmission-show.profile
+++ b/etc/transmission-show.profile
@@ -11,6 +11,7 @@ noblacklist ${HOME}/.config/transmission
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -38,5 +39,3 @@ private-lib
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/viewnior.profile
+++ b/etc/viewnior.profile
@@ -14,6 +14,7 @@ noblacklist ${HOME}/.steam
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -45,5 +46,3 @@ private-tmp
 
 # memory-deny-write-executes breaks on Arch - see issue #1808
 #memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/vlc.profile
+++ b/etc/vlc.profile
@@ -14,6 +14,7 @@ noblacklist ${VIDEOS}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -39,5 +40,3 @@ private-tmp
 
 # mdwe is disabled due to breaking hardware accelerated decoding
 #memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/wireshark.profile
+++ b/etc/wireshark.profile
@@ -18,6 +18,7 @@ noblacklist /usr/share/lua
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -48,5 +49,3 @@ private-dev
 # private-etc alternatives,fonts,group,hosts,machine-id,passwd,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/xed.profile
+++ b/etc/xed.profile
@@ -15,6 +15,7 @@ noblacklist /usr/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -47,5 +48,3 @@ private-tmp
 
 # xed uses python plugins, memory-deny-write-execute breaks python
 # memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/xfce4-mixer.profile
+++ b/etc/xfce4-mixer.profile
@@ -10,6 +10,7 @@ noblacklist ${HOME}/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-mixer.xml
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -45,5 +46,3 @@ private-etc alternatives,asound.conf,fonts,pulse,machine-id
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/xplayer.profile
+++ b/etc/xplayer.profile
@@ -18,6 +18,7 @@ noblacklist /usr/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -43,5 +44,3 @@ private-dev
 # private-etc alternatives,fonts,machine-id,pulse,asound.conf,ca-certificates,ssl,pki,crypto-policies
 private-tmp
 
-noexec ${HOME}
-noexec /tmp

--- a/etc/xreader.profile
+++ b/etc/xreader.profile
@@ -12,6 +12,7 @@ noblacklist ${DOCUMENTS}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -42,5 +43,3 @@ private-etc alternatives,fonts,ld.so.cache
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/xviewer.profile
+++ b/etc/xviewer.profile
@@ -12,6 +12,7 @@ noblacklist ${HOME}/.steam
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -43,5 +44,3 @@ private-lib
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp


### PR DESCRIPTION
As discussed in #2385 and #2505. These restrictions already exist in the firejail-default `apparmor` policy, so there should be no regressions (only uncovered bugs).