### PR TITLE
Run firefox with your profile when clicking a link

### DIFF
--- a/etc/thunderbird.profile
+++ b/etc/thunderbird.profile
@@ -14,6 +14,12 @@ noblacklist ${HOME}/.gnupg
 # noblacklist ${HOME}/.icedove
 noblacklist ${HOME}/.thunderbird
 
+# Allow Firefox to load your profile when clicking a link in an email
+#noblacklist ${HOME}/.cache/mozilla
+#noblacklist ${HOME}/.mozilla
+#whitelist ${HOME}/.cache/mozilla/firefox
+#whitelist ${HOME}/.mozilla
+
 # If you have setup Thunderbird to archive emails to a local folder,
 # make sure you add the path to that folder to the mkdir and whitelist
 # rules below. Otherwise they will be deleted when you close Thunderbird.

--- a/etc/thunderbird.profile
+++ b/etc/thunderbird.profile
@@ -14,7 +14,8 @@ noblacklist ${HOME}/.gnupg
 # noblacklist ${HOME}/.icedove
 noblacklist ${HOME}/.thunderbird
 
-# Allow Firefox to load your profile when clicking a link in an email
+# Uncomment the next 4 lines or put they in your thunderbird.local to
+# allow Firefox to load your profile when clicking a link in an email
 #noblacklist ${HOME}/.cache/mozilla
 #noblacklist ${HOME}/.mozilla
 #whitelist ${HOME}/.cache/mozilla/firefox


### PR DESCRIPTION
When clicking a link in an email in Thunderbird, Firefox profile is not loaded. 

This fix add the commented parameters required to load the Firefox profile when the user clicked in an email.
