### PR TITLE
document profile support for allow-debuggers in firejail-profile man page

### DIFF
--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -337,6 +337,9 @@ directory, and a skeleton filesystem is created based on the original /var/log.
 The following security filters are currently implemented:
 
 .TP
+\fBallow-debuggers
+Allow tools such as strace and gdb inside the sandbox by whitelisting system calls ptrace and process_vm_readv.
+.TP
 \fBapparmor
 Enable AppArmor confinement.
 .TP


### PR DESCRIPTION
Adds documentation to firejail-profile man page for the new `allow-debuggers` profile option from #2856 as discussed by @SkewedZeppelin  in https://github.com/netblue30/firejail/pull/2856#issuecomment-511560561.

 