### PR TITLE
Make 'allow-debuggers' configurable in profiles

### DIFF
--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -941,6 +941,11 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		return 0;
 	}
 
+	if (strcmp(ptr, "allow-debuggers") == 0) {
+		arg_allow_debuggers = 1;
+		return 0;
+	}
+
 	if (strcmp(ptr, "x11 none") == 0) {
 		arg_x11_block = 1;
 		return 0;


### PR DESCRIPTION
When debugging applications inside an IDE regularly, always passing the command line option `--allow-debuggers` becomes cumbersome.

This fix adds a new option `allow-debuggers` to the profile code, so if debugging capabilities are always needed, the profile of the application can simply be extended with that option. 