### PR TITLE
Streamline 'Allow python' options

### DIFF
--- a/etc/arm.profile
+++ b/etc/arm.profile
@@ -13,6 +13,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/authenticator.profile
+++ b/etc/authenticator.profile
@@ -8,9 +8,13 @@ include globals.local
 
 noblacklist ${HOME}/.config/Authenticator
 
-# Allow python 3.x (blacklisted by disable-interpreters.inc)
+# Allow python (blacklisted by disable-interpreters.inc)
+#noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
+#noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+#noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/bleachbit.profile
+++ b/etc/bleachbit.profile
@@ -11,6 +11,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/blender.profile
+++ b/etc/blender.profile
@@ -13,6 +13,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/caja.profile
+++ b/etc/caja.profile
@@ -18,6 +18,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/catfish.profile
+++ b/etc/catfish.profile
@@ -16,6 +16,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 # include disable-devel.inc

--- a/etc/cherrytree.profile
+++ b/etc/cherrytree.profile
@@ -14,6 +14,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/d-feet.profile
+++ b/etc/d-feet.profile
@@ -13,6 +13,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/deluge.profile
+++ b/etc/deluge.profile
@@ -13,6 +13,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 # include disable-devel.inc

--- a/etc/display.profile
+++ b/etc/display.profile
@@ -12,6 +12,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/electrum.profile
+++ b/etc/electrum.profile
@@ -13,6 +13,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/exfalso.profile
+++ b/etc/exfalso.profile
@@ -14,6 +14,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/filezilla.profile
+++ b/etc/filezilla.profile
@@ -14,6 +14,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/flowblade.profile
+++ b/etc/flowblade.profile
@@ -14,6 +14,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/font-manager.profile
+++ b/etc/font-manager.profile
@@ -14,6 +14,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/fontforge.profile
+++ b/etc/fontforge.profile
@@ -14,6 +14,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/gajim.profile
+++ b/etc/gajim.profile
@@ -10,10 +10,13 @@ noblacklist ${HOME}/.cache/gajim
 noblacklist ${HOME}/.config/gajim
 noblacklist ${HOME}/.local/share/gajim
 
-# Allow Python (blacklisted by disable-interpreters.inc)
+# Allow python (blacklisted by disable-interpreters.inc)
+#noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
+#noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
-noblacklist /usr/lib64/python3*
+#noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/gconf.profile
+++ b/etc/gconf.profile
@@ -8,11 +8,13 @@ include globals.local
 
 noblacklist ${HOME}/.config/gconf
 
-# Allow python2 (blacklisted by disable-interpreters.inc)
+# Allow python (blacklisted by disable-interpreters.inc)
 noblacklist ${PATH}/python2*
 #noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 #noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+#noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/gnome-music.profile
+++ b/etc/gnome-music.profile
@@ -14,6 +14,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/gnome-schedule.profile
+++ b/etc/gnome-schedule.profile
@@ -35,11 +35,13 @@ noblacklist ${PATH}/urxvtcd
 noblacklist ${PATH}/xfce4-terminal
 noblacklist ${PATH}/xfce4-terminal.wrapper
 
-# Allow python (disabled by disable-interpreters.inc)
+# Allow python (blacklisted by disable-interpreters.inc)
 noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/hexchat.profile
+++ b/etc/hexchat.profile
@@ -14,6 +14,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/inkscape.profile
+++ b/etc/inkscape.profile
@@ -17,6 +17,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/kodi.profile
+++ b/etc/kodi.profile
@@ -19,6 +19,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/krita.profile
+++ b/etc/krita.profile
@@ -19,6 +19,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/liferea.profile
+++ b/etc/liferea.profile
@@ -15,6 +15,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/lollypop.profile
+++ b/etc/lollypop.profile
@@ -14,6 +14,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/macrofusion.profile
+++ b/etc/macrofusion.profile
@@ -13,6 +13,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/mendeleydesktop.profile
+++ b/etc/mendeleydesktop.profile
@@ -19,6 +19,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/mpDris2.profile
+++ b/etc/mpDris2.profile
@@ -13,6 +13,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/ms-office.profile
+++ b/etc/ms-office.profile
@@ -13,6 +13,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/natron.profile
+++ b/etc/natron.profile
@@ -5,11 +5,13 @@ include natron.local
 # Persistent global definitions
 include globals.local
 
