### PR TITLE
Change include/redirect logic in autokey profiles

### DIFF
--- a/etc/autokey-common.profile
+++ b/etc/autokey-common.profile
@@ -4,7 +4,8 @@
 # Persistent local customizations
 include autokey-common.local
 # Persistent global definitions
-include globals.local
+# added by caller profile
+#include globals.local
 
 noblacklist ${HOME}/.config/autokey
 noblacklist ${HOME}/.local/share/autokey

--- a/etc/autokey-gtk.profile
+++ b/etc/autokey-gtk.profile
@@ -4,8 +4,7 @@
 # Persistent local customizations
 include autokey-gtk.local
 # Persistent global definitions
-# added by included profile
-#include globals.local
+include globals.local
 
 # Redirect
 include autokey-common.profile

--- a/etc/autokey-qt.profile
+++ b/etc/autokey-qt.profile
@@ -4,8 +4,7 @@
 # Persistent local customizations
 include autokey-qt.local
 # Persistent global definitions
-# added by included profile
-#include globals.local
+include globals.local
 
 # Redirect
 include autokey-common.profile

--- a/etc/autokey-run.profile
+++ b/etc/autokey-run.profile
@@ -4,8 +4,7 @@
 # Persistent local customizations
 include autokey-run.local
 # Persistent global definitions
-# added by included profile
-#include globals.local
+include globals.local
 
 # Redirect
 include autokey-common.profile

--- a/etc/autokey-shell.profile
+++ b/etc/autokey-shell.profile
@@ -4,8 +4,7 @@
 # Persistent local customizations
 include autokey-shell.local
 # Persistent global definitions
-# added by included profile
-#include globals.local
+include globals.local
 
 # Redirect
 include autokey-common.profile


### PR DESCRIPTION
This brings the autokey profiles inline with all other redirect profiles. It should help users who use the templates, now that the instructions are correctly implemented (especially from https://github.com/netblue30/firejail/commit/19e8ce46412670172e72cb987f085c770ae5c3ec).