### PR TITLE
Sort private-lib

### DIFF
--- a/etc/assogiate.profile
+++ b/etc/assogiate.profile
@@ -43,7 +43,7 @@ disable-mnt
 private-bin assogiate,gtk-update-icon-cache,update-mime-database
 private-cache
 private-dev
-private-lib gnome-vfs-2.0,libattr.so.*,libacl.so.*,libfam.so.*
+private-lib gnome-vfs-2.0,libacl.so.*,libattr.so.*,libfam.so.*
 private-tmp
 
 memory-deny-write-execute

--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -43,7 +43,7 @@ private-bin evince,evince-previewer,evince-thumbnailer
 private-cache
 private-dev
 private-etc alternatives,fonts,group,machine-id,passwd
-private-lib evince,gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libdjvulibre.so.*,libgconf-2.so.*,libpoppler-glib.so.*,librsvg-2.so.*,libspectre.so.*,gconv
+private-lib evince,gconv,gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libdjvulibre.so.*,libgconf-2.so.*,libpoppler-glib.so.*,librsvg-2.so.*,libspectre.so.*
 private-tmp
 
 # memory-deny-write-execute - might break application (https://github.com/netblue30/firejail/issues/1803)

--- a/etc/gedit.profile
+++ b/etc/gedit.profile
@@ -45,6 +45,6 @@ tracelog
 # private-bin gedit
 private-dev
 # private-etc alternatives,fonts
-private-lib /usr/bin/gedit,libtinfo.so.*,libreadline.so.*,gedit,libgspell-1.so.*,gconv,aspell
+private-lib aspell,gconv,gedit,libgspell-1.so.*,libreadline.so.*,libtinfo.so.*
 private-tmp
 

--- a/etc/gnome-nettool.profile
+++ b/etc/gnome-nettool.profile
@@ -39,6 +39,6 @@ disable-mnt
 private
 private-cache
 private-dev
-private-lib libgtk-3.so.*,libgtop*,libbind9.so.*,libcrypto.so.*,libdns.so.*,libirs.so.*,liblua.so.*,libssh2.so.*,libssl.so.*
+private-lib libbind9.so.*,libcrypto.so.*,libdns.so.*,libgtk-3.so.*,libgtop*,libirs.so.*,liblua.so.*,libssh2.so.*,libssl.so.*
 private-tmp
 


### PR DESCRIPTION
In similar vain as https://github.com/netblue30/firejail/pull/2766, but this time for private-lib. The little [gem](https://gist.github.com/rusty-snake/a1010a3daf3c54e93dfe03f2f5ce3d96) from @rusty-snake was easily extended to handle private-lib besides private-bin and private-etc. Might be another nice addition for contrib.