-# Allow access to python
+# Allow python (blacklisted by disable-interpreters.inc)
 noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 noblacklist ${HOME}/.Natron
 noblacklist ${HOME}/.cache/INRIA/Natron

--- a/etc/nautilus.profile
+++ b/etc/nautilus.profile
@@ -19,6 +19,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/nemo.profile
+++ b/etc/nemo.profile
@@ -16,6 +16,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/nitroshare.profile
+++ b/etc/nitroshare.profile
@@ -14,6 +14,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/obs.profile
+++ b/etc/obs.profile
@@ -15,6 +15,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/onionshare-gui.profile
+++ b/etc/onionshare-gui.profile
@@ -10,6 +10,7 @@ noblacklist ${HOME}/.config/onionshare
 # Allow python (blacklisted by disable-interpreters.inc)
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/openshot.profile
+++ b/etc/openshot.profile
@@ -14,6 +14,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/picard.profile
+++ b/etc/picard.profile
@@ -15,6 +15,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/pithos.profile
+++ b/etc/pithos.profile
@@ -11,6 +11,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/pitivi.profile
+++ b/etc/pitivi.profile
@@ -14,6 +14,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/playonlinux.profile
+++ b/etc/playonlinux.profile
@@ -20,6 +20,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 # Allow perl (blacklisted by disable-interpreters.inc)
 noblacklist ${PATH}/cpan*

--- a/etc/pybitmessage.profile
+++ b/etc/pybitmessage.profile
@@ -14,6 +14,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/qbittorrent.profile
+++ b/etc/qbittorrent.profile
@@ -16,6 +16,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/qutebrowser.profile
+++ b/etc/qutebrowser.profile
@@ -15,6 +15,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 # with >=llvm-4 mesa drivers need llvm stuff
 noblacklist /usr/lib/llvm*

--- a/etc/ranger.profile
+++ b/etc/ranger.profile
@@ -15,6 +15,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 # Allow perl
 # noblacklist ${PATH}/cpan*

--- a/etc/scribus.profile
+++ b/etc/scribus.profile
@@ -31,6 +31,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/sdat2img.profile
+++ b/etc/sdat2img.profile
@@ -11,6 +11,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/soundconverter.profile
+++ b/etc/soundconverter.profile
@@ -13,6 +13,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/steam.profile
+++ b/etc/steam.profile
@@ -36,6 +36,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/subdownloader.profile
+++ b/etc/subdownloader.profile
@@ -14,6 +14,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/torbrowser-launcher.profile
+++ b/etc/torbrowser-launcher.profile
@@ -16,6 +16,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/transmission-remote-cli.profile
+++ b/etc/transmission-remote-cli.profile
@@ -7,11 +7,13 @@ include transmission-remote-cli.local
 # added by included profile
 #include globals.local
 
-# Allow python (disabled by disable-interpreters.inc)
+# Allow python (blacklisted by disable-interpreters.inc)
 noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 mkdir ${HOME}/.cache/transmission
 mkdir ${HOME}/.config/transmission

--- a/etc/uzbl-browser.profile
+++ b/etc/uzbl-browser.profile
@@ -14,6 +14,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/xed.profile
+++ b/etc/xed.profile
@@ -12,6 +12,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/xplayer.profile
+++ b/etc/xplayer.profile
@@ -15,6 +15,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/xpra.profile
+++ b/etc/xpra.profile
@@ -21,6 +21,8 @@ noblacklist ${PATH}/python2*
 noblacklist ${PATH}/python3*
 noblacklist /usr/lib/python2*
 noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
 
 include disable-common.inc
 include disable-devel.inc


### PR DESCRIPTION
Several profiles were missing the `noblacklist /usr/local/lib/python2*` and `noblacklist /usr/local/lib/python3*` options. Existing logic is kept intact for profiles that only use python2* or python3* options.