### PR TITLE
glibc missing O_PATH definition on CentOS 6

### DIFF
--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -27,7 +27,11 @@
 #include <glob.h>
 #include <dirent.h>
 #include <errno.h>
+
 #include <fcntl.h>
+#ifndef O_PATH
+# define O_PATH 010000000
+#endif
 
 #define MAX_BUF 4096
 #define EMPTY_STRING ("")

--- a/src/firejail/fs_home.c
+++ b/src/firejail/fs_home.c
@@ -22,7 +22,6 @@
 #include <linux/limits.h>
 #include <glob.h>
 #include <dirent.h>
-#include <fcntl.h>
 #include <errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -30,6 +29,11 @@
 #include <unistd.h>
 #include <grp.h>
 //#include <ftw.h>
+
+#include <fcntl.h>
+#ifndef O_PATH
+# define O_PATH 010000000
+#endif
 
 static void skel(const char *homedir, uid_t u, gid_t g) {
 	char *fname;

--- a/src/firejail/fs_whitelist.c
+++ b/src/firejail/fs_whitelist.c
@@ -24,8 +24,12 @@
 #include <fnmatch.h>
 #include <glob.h>
 #include <dirent.h>
-#include <fcntl.h>
 #include <errno.h>
+
+#include <fcntl.h>
+#ifndef O_PATH
+# define O_PATH 010000000
+#endif
 
 // mountinfo functionality test;
 // 1. enable TEST_MOUNTINFO definition

--- a/src/firejail/mountinfo.c
+++ b/src/firejail/mountinfo.c
@@ -19,7 +19,11 @@
 */
 
 #include "firejail.h"
+
 #include <fcntl.h>
+#ifndef O_PATH
+# define O_PATH 010000000
+#endif
 
 #define MAX_BUF 4096
 

--- a/src/firejail/pulseaudio.c
+++ b/src/firejail/pulseaudio.c
@@ -24,7 +24,11 @@
 #include <sys/mount.h>
 #include <dirent.h>
 #include <sys/wait.h>
+
 #include <fcntl.h>
+#ifndef O_PATH
+# define O_PATH 010000000
+#endif
 
 // disable pulseaudio socket
 void pulseaudio_disable(void) {

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -29,7 +29,11 @@
 #include <sys/ioctl.h>
 #include <termios.h>
 #include <sys/wait.h>
+
 #include <fcntl.h>
+#ifndef O_PATH
+# define O_PATH 010000000
+#endif
 
 #define MAX_GROUPS 1024
 #define MAXBUF 4098

--- a/src/firejail/x11.c
+++ b/src/firejail/x11.c
@@ -31,7 +31,11 @@
 #include <sys/wait.h>
 #include <errno.h>
 #include <limits.h>
+
 #include <fcntl.h>
+#ifndef O_PATH
+# define O_PATH 010000000
+#endif
 
 
 // Parse the DISPLAY environment variable and return a display number.


### PR DESCRIPTION
There has been decbe96a48fc21c11349867ff2c1ada7c88a0113 and b65dfff0f3b7ff5a16771ac4eca80d0609cbbf44, but CentOS 6 is an actively maintained distribution, unlike Debian 7.

So I'd propose to bring back the fix.

 #2696