### PR TITLE
automatically fixed all private-{bin,etc} lines

### DIFF
--- a/etc/QMediathekView.profile
+++ b/etc/QMediathekView.profile
@@ -45,7 +45,7 @@ shell none
 tracelog
 
 disable-mnt
-private-bin QMediathekView,mplayer,mpv,smplayer,totem,vlc,xplayer
+private-bin mplayer,mpv,QMediathekView,smplayer,totem,vlc,xplayer
 private-cache
 private-dev
 # private-etc alternatives

--- a/etc/QOwnNotes.profile
+++ b/etc/QOwnNotes.profile
@@ -47,8 +47,8 @@ shell none
 tracelog
 
 disable-mnt
-private-bin QOwnNotes,gio
+private-bin gio,QOwnNotes
 private-dev
-private-etc alternatives,fonts,ld.so.cache,pulse,resolv.conf,hosts,nsswitch.conf,host.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,ca-certificates,crypto-policies,fonts,host.conf,hosts,ld.so.cache,nsswitch.conf,pki,pulse,resolv.conf,ssl
 private-tmp
 

--- a/etc/Viber.profile
+++ b/etc/Viber.profile
@@ -32,8 +32,8 @@ seccomp
 shell none
 
 disable-mnt
-private-bin sh,bash,dig,awk,Viber
-private-etc hosts,fonts,mailcap,resolv.conf,X11,pulse,alternatives,localtime,nsswitch.conf,ssl,proxychains.conf,pki,ca-certificates,crypto-policies,machine-id,asound.conf
+private-bin awk,bash,dig,sh,Viber
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,hosts,localtime,machine-id,mailcap,nsswitch.conf,pki,proxychains.conf,pulse,resolv.conf,ssl,X11
 private-tmp
 
 env QTWEBENGINE_DISABLE_SANDBOX=1

--- a/etc/XMind.profile
+++ b/etc/XMind.profile
@@ -32,7 +32,7 @@ seccomp
 shell none
 
 disable-mnt
-private-bin XMind,sh,cp
+private-bin cp,sh,XMind
 private-tmp
 private-dev
 

--- a/etc/Xvfb.profile
+++ b/etc/Xvfb.profile
@@ -40,5 +40,5 @@ private
 # private-bin Xvfb,sh,xkbcomp
 # private-bin Xvfb,sh,xkbcomp,strace,bash,cat,ls
 private-dev
-private-etc alternatives,ld.so.conf,ld.so.cache,resolv.conf,host.conf,nsswitch.conf,gai.conf,hosts,hostname
+private-etc alternatives,gai.conf,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,nsswitch.conf,resolv.conf
 private-tmp

--- a/etc/akregator.profile
+++ b/etc/akregator.profile
@@ -40,7 +40,7 @@ seccomp.drop @clock,@cpu-emulation,@debug,@module,@obsolete,@raw-io,@reboot,@res
 shell none
 
 disable-mnt
-private-bin akregator,akregatorstorageexporter,dbus-launch,kdeinit5,kshell5,kdeinit5_shutdown,kdeinit5_wrapper,kdeinit4,kshell4,kdeinit4_shutdown,kdeinit4_wrapper
+private-bin akregator,akregatorstorageexporter,dbus-launch,kdeinit4,kdeinit4_shutdown,kdeinit4_wrapper,kdeinit5,kdeinit5_shutdown,kdeinit5_wrapper,kshell4,kshell5
 private-dev
 private-tmp
 

--- a/etc/anki.profile
+++ b/etc/anki.profile
@@ -50,5 +50,5 @@ disable-mnt
 private-bin anki,python*
 private-cache
 private-dev
-private-etc alternatives,ca-certificates,fonts,gtk-2.0,hostname,hosts,machine-id,pki,resolv.conf,Trolltech.conf,ssl
+private-etc alternatives,ca-certificates,fonts,gtk-2.0,hostname,hosts,machine-id,pki,resolv.conf,ssl,Trolltech.conf
 private-tmp

--- a/etc/apktool.profile
+++ b/etc/apktool.profile
@@ -31,6 +31,6 @@ protocol unix
 seccomp
 shell none
 
-private-bin apktool,bash,java,dirname,basename,expr,sh
+private-bin apktool,basename,bash,dirname,expr,java,sh
 private-cache
 private-dev

--- a/etc/archaudit-report.profile
+++ b/etc/archaudit-report.profile
@@ -36,7 +36,7 @@ shell none
 
 disable-mnt
 private
-private-bin archaudit-report,arch-audit,bash,cat,comm,cut,date,fold,grep,pacman,pactree,rm,sed,sort,whoneeds
+private-bin arch-audit,archaudit-report,bash,cat,comm,cut,date,fold,grep,pacman,pactree,rm,sed,sort,whoneeds
 #private-dev
 private-tmp
 

--- a/etc/aria2c.profile
+++ b/etc/aria2c.profile
@@ -37,7 +37,7 @@ shell none
 private-bin aria2c,gzip
 private-cache
 private-dev
-private-etc alternatives,ca-certificates,ssl,resolv.conf
+private-etc alternatives,ca-certificates,resolv.conf,ssl
 private-lib libreadline.so.*
 private-tmp
 

--- a/etc/ark.profile
+++ b/etc/ark.profile
@@ -34,7 +34,7 @@ protocol unix
 seccomp
 shell none
 
-private-bin ark,unrar,rar,unzip,zip,zipinfo,7z,p7zip,unar,lsar,lrzip,lzop,lz4,bash,sh,tclsh
+private-bin 7z,ark,bash,lrzip,lsar,lz4,lzop,p7zip,rar,sh,tclsh,unar,unrar,unzip,zip,zipinfo
 #private-etc alternatives,smb.conf,samba,mtab,fonts,drirc,kde5rc,passwd,group,xdg
 
 private-dev

--- a/etc/arm.profile
+++ b/etc/arm.profile
@@ -41,8 +41,8 @@ shell none
 tracelog
 
 disable-mnt
-private-bin arm,tor,sh,bash,python*,ps,lsof,ldconfig
+private-bin arm,bash,ldconfig,lsof,ps,python*,sh,tor
 private-dev
-private-etc alternatives,tor,passwd,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,ca-certificates,crypto-policies,passwd,pki,ssl,tor
 private-tmp
 

--- a/etc/artha.profile
+++ b/etc/artha.profile
@@ -38,7 +38,7 @@ disable-mnt
 private-bin artha,enchant,notify-send
 private-cache
 private-dev
-private-etc alternatives,machine-id,fonts
+private-etc alternatives,fonts,machine-id
 private-lib libnotify.so.*
 private-tmp
 

--- a/etc/atool.profile
+++ b/etc/atool.profile
@@ -45,7 +45,7 @@ tracelog
 private-cache
 private-dev
 # without login.defs atool complains and uses UID/GID 1000 by default
-private-etc alternatives,passwd,group,login.defs
+private-etc alternatives,group,login.defs,passwd
 private-tmp
 
 memory-deny-write-execute

