### PR TITLE
Fix seahorse.profile seahorse-tool.profile

### DIFF
--- a/etc/seahorse-tool.profile
+++ b/etc/seahorse-tool.profile
@@ -8,7 +8,6 @@ include seahorse-tool.local
 #include globals.local
 
 # dconf
-mkdir ${HOME}/.config/dconf
 noblacklist ${HOME}/.config/dconf
 
 include disable-exec.inc

--- a/etc/seahorse.profile
+++ b/etc/seahorse.profile
@@ -8,7 +8,6 @@ include seahorse.local
 #include globals.local
 
 # dconf
-mkdir ${HOME}/.config/dconf
 noblacklist ${HOME}/.config/dconf
 
 # ssh


### PR DESCRIPTION
Remove `mkdir` beacause it is not needed anymore since https://github.com/netblue30/firejail/commit/f55071c5f9c349a7bb9af08d2d8d1476341c4bf3.