### PR TITLE
exiftool needs access to the /usr/bin/vendor_perl directory in archlinux

### DIFF
--- a/etc/exiftool.profile
+++ b/etc/exiftool.profile
@@ -40,6 +40,8 @@ seccomp
 shell none
 tracelog
 
+# To support exiftool in private-bin on Arch Linux (and derivatives), symlink /usr/bin/vendor_perl/exiftool to /usr/bin/exiftool and uncomment the below.
+# Users on non-Arch Linux distributions can safely uncomment the below to enable extra hardening.
 #private-bin exiftool,perl
 private-cache
 private-dev

--- a/etc/exiftool.profile
+++ b/etc/exiftool.profile
@@ -40,7 +40,7 @@ seccomp
 shell none
 tracelog
 
-private-bin exiftool,perl
+#private-bin exiftool,perl
 private-cache
 private-dev
 private-etc alternatives


### PR DESCRIPTION
i couldn't get private-bin to work with directories, if there is a way, that'd be preferred over commenting out private-bin completely.