--- a/etc/bitwarden.profile
+++ b/etc/bitwarden.profile
@@ -47,7 +47,7 @@ private-bin bitwarden
 private-cache
 ?HAS_APPIMAGE: ignore private-dev
 private-dev
-private-etc alternatives,ca-certificates,crypto-policies,hosts,nsswitch.conf,fonts,pki,resolv.conf,ssl
+private-etc alternatives,ca-certificates,crypto-policies,fonts,hosts,nsswitch.conf,pki,resolv.conf,ssl
 private-opt Bitwarden
 private-tmp
 

--- a/etc/bsdtar.profile
+++ b/etc/bsdtar.profile
@@ -37,9 +37,9 @@ shell none
 tracelog
 
 # support compressed archives
-private-bin sh,bash,bsdcat,bsdcpio,bsdtar,gtar,compress,gzip,lzma,xz,bzip2,lbzip2,lzip,lzop,lz4,libarchive
+private-bin bash,bsdcat,bsdcpio,bsdtar,bzip2,compress,gtar,gzip,lbzip2,libarchive,lz4,lzip,lzma,lzop,sh,xz
 private-cache
 private-dev
-private-etc alternatives,passwd,group,localtime
+private-etc alternatives,group,localtime,passwd
 
 memory-deny-write-execute

--- a/etc/bzflag.profile
+++ b/etc/bzflag.profile
@@ -38,7 +38,7 @@ shell none
 tracelog
 
 disable-mnt
-private-bin bzflag,bzflag-wrapper,bzfs,bzadmin
+private-bin bzadmin,bzflag,bzflag-wrapper,bzfs
 private-cache
 private-dev
 private-tmp

--- a/etc/celluloid.profile
+++ b/etc/celluloid.profile
@@ -38,9 +38,9 @@ seccomp
 shell none
 tracelog
 
-private-bin celluloid,gnome-mpv,youtube-dl,python*,env
+private-bin celluloid,env,gnome-mpv,python*,youtube-dl
 private-cache
-private-etc alternatives,ca-certificates,ssl,pki,pkcs11,hosts,machine-id,localtime,libva.conf,drirc,fonts,gtk-3.0,dconf,crypto-policies,xdg,selinux,resolv.conf
+private-etc alternatives,ca-certificates,crypto-policies,dconf,drirc,fonts,gtk-3.0,hosts,libva.conf,localtime,machine-id,pkcs11,pki,resolv.conf,selinux,ssl,xdg
 private-dev
 private-tmp
 

--- a/etc/cheese.profile
+++ b/etc/cheese.profile
@@ -41,5 +41,5 @@ tracelog
 disable-mnt
 private-bin cheese
 private-cache
-private-etc alternatives,fonts,drirc,clutter-1.0,gtk-3.0,dconf
+private-etc alternatives,clutter-1.0,dconf,drirc,fonts,gtk-3.0
 private-tmp

--- a/etc/cmus.profile
+++ b/etc/cmus.profile
@@ -27,4 +27,4 @@ seccomp
 shell none
 
 private-bin cmus
-private-etc alternatives,group,machine-id,pulse,asound.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,group,machine-id,pki,pulse,ssl

--- a/etc/crow.profile
+++ b/etc/crow.profile
@@ -38,7 +38,7 @@ shell none
 disable-mnt
 private-bin crow
 private-dev
-private-etc alternatives,ca-certificates,ssl,machine-id,dconf,nsswitch.conf,resolv.conf,fonts,asound.conf,pulse,pki,crypto-policies
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,dconf,fonts,machine-id,nsswitch.conf,pki,pulse,resolv.conf,ssl
 private-opt none
 private-tmp
 private-srv none

--- a/etc/deluge.profile
+++ b/etc/deluge.profile
@@ -39,6 +39,6 @@ seccomp
 shell none
 
 # deluge is using python on Debian
-private-bin deluge,deluge-console,deluged,deluge-gtk,deluge-web,sh,python*,uname
+private-bin deluge,deluge-console,deluge-gtk,deluge-web,deluged,python*,sh,uname
 private-dev
 private-tmp

--- a/etc/dex2jar.profile
+++ b/etc/dex2jar.profile
@@ -35,7 +35,7 @@ protocol unix
 seccomp
 shell none
 
-private-bin dex2jar,java,sh,bash,expr,dirname,ls,uname,grep
+private-bin bash,dex2jar,dirname,expr,grep,java,ls,sh,uname
 private-cache
 private-dev
 

--- a/etc/dig.profile
+++ b/etc/dig.profile
@@ -42,7 +42,7 @@ shell none
 
 disable-mnt
 private
-private-bin sh,bash,dig
+private-bin bash,dig,sh
 private-cache
 private-dev
 # private-etc alternatives,resolv.conf

--- a/etc/discord-common.profile
+++ b/etc/discord-common.profile
@@ -27,9 +27,9 @@ novideo
 protocol unix,inet,inet6,netlink
 seccomp
 
-private-bin sh,xdg-mime,tr,sed,echo,head,cut,xdg-open,grep,egrep,bash,zsh
+private-bin bash,cut,echo,egrep,grep,head,sed,sh,tr,xdg-mime,xdg-open,zsh
 private-dev
-private-etc alternatives,ca-certificates,crypto-policies,fonts,group,machine-id,ld.so.cache,localtime,login.defs,password,pki,resolv.conf,ssl
+private-etc alternatives,ca-certificates,crypto-policies,fonts,group,ld.so.cache,localtime,login.defs,machine-id,password,pki,resolv.conf,ssl
 private-tmp
 
 noexec /tmp

--- a/etc/electrum.profile
+++ b/etc/electrum.profile
@@ -46,6 +46,6 @@ disable-mnt
 private-bin electrum,python*
 private-cache
 private-dev
-private-etc alternatives,fonts,dconf,ca-certificates,ssl,pki,crypto-policies,machine-id,resolv.conf
+private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,machine-id,pki,resolv.conf,ssl
 private-tmp
 

--- a/etc/enpass.profile
+++ b/etc/enpass.profile
@@ -53,7 +53,7 @@ seccomp
 shell none
 tracelog
 
-private-bin dirname,Enpass,importer_enpass,sh,readlink
+private-bin dirname,Enpass,importer_enpass,readlink,sh
 ?HAS_APPIMAGE: ignore private-dev
 private-dev
 private-opt Enpass

--- a/etc/ffmpeg.profile
+++ b/etc/ffmpeg.profile
@@ -43,7 +43,7 @@ tracelog
 private-bin ffmpeg
 private-cache
 private-dev
-private-etc alternatives,pki,pkcs11,hosts,ssl,ca-certificates,resolv.conf
+private-etc alternatives,ca-certificates,hosts,pkcs11,pki,resolv.conf,ssl
 private-tmp
 
 # memory-deny-write-execute - it breaks old versions of ffmpeg

