### PR TITLE
private-bin breaks --join for filezilla

### DIFF
--- a/etc/filezilla.profile
+++ b/etc/filezilla.profile
@@ -36,6 +36,7 @@ protocol unix,inet,inet6
 seccomp
 shell none
 
-private-bin filezilla,uname,sh,bash,python*,lsb_release,fzputtygen,fzsftp
+# private-bin breaks --join
+# private-bin filezilla,uname,sh,bash,python*,lsb_release,fzputtygen,fzsftp
 private-dev
 private-tmp


### PR DESCRIPTION
perhaps there's another solution, but this is the only fix i could find for fixing --join.

error i get:
```
Switching to pid 13327, the first child process inside the sandbox
Warning: cleaning all supplementary groups
Child process initialized in 10.86 ms
execvp: No such file or directory
```