### PR TITLE
Update pid.c

### DIFF
--- a/src/lib/pid.c
+++ b/src/lib/pid.c
@@ -329,10 +329,9 @@ void pid_read(pid_t mon_pid) {
 		}
 	}
 
-	pid_t child = -1;
 	struct dirent *entry;
 	char *end;
-	while (child < 0 && (entry = readdir(dir))) {
+	while ((entry = readdir(dir))) {
 		pid_t pid = strtol(entry->d_name, &end, 10);
 		pid %= max_pids;
 		if (end == entry->d_name || *end)


### PR DESCRIPTION
Remove redundant `child` variable in src/lib/pid.c.

The `child` variable once set to `-1`, is never reassigned/changed later on.

Found with LGTM: https://lgtm.com/projects/g/netblue30/firejail/snapshot/961c4ca00425b60a7bc8543460031a8ebf3d8aa6/files/src/lib/pid.c?sort=name&dir=ASC&mode=heatmap#xf54d23e21602e321:1