--- a/etc/file.profile
+++ b/etc/file.profile
@@ -38,7 +38,7 @@ x11 none
 #private-bin file
 private-cache
 private-dev
-private-etc alternatives,magic.mgc,magic,localtime
+private-etc alternatives,localtime,magic,magic.mgc
 private-lib libarchive.so.*,libfakeroot,libmagic.so.*
 
 memory-deny-write-execute

--- a/etc/filezilla.profile
+++ b/etc/filezilla.profile
@@ -33,6 +33,6 @@ seccomp
 shell none
 
 # private-bin breaks --join if the user has zsh set as $SHELL - adding zsh on private-bin
-private-bin filezilla,uname,sh,bash,zsh,python*,lsb_release,fzputtygen,fzsftp
+private-bin bash,filezilla,fzputtygen,fzsftp,lsb_release,python*,sh,uname,zsh
 private-dev
 private-tmp

--- a/etc/flameshot.profile
+++ b/etc/flameshot.profile
@@ -37,7 +37,7 @@ shell none
 disable-mnt
 private-bin flameshot
 private-cache
-private-etc alternatives,fonts,ld.so.conf,resolv.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.conf,pki,resolv.conf,ssl
 private-dev
 private-tmp
 

--- a/etc/freeciv.profile
+++ b/etc/freeciv.profile
@@ -38,7 +38,7 @@ shell none
 tracelog
 
 disable-mnt
-private-bin freeciv-gtk3,freeciv-mp-gtk3,freeciv-server,freeciv-manual
+private-bin freeciv-gtk3,freeciv-manual,freeciv-mp-gtk3,freeciv-server
 private-cache
 private-dev
 private-tmp

--- a/etc/freemind.profile
+++ b/etc/freemind.profile
@@ -42,7 +42,7 @@ shell none
 tracelog
 
 disable-mnt
-private-bin freemind,java,bash,sed,sh,grep,mkdir,echo,cp,uname,which,lsb_release,rpm,dpkg,dirname,readlink
+private-bin bash,cp,dirname,dpkg,echo,freemind,grep,java,lsb_release,mkdir,readlink,rpm,sed,sh,uname,which
 private-cache
 private-dev
 #private-etc alternatives,fonts,java

--- a/etc/gajim.profile
+++ b/etc/gajim.profile
@@ -46,7 +46,7 @@ shell none
 tracelog
 
 disable-mnt
-private-bin python,python3,sh,gpg,gpg2,gajim,bash,zsh,paplay,gajim-history-manager
+private-bin bash,gajim,gajim-history-manager,gpg,gpg2,paplay,python,python3,sh,zsh
 private-dev
 private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,group,hostname,hosts,ld.so.cache,ld.so.conf,localtime,machine-id,passwd,pki,pulse,resolv.conf,ssl
 private-tmp

--- a/etc/gcloud.profile
+++ b/etc/gcloud.profile
@@ -36,5 +36,5 @@ tracelog
 
 disable-mnt
 private-dev
-private-etc alternatives,ca-certificates,ssl,hosts,localtime,nsswitch.conf,resolv.conf,pki,crypto-policies,ld.so.cache
+private-etc alternatives,ca-certificates,crypto-policies,hosts,ld.so.cache,localtime,nsswitch.conf,pki,resolv.conf,ssl
 private-tmp

--- a/etc/geekbench.profile
+++ b/etc/geekbench.profile
@@ -41,7 +41,7 @@ disable-mnt
 private-bin bash,geekbenc*,sh
 private-cache
 private-dev
-private-etc alternatives,group,passwd,lsb-release
+private-etc alternatives,group,lsb-release,passwd
 private-lib libstdc++.so.*
 private-opt none
 private-tmp

--- a/etc/ghostwriter.profile
+++ b/etc/ghostwriter.profile
@@ -49,7 +49,7 @@ tracelog
 #private-bin ghostwriter,pandoc
 private-cache
 private-dev
-private-etc alternatives,cups,crypto-policies,localtime,drirc,fonts,gtk-3.0,dconf,machine-id
+private-etc alternatives,crypto-policies,cups,dconf,drirc,fonts,gtk-3.0,localtime,machine-id
 # Breaks Translation
 #private-lib
 private-tmp

--- a/etc/gitg.profile
+++ b/etc/gitg.profile
@@ -35,7 +35,7 @@ protocol unix,inet,inet6
 seccomp
 shell none
 
-private-bin gitg,git,ssh
+private-bin git,gitg,ssh
 private-cache
 private-dev
 private-tmp

--- a/etc/gitter.profile
+++ b/etc/gitter.profile
@@ -37,7 +37,7 @@ shell none
 
 disable-mnt
 private-bin bash,env,gitter
-private-etc alternatives,fonts,pulse,resolv.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,ca-certificates,crypto-policies,fonts,pki,pulse,resolv.conf,ssl
 private-opt Gitter
 private-dev
 private-tmp

--- a/etc/gnome-chess.profile
+++ b/etc/gnome-chess.profile
@@ -37,7 +37,7 @@ shell none
 tracelog
 
 disable-mnt
-private-bin fairymax,gnome-chess,hoichess,gnuchess
+private-bin fairymax,gnome-chess,gnuchess,hoichess
 private-cache
 private-dev
 private-etc alternatives,dconf,fonts,gnome-chess,gtk-3.0

--- a/etc/gnome-clocks.profile
+++ b/etc/gnome-clocks.profile
@@ -37,6 +37,6 @@ disable-mnt
 private-bin gnome-clocks,gsound-play
 private-cache
 private-dev
-private-etc alternatives,fonts,ca-certificates,ssl,pki,crypto-policies,machine-id,hosts,pkcs11,localtime,gtk-3.0,dconf
+private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gtk-3.0,hosts,localtime,machine-id,pkcs11,pki,ssl
 private-tmp
 

--- a/etc/gnome-music.profile
+++ b/etc/gnome-music.profile
@@ -37,8 +37,8 @@ seccomp
 shell none
 tracelog
 
-private-bin gnome-music,python*,env,gio-launch-desktop,yelp
+private-bin env,gio-launch-desktop,gnome-music,python*,yelp
 private-dev
-private-etc alternatives,fonts,machine-id,pulse,asound.conf
+private-etc alternatives,asound.conf,fonts,machine-id,pulse
 private-tmp
 

--- a/etc/gnome-recipes.profile
+++ b/etc/gnome-recipes.profile
@@ -43,7 +43,7 @@ shell none
 disable-mnt
 private-bin gnome-recipes,tar
 private-dev
-private-etc alternatives,ca-certificates,fonts,ssl,crypto-policies,pki
+private-etc alternatives,ca-certificates,crypto-policies,fonts,pki,ssl
 private-lib gdk-pixbuf-2.0,gio,gvfs/libgvfscommon.so,libgconf-2.so.*,libgnutls.so.*,libjpeg.so.*,libp11-kit.so.*,libproxy.so.*,librsvg-2.so.*
 private-tmp
 

