### PR TITLE
chromium: disable nodbus

### DIFF
--- a/etc/chromium-common.profile
+++ b/etc/chromium-common.profile
@@ -29,8 +29,7 @@ include whitelist-var-common.inc
 apparmor
 caps.keep sys_chroot,sys_admin
 netfilter
-# Breaks Gnome connector - disable if you use that
-nodbus
+# nodbus - prevents access to passwords saved in GNOME Keyring, also breaks Gnome connector
 nodvd
 nogroups
 notv


### PR DESCRIPTION
Unfortunately `nodbus` prevents access to site passwords if they are stored in [GNOME Keyring](https://wiki.gnome.org/Projects/GnomeKeyring). According to [docs](https://chromium.googlesource.com/chromium/src.git/+/master/docs/linux_password_storage.md) chromium can store password in 3 different ways:

- GNOME Keyring
- KWallet 4
- plain text

As KWallet storage may be broken in a same way, using `nodbus` will force chromium to store passwords in plain text which isn't best option for security and for firejail default.