### PR TITLE
Refactor pidgin as whitelist profile

### DIFF
--- a/etc/pidgin.profile
+++ b/etc/pidgin.profile
@@ -6,14 +6,24 @@ include pidgin.local
 # Persistent global definitions
 include globals.local
 
+mkdir ${HOME}/.purple
 noblacklist ${HOME}/.purple
+whitelist ${HOME}/.purple
+
+ignore noexec ${RUNUSER}
+ignore noexec /dev/shm
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
+include disable-xdg.inc
+include whitelist-common.inc
+include whitelist-var-common.inc
 
+apparmor
 caps.drop all
 netfilter
 nodvd
@@ -24,13 +34,10 @@ notv
 nou2f
 protocol unix,inet,inet6
 seccomp
-shell none
+# shell none
 tracelog
 
-private-bin pidgin
+# private-bin pidgin
 private-cache
 private-dev
 private-tmp
-
-noexec ${HOME}
-noexec /tmp


### PR DESCRIPTION
Whitelist profile for pidgin should be more secure. Also might fix https://github.com/netblue30/firejail/issues/2550.