--- a/etc/godot.profile
+++ b/etc/godot.profile
@@ -39,5 +39,5 @@ disable-mnt
 private-bin godot
 private-cache
 private-dev
-private-etc ca-certificates,crypto-policies,nsswitch.conf,pki,resolv.conf,ssl,fonts,alsa,asound.conf,machine-id,openal,pulse,alternatives,drirc
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,drirc,fonts,machine-id,nsswitch.conf,openal,pki,pulse,resolv.conf,ssl
 private-tmp

--- a/etc/google-earth.profile
+++ b/etc/google-earth.profile
@@ -45,7 +45,7 @@ seccomp
 shell none
 
 disable-mnt
-private-bin google-earth,sh,bash,grep,sed,ls,dirname
+private-bin bash,dirname,google-earth,grep,ls,sed,sh
 private-dev
 private-opt google
 

--- a/etc/gpredict.profile
+++ b/etc/gpredict.profile
@@ -35,6 +35,6 @@ tracelog
 
 private-bin gpredict
 private-dev
-private-etc alternatives,fonts,resolv.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,ca-certificates,crypto-policies,fonts,pki,resolv.conf,ssl
 private-tmp
 

--- a/etc/gradio.profile
+++ b/etc/gradio.profile
@@ -35,6 +35,6 @@ protocol unix,inet,inet6
 seccomp
 shell none
 
-private-etc alternatives,asound.conf,ca-certificates,fonts,host.conf,hostname,hosts,pulse,resolv.conf,ssl,pki,crypto-policies,gtk-3.0,xdg,machine-id
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-3.0,host.conf,hostname,hosts,machine-id,pki,pulse,resolv.conf,ssl,xdg
 private-tmp
 

--- a/etc/gwenview.profile
+++ b/etc/gwenview.profile
@@ -43,7 +43,7 @@ seccomp
 shell none
 # tracelog
 
-private-bin gwenview,gimp*,kbuildsycoca4,kdeinit4
+private-bin gimp*,gwenview,kbuildsycoca4,kdeinit4
 private-dev
 private-etc alternatives,fonts,gimp,gtk-2.0,kde4rc,kde5rc,ld.so.cache,machine-id,pulse,xdg
 

--- a/etc/hugin.profile
+++ b/etc/hugin.profile
@@ -33,7 +33,7 @@ protocol unix
 seccomp
 shell none
 
-private-bin PTBatcherGUI,calibrate_lens_gui,hugin,hugin_stitch_project,align_image_stack,autooptimiser,celeste_standalone,checkpto,cpclean,cpfind,deghosting_mask,fulla,geocpset,hugin_executor,hugin_hdrmerge,hugin_lensdb,icpfind,linefind,nona,pano_modify,pano_trafo,pto_gen,pto_lensstack,pto_mask,pto_merge,pto_move,pto_template,pto_var,tca_correct,verdandi,vig_optimize,enblend
+private-bin align_image_stack,autooptimiser,calibrate_lens_gui,celeste_standalone,checkpto,cpclean,cpfind,deghosting_mask,enblend,fulla,geocpset,hugin,hugin_executor,hugin_hdrmerge,hugin_lensdb,hugin_stitch_project,icpfind,linefind,nona,pano_modify,pano_trafo,PTBatcherGUI,pto_gen,pto_lensstack,pto_mask,pto_merge,pto_move,pto_template,pto_var,tca_correct,verdandi,vig_optimize
 private-cache
 private-dev
 private-tmp

--- a/etc/imagej.profile
+++ b/etc/imagej.profile
@@ -34,7 +34,7 @@ protocol unix
 seccomp
 shell none
 
-private-bin imagej,bash,grep,sort,tail,tr,cut,whoami,hostname,uname,mkdir,ls,touch,free,awk,update-java-alternatives,basename,xprop,rm,ln
+private-bin awk,basename,bash,cut,free,grep,hostname,imagej,ln,ls,mkdir,rm,sort,tail,touch,tr,uname,update-java-alternatives,whoami,xprop
 private-dev
 private-tmp
 

--- a/etc/jd-gui.profile
+++ b/etc/jd-gui.profile
@@ -37,7 +37,7 @@ protocol unix
 seccomp
 shell none
 
-private-bin jd-gui,sh,bash
+private-bin bash,jd-gui,sh
 private-cache
 private-dev
 private-tmp

--- a/etc/kdeinit4.profile
+++ b/etc/kdeinit4.profile
@@ -30,7 +30,7 @@ protocol unix,inet,inet6,netlink
 seccomp
 shell none
 
-private-bin kdeinit4,kbuildsycoca4,kded4,knotify4
+private-bin kbuildsycoca4,kded4,kdeinit4,knotify4
 private-dev
 private-tmp
 

--- a/etc/kdenlive.profile
+++ b/etc/kdenlive.profile
@@ -33,6 +33,6 @@ protocol unix,netlink
 seccomp
 shell none
 
-private-bin kdenlive,kdenlive_render,dbus-launch,melt,ffmpeg,ffplay,ffprobe,dvdauthor,genisoimage,vlc,xine,kdeinit5,kshell5,kdeinit5_shutdown,kdeinit5_wrapper,kdeinit4,kshell4,kdeinit4_shutdown,kdeinit4_wrapper,mlt-melt
+private-bin dbus-launch,dvdauthor,ffmpeg,ffplay,ffprobe,genisoimage,kdeinit4,kdeinit4_shutdown,kdeinit4_wrapper,kdeinit5,kdeinit5_shutdown,kdeinit5_wrapper,kdenlive,kdenlive_render,kshell4,kshell5,melt,mlt-melt,vlc,xine
 private-dev
 # private-etc alternatives,fonts,kde4rc,kde5rc,ld.so.cache,machine-id,passwd,pulse,xdg,X11

--- a/etc/kid3.profile
+++ b/etc/kid3.profile
@@ -37,7 +37,7 @@ tracelog
 
 private-cache
 private-dev
-private-etc alternatives,drirc,fonts,kde5rc,gtk-3.0,dconf,machine-id,ca-certificates,ssl,pki,hostname,hosts,resolv.conf,pulse,,crypto-policies
+private-etc ,alternatives,ca-certificates,crypto-policies,dconf,drirc,fonts,gtk-3.0,hostname,hosts,kde5rc,machine-id,pki,pulse,resolv.conf,ssl
 private-tmp
 private-opt none
 private-srv none

--- a/etc/kid3.profile
+++ b/etc/kid3.profile
@@ -37,7 +37,7 @@ tracelog
 
 private-cache
 private-dev
-private-etc ,alternatives,ca-certificates,crypto-policies,dconf,drirc,fonts,gtk-3.0,hostname,hosts,kde5rc,machine-id,pki,pulse,resolv.conf,ssl
+private-etc alternatives,ca-certificates,crypto-policies,dconf,drirc,fonts,gtk-3.0,hostname,hosts,kde5rc,machine-id,pki,pulse,resolv.conf,ssl
 private-tmp
 private-opt none
 private-srv none

