### PR TITLE
Fix QOwnNotes path

### DIFF
--- a/etc/QOwnNotes.profile
+++ b/etc/QOwnNotes.profile
@@ -20,7 +20,7 @@ include disable-programs.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/Nextcloud/Notes
-mkdir ${HOME}.config/PBE
+mkdir ${HOME}/.config/PBE
 mkdir ${HOME}/.local/share/PBE
 whitelist ${DOCUMENTS}
 whitelist ${HOME}/Nextcloud/Notes


### PR DESCRIPTION
Every time QOwnNotes was started, setup Wizard was shown. Log shown:
`Warning: cannot create xxx.config directory`
