### PR TITLE
Gajim: Allow reading of system-wide Flatpak locale

### DIFF
--- a/etc/gajim.profile
+++ b/etc/gajim.profile
@@ -32,6 +32,7 @@ whitelist ${HOME}/.cache/gajim
 whitelist ${HOME}/.config/gajim
 whitelist ${HOME}/.local/share/gajim
 whitelist ${DOWNLOADS}
+whitelist /var/lib/flatpak/exports/share/locale
 include whitelist-common.inc
 
 caps.drop all


### PR DESCRIPTION
Gajim will not start without being able to read this file, even if it
doesn't exist.