--- a/etc/konversation.profile
+++ b/etc/konversation.profile
@@ -34,7 +34,7 @@ seccomp
 shell none
 tracelog
 
-private-bin konversation,kbuildsycoca4
+private-bin kbuildsycoca4,konversation
 private-cache
 private-dev
 private-tmp

--- a/etc/ktorrent.profile
+++ b/etc/ktorrent.profile
@@ -52,7 +52,7 @@ protocol unix,inet,inet6,netlink
 seccomp
 shell none
 
-private-bin ktorrent,kbuildsycoca4,kdeinit4
+private-bin kbuildsycoca4,kdeinit4,ktorrent
 private-dev
 # private-lib - problems on Arch
 private-tmp

--- a/etc/kwrite.profile
+++ b/etc/kwrite.profile
@@ -43,7 +43,7 @@ seccomp
 shell none
 tracelog
 
-private-bin kwrite,kbuildsycoca4,kdeinit4
+private-bin kbuildsycoca4,kdeinit4,kwrite
 private-dev
 private-etc alternatives,fonts,kde4rc,kde5rc,ld.so.cache,machine-id,pulse,xdg
 private-tmp

--- a/etc/lollypop.profile
+++ b/etc/lollypop.profile
@@ -37,6 +37,6 @@ seccomp
 shell none
 
 private-dev
-private-etc alternatives,asound.conf,ca-certificates,fonts,host.conf,hostname,hosts,pulse,resolv.conf,ssl,pki,crypto-policies,gtk-3.0,xdg,machine-id
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-3.0,host.conf,hostname,hosts,machine-id,pki,pulse,resolv.conf,ssl,xdg
 private-tmp
 

--- a/etc/macrofusion.profile
+++ b/etc/macrofusion.profile
@@ -36,7 +36,7 @@ protocol unix
 seccomp
 shell none
 
-private-bin python*,macrofusion,env,enfuse,exiftool,align_image_stack
+private-bin align_image_stack,enfuse,env,exiftool,macrofusion,python*
 private-cache
 private-dev
 private-tmp

--- a/etc/mate-dictionary.profile
+++ b/etc/mate-dictionary.profile
@@ -35,7 +35,7 @@ shell none
 
 disable-mnt
 private-bin mate-dictionary
-private-etc alternatives,fonts,resolv.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,ca-certificates,crypto-policies,fonts,pki,resolv.conf,ssl
 private-opt mate-dictionary
 private-dev
 private-tmp

--- a/etc/mcabber.profile
+++ b/etc/mcabber.profile
@@ -30,4 +30,4 @@ shell none
 
 private-bin mcabber
 private-dev
-private-etc alternatives,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,ca-certificates,crypto-policies,pki,ssl

--- a/etc/mendeleydesktop.profile
+++ b/etc/mendeleydesktop.profile
@@ -43,7 +43,7 @@ shell none
 tracelog
 
 disable-mnt
-private-bin mendeleydesktop,python*,env,gconftool-2,which,sh,ln,cat,update-desktop-database
+private-bin cat,env,gconftool-2,ln,mendeleydesktop,python*,sh,update-desktop-database,which
 private-dev
 private-tmp
 

--- a/etc/mp3splt-gtk.profile
+++ b/etc/mp3splt-gtk.profile
@@ -37,5 +37,5 @@ tracelog
 private-bin mp3splt-gtk
 private-cache
 private-dev
-private-etc alsa,alternatives,asound.conf,fonts,gtk-3.0,dconf,machine-id,openal,pulse
+private-etc alsa,alternatives,asound.conf,dconf,fonts,gtk-3.0,machine-id,openal,pulse
 private-tmp

--- a/etc/mpsyt.profile
+++ b/etc/mpsyt.profile
@@ -50,7 +50,7 @@ seccomp
 shell none
 tracelog
 
-private-bin mpsyt,mplayer,mpv,youtube-dl,python*,env,ffmpeg
+private-bin env,ffmpeg,mplayer,mpsyt,mpv,python*,youtube-dl
 private-dev
 private-tmp
 

--- a/etc/mpv.profile
+++ b/etc/mpv.profile
@@ -40,6 +40,6 @@ seccomp
 shell none
 tracelog
 
-private-bin mpv,youtube-dl,python*,env
+private-bin env,mpv,python*,youtube-dl
 private-cache
 private-dev

--- a/etc/ms-office.profile
+++ b/etc/ms-office.profile
@@ -35,8 +35,8 @@ shell none
 tracelog
 
 disable-mnt
-private-bin bash,fonts,env,jak,ms-office,python*,sh
-private-etc alternatives,resolv.conf,ca-certificates,ssl,pki,crypto-policies
+private-bin bash,env,fonts,jak,ms-office,python*,sh
+private-etc alternatives,ca-certificates,crypto-policies,pki,resolv.conf,ssl
 private-dev
 private-tmp
 

--- a/etc/musixmatch.profile
+++ b/etc/musixmatch.profile
@@ -32,5 +32,5 @@ seccomp
 
 disable-mnt
 private-dev
-private-etc alternatives,machine-id,pulse,asound.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,machine-id,pki,pulse,ssl
 

--- a/etc/mypaint.profile
+++ b/etc/mypaint.profile
@@ -44,6 +44,6 @@ tracelog
 
 private-cache
 private-dev
-private-etc alternatives,fonts,gtk-3.0,dconf
+private-etc alternatives,dconf,fonts,gtk-3.0
 private-tmp
 

--- a/etc/nomacs.profile
+++ b/etc/nomacs.profile
@@ -41,7 +41,7 @@ tracelog
 #private-bin nomacs
 private-cache
 private-dev
-private-etc alternatives,hosts,ca-certificates,ssl,pki,crypto-policies,resolv.conf,drirc,fonts,gtk-3.0,dconf,machine-id,login.defs
+private-etc alternatives,ca-certificates,crypto-policies,dconf,drirc,fonts,gtk-3.0,hosts,login.defs,machine-id,pki,resolv.conf,ssl
 private-tmp
 
 memory-deny-write-execute

--- a/etc/nyx.profile
+++ b/etc/nyx.profile
@@ -45,7 +45,7 @@ disable-mnt
 private-bin nyx,python*
 private-cache
 private-dev
-private-etc alternatives,passwd,tor,fonts
+private-etc alternatives,fonts,passwd,tor
 private-opt none
 private-srv none
 private-tmp

--- a/etc/okular.profile
+++ b/etc/okular.profile
@@ -47,7 +47,7 @@ seccomp
 shell none
 tracelog
 
-private-bin okular,kbuildsycoca4,kdeinit4,lpr
+private-bin kbuildsycoca4,kdeinit4,lpr,okular
 private-dev
 private-etc alternatives,cups,fonts,kde4rc,kde5rc,ld.so.cache,machine-id,xdg
 # private-tmp - on KDE we need access to the real /tmp for data exchange with email clients

