### PR TITLE
Streamline redirect profiles (follow-up)

### DIFF
--- a/etc/Discord.profile
+++ b/etc/Discord.profile
@@ -5,7 +5,6 @@ include Discord.local
 # Persistent global definitions
 include globals.local
 
-
 noblacklist ${HOME}/.config/discord
 
 mkdir ${HOME}/.config/discord
@@ -14,5 +13,5 @@ whitelist ${HOME}/.config/discord
 private-bin Discord
 private-opt Discord
 
-#Redirect
+# Redirect
 include discord-common.profile

--- a/etc/DiscordCanary.profile
+++ b/etc/DiscordCanary.profile
@@ -5,7 +5,6 @@ include DiscordCanary.local
 # Persistent global definitions
 include globals.local
 
-
 noblacklist ${HOME}/.config/discordcanary
 
 mkdir ${HOME}/.config/discordcanary
@@ -14,5 +13,5 @@ whitelist ${HOME}/.config/discordcanary
 private-bin DiscordCanary
 private-opt DiscordCanary
 
-#Redirect
+# Redirect
 include discord-common.profile

--- a/etc/atom-beta.profile
+++ b/etc/atom-beta.profile
@@ -2,5 +2,9 @@
 # This file is overwritten after every install/update
 # Persistent local customizations
 include atom-beta.local
-# Profile redirect
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+# Redirect
 include atom.profile

--- a/etc/autokey-gtk.profile
+++ b/etc/autokey-gtk.profile
@@ -7,5 +7,5 @@ include autokey-gtk.local
 # added by included profile
 #include globals.local
 
-#Redirect
+# Redirect
 include autokey-common.profile

--- a/etc/autokey-qt.profile
+++ b/etc/autokey-qt.profile
@@ -7,5 +7,5 @@ include autokey-qt.local
 # added by included profile
 #include globals.local
 
-#Redirect
+# Redirect
 include autokey-common.profile

--- a/etc/autokey-run.profile
+++ b/etc/autokey-run.profile
@@ -7,5 +7,5 @@ include autokey-run.local
 # added by included profile
 #include globals.local
 
-#Redirect
+# Redirect
 include autokey-common.profile

--- a/etc/autokey-shell.profile
+++ b/etc/autokey-shell.profile
@@ -7,5 +7,5 @@ include autokey-shell.local
 # added by included profile
 #include globals.local
 
-#Redirect
+# Redirect
 include autokey-common.profile

--- a/etc/chromium-common.profile
+++ b/etc/chromium-common.profile
@@ -3,7 +3,7 @@
 # Persistent local customizations
 include chromium-common.local
 # Persistent global definitions
-# already included by caller profile
+# added by caller profile
 #include globals.local
 
 # noexec ${HOME} breaks DRM binaries.

--- a/etc/cryptocat.profile
+++ b/etc/cryptocat.profile
@@ -1,6 +1,5 @@
 # Firejail profile alias for Cryptocat
 # This file is overwritten after every install/update
 
-
 # Redirect
 include Cryptocat.profile

--- a/etc/discord-canary.profile
+++ b/etc/discord-canary.profile
@@ -5,7 +5,6 @@ include discord-canary.local
 # Persistent global definitions
 include globals.local
 
-
 noblacklist ${HOME}/.config/discordcanary
 
 mkdir ${HOME}/.config/discordcanary

--- a/etc/discord-canary.profile
+++ b/etc/discord-canary.profile
@@ -13,5 +13,5 @@ whitelist ${HOME}/.config/discordcanary
 private-bin discord-canary
 private-opt discord-canary
 
-#Redirect
+# Redirect
 include discord-common.profile

--- a/etc/discord-common.profile
+++ b/etc/discord-common.profile
@@ -3,7 +3,7 @@
 # Persistent local customizations
 include discord-common.local
 # Persistent global definitions
-# already included by caller profile
+# added by caller profile
 #include globals.local
 
 include disable-common.inc

--- a/etc/discord.profile
+++ b/etc/discord.profile
@@ -5,7 +5,6 @@ include discord.local
 # Persistent global definitions
 include globals.local
 
-
 noblacklist ${HOME}/.config/discord
 
 mkdir ${HOME}/.config/discord

--- a/etc/discord.profile
+++ b/etc/discord.profile
@@ -13,5 +13,5 @@ whitelist ${HOME}/.config/discord
 private-bin discord
 private-opt discord
 
-#Redirect
+# Redirect
 include discord-common.profile

--- a/etc/firefox-common.profile
+++ b/etc/firefox-common.profile
@@ -3,7 +3,7 @@
 # Persistent local customizations
 include firefox-common.local
 # Persistent global definitions
-# already included by caller profile
+# added by caller profile
 #include globals.local
 
 # noexec ${HOME} breaks DRM binaries.


### PR DESCRIPTION
I missed these in https://github.com/netblue30/firejail/pull/2802. Thanks at @rusty-snake for nudging me about this.

@rusty-snake I didn't fully understand your message in https://github.com/netblue30/firejail/pull/2802. GH hides something that I can read in the email version:

> Great, still need streamlining:
> * atom-beta.profile
> * cryptocat.profile
> * cyberfox.profile
> * discord-canary.profile
> * DiscordCanary.profile
> * discord.profile
> * Discord.profile
> 
> 
> > @@ -16,6 +16,5 @@ whitelist ${HOME}/.mozilla  
>  \# private-etc must first be enabled in firefox-common.profile
> 
> `include globals.local`

If this relates to cyberfox.profile: that redirects to firefox-common.profile, which does not include globals.local (cfr. the comment inside). So I didn't need to touch cyberfox.profile. But you might have been referring to something else. If so, would you be so kind to reformulate what I've missed please?