### PR TITLE
Support Enpass v6

### DIFF
--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -100,6 +100,7 @@ blacklist ${HOME}/.config/Rambox
 blacklist ${HOME}/.config/Riot
 blacklist ${HOME}/.config/Rocket.Chat
 blacklist ${HOME}/.config/Signal
+blacklist ${HOME}/.config/Sinew Software Systems
 blacklist ${HOME}/.config/Slack
 blacklist ${HOME}/.config/Standard Notes
 blacklist ${HOME}/.config/SubDownloader
@@ -261,6 +262,7 @@ blacklist ${HOME}/.config/redshift.conf
 blacklist ${HOME}/.config/remmina
 blacklist ${HOME}/.config/ristretto
 blacklist ${HOME}/.config/scribus
+blacklist ${HOME}/.config/sinew.in
 blacklist ${HOME}/.config/skypeforlinux
 blacklist ${HOME}/.config/slimjet
 blacklist ${HOME}/.config/smplayer
@@ -428,6 +430,7 @@ blacklist ${HOME}/.local/share/0ad
 blacklist ${HOME}/.local/share/3909/PapersPlease
 blacklist ${HOME}/.local/share/Anki2
 blacklist ${HOME}/.local/share/Empathy
+blacklist ${HOME}/.local/share/Enpass
 blacklist ${HOME}/.local/share/JetBrains
 blacklist ${HOME}/.local/share/Mendeley Ltd.
 blacklist ${HOME}/.local/share/Mumble
@@ -633,6 +636,7 @@ blacklist ${HOME}/.cache/8pecxstudios
 blacklist ${HOME}/.cache/Authenticator
 blacklist ${HOME}/.cache/Clementine
 blacklist ${HOME}/.cache/Enox
+blacklist ${HOME}/.cache/Enpass
 blacklist ${HOME}/.cache/Franz
 blacklist ${HOME}/.cache/INRIA
 blacklist ${HOME}/.cache/MusicBrainz

--- a/etc/enpass.profile
+++ b/etc/enpass.profile
@@ -12,12 +12,6 @@ noblacklist ${HOME}/.config/Sinew Software Systems
 noblacklist ${HOME}/.local/share/Enpass
 noblacklist ${DOCUMENTS}
 
-whitelist ${HOME}/.cache/Enpass
-whitelist ${HOME}/.config/sinew.in
-whitelist ${HOME}/.config/Sinew Software Systems
-whitelist ${HOME}/.local/share/Enpass
-whitelist ${DOCUMENTS}
-
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
@@ -25,6 +19,12 @@ include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-xdg.inc
+
+whitelist ${HOME}/.cache/Enpass
+whitelist ${HOME}/.config/sinew.in
+whitelist ${HOME}/.config/Sinew Software Systems
+whitelist ${HOME}/.local/share/Enpass
+whitelist ${DOCUMENTS}
 
 include whitelist-var-common.inc
 
@@ -35,6 +35,7 @@ include whitelist-var-common.inc
 caps.drop all
 machine-id
 netfilter
+no3d
 nodvd
 nogroups
 nonewprivs

--- a/etc/enpass.profile
+++ b/etc/enpass.profile
@@ -6,8 +6,17 @@ include enpass.local
 # Persistent global definitions
 include globals.local
 
+noblacklist ${HOME}/.cache/Enpass
+noblacklist ${HOME}/.config/sinew.in
 noblacklist ${HOME}/.config/Sinew Software Systems
+noblacklist ${HOME}/.local/share/Enpass
 noblacklist ${DOCUMENTS}
+
+whitelist ${HOME}/.cache/Enpass
+whitelist ${HOME}/.config/sinew.in
+whitelist ${HOME}/.config/Sinew Software Systems
+whitelist ${HOME}/.local/share/Enpass
+whitelist ${DOCUMENTS}
 
 include disable-common.inc
 include disable-devel.inc
@@ -19,10 +28,13 @@ include disable-xdg.inc
 
 include whitelist-var-common.inc
 
+# machine-id and nosound break audio notification functionality
+# comment both if you need that functionality or put 'ignore machine-id'
+# and 'ignore nosound' in your enpass.local
+
 caps.drop all
 machine-id
-net none
-no3d
+netfilter
 nodvd
 nogroups
 nonewprivs
@@ -31,14 +43,15 @@ nosound
 notv
 nou2f
 novideo
-protocol unix
+protocol unix,inet,inet6,netlink
 seccomp
 shell none
 tracelog
 
-private-bin sh,readlink,dirname
+private-bin dirname,Enpass,importer_enpass,sh,readlink
+?HAS_APPIMAGE: ignore private-dev
 private-dev
 private-opt Enpass
 private-tmp
 
-memory-deny-write-execute
+#memory-deny-write-execute - breaks on Arch


### PR DESCRIPTION
Added support for latest upstream version and refactored enpass.profile as a whitelisting profile.

`Note`: when sandboxing enpass, I couldn't get its companion webextension to work in browsers that already run firejailed. Not sure whether or not this was already the case with Enpass versions pre-dating v6. In all honesty I didn't spend all that much time testing different browsers/extensions as I personally moved to Bitwarden (which has a similar if not larger feature-set, is fully open-source and doesn't suffer from this dysfunctionality). Perhaps someone who actively uses Enpass can confirm all this and add a note to the profile accordingly.