### PR TITLE
nodbus enhancements

### DIFF
--- a/src/firejail/dbus.c
+++ b/src/firejail/dbus.c
@@ -43,6 +43,12 @@ void dbus_session_disable(void) {
 	free(path);
 	free(env_var);
 
+	// blacklist the dbus-launch user directory
+	if (asprintf(&path, "%s/.dbus", cfg.homedir) == -1)
+		errExit("asprintf");
+	disable_file_or_dir(path);
+	free(path);
+
 	// look for a possible abstract unix socket
 
 	// --net=none

--- a/src/firejail/dbus.c
+++ b/src/firejail/dbus.c
@@ -29,7 +29,7 @@ void dbus_session_disable(void) {
 	if (asprintf(&path, "/run/user/%d/bus", getuid()) == -1)
 		errExit("asprintf");
 	char *env_var;
-	if (asprintf(&env_var, "DBUS_SESSION_BUS_ADDRESS=unix:path=%s", path) == -1)
+	if (asprintf(&env_var, "unix:path=%s", path) == -1)
 		errExit("asprintf");
 
 	// set a new environment variable: DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/<UID>/bus


### PR DESCRIPTION
Hi,

This PR adds/changes the following behaviors of `nodbus`:

* blacklist `~/.dbus` by default
* fix the overridden value of `DBUS_SESSION_BUS_ADDRESS`

`~/.dbus` is created by `dbus-launch` and contains an environment file that can be sourced by the shell. It sets the values of `DBUS_SESSION_BUS_ADDRESS` and other DBus-related envvars, so that processes spawned by the shell can communicate with the session bus. Blacklisting it removes one way for firejailed programs to find out about the real address of the session bus (though other ways sadly still remain).

As for the overridden value of `DBUS_SESSION_BUS_ADDRESS`, it contained `DBUS_SESSION_BUS_ADDRESS=` itself at the start, which seemed like a mistake.

Hope this is helpful!