--- a/etc/openclonk.profile
+++ b/etc/openclonk.profile
@@ -38,7 +38,7 @@ shell none
 tracelog
 
 disable-mnt
-private-bin openclonk,c4group
+private-bin c4group,openclonk
 private-cache
 private-dev
 private-tmp

--- a/etc/parole.profile
+++ b/etc/parole.profile
@@ -25,6 +25,6 @@ protocol unix,inet,inet6
 seccomp
 shell none
 
-private-bin parole,dbus-launch
+private-bin dbus-launch,parole
 private-cache
-private-etc alternatives,passwd,group,fonts,machine-id,pulse,asound.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,group,machine-id,passwd,pki,pulse,ssl

--- a/etc/pdfsam.profile
+++ b/etc/pdfsam.profile
@@ -37,7 +37,7 @@ protocol unix
 seccomp
 shell none
 
-private-bin pdfsam,sh,bash,java,archlinux-java,grep,awk,dirname,uname,which,sort,find,readlink,expr,ls,java-config
+private-bin archlinux-java,awk,bash,dirname,expr,find,grep,java,java-config,ls,pdfsam,readlink,sh,sort,uname,which
 private-cache
 private-dev
 private-tmp

--- a/etc/pioneer.profile
+++ b/etc/pioneer.profile
@@ -38,7 +38,7 @@ shell none
 tracelog
 
 disable-mnt
-private-bin pioneer,modelcompiler,savegamedump
+private-bin modelcompiler,pioneer,savegamedump
 private-cache
 private-dev
 private-tmp

--- a/etc/pithos.profile
+++ b/etc/pithos.profile
@@ -36,7 +36,7 @@ seccomp
 shell none
 
 disable-mnt
-private-bin pithos,env,python*
+private-bin env,pithos,python*
 private-dev
 private-tmp
 

--- a/etc/ppsspp.profile
+++ b/etc/ppsspp.profile
@@ -38,7 +38,7 @@ shell none
 
 # private-dev is disabled to allow controller support
 #private-dev
-private-etc alternatives,asound.conf,ca-certificates,drirc,fonts,group,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,nsswitch.conf,passwd,pulse,resolv.conf,ssl,pki,crypto-policies,machine-id
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,drirc,fonts,group,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,machine-id,nsswitch.conf,passwd,pki,pulse,resolv.conf,ssl
 private-opt ppsspp
 private-tmp
 

--- a/etc/pragha.profile
+++ b/etc/pragha.profile
@@ -33,6 +33,6 @@ seccomp
 shell none
 
 private-dev
-private-etc alternatives,asound.conf,ca-certificates,fonts,host.conf,hostname,hosts,pulse,resolv.conf,ssl,pki,crypto-policies,gtk-3.0,xdg,machine-id
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-3.0,host.conf,hostname,hosts,machine-id,pki,pulse,resolv.conf,ssl,xdg
 private-tmp
 

--- a/etc/pybitmessage.profile
+++ b/etc/pybitmessage.profile
@@ -39,8 +39,8 @@ seccomp
 shell none
 
 disable-mnt
-private-bin pybitmessage,python*,sh,ldconfig,env,bash,stat
+private-bin bash,env,ldconfig,pybitmessage,python*,sh,stat
 private-dev
-private-etc alternatives,PyBitmessage,PyBitmessage.conf,Trolltech.conf,fonts,gtk-2.0,hosts,ld.so.cache,ld.so.preload,localtime,pki,resolv.conf,selinux,sni-qt.conf,system-fips,xdg,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,ca-certificates,crypto-policies,fonts,gtk-2.0,hosts,ld.so.cache,ld.so.preload,localtime,pki,pki,PyBitmessage,PyBitmessage.conf,resolv.conf,selinux,sni-qt.conf,ssl,system-fips,Trolltech.conf,xdg
 private-tmp
 

--- a/etc/qbittorrent.profile
+++ b/etc/qbittorrent.profile
@@ -51,7 +51,7 @@ protocol unix,inet,inet6,netlink
 seccomp
 shell none
 
-private-bin qbittorrent,python*
+private-bin python*,qbittorrent
 private-dev
 # private-etc alternatives,X11,fonts,xdg,resolv.conf,ca-certificates,ssl,pki,crypto-policies
 # private-lib - problems on Arch

--- a/etc/qgis.profile
+++ b/etc/qgis.profile
@@ -53,5 +53,5 @@ tracelog
 disable-mnt
 private-cache
 private-dev
-private-etc alternatives,ca-certificates,crypto-policies,fonts,machine-id,pki,resolv.conf,ssl,QGIS,QGIS.conf,Trolltech.conf
+private-etc alternatives,ca-certificates,crypto-policies,fonts,machine-id,pki,QGIS,QGIS.conf,resolv.conf,ssl,Trolltech.conf
 private-tmp

--- a/etc/qmmp.profile
+++ b/etc/qmmp.profile
@@ -31,7 +31,7 @@ seccomp
 shell none
 tracelog
 
-private-bin qmmp,tar,unzip,bzip2,gzip
+private-bin bzip2,gzip,qmmp,tar,unzip
 private-dev
 private-tmp
 

--- a/etc/qtox.profile
+++ b/etc/qtox.profile
@@ -42,7 +42,7 @@ disable-mnt
 private-bin qtox
 private-cache
 private-dev
-private-etc alternatives,fonts,resolv.conf,ld.so.cache,localtime,ca-certificates,ssl,pki,crypto-policies,machine-id,pulse
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,localtime,machine-id,pki,pulse,resolv.conf,ssl
 private-tmp
 
 memory-deny-write-execute

--- a/etc/sdat2img.profile
+++ b/etc/sdat2img.profile
@@ -36,7 +36,7 @@ protocol unix
 seccomp
 shell none
 
-private-bin sdat2img,env,python*
+private-bin env,python*,sdat2img
 private-cache
 private-dev
 

--- a/etc/silentarmy.profile
+++ b/etc/silentarmy.profile
@@ -32,7 +32,7 @@ shell none
 
 disable-mnt
 private
-private-bin silentarmy,sa-solver,python*
+private-bin python*,sa-solver,silentarmy
 private-dev
 private-opt none
 private-tmp

--- a/etc/slack.profile
+++ b/etc/slack.profile
@@ -33,7 +33,7 @@ seccomp
 shell none
 
 disable-mnt
-private-bin slack,locale
+private-bin locale,slack
 private-dev
-private-etc alternatives,asound.conf,ca-certificates,fonts,group,passwd,pulse,resolv.conf,ssl,ld.so.conf,ld.so.cache,localtime,pki,crypto-policies,machine-id
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,group,ld.so.cache,ld.so.conf,localtime,machine-id,passwd,pki,pulse,resolv.conf,ssl
 private-tmp

--- a/etc/smplayer.profile
+++ b/etc/smplayer.profile
@@ -37,7 +37,7 @@ protocol unix,inet,inet6,netlink
 seccomp
 shell none
 
