### PR TITLE
qpdfview: Fix issue when opening a file from file manager

### DIFF
--- a/etc/qpdfview.profile
+++ b/etc/qpdfview.profile
@@ -22,7 +22,6 @@ include whitelist-var-common.inc
 
 caps.drop all
 machine-id
-nodbus
 nodvd
 nogroups
 nonewprivs


### PR DESCRIPTION
I can confirm https://github.com/netblue30/firejail/pull/2837#issuecomment-511334363 when opening a file from `pcmanfm`, it doesn't open if qpdfview contains `nodbus`