### PR TITLE
Update libpostexecseccomp.c

### DIFF
--- a/src/libpostexecseccomp/libpostexecseccomp.c
+++ b/src/libpostexecseccomp/libpostexecseccomp.c
@@ -40,9 +40,7 @@ static void load_seccomp(void) {
 		return;
 	}
 	unsigned short entries = (unsigned short) size / (unsigned short) sizeof(struct sock_filter);
-	struct sock_filter *filter = MAP_FAILED;
-	
-	filter = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+	struct sock_filter *filter = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
 	close(fd);
 
 	if (filter == MAP_FAILED) {

--- a/src/libpostexecseccomp/libpostexecseccomp.c
+++ b/src/libpostexecseccomp/libpostexecseccomp.c
@@ -41,8 +41,8 @@ static void load_seccomp(void) {
 	}
 	unsigned short entries = (unsigned short) size / (unsigned short) sizeof(struct sock_filter);
 	struct sock_filter *filter = MAP_FAILED;
-	if (size != 0)
-		filter = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+	
+	filter = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
 	close(fd);
 
 	if (filter == MAP_FAILED) {


### PR DESCRIPTION
Removes `if (size != 0)` condition, which is always true as there is a `if (size <= 0)` condition before.

Also note that if the `if (size <= 0)` condition wouldn't be there and `size` would be 0, there would have been an undefined behavior in due to division by zero in `(unsigned short) size / (unsigned short) sizeof(struct sock_filter);`.

Found with LGTM: https://lgtm.com/projects/g/netblue30/firejail/snapshot/961c4ca00425b60a7bc8543460031a8ebf3d8aa6/files/src/libpostexecseccomp/libpostexecseccomp.c#x838c24f710410160:1
