### PR TITLE
Avoid including globals.local twice

### DIFF
--- a/etc/acat.profile
+++ b/etc/acat.profile
@@ -3,7 +3,8 @@
 # Persistent local customizations
 include acat.local
 # Persistent global definitions
-include globals.local
+# added by included profile
+#include globals.local
 
 # Redirect
 include atool.profile

--- a/etc/adiff.profile
+++ b/etc/adiff.profile
@@ -3,7 +3,8 @@
 # Persistent local customizations
 include adiff.local
 # Persistent global definitions
-include globals.local
+# added by included profile
+#include globals.local
 
 # Redirect
 include atool.profile

--- a/etc/als.profile
+++ b/etc/als.profile
@@ -3,7 +3,8 @@
 # Persistent local customizations
 include als.local
 # Persistent global definitions
-include globals.local
+# added by included profile
+#include globals.local
 
 # Redirect
 include atool.profile

--- a/etc/apack.profile
+++ b/etc/apack.profile
@@ -3,7 +3,8 @@
 # Persistent local customizations
 include apack.local
 # Persistent global definitions
-include globals.local
+# added by included profile
+#include globals.local
 
 # Redirect
 include atool.profile

--- a/etc/arepack.profile
+++ b/etc/arepack.profile
@@ -3,7 +3,8 @@
 # Persistent local customizations
 include arepack.local
 # Persistent global definitions
-include globals.local
+# added by included profile
+#include globals.local
 
 # Redirect
 include atool.profile

--- a/etc/aunpack.profile
+++ b/etc/aunpack.profile
@@ -3,7 +3,8 @@
 # Persistent local customizations
 include aunpack.local
 # Persistent global definitions
-include globals.local
+# added by included profile
+#include globals.local
 
 # Redirect
 include atool.profile

--- a/etc/bunzip2.profile
+++ b/etc/bunzip2.profile
@@ -3,7 +3,8 @@
 # Persistent local customizations
 include bunzip2.local
 # Persistent global definitions
-include globals.local
+# added by included profile
+#include globals.local
 
 # Redirect
 include gzip.profile

--- a/etc/gunzip.profile
+++ b/etc/gunzip.profile
@@ -3,7 +3,8 @@
 # Persistent local customizations
 include gunzip.local
 # Persistent global definitions
-include globals.local
+# added by included profile
+#include globals.local
 
 # Redirect
 include gzip.profile

--- a/etc/gzip.profile
+++ b/etc/gzip.profile
@@ -5,8 +5,7 @@ quiet
 # Persistent local customizations
 include gzip.local
 # Persistent global definitions
-# added by included profile
-#include globals.local
+include globals.local
 
 blacklist /tmp/.X11-unix
 


### PR DESCRIPTION
This is similar to what happened for https://github.com/netblue30/firejail/issues/2006 and extended in https://github.com/netblue30/firejail/pull/2010. All current profiles checked and fixed as of this PR.