### PR TITLE
Propagate --quiet to children Firejail'ed processes

### DIFF
--- a/src/firejail/env.c
+++ b/src/firejail/env.c
@@ -160,6 +160,11 @@ void env_defaults(void) {
 	// set the window title
 	if (!arg_quiet)
 		printf("\033]0;firejail %s\007", cfg.window_title);
+
+	// pass --quiet as an environment variable, in case the command calls further firejailed commands
+	if (arg_quiet)
+		setenv("FIREJAIL_QUIET", "yes", 1);
+
 	fflush(0);
 }
 

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -907,7 +907,8 @@ int main(int argc, char **argv) {
 
 	// get starting timestamp, process --quiet
 	start_timestamp = getticks();
-	if (check_arg(argc, argv, "--quiet", 1))
+	char *env_quiet = getenv("FIREJAIL_QUIET");
+	if (check_arg(argc, argv, "--quiet", 1) || (env_quiet && strcmp(env_quiet, "yes") == 0))
 		arg_quiet = 1;
 
 	// cleanup at exit
@@ -2421,6 +2422,10 @@ int main(int argc, char **argv) {
 			fmessage("\n** Note: you can use --noprofile to disable %s.profile **\n\n", profile_name);
 	}
 	EUID_ASSERT();
+
+	// pass --quiet as an environment variable, in case the command calls further firejailed commands
+	if (arg_quiet)
+		setenv("FIREJAIL_QUIET", "yes", 1);
 
 	// block X11 sockets
 	if (arg_x11_block)

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -2423,10 +2423,6 @@ int main(int argc, char **argv) {
 	}
 	EUID_ASSERT();
 
-	// pass --quiet as an environment variable, in case the command calls further firejailed commands
-	if (arg_quiet)
-		setenv("FIREJAIL_QUIET", "yes", 1);
-
 	// block X11 sockets
 	if (arg_x11_block)
 		x11_block();


### PR DESCRIPTION
Some Firejailed programs end up calling other programs for which a symlink to Firejail is also set up. When the child Firejailed process detects this, it prints on `stderr` a message along the lines of:

    Warning: an existing sandbox was detected. /usr/bin/foobar will run without any additional sandboxing features

This breaks the behavior of some programs, which actually capture the standard error of their child process and don't expect to see Firejail output there. Examples include:

* Github's [hub](https://github.com/github/hub): breaks when resolving `git` aliases
* tpope's [vim-fugitive](https://github.com/tpope/vim-fugitive): breaks the `fugitive://` URLs built to view e.g. a commit from a blame window

Using `--quiet` (or `quiet` in the profile) for either the parent Firejailed process or its child does not fix the issue: `--quiet` is not propagated from a parent Firejailed process to its children, nor is any profile taken into account when Firejail detects it is running inside another Firejail process and prints the above warning.

This PR attempts to remedy this by having Firejail export the environment variable `FIREJAIL_QUIET` (when running with `--quiet` or `quiet` in the profile), so that any children Firejailed process takes notice and becomes quiet too.

Please feel free to discuss alternative solutions to this issue! :)