### PR TITLE
improve/add support for arbitrary home directories

### DIFF
--- a/etc/firejail.config
+++ b/etc/firejail.config
@@ -2,6 +2,9 @@
 # keyword-argument pairs, one per line. Most features are enabled by default.
 # Use 'yes' or 'no' as configuration values.
 
+# Allow symbolic links in the path of user home directories, default disabled.
+# homedir-symlink no
+
 # Enable AppArmor functionality, default enabled.
 # apparmor yes
 

--- a/src/firejail/checkcfg.c
+++ b/src/firejail/checkcfg.c
@@ -50,6 +50,7 @@ int checkcfg(int val) {
 		cfg_val[CFG_DISABLE_MNT] = 0;
 		cfg_val[CFG_ARP_PROBES] = DEFAULT_ARP_PROBES;
 		cfg_val[CFG_XPRA_ATTACH] = 0;
+		cfg_val[CFG_HOMEDIR_SYMLINK] = 0;
 
 		// open configuration file
 		const char *fname = SYSCONFDIR "/firejail.config";
@@ -112,6 +113,7 @@ int checkcfg(int val) {
 			PARSE_YESNO(CFG_XPRA_ATTACH, "xpra-attach")
 			PARSE_YESNO(CFG_BROWSER_DISABLE_U2F, "browser-disable-u2f")
 			PARSE_YESNO(CFG_BROWSER_ALLOW_DRM, "browser-allow-drm")
+			PARSE_YESNO(CFG_HOMEDIR_SYMLINK, "homedir-symlink")
 #undef PARSE_YESNO
 
 			// netfilter

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -713,6 +713,7 @@ enum {
 	CFG_PRIVATE_CACHE,
 	CFG_CGROUP,
 	CFG_NAME_CHANGE,
+	CFG_HOMEDIR_SYMLINK,
 	CFG_MAX // this should always be the last entry
 };
 extern char *xephyr_screen;

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -456,7 +456,6 @@ int is_link(const char *fname);
 void trim_trailing_slash_or_dot(char *path);
 char *line_remove_spaces(const char *buf);
 char *split_comma(char *str);
-char *clean_pathname(const char *path);
 void check_unsigned(const char *str, const char *msg);
 int find_child(pid_t parent, pid_t *child);
 void check_private_dir(void);

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -456,6 +456,7 @@ int is_link(const char *fname);
 void trim_trailing_slash_or_dot(char *path);
 char *line_remove_spaces(const char *buf);
 char *split_comma(char *str);
+char *clean_pathname(const char *path);
 void check_unsigned(const char *str, const char *msg);
 int find_child(pid_t parent, pid_t *child);
 void check_private_dir(void);

--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -681,13 +681,9 @@ void fs_mnt(const int enforce) {
 // mount /proc and /sys directories
 void fs_proc_sys_dev_boot(void) {
 
-	if (arg_debug)
-		printf("Remounting /proc and /proc/sys filesystems\n");
-	if (mount("proc", "/proc", "proc", MS_NOSUID | MS_NOEXEC | MS_NODEV | MS_REC, NULL) < 0)
-		errExit("mounting /proc");
-	fs_logger("remount /proc");
-
 	// remount /proc/sys readonly
+	if (arg_debug)
+		printf("Mounting read-only /proc/sys\n");
 	if (mount("/proc/sys", "/proc/sys", NULL, MS_BIND | MS_REC, NULL) < 0 ||
 	    mount(NULL, "/proc/sys", NULL, MS_BIND | MS_REMOUNT | MS_RDONLY | MS_NOSUID | MS_NOEXEC | MS_NODEV | MS_REC, NULL) < 0)
 		errExit("mounting /proc/sys");
@@ -697,7 +693,8 @@ void fs_proc_sys_dev_boot(void) {
 	/* Mount a version of /sys that describes the network namespace */
 	if (arg_debug)
 		printf("Remounting /sys directory\n");
-	// if this is an overlay, don't try to unmount, just mount a new sysfs
+	// sysfs not yet mounted in overlays, so don't try to unmount it
+	// expect that unmounting /sys fails in a chroot, no need to print a warning in that case
 	if (!arg_overlay) {
 		if (umount2("/sys", MNT_DETACH) < 0 && !cfg.chrootdir)
 			fwarning("failed to unmount /sys\n");
@@ -952,7 +949,7 @@ char *fs_check_overlay_dir(const char *subdirname, int allow_reuse) {
 // # umount /root/overlay/root
 
 
-// to do: fix the code below; also, it might work without /dev, but consider keeping /dev/shm; add locking mechanism for overlay-clean
+// TODO: fix the code below
 #include <sys/utsname.h>
 void fs_overlayfs(void) {
 	struct stat s;
@@ -1175,6 +1172,15 @@ void fs_overlayfs(void) {
 		errExit("mounting /tmp");
 	fs_logger("whitelist /tmp");
 
+	// mount a new proc filesystem
+	if (arg_debug)
+		printf("Mounting /proc\n");
+	char *proc;
+	if (asprintf(&proc, "%s/proc", oroot) == -1)
+		errExit("asprintf");
+	if (mount("proc", proc, "proc", MS_NOSUID | MS_NOEXEC | MS_NODEV | MS_REC, NULL) < 0)
+		errExit("mounting /proc");
+
 	// chroot in the new filesystem
 #ifdef HAVE_GCOV
 	__gcov_flush();
@@ -1209,6 +1215,7 @@ void fs_overlayfs(void) {
 	free(dev);
 	free(run);
 	free(tmp);
+	free(proc);
 }
 #endif
 
@@ -1378,6 +1385,16 @@ void fs_chroot(const char *rootdir) {
 	if (mount("/dev", newdev, NULL, MS_BIND|MS_REC, NULL) < 0)
 		errExit("mounting /dev");
 	free(newdev);
+
+	// mount a new proc filesystem
+	char *newproc;
+	if (asprintf(&newproc, "%s/proc", rootdir) == -1)
+		errExit("asprintf");
+	if (arg_debug)
+		printf("Mounting /proc filesystem on %s\n", newproc);
+	if (mount("proc", newproc, "proc", MS_NOSUID | MS_NOEXEC | MS_NODEV | MS_REC, NULL) < 0)
+		errExit("mounting /proc");
+	free(newproc);
 
 	// x11
 	if (getenv("FIREJAIL_X11")) {

--- a/src/firejail/fs_home.c
+++ b/src/firejail/fs_home.c
@@ -269,6 +269,12 @@ void fs_private_homedir(void) {
 	free(proc2);
 	close(fd1);
 	close(fd2);
+	// check /proc/self/mountinfo to confirm the mount is ok
+	size_t len = strlen(homedir);
+	MountData *mptr = get_last_mount();
+	if (strncmp(mptr->dir, homedir, len) != 0 ||
+	   (*(mptr->dir + len) != '\0' && *(mptr->dir + len) != '/'))
+		errLogExit("invalid private mount");
 
 	fs_logger3("mount-bind", private_homedir, homedir);
 	fs_logger2("whitelist", homedir);
@@ -550,6 +556,10 @@ void fs_private_home_list(void) {
 		errExit("mount bind");
 	free(proc);
 	close(fd);
+	// check /proc/self/mountinfo to confirm the mount is ok
+	MountData *mptr = get_last_mount();
+	if (strcmp(mptr->dir, homedir) != 0 || strcmp(mptr->fstype, "tmpfs") != 0)
+		errLogExit("invalid private-home mount");
 	fs_logger2("tmpfs", homedir);
 
 	if (uid != 0) {

--- a/src/firejail/fs_home.c
+++ b/src/firejail/fs_home.c
@@ -247,7 +247,6 @@ void fs_private_homedir(void) {
 	if (fd2 == -1)
 		errExit("safe_fd");
 	// check if private_homedir is owned by the user
-	// this was checked already for homedir
 	struct stat s;
 	if (fstat(fd1, &s) == -1)
 		errExit("fstat");

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -279,6 +279,7 @@ static void init_cfg(int argc, char **argv) {
 		}
 		exit(1);
 	}
+	close(fd);
 
 	cfg.cwd = getcwd(NULL, 0);
 	if (!cfg.cwd && errno != ENOENT)

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1722,7 +1722,7 @@ int main(int argc, char **argv) {
 				exit(1);
 			}
 			if (strncmp(cfg.homedir, "/etc/", 5) == 0) {
-				fprintf(stderr, "Error: user directory in /etc, private-etc is disabled\n");
+				fprintf(stderr, "Error: user home directory in /etc, private-etc is disabled\n");
 				exit(1);
 			}
 
@@ -1740,7 +1740,7 @@ int main(int argc, char **argv) {
 		}
 		else if (strncmp(argv[i], "--private-opt=", 14) == 0) {
 			if (strncmp(cfg.homedir, "/opt/", 5) == 0) {
-				fprintf(stderr, "Error: user directory in /opt, private-opt is disabled\n");
+				fprintf(stderr, "Error: user home directory in /opt, private-opt is disabled\n");
 				exit(1);
 			}
 			// extract private opt list
@@ -1757,7 +1757,7 @@ int main(int argc, char **argv) {
 		}
 		else if (strncmp(argv[i], "--private-srv=", 14) == 0) {
 			if (strncmp(cfg.homedir, "/srv/", 5) == 0) {
-				fprintf(stderr, "Error: user directory in /srv, private-srv is disabled\n");
+				fprintf(stderr, "Error: user home directory in /srv, private-srv is disabled\n");
 				exit(1);
 			}
 			// extract private srv list

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -247,8 +247,9 @@ static void build_cfg_homedir(const char *dir) {
 		if (cfg.homedir) {
 			if (getuid() != 0) {
 				// realpath return value might be under control of the user
-				// enforce a user owned directory outside /proc and /sys
-				if (strncmp(cfg.homedir, "/proc/", 6) == 0 || strncmp(cfg.homedir, "/sys/", 5) == 0) {
+				// enforce a user owned directory outside /proc, /sys, /run/firejail
+				if (strncmp(cfg.homedir, "/proc/", 6) == 0 || strncmp(cfg.homedir, "/sys/", 5) == 0 ||
+				    strncmp(cfg.homedir, RUN_FIREJAIL_DIR, strlen(RUN_FIREJAIL_DIR)) == 0) {
 					fprintf(stderr, "Error: invalid user directory\n");
 					exit(1);
 				}

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -237,6 +237,56 @@ static pid_t require_pid(const char *name) {
 	return pid;
 }
 
+static void build_cfg_homedir(const char *dir) {
+	EUID_ASSERT();
+	assert(dir);
+
+	if (checkcfg(CFG_HOMEDIR_SYMLINK)) {
+		// resolve symbolic links
+		cfg.homedir = realpath(dir, NULL);
+		if (cfg.homedir) {
+			if (getuid() != 0) {
+				// realpath return value might be under control of the user
+				// enforce a user owned directory outside /proc and /sys
+				if (strncmp(cfg.homedir, "/proc/", 6) == 0 || strncmp(cfg.homedir, "/sys/", 5) == 0) {
+					fprintf(stderr, "Error: invalid user directory\n");
+					exit(1);
+				}
+				int fd = safe_fd(cfg.homedir, O_PATH|O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC);
+				if (fd == -1)
+					errExit("safe_fd");
+				struct stat s;
+				if (fstat(fd, &s) == -1)
+					errExit("fstat");
+				if (s.st_uid != getuid()) {
+					fprintf(stderr, "Error: user directory %s is not owned by user %s\n", cfg.homedir, cfg.username);
+					exit(1);
+				}
+				close(fd);
+			}
+		}
+		else {
+			cfg.homedir = clean_pathname(dir);
+			assert(cfg.homedir);
+		}
+	}
+	else {
+		cfg.homedir = clean_pathname(dir);
+		assert(cfg.homedir);
+		// symbolic links are rejected
+		int fd = safe_fd(cfg.homedir, O_PATH|O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC);
+		if (fd == -1) {
+			if (errno == ENOTDIR) {
+				fprintf(stderr, "Error: invalid user directory %s: path element is not a directory.\n"
+						"Following symbolic links is disabled in Firejail configuration file.\n", cfg.homedir);
+				exit(1);
+			}
+		}
+		else
+			close(fd);
+	}
+}
+
 // init configuration
 static void init_cfg(int argc, char **argv) {
 	EUID_ASSERT();
@@ -264,49 +314,7 @@ static void init_cfg(int argc, char **argv) {
 		fprintf(stderr, "Error: user %s doesn't have a user directory assigned\n", cfg.username);
 		exit(1);
 	}
-	if (checkcfg(CFG_HOMEDIR_SYMLINK)) {  // resolve symbolic links
-		cfg.homedir = realpath(pw->pw_dir, NULL);
-		if (cfg.homedir) {
-			if (getuid() != 0) {
-				// realpath return value might be under control of the user
-				// enforce a user owned directory outside /proc and /sys
-				if (strncmp(cfg.homedir, "/proc/", 6) == 0 || strncmp(cfg.homedir, "/sys/", 5) == 0) {
-					fprintf(stderr, "Error: invalid user directory\n");
-					exit(1);
-				}
-				int fd = safe_fd(cfg.homedir, O_PATH|O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC);
-				if (fd == -1)
-					errExit("safe_fd");
-				struct stat s;
-				if (fstat(fd, &s) == -1)
-					errExit("fstat");
-				if (s.st_uid != getuid()) {
-					fprintf(stderr, "Error: user directory %s is not owned by user %s\n", cfg.homedir, cfg.username);
-					exit(1);
-				}
-				close(fd);
-			}
-		}
-		else {
-			cfg.homedir = clean_pathname(pw->pw_dir);
-			assert(cfg.homedir);
-		}
-	}
-	else {  // reject symbolic links
-		cfg.homedir = clean_pathname(pw->pw_dir);
-		assert(cfg.homedir);
-
-		int fd = safe_fd(cfg.homedir, O_PATH|O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC);
-		if (fd == -1) {
-			if (errno == ENOTDIR) {
-				fprintf(stderr, "Error: invalid user directory %s: path element is not a directory.\n"
-						"Following symbolic links is disabled in Firejail configuration file\n", cfg.homedir);
-				exit(1);
-			}
-		}
-		else
-			close(fd);
-	}
+	build_cfg_homedir(pw->pw_dir);
 
 	cfg.cwd = getcwd(NULL, 0);
 	if (!cfg.cwd && errno != ENOENT)

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -269,17 +269,13 @@ static void init_cfg(int argc, char **argv) {
 	// detect problems with user home directory
 	int fd = safe_fd(cfg.homedir, O_PATH|O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC);
 	if (fd == -1) {
-		if (errno == ENOENT)
-			fprintf(stderr, "Error: cannot find user directory %s\n", cfg.homedir);
-		else if (errno == ENOTDIR)
+		if (errno == ENOTDIR) {
 			fprintf(stderr, "Error: user directory %s is invalid (symbolic links are not allowed)\n", cfg.homedir);
-		else {
-			perror("open");
-			fprintf(stderr, "Error: cannot open user directory %s\n", cfg.homedir);
+			exit(1);
 		}
-		exit(1);
 	}
-	close(fd);
+	else
+		close(fd);
 
 	cfg.cwd = getcwd(NULL, 0);
 	if (!cfg.cwd && errno != ENOENT)

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1721,6 +1721,10 @@ int main(int argc, char **argv) {
 				fprintf(stderr, "Error: --private-etc and --writable-etc are mutually exclusive\n");
 				exit(1);
 			}
+			if (strncmp(cfg.homedir, "/etc/", 5) == 0) {
+				fprintf(stderr, "Error: user directory in /etc, private-etc is disabled\n");
+				exit(1);
+			}
 
 			// extract private etc list
 			if (*(argv[i] + 14) == '\0') {
@@ -1735,6 +1739,10 @@ int main(int argc, char **argv) {
 			arg_private_etc = 1;
 		}
 		else if (strncmp(argv[i], "--private-opt=", 14) == 0) {
+			if (strncmp(cfg.homedir, "/opt/", 5) == 0) {
+				fprintf(stderr, "Error: user directory in /opt, private-opt is disabled\n");
+				exit(1);
+			}
 			// extract private opt list
 			if (*(argv[i] + 14) == '\0') {
 				fprintf(stderr, "Error: invalid private-opt option\n");
@@ -1748,6 +1756,10 @@ int main(int argc, char **argv) {
 			arg_private_opt = 1;
 		}
 		else if (strncmp(argv[i], "--private-srv=", 14) == 0) {
+			if (strncmp(cfg.homedir, "/srv/", 5) == 0) {
+				fprintf(stderr, "Error: user directory in /srv, private-srv is disabled\n");
+				exit(1);
+			}
 			// extract private srv list
 			if (*(argv[i] + 14) == '\0') {
 				fprintf(stderr, "Error: invalid private-srv option\n");

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -1038,6 +1038,10 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 			fprintf(stderr, "Error: --private-etc and --writable-etc are mutually exclusive\n");
 			exit(1);
 		}
+		if (strncmp(cfg.homedir, "/etc/", 5) == 0) {
+			fprintf(stderr, "Error: user directory in /etc, private-etc is disabled\n");
+			exit(1);
+		}
 		if (cfg.etc_private_keep) {
 			if ( asprintf(&cfg.etc_private_keep, "%s,%s", cfg.etc_private_keep, ptr + 12) < 0 )
 				errExit("asprintf");
@@ -1051,6 +1055,10 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 
 	// private /opt list of files and directories
 	if (strncmp(ptr, "private-opt ", 12) == 0) {
+		if (strncmp(cfg.homedir, "/opt/", 5) == 0) {
+			fprintf(stderr, "Error: user directory in /opt, private-opt is disabled\n");
+			exit(1);
+		}
 		if (cfg.opt_private_keep) {
 			if ( asprintf(&cfg.opt_private_keep, "%s,%s", cfg.opt_private_keep, ptr + 12) < 0 )
 				errExit("asprintf");
@@ -1064,6 +1072,10 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 
 	// private /srv list of files and directories
 	if (strncmp(ptr, "private-srv ", 12) == 0) {
+		if (strncmp(cfg.homedir, "/srv/", 5) == 0) {
+			fprintf(stderr, "Error: user directory in /srv, private-srv is disabled\n");
+			exit(1);
+		}
 		if (cfg.srv_private_keep) {
 			if ( asprintf(&cfg.srv_private_keep, "%s,%s", cfg.srv_private_keep, ptr + 12) < 0 )
 				errExit("asprintf");

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -1039,8 +1039,8 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 			exit(1);
 		}
 		if (strncmp(cfg.homedir, "/etc/", 5) == 0) {
-			fprintf(stderr, "Error: user directory in /etc, private-etc is disabled\n");
-			exit(1);
+			fwarning("user home directory in /etc, private-etc is disabled\n");
+			return 0;
 		}
 		if (cfg.etc_private_keep) {
 			if ( asprintf(&cfg.etc_private_keep, "%s,%s", cfg.etc_private_keep, ptr + 12) < 0 )
@@ -1056,8 +1056,8 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 	// private /opt list of files and directories
 	if (strncmp(ptr, "private-opt ", 12) == 0) {
 		if (strncmp(cfg.homedir, "/opt/", 5) == 0) {
-			fprintf(stderr, "Error: user directory in /opt, private-opt is disabled\n");
-			exit(1);
+			fwarning("user home directory in /opt, private-opt is disabled\n");
+			return 0;
 		}
 		if (cfg.opt_private_keep) {
 			if ( asprintf(&cfg.opt_private_keep, "%s,%s", cfg.opt_private_keep, ptr + 12) < 0 )
@@ -1073,8 +1073,8 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 	// private /srv list of files and directories
 	if (strncmp(ptr, "private-srv ", 12) == 0) {
 		if (strncmp(cfg.homedir, "/srv/", 5) == 0) {
-			fprintf(stderr, "Error: user directory in /srv, private-srv is disabled\n");
-			exit(1);
+			fwarning("user home directory in /srv, private-srv is disabled\n");
+			return 0;
 		}
 		if (cfg.srv_private_keep) {
 			if ( asprintf(&cfg.srv_private_keep, "%s,%s", cfg.srv_private_keep, ptr + 12) < 0 )

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -623,6 +623,16 @@ int sandbox(void* sandbox_arg) {
 		errExit("mounting " RUN_FIREJAIL_LIB_DIR);
 
 	//****************************
+	// mount new proc filesystem
+	// representing the pid namespace
+	//****************************
+
+	if (arg_debug)
+		printf("Remounting /proc filesystem\n");
+	if (mount("proc", "/proc", "proc", MS_NOSUID | MS_NOEXEC | MS_NODEV | MS_REC, NULL) < 0)
+		errExit("mounting /proc");
+
+	//****************************
 	// log sandbox data
 	//****************************
 	if (cfg.name)

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -548,6 +548,44 @@ char *split_comma(char *str) {
 }
 
 
+// remove consecutive and trailing slashes
+// and return allocated memory
+// e.g. /home//user/ -> /home/user
+char *clean_pathname(const char *path) {
+	assert(path);
+	size_t len = strlen(path);
+	assert(len + 1 != 0 && path[len] == '\0');
+
+	char *rv = malloc(len + 1);
+	if (!rv)
+		errExit("malloc");
+
+	if (len > 0) {
+		size_t i, j, cnt;
+		for (i = 0, j = 0, cnt = 0; i < len; i++) {
+			if (path[i] == '/')
+				cnt++;
+			else
+				cnt = 0;
+
+			if (cnt < 2) {
+				rv[j] = path[i];
+				j++;
+			}
+		}
+		rv[j] = '\0';
+
+		// remove a trailing slash
+		if (j > 1 && rv[j - 1] == '/')
+			rv[j - 1] = '\0';
+	}
+	else
+		*rv = '\0';
+
+	return rv;
+}
+
+
 void check_unsigned(const char *str, const char *msg) {
 	EUID_ASSERT();
 	const char *ptr = str;

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -548,44 +548,6 @@ char *split_comma(char *str) {
 }
 
 
-// remove consecutive and trailing slashes
-// and return allocated memory
-// e.g. /home//user/ -> /home/user
-char *clean_pathname(const char *path) {
-	assert(path);
-	size_t len = strlen(path);
-	assert(len + 1 != 0 && path[len] == '\0');
-
-	char *rv = malloc(len + 1);
-	if (!rv)
-		errExit("malloc");
-
-	if (len > 0) {
-		size_t i, j, cnt;
-		for (i = 0, j = 0, cnt = 0; i < len; i++) {
-			if (path[i] == '/')
-				cnt++;
-			else
-				cnt = 0;
-
-			if (cnt < 2) {
-				rv[j] = path[i];
-				j++;
-			}
-		}
-		rv[j] = '\0';
-
-		// remove a trailing slash
-		if (j > 1 && rv[j - 1] == '/')
-			rv[j - 1] = '\0';
-	}
-	else
-		*rv = '\0';
-
-	return rv;
-}
-
-
 void check_unsigned(const char *str, const char *msg) {
 	EUID_ASSERT();
 	const char *ptr = str;

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -487,7 +487,7 @@ char *line_remove_spaces(const char *buf) {
 	size_t len = strlen(buf);
 	if (len == 0)
 		return NULL;
-	assert(len + 1 != 0 && buf[len] == '\0');
+	assert(len + 1 != 0);
 
 	// allocate memory for the new string
 	char *rv = malloc(len + 1);
@@ -554,7 +554,7 @@ char *split_comma(char *str) {
 char *clean_pathname(const char *path) {
 	assert(path);
 	size_t len = strlen(path);
-	assert(len + 1 != 0 && path[len] == '\0');
+	assert(len + 1 != 0);
 
 	char *rv = malloc(len + 1);
 	if (!rv)


### PR DESCRIPTION
Relevant mostly for home directories outside /home or paths containing symbolic links. This pull request aims at removing all implicit assumptions about the location of the user home directory (which in fact can be almost anywhere in the filesystem). Instead it adds a new restriction that the home directory must be owned by the user.

#1078
Fixes #2259 (kind of)