### PR TITLE
Add warning about nodbus breaking evince two-page-view on some systems

### DIFF
--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -23,7 +23,7 @@ machine-id
 # net none - breaks AppArmor on Ubuntu systems
 netfilter
 no3d
-nodbus
+nodbus # might break two-page-view on some systems
 nodvd
 nogroups
 nonewprivs


### PR DESCRIPTION
See https://github.com/netblue30/firejail/issues/2621