### PR TITLE
Fix PostScript file opening in Evince

### DIFF
--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -43,7 +43,7 @@ private-bin evince,evince-previewer,evince-thumbnailer
 private-cache
 private-dev
 private-etc alternatives,fonts,group,machine-id,passwd
-private-lib evince,gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libdjvulibre.so.*,libgconf-2.so.*,libpoppler-glib.so.*,librsvg-2.so.*,gconv
+private-lib evince,gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libdjvulibre.so.*,libgconf-2.so.*,libpoppler-glib.so.*,librsvg-2.so.*,libspectre.so.*,gconv
 private-tmp
 
 # memory-deny-write-execute - might break application (https://github.com/netblue30/firejail/issues/1803)


### PR DESCRIPTION
Evince uses [libspectre](https://www.freedesktop.org/wiki/Software/libspectre/) as its PostScript backend. Without access to this library, PostScript documents fail to open.