### PR TITLE
SMPlayer: Add support for python and youtube-dl

### DIFF
--- a/etc/smplayer.profile
+++ b/etc/smplayer.profile
@@ -11,6 +11,14 @@ noblacklist ${HOME}/.mplayer
 noblacklist ${MUSIC}
 noblacklist ${VIDEOS}
 
+# Allow python (blacklisted by disable-interpreters.inc)
+noblacklist ${PATH}/python2*
+noblacklist ${PATH}/python3*
+noblacklist /usr/lib/python2*
+noblacklist /usr/lib/python3*
+noblacklist /usr/local/lib/python2*
+noblacklist /usr/local/lib/python3*
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
@@ -33,7 +41,7 @@ protocol unix,inet,inet6,netlink
 seccomp
 shell none
 
-private-bin smplayer,smtube,mplayer,mpv
+private-bin smplayer,smtube,mplayer,mpv,youtube-dl,python*,env
 private-dev
 private-tmp
 


### PR DESCRIPTION
This PR adds support for playing videos from streaming sites in SMPlayer, when it is set to use `mpv+youtube-dl` in *Options -> Preferences -> Network -> YouTube (and other sites) -> Support for video sites*.

Profile changes are the same as in #2279 for *gnome-mpv*. Not sure why `env` was needed in `private-bin`, because in my setup it looks not necessary. Perhaps it was needed for other distributions or setups, so I added it just in case.

Tested changes in freshly updated Arch Linux with smplayer 19.1.0-1 and firejail 0.9.60-rc1 (custom built using official PKGBUILD where only version number was changed).