### PR TITLE
Add private-cwd option to control working directory within jail

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -283,6 +283,7 @@ extern int arg_private_srv;	// private srv directory
 extern int arg_private_bin;	// private bin directory
 extern int arg_private_tmp;	// private tmp directory
 extern int arg_private_lib;	// private lib directory
+extern int arg_private_cwd;	// private working directory
 extern int arg_scan;		// arp-scan all interfaces
 extern int arg_whitelist;	// whitelist command
 extern int arg_nosound;	// disable sound
@@ -521,6 +522,8 @@ void fs_private(void);
 void fs_private_homedir(void);
 // check new private home directory (--private= option) - exit if it fails
 void fs_check_private_dir(void);
+// check new private working directory (--private-cwd= option) - exit if it fails
+void fs_check_private_cwd(void);
 void fs_private_home_list(void);
 
 

--- a/src/firejail/fs_home.c
+++ b/src/firejail/fs_home.c
@@ -370,6 +370,21 @@ void fs_check_private_dir(void) {
 	}
 }
 
+// check new private working directory (--private-cwd= option) - exit if it fails
+void fs_check_private_cwd(void) {
+	EUID_ASSERT();
+	invalid_filename(cfg.cwd, 0); // no globbing
+
+	// Expand the working directory
+	cfg.cwd = expand_macros(cfg.cwd);
+
+	// realpath/is_dir not used because path may not exist outside of jail
+	if (!cfg.cwd) {
+		fprintf(stderr, "Error: invalid private working directory\n");
+		exit(1);
+	}
+}
+
 //***********************************************************************************
 // --private-home
 //***********************************************************************************

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -92,6 +92,7 @@ int arg_private_srv = 0;			// private srv directory
 int arg_private_bin = 0;			// private bin directory
 int arg_private_tmp = 0;			// private tmp directory
 int arg_private_lib = 0;			// private lib directory
+int arg_private_cwd = 0;			// private working directory
 int arg_scan = 0;				// arp-scan all interfaces
 int arg_whitelist = 0;				// whitelist command
 int arg_nosound = 0;				// disable sound
@@ -1772,6 +1773,20 @@ int main(int argc, char **argv) {
 				arg_private_cache = 1;
 			else
 				exit_err_feature("private-cache");
+		}
+		else if (strcmp(argv[i], "--private-cwd") == 0) {
+			cfg.cwd = NULL;
+			arg_private_cwd = 1;
+		}
+		else if (strncmp(argv[i], "--private-cwd=", 14) == 0) {
+			cfg.cwd = argv[i] + 14;
+			if (*cfg.cwd == '\0') {
+				fprintf(stderr, "Error: invalid private-cwd option\n");
+				exit(1);
+			}
+
+			fs_check_private_cwd();
+			arg_private_cwd = 1;
 		}
 
 		//*************************************

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -338,7 +338,7 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		arg_private = 1;
 		return 0;
 	}
-	if (strncmp(ptr, "private-home ", 13) == 0) {
+	else if (strncmp(ptr, "private-home ", 13) == 0) {
 #ifdef HAVE_PRIVATE_HOME
 		if (checkcfg(CFG_PRIVATE_HOME)) {
 			if (cfg.home_private_keep) {
@@ -351,6 +351,18 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		else
 			warning_feature_disabled("private-home");
 #endif
+		return 0;
+	}
+	else if (strcmp(ptr, "private-cwd") == 0) {
+		cfg.cwd = NULL;
+		arg_private_cwd = 1;
+		return 0;
+	}
+	else if (strncmp(ptr, "private-cwd ", 12) == 0) {
+		cfg.cwd = strdup(ptr + 12);
+
+		fs_check_private_cwd();
+		arg_private_cwd = 1;
 		return 0;
 	}
 	else if (strcmp(ptr, "allusers") == 0) {

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -1016,6 +1016,10 @@ int sandbox(void* sandbox_arg) {
 	if (cfg.cwd) {
 		if (chdir(cfg.cwd) == 0)
 			cwd = 1;
+		else if (arg_private_cwd) {
+			fprintf(stderr, "Error: unabled to enter private working directory: %s: %s\n", cfg.cwd, strerror(errno));
+			exit(1);
+		}
 	}
 
 	if (!cwd) {

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -162,6 +162,8 @@ static char *usage_str =
 	"    --private-etc=file,directory - build a new /etc in a temporary\n"
 	"\tfilesystem, and copy the files and directories in the list.\n"
 	"    --private-tmp - mount a tmpfs on top of /tmp directory.\n"
+	"    --private-cwd - do not inherit working directory inside jail.\n"
+	"    --private-cwd=directory - set working directory inside jail.\n"
 	"    --private-opt=file,directory - build a new /opt in a temporary filesystem.\n"
 	"    --private-srv=file,directory - build a new /srv in a temporary filesystem.\n"
 	"    --profile=filename|profile_name - use a custom profile.\n"

--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -288,6 +288,12 @@ All modifications are discarded when the sandbox is closed.
 \fBprivate-tmp
 Mount an empty temporary filesystem on top of /tmp directory whitelisting /tmp/.X11-unix.
 .TP
+\fBprivate-cwd
+Set working directory inside jail to the home directory, and failing that, the root directory.
+.TP
+\fBprivate-cwd directory
+Set working directory inside the jail.
+.TP
 \fBread-only file_or_directory
 Make directory or file read-only.
 .TP

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -1568,6 +1568,48 @@ drwx------  2 nobody nogroup 4096 Apr 30 10:52 pulse-PKdhtXMmr18n
 drwxrwxrwt  2 nobody nogroup 4096 Apr 30 10:52 .X11-unix
 .br
 
+.TP
+\fB\-\-private-cwd
+Set working directory inside jail to the home directory, and failing that, the root directory.
+.br
+Does not impact working directory of profile include paths.
+.br
+
+.br
+Example:
+.br
+$ pwd
+.br
+/tmp
+.br
+$ firejail \-\-private-cwd
+.br
+$ pwd
+.br
+/home/user
+.br
+
+.TP
+\fB\-\-private-cwd=directory
+Set working directory inside the jail.
+.br
+Does not impact working directory of profile include paths.
+.br
+
+.br
+Example:
+.br
+$ pwd
+.br
+/tmp
+.br
+$ firejail \-\-private-cwd=/opt
+.br
+$ pwd
+.br
+/opt
+.br
+
 
 .TP
 \fB\-\-profile=filename_or_profilename

--- a/test/fs/fs.sh
+++ b/test/fs/fs.sh
@@ -69,6 +69,9 @@ echo "TESTING: empty private-etc (test/fs/private-etc-empty.exp)"
 echo "TESTING: private-bin (test/fs/private-bin.exp)"
 ./private-bin.exp
 
+echo "TESTING: private-cwd (test/fs/private-cwd.exp)"
+./private-cwd.exp
+
 echo "TESTING: macros (test/fs/macro.exp)"
 ./macro.exp
 

--- a/test/fs/private-cwd.exp
+++ b/test/fs/private-cwd.exp
@@ -1,0 +1,52 @@
+#!/usr/bin/expect -f
+# This file is part of Firejail project
+# Copyright (C) 2014-2019 Firejail Authors
+# License GPL v2
+
+set timeout 10
+spawn $env(SHELL)
+match_max 100000
+
+send -- "cd /tmp\r"
+after 100
+
+# testing profile and private
+send -- "firejail --private-cwd\r"
+expect {
+	timeout {puts "TESTING ERROR 0\n";exit}
+	"Child process initialized"
+}
+sleep 1
+
+send -- "pwd\r"
+expect {
+	timeout {puts "TESTING ERROR 1\n";exit}
+	"$env(HOME)"
+}
+after 100
+
+send -- "exit\r"
+sleep 1
+
+send -- "cd /\r"
+after 100
+
+# testing profile and private
+send -- "firejail --private-cwd=/tmp\r"
+expect {
+	timeout {puts "TESTING ERROR 3\n";exit}
+	"Child process initialized"
+}
+sleep 1
+
+send -- "pwd\r"
+expect {
+	timeout {puts "TESTING ERROR 4\n";exit}
+	"/tmp"
+}
+after 100
+
+send -- "exit\r"
+sleep 1
+
+puts "all done\n"


### PR DESCRIPTION
Main motivating use case for this patch is within [compiler-explorer](https://github.com/mattgodbolt/compiler-explorer).

We want to use relative paths in profile include statements, which requires a specific working directory when launching firejail.

However, we also need to ensure the application *within* firejail runs in another working directory.

`--private-cwd` causes the jail to change to the users home directory
`--private-cwd=/path` causes the jail to change to the specified directory once inside the filesystem namespace of the jail