### PR TITLE
Update keepassxc.profile

### DIFF
--- a/etc/keepassxc.profile
+++ b/etc/keepassxc.profile
@@ -41,7 +41,7 @@ protocol netlink,unix
 seccomp
 shell none
 
-private-bin keepassxc
+private-bin keepassxc,keepassxc-proxy
 private-dev
 private-etc alternatives,fonts,ld.so.cache,machine-id
 private-tmp


### PR DESCRIPTION
Adding `keepassxc-proxy` to `private-bin`as without it there is a related error message in Settings->Browser Integration (via the Keepassxc-Browser add-on).