### PR TITLE
Tighten SSH with nodbus

### DIFF
--- a/etc/ssh-agent.profile
+++ b/etc/ssh-agent.profile
@@ -19,6 +19,7 @@ include disable-programs.inc
 caps.drop all
 netfilter
 no3d
+nodbus
 nodvd
 nonewprivs
 noroot

--- a/etc/ssh.profile
+++ b/etc/ssh.profile
@@ -22,6 +22,7 @@ caps.drop all
 ipc-namespace
 netfilter
 no3d
+nodbus
 nodvd
 nogroups
 nonewprivs


### PR DESCRIPTION
I've been running a few weeks with `nodbus` added to ssh{,-agent}.profile. No mishaps so far. Obviously SSH has a wide variety of use-cases, of which I personally run only a fraction on a daily basis. Hence the `draft` status, to get more feedback on the topic. Any reason(s) why D-Bus might be required in these profiles?