-private-bin smplayer,smtube,mplayer,mpv,youtube-dl,python*,env
+private-bin env,mplayer,mpv,python*,smplayer,smtube,youtube-dl
 private-dev
 private-tmp
 

--- a/etc/spotify.profile
+++ b/etc/spotify.profile
@@ -42,9 +42,9 @@ shell none
 tracelog
 
 disable-mnt
-private-bin spotify,bash,sh,zenity
+private-bin bash,sh,spotify,zenity
 private-dev
-private-etc alternatives,fonts,group,ld.so.cache,machine-id,pulse,resolv.conf,hosts,nsswitch.conf,host.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,ca-certificates,crypto-policies,fonts,group,host.conf,hosts,ld.so.cache,machine-id,nsswitch.conf,pki,pulse,resolv.conf,ssl
 private-opt spotify
 private-srv none
 private-tmp

--- a/etc/standardnotes-desktop.profile
+++ b/etc/standardnotes-desktop.profile
@@ -39,5 +39,5 @@ seccomp
 disable-mnt
 private-dev
 private-tmp
-private-etc alternatives,ca-certificates,fonts,host.conf,hostname,hosts,resolv.conf,ssl,pki,crypto-policies,xdg
+private-etc alternatives,ca-certificates,crypto-policies,fonts,host.conf,hostname,hosts,pki,resolv.conf,ssl,xdg
 

--- a/etc/start-tor-browser.profile
+++ b/etc/start-tor-browser.profile
@@ -34,7 +34,7 @@ shell none
 #tracelog
 
 disable-mnt
-private-bin bash,sh,grep,tail,env,gpg,id,readlink,dirname,test,mkdir,ln,sed,cp,rm,getconf
+private-bin bash,cp,dirname,env,getconf,gpg,grep,id,ln,mkdir,readlink,rm,sed,sh,tail,test
 private-dev
-private-etc alternatives,fonts,hostname,hosts,resolv.conf,pki,ssl,ca-certificates,crypto-policies,alsa,asound.conf,pulse,machine-id,ld.so.cache
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,hostname,hosts,ld.so.cache,machine-id,pki,pulse,resolv.conf,ssl
 private-tmp

--- a/etc/steam.profile
+++ b/etc/steam.profile
@@ -69,5 +69,5 @@ shell none
 # private-dev should be commented for controllers
 private-dev
 # private-etc breaks a small selection of games on some systems, comment to support those
-private-etc alternatives,asound.conf,ca-certificates,dbus-1,drirc,fonts,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,ld.so.conf,ld.so.conf.d,localtime,lsb-release,machine-id,mime.types,passwd,pulse,resolv.conf,ssl,pki,services,crypto-policies,alternatives,bumblebee,nvidia,os-release
+private-etc alternatives,alternatives,asound.conf,bumblebee,ca-certificates,crypto-policies,dbus-1,drirc,fonts,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,lsb-release,machine-id,mime.types,nvidia,os-release,passwd,pki,pulse,resolv.conf,services,ssl
 private-tmp

--- a/etc/supertuxkart.profile
+++ b/etc/supertuxkart.profile
@@ -47,7 +47,7 @@ disable-mnt
 private-bin supertuxkart
 private-cache
 private-dev
-private-etc alternatives,resolv.conf,ca-certificates,ssl,hosts,machine-id,xdg,openal,crypto-policies,pki,drirc,system-fips,selinux
+private-etc alternatives,ca-certificates,crypto-policies,drirc,hosts,machine-id,openal,pki,resolv.conf,selinux,ssl,system-fips,xdg
 private-tmp
 private-opt none
 private-srv none

--- a/etc/surf.profile
+++ b/etc/surf.profile
@@ -32,8 +32,8 @@ shell none
 tracelog
 
 disable-mnt
-private-bin ls,surf,sh,bash,curl,dmenu,printf,sed,sleep,st,stterm,xargs,xprop
+private-bin bash,curl,dmenu,ls,printf,sed,sh,sleep,st,stterm,surf,xargs,xprop
 private-dev
-private-etc alternatives,passwd,group,hosts,resolv.conf,fonts,ssl,pki,ca-certificates,crypto-policies
+private-etc alternatives,ca-certificates,crypto-policies,fonts,group,hosts,passwd,pki,resolv.conf,ssl
 private-tmp
 

--- a/etc/tar.profile
+++ b/etc/tar.profile
@@ -38,10 +38,10 @@ shell none
 tracelog
 
 # support compressed archives
-private-bin sh,bash,tar,gtar,compress,gzip,lzma,xz,bzip2,lbzip2,lzip,lzop
+private-bin bash,bzip2,compress,gtar,gzip,lbzip2,lzip,lzma,lzop,sh,tar,xz
 private-cache
 private-dev
-private-etc alternatives,passwd,group,localtime
+private-etc alternatives,group,localtime,passwd
 private-lib libfakeroot
 
 memory-deny-write-execute

--- a/etc/teams-for-linux.profile
+++ b/etc/teams-for-linux.profile
@@ -35,8 +35,8 @@ seccomp
 shell none
 
 disable-mnt
-private-bin sh,xdg-mime,tr,sed,echo,head,cut,xdg-open,grep,egrep,bash,zsh,teams-for-linux
+private-bin bash,cut,echo,egrep,grep,head,sed,sh,teams-for-linux,tr,xdg-mime,xdg-open,zsh
 private-cache
 private-dev
-private-etc fonts,machine-id,localtime,ld.so.cache,ca-certificates,ssl,pki,crypto-policies,resolv.conf
+private-etc ca-certificates,crypto-policies,fonts,ld.so.cache,localtime,machine-id,pki,resolv.conf,ssl
 private-tmp

--- a/etc/terasology.profile
+++ b/etc/terasology.profile
@@ -44,5 +44,5 @@ shell none
 
 disable-mnt
 private-dev
-private-etc alternatives,asound.conf,ca-certificates,dbus-1,drirc,fonts,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,lsb-release,machine-id,mime.types,passwd,pulse,resolv.conf,ssl,java-8-openjdk,java-7-openjdk,pki,crypto-policies
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,dbus-1,drirc,fonts,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,java-7-openjdk,java-8-openjdk,ld.so.cache,ld.so.preload,localtime,lsb-release,machine-id,mime.types,passwd,pki,pulse,resolv.conf,ssl
 private-tmp

--- a/etc/tor.profile
+++ b/etc/tor.profile
@@ -44,9 +44,9 @@ writable-var
 
 disable-mnt
 private
-private-bin tor,bash
+private-bin bash,tor
 private-cache
 private-dev
-private-etc alternatives,tor,passwd,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,ca-certificates,crypto-policies,passwd,pki,ssl,tor
 private-tmp
 

--- a/etc/torbrowser-launcher.profile
+++ b/etc/torbrowser-launcher.profile
@@ -50,5 +50,5 @@ shell none
 disable-mnt
 private-bin bash,cp,dirname,env,expr,file,getconf,gpg,grep,id,ln,mkdir,python*,readlink,rm,sed,sh,tail,tar,tclsh,test,tor-browser-en,torbrowser-launcher,xz
 private-dev
-private-etc alternatives,fonts,hostname,hosts,resolv.conf,pki,ssl,ca-certificates,crypto-policies,alsa,asound.conf,pulse,machine-id,ld.so.cache
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,hostname,hosts,ld.so.cache,machine-id,pki,pulse,resolv.conf,ssl
 private-tmp

--- a/etc/tremulous.profile
+++ b/etc/tremulous.profile
@@ -38,7 +38,7 @@ shell none
 tracelog
 
 disable-mnt
-private-bin tremulous,tremulous-wrapper,tremded
+private-bin tremded,tremulous,tremulous-wrapper
 private-cache
 private-dev
 private-tmp

--- a/etc/unrar.profile
+++ b/etc/unrar.profile
@@ -38,5 +38,5 @@ tracelog
 
 private-bin unrar
 private-dev
-private-etc alternatives,passwd,group,localtime
+private-etc alternatives,group,localtime,passwd
 private-tmp

--- a/etc/unzip.profile
+++ b/etc/unzip.profile
@@ -42,4 +42,4 @@ tracelog
 private-bin unzip
 private-cache
 private-dev
-private-etc alternatives,passwd,group,localtime
+private-etc alternatives,group,localtime,passwd

--- a/etc/utox.profile
+++ b/etc/utox.profile
@@ -41,7 +41,7 @@ disable-mnt
 private-bin utox
 private-cache
 private-dev
-private-etc alternatives,fonts,resolv.conf,ld.so.cache,localtime,ca-certificates,ssl,pki,crypto-policies,machine-id,pulse,openal
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,localtime,machine-id,openal,pki,pulse,resolv.conf,ssl
 private-tmp
 
 memory-deny-write-execute

--- a/etc/vlc.profile
+++ b/etc/vlc.profile
@@ -34,7 +34,7 @@ protocol unix,inet,inet6,netlink
 seccomp
 shell none
 
-private-bin vlc,cvlc,nvlc,rvlc,qvlc,svlc
+private-bin cvlc,nvlc,qvlc,rvlc,svlc,vlc
 private-dev
 private-tmp
 

--- a/etc/w3m.profile
+++ b/etc/w3m.profile
@@ -36,5 +36,5 @@ tracelog
 # private-bin w3m
 private-cache
 private-dev
-private-etc alternatives,resolv.conf,ssl,pki,ca-certificates,crypto-policies
+private-etc alternatives,ca-certificates,crypto-policies,pki,resolv.conf,ssl
 private-tmp

--- a/etc/whois.profile
+++ b/etc/whois.profile
@@ -36,7 +36,7 @@ shell none
 
 disable-mnt
 private
-private-bin sh,bash,whois
+private-bin bash,sh,whois
 private-cache
 private-dev
 # private-etc alternatives,hosts,services,whois.conf

--- a/etc/wire-desktop.profile
+++ b/etc/wire-desktop.profile
@@ -34,7 +34,7 @@ shell none
 # it is not in PATH. To use Wire with firejail, run "firejail /opt/wire-desktop/wire-desktop"
 
 disable-mnt
-private-bin wire-desktop,bash,sh,env,electron
+private-bin bash,electron,env,sh,wire-desktop
 private-dev
-private-etc alternatives,fonts,machine-id,resolv.conf,ca-certificates,ssl,pki,crypto-policies
+private-etc alternatives,ca-certificates,crypto-policies,fonts,machine-id,pki,resolv.conf,ssl
 private-tmp

--- a/etc/xfce4-mixer.profile
+++ b/etc/xfce4-mixer.profile
@@ -42,7 +42,7 @@ disable-mnt
 private-bin xfce4-mixer,xfconf-query
 private-cache
 private-dev
-private-etc alternatives,asound.conf,fonts,pulse,machine-id
+private-etc alternatives,asound.conf,fonts,machine-id,pulse
 private-tmp
 
 memory-deny-write-execute

--- a/etc/xiphos.profile
+++ b/etc/xiphos.profile
@@ -46,5 +46,5 @@ disable-mnt
 private-bin xiphos
 private-cache
 private-dev
-private-etc alternatives,fonts,resolv.conf,sword,ca-certificates,ssli,sword.conf,pki,crypto-policies
+private-etc alternatives,ca-certificates,crypto-policies,fonts,pki,resolv.conf,ssli,sword,sword.conf
 private-tmp

--- a/etc/xonotic.profile
+++ b/etc/xonotic.profile
@@ -37,6 +37,6 @@ shell none
 disable-mnt
 private-bin bash,blind-id,darkplaces-glx,darkplaces-sdl,dirname,grep,ldd,netstat,ps,readlink,sh,uname,xonotic,xonotic-glx,xonotic-linux32-dedicated,xonotic-linux32-glx,xonotic-linux32-sdl,xonotic-linux64-dedicated,xonotic-linux64-glx,xonotic-linux64-sdl,xonotic-sdl
 private-dev
-private-etc alternatives,asound.conf,ca-certificates,drirc,fonts,group,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,nsswitch.conf,passwd,pulse,resolv.conf,ssl,pki,crypto-policies,machine-id
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,drirc,fonts,group,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,machine-id,nsswitch.conf,passwd,pki,pulse,resolv.conf,ssl
 private-tmp
 

--- a/etc/youtube-dl.profile
+++ b/etc/youtube-dl.profile
@@ -49,10 +49,10 @@ shell none
 tracelog
 
 disable-mnt
-private-bin youtube-dl,python*,ffmpeg,env
+private-bin env,ffmpeg,python*,youtube-dl
 private-cache
 private-dev
-private-etc alternatives,ssl,pki,ca-certificates,hostname,hosts,resolv.conf,youtube-dl.conf,crypto-policies,mime.types
+private-etc alternatives,ca-certificates,crypto-policies,hostname,hosts,mime.types,pki,resolv.conf,ssl,youtube-dl.conf
 private-tmp
 
 # memory-deny-write-execute - breaks on Arch

--- a/etc/zart.profile
+++ b/etc/zart.profile
@@ -31,6 +31,6 @@ protocol unix
 seccomp
 shell none
 
-private-bin zart,ffmpeg,melt,ffprobe,ffplay
+private-bin ffmpeg,ffplay,ffprobe,melt,zart
 private-dev
 


### PR DESCRIPTION
Bring all private-etc and private-bin lines into an alphabetical order, using this:
https://gist.github.com/rusty-snake/a1010a3daf3c54e93dfe03f2f5ce3d96

* special characters are ignored
* the script order case insensitive

Missing (will not be implemented, only for completeness): 
 * commented lines
   * `#private-{bin,etc}`, `# private-{bin,etc}`
   * What about something like `# private-etc foo,bar -- breaks baz` and
`# private-etc must first be enabled in foobar`
 * `private-lib`
 * see also https://github.com/netblue30/firejail/issues/2739#issuecomment-499892002
 * review
