### PR TITLE
Add new Tor Browser alias

### DIFF
--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -627,6 +627,7 @@ blacklist ${HOME}/.teeworlds
 blacklist ${HOME}/.thunderbird
 blacklist ${HOME}/.tilp
 blacklist ${HOME}/.tooling
+blacklist ${HOME}/.tor-browser
 blacklist ${HOME}/.tor-browser-*
 blacklist ${HOME}/.tor-browser_*
 blacklist ${HOME}/.torcs

--- a/etc/tor-browser.profile
+++ b/etc/tor-browser.profile
@@ -1,0 +1,10 @@
+# Firejail profile alias for torbrowser-launcher
+# This file is overwritten after every install/update
+
+noblacklist ${HOME}/.tor-browser
+
+mkdir ${HOME}/.tor-browser
+whitelist ${HOME}/.tor-browser
+
+# Redirect
+include torbrowser-launcher.profile

--- a/etc/torbrowser-launcher.profile
+++ b/etc/torbrowser-launcher.profile
@@ -48,7 +48,7 @@ shell none
 #tracelog
 
 disable-mnt
-private-bin bash,cat,cp,cut,dirname,env,expr,file,getconf,gpg,grep,gxmessage,id,kdialog,ln,mkdir,pwd,python*,readlink,realpath,rm,sed,sh,tail,tar,tclsh,test,tor-browser-en,torbrowser-launcher,update-desktop-database,xmessage,xz,zenity
+private-bin bash,cat,cp,cut,dirname,env,expr,file,getconf,gpg,grep,gxmessage,id,kdialog,ln,mkdir,mv,pwd,python*,readlink,realpath,rm,sed,sh,tail,tar,tclsh,test,tor-browser,tor-browser-en,torbrowser-launcher,update-desktop-database,xmessage,xz,zenity
 private-dev
 private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,hostname,hosts,ld.so.cache,machine-id,pki,pulse,resolv.conf,ssl
 private-tmp

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -561,6 +561,7 @@ thunderbird
 thunderbird-beta
 thunderbird-wayland
 tilp
+tor-browser
 tor-browser-ar
 tor-browser-ca
 tor-browser-cs


### PR DESCRIPTION
- tor-browser in the AUR is an international package; all other
individual language variants have been removed, so, add new alias
- Add 'tor-browser' and 'mv' to private-bin in launcher profile ('mv' is
required when upgrading tor-browser versions)
- Add 'tor-browser' to firecfg.config
- Add config dir to disable-programs.inc