### PR TITLE
Add electron4 to allow wire-desktop to launch on Arch Linux

### DIFF
--- a/etc/wire-desktop.profile
+++ b/etc/wire-desktop.profile
@@ -34,7 +34,7 @@ shell none
 # it is not in PATH. To use Wire with firejail, run "firejail /opt/wire-desktop/wire-desktop"
 
 disable-mnt
-private-bin bash,electron,env,sh,wire-desktop
+private-bin bash,electron,electron4,env,sh,wire-desktop
 private-dev
 private-etc alternatives,ca-certificates,crypto-policies,fonts,machine-id,pki,resolv.conf,ssl
 private-tmp


### PR DESCRIPTION
`electron` has recently been changed on Arch Linux and `wire-desktop` launches with `electron4` now instead of `electron`. This is the new launcher script from the Arch package:

```
#!/usr/bin/env sh

electron4 "/usr/lib/wire-desktop" "$@"
```
This PR adds `electron4` to the `private-bin` declaration to allow the program to successfully launch on Arch.