### PR TITLE
Seahorse revisited

### DIFF
--- a/etc/seahorse-daemon.profile
+++ b/etc/seahorse-daemon.profile
@@ -1,0 +1,13 @@
+# Firejail profile for seahorse-daemon
+# Description: PGP encryption and signing
+# This file is overwritten after every install/update
+# Persistent local customizations
+include seahorse-daemon.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+memory-deny-write-execute
+
+# Redirect
+include seahorse.profile

--- a/etc/seahorse-daemon.profile
+++ b/etc/seahorse-daemon.profile
@@ -7,6 +7,8 @@ include seahorse-daemon.local
 # added by included profile
 #include globals.local
 
+blacklist /tmp/.X11-unix
+
 memory-deny-write-execute
 
 # Redirect

--- a/etc/seahorse-tool.profile
+++ b/etc/seahorse-tool.profile
@@ -7,21 +7,11 @@ include seahorse-tool.local
 # added by included profile
 #include globals.local
 
-# dconf
-mkdir ${HOME}/.config/dconf
-noblacklist ${HOME}/.config/dconf
+noblacklist ${DOWNLOADS}
 
-include disable-exec.inc
-include disable-xdg.inc
-include whitelist-var-common.inc
-
-apparmor
-ipc-namespace
-
-disable-mnt
 private-tmp
 
 memory-deny-write-execute
 
 # Redirect
-include gpg.profile
+include seahorse.profile

--- a/etc/seahorse.profile
+++ b/etc/seahorse.profile
@@ -4,23 +4,60 @@
 # Persistent local customizations
 include seahorse.local
 # Persistent global definitions
-# added by included profile
-#include globals.local
+include globals.local
+
+blacklist /tmp/.X11-unix
 
 # dconf
 mkdir ${HOME}/.config/dconf
 noblacklist ${HOME}/.config/dconf
+whitelist ${HOME}/.config/dconf
+
+# gpg
+mkdir ${HOME}/.gnupg
+noblacklist ${HOME}/.gnupg
+whitelist ${HOME}/.gnupg
 
 # ssh
+whitelist /etc/ld.so.preload
 noblacklist /etc/ssh
+whitelist /etc/ssh
 noblacklist /tmp/ssh-*
+whitelist /tmp/ssh-*
+mkdir ${HOME}/.ssh
 noblacklist ${HOME}/.ssh
+whitelist ${HOME}/.ssh
 
+include disable-common.inc
+include disable-devel.inc
 include disable-exec.inc
+include disable-interpreters.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
+include disable-xdg.inc
+include whitelist-common.inc
 include whitelist-var-common.inc
 
 apparmor
-ipc-namespace
+caps.drop all
+machine-id
+netfilter
+no3d
+nodvd
+nogroups
+nonewprivs
+noroot
+nosound
+notv
+nou2f
+novideo
+protocol unix,inet,inet6
+seccomp
+# shell none - causes gpg to hang
+tracelog
 
-# Redirect
-include gpg.profile
+disable-mnt
+private-cache
+private-dev
+
+writable-run-user

--- a/etc/seahorse.profile
+++ b/etc/seahorse.profile
@@ -6,8 +6,6 @@ include seahorse.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
-
 # dconf
 mkdir ${HOME}/.config/dconf
 noblacklist ${HOME}/.config/dconf

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -432,6 +432,7 @@ scallion
 scribus
 sdat2img
 seahorse
+seahorse-daemon
 seahorse-tool
 seamonkey
 seamonkey-bin


### PR DESCRIPTION
Currently the seahorse{-tool} profiles include gpg.profile, which works fine. IMHO this could be improved upon. This draft attempts to do so by decoupling seahorse{-tool} from the gpg profile and by making seahorse profiles fully whitelist profiles instead.

Comments, opinions, etcetera very welcome.