### PR TITLE
Fix incorrect parsing of --keep-var-tmp command

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1626,7 +1626,7 @@ int main(int argc, char **argv) {
 		else if (strcmp(argv[i], "--writable-var") == 0) {
 			arg_writable_var = 1;
 		}
-		else if (strcmp(argv[1], "--keep-var-tmp") == 0) {
+		else if (strcmp(argv[i], "--keep-var-tmp") == 0) {
 		        arg_keep_var_tmp = 1;
 		}
 		else if (strcmp(argv[i], "--writable-run-user") == 0) {


### PR DESCRIPTION
The command was only recognized if it was passed as the first argument.
Passing it on any other position on the command line caused the following
error:

    Error: invalid --keep-var-tmp command line option

Supplying it as the first argument also resulted in other commands that are
parsed after it to be silently ignored.