### PR TITLE
Sort caps.keep and seccomp.drop options

### DIFF
--- a/etc/chromium-common.profile
+++ b/etc/chromium-common.profile
@@ -27,7 +27,7 @@ include whitelist-common.inc
 include whitelist-var-common.inc
 
 apparmor
-caps.keep sys_chroot,sys_admin
+caps.keep sys_admin,sys_chroot
 netfilter
 # nodbus - prevents access to passwords saved in GNOME Keyring, also breaks Gnome connector
 nodvd

--- a/etc/dnscrypt-proxy.profile
+++ b/etc/dnscrypt-proxy.profile
@@ -26,7 +26,7 @@ nosound
 notv
 nou2f
 novideo
-seccomp.drop mount,umount2,ptrace,kexec_load,kexec_file_load,open_by_handle_at,init_module,finit_module,delete_module,iopl,ioperm,swapon,swapoff,syslog,process_vm_readv,process_vm_writev,sysfs,_sysctl,adjtimex,clock_adjtime,lookup_dcookie,perf_event_open,fanotify_init,kcmp,add_key,request_key,keyctl,uselib,acct,modify_ldt,pivot_root,io_setup,io_destroy,io_getevents,io_submit,io_cancel,remap_file_pages,mbind,get_mempolicy,set_mempolicy,migrate_pages,move_pages,vmsplice,perf_event_open
+seccomp.drop _sysctl,acct,add_key,adjtimex,clock_adjtime,delete_module,fanotify_init,finit_module,get_mempolicy,init_module,io_cancel,io_destroy,io_getevents,io_setup,io_submit,ioperm,iopl,kcmp,kexec_file_load,kexec_load,keyctl,lookup_dcookie,mbind,migrate_pages,modify_ldt,mount,move_pages,open_by_handle_at,perf_event_open,perf_event_open,pivot_root,process_vm_readv,process_vm_writev,ptrace,remap_file_pages,request_key,set_mempolicy,swapoff,swapon,sysfs,syslog,umount2,uselib,vmsplice
 
 disable-mnt
 private

--- a/etc/qgis.profile
+++ b/etc/qgis.profile
@@ -45,7 +45,7 @@ notv
 nou2f
 novideo
 # blacklisting of mbind system calls breaks old version
-seccomp.drop @cpu-emulation,@debug,@obsolete,@privileged,set_mempolicy,migrate_pages,move_pages,open_by_handle_at,name_to_handle_at,ioprio_set,ni_syscall,syslog,fanotify_init,kcmp,add_key,request_key,keyctl,io_setup,io_destroy,io_getevents,io_submit,io_cancel,remap_file_pages,vmsplice,umount,userfaultfd,mincore
+seccomp.drop @cpu-emulation,@debug,@obsolete,@privileged,add_key,fanotify_init,io_cancel,io_destroy,io_getevents,io_setup,io_submit,ioprio_set,kcmp,keyctl,migrate_pages,mincore,move_pages,name_to_handle_at,ni_syscall,open_by_handle_at,remap_file_pages,request_key,set_mempolicy,syslog,umount,userfaultfd,vmsplice
 protocol unix,inet,inet6,netlink
 shell none
 tracelog

--- a/etc/tor.profile
+++ b/etc/tor.profile
@@ -25,7 +25,7 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-xdg.inc
 
-caps.keep setuid,setgid,net_bind_service,dac_read_search
+caps.keep dac_read_search,net_bind_service,setgid,setuid
 ipc-namespace
 machine-id
 netfilter

--- a/etc/unbound.profile
+++ b/etc/unbound.profile
@@ -29,7 +29,7 @@ nosound
 notv
 nou2f
 novideo
-seccomp.drop mount,umount2,ptrace,kexec_load,kexec_file_load,open_by_handle_at,init_module,finit_module,delete_module,iopl,ioperm,swapon,swapoff,syslog,process_vm_readv,process_vm_writev,sysfs,_sysctl,adjtimex,clock_adjtime,lookup_dcookie,perf_event_open,fanotify_init,kcmp,add_key,request_key,keyctl,uselib,acct,modify_ldt,pivot_root,io_setup,io_destroy,io_getevents,io_submit,io_cancel,remap_file_pages,mbind,get_mempolicy,set_mempolicy,migrate_pages,move_pages,vmsplice,perf_event_open
+seccomp.drop _sysctl,acct,add_key,adjtimex,clock_adjtime,delete_module,fanotify_init,finit_module,get_mempolicy,init_module,io_cancel,io_destroy,io_getevents,io_setup,io_submit,ioperm,iopl,kcmp,kexec_file_load,kexec_load,keyctl,lookup_dcookie,mbind,migrate_pages,modify_ldt,mount,move_pages,open_by_handle_at,perf_event_open,perf_event_open,pivot_root,process_vm_readv,process_vm_writev,ptrace,remap_file_pages,request_key,set_mempolicy,swapoff,swapon,sysfs,syslog,umount2,uselib,vmsplice
 writable-var
 
 disable-mnt


### PR DESCRIPTION
Follow-up on https://github.com/netblue30/firejail/pull/2766, https://github.com/netblue30/firejail/pull/2778 and https://github.com/netblue30/firejail/pull/2779. This time caps.{drop,keep} and seccomp.{drop,keep} lines are alphabetically sorted.

Again, all credit goes to @rusty-snake for having started the sorting work and for creating and extending [sort.py](https://gist.github.com/rusty-snake/a1010a3daf3c54e93dfe03f2f5ce3d96). I took the liberty of [building upon his script](https://gist.github.com/glitsj16/5304988cfa7fd2d7f8db2d88cc6e86cf) to account for caps.{drop,keep} and seccomp.{drop,keep}.