### PR TITLE
Add youtube-dl config handling

### DIFF
--- a/etc/celluloid.profile
+++ b/etc/celluloid.profile
@@ -6,8 +6,9 @@ include celluloid.local
 # Persistent global definitions
 include globals.local
 
-noblacklist ${HOME}/.config/gnome-mpv
 noblacklist ${HOME}/.config/celluloid
+noblacklist ${HOME}/.config/gnome-mpv
+noblacklist ${HOME}/.config/youtube-dl
 noblacklist ${MUSIC}
 noblacklist ${VIDEOS}
 

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -319,6 +319,7 @@ blacklist ${HOME}/.config/xviewer
 blacklist ${HOME}/.config/yandex-browser
 blacklist ${HOME}/.config/yandex-browser-beta
 blacklist ${HOME}/.config/yelp
+blacklist ${HOME}/.config/youtube-dl
 blacklist ${HOME}/.config/zathura
 blacklist ${HOME}/.config/zoomus.conf
 blacklist ${HOME}/.conkeror.mozdev.org

--- a/etc/mpsyt.profile
+++ b/etc/mpsyt.profile
@@ -8,6 +8,7 @@ include globals.local
 
 noblacklist ${HOME}/.config/mps-youtube
 noblacklist ${HOME}/.config/mpv
+noblacklist ${HOME}/.config/youtube-dl
 noblacklist ${HOME}/.mplayer
 noblacklist ${HOME}/.netrc
 noblacklist ${HOME}/mps
@@ -29,10 +30,12 @@ include disable-xdg.inc
 
 mkdir ${HOME}/.config/mps-youtube
 mkdir ${HOME}/.config/mpv
+mkdir ${HOME}/.config/youtube-dl
 mkdir ${HOME}/.mplayer
 mkdir ${HOME}/mps
 whitelist ${HOME}/.config/mps-youtube
 whitelist ${HOME}/.config/mpv
+whitelist ${HOME}/.config/youtube-dl
 whitelist ${HOME}/.mplayer
 whitelist ${HOME}/.netrc
 whitelist ${HOME}/mps

--- a/etc/mpv.profile
+++ b/etc/mpv.profile
@@ -8,6 +8,7 @@ include mpv.local
 include globals.local
 
 noblacklist ${HOME}/.config/mpv
+noblacklist ${HOME}/.config/youtube-dl
 noblacklist ${HOME}/.netrc
 
 # Allow python (blacklisted by disable-interpreters.inc)

--- a/etc/smplayer.profile
+++ b/etc/smplayer.profile
@@ -7,6 +7,7 @@ include smplayer.local
 include globals.local
 
 noblacklist ${HOME}/.config/smplayer
+noblacklist ${HOME}/.config/youtube-dl
 noblacklist ${HOME}/.mplayer
 
 # Allow python (blacklisted by disable-interpreters.inc)

--- a/etc/youtube-dl.profile
+++ b/etc/youtube-dl.profile
@@ -10,6 +10,7 @@ include globals.local
 # breaks when installed via pip
 ignore noexec ${HOME}
 
+noblacklist ${HOME}/.config/youtube-dl
 noblacklist ${HOME}/.netrc
 noblacklist ${MUSIC}
 noblacklist ${VIDEOS}


### PR DESCRIPTION
Was there any reason not to handle `${HOME}/.config/youtube-dl` like the rest of the profiles do with application's configuration files?