### PR TITLE
Re-add 'shell none' to gpg.profile

### DIFF
--- a/etc/gpg.profile
+++ b/etc/gpg.profile
@@ -29,8 +29,7 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-# Causes gpg to hang
-#shell none
+shell none
 tracelog
 
 # private-bin gpg,gpg-agent

--- a/etc/seahorse.profile
+++ b/etc/seahorse.profile
@@ -50,7 +50,7 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-# shell none - causes gpg to hang
+shell none
 tracelog
 
 disable-mnt


### PR DESCRIPTION
The 'shell none' option is no longer causing hangs. Although I can't find the exact PR right now, I'm quite sure something recent solved this. The corresponding comment in seahorse.profile also becomes obsolete.