### PR TITLE
allow nodbus in thunderbird profile

### DIFF
--- a/etc/thunderbird.profile
+++ b/etc/thunderbird.profile
@@ -32,16 +32,14 @@ ignore private-tmp
 # machine-id breaks audio in browsers; enable it when sound is not required
 # machine-id
 read-only ${HOME}/.config/mimeapps.list
-# writable-run-user is needed for signing and encrypting emails
+# writable-run-user and nodbus are needed for signing and encrypting emails
+ignore nodbus
 writable-run-user
 
 # If you want to read local mail stored in /var/mail, add the following to thunderbird.local:
 # noblacklist /var/mail
 # noblacklist /var/spool/mail
 # writable-var
-
-# Uncomment (or put in thunderbird.local) if you use enigmail
-#ignore nodbus
 
 # allow browsers
 # Redirect

--- a/etc/thunderbird.profile
+++ b/etc/thunderbird.profile
@@ -32,9 +32,9 @@ ignore private-tmp
 # machine-id breaks audio in browsers; enable it when sound is not required
 # machine-id
 read-only ${HOME}/.config/mimeapps.list
-# writable-run-user and nodbus are needed for signing and encrypting emails
-ignore nodbus
+# writable-run-user and dbus are needed by enigmail
 writable-run-user
+ignore nodbus
 
 # If you want to read local mail stored in /var/mail, add the following to thunderbird.local:
 # noblacklist /var/mail


### PR DESCRIPTION
The current state is not consistent, in that we permit access to the gnupg-agent sockets but disallow
access to the d-bus.

Both of them tear a hole into the sandbox, the question is if the profile should support enigmail out of the box or not (as you could guess from the pull request I'm leaning more to supporting it).