### PR TITLE
get_user() do not use the unreliable getlogin()

### DIFF
--- a/src/firecfg/main.c
+++ b/src/firecfg/main.c
@@ -284,9 +284,9 @@ static void set_links_homedir(const char *homedir) {
 }
 
 static char *get_user(void) {
-	char *user = getlogin();
+	char *user = getenv("SUDO_USER");
 	if (!user) {
-		user = getenv("SUDO_USER");
+		user = getpwuid(getuid())->pw_name;
 		if (!user) {
 			fprintf(stderr, "Error: cannot detect login user\n");
 			exit(1);


### PR DESCRIPTION
getlogin() is unreliable, see the [manual](http://man7.org/linux/man-pages/man3/getlogin.3.html#BUGS):
> BUGS
>       Unfortunately, it is often rather easy to fool getlogin().  Sometimes
>       it does not work at all, because some program messed up the utmp
>       file.  Often, it gives only the first 8 characters of the login name.
>       The user currently logged in on the controlling terminal of our
>       program need not be the user who started it.  Avoid getlogin() for
>       security-related purposes.

It certainly fails on my systems, making it impossible to use `firecfg` without `sudo` or setting SUDO_USER manually. 

With this PR the process owner's name is returned if SUDO_USER is not in the environment. 