### PR TITLE
remove x11 xorg

### DIFF
--- a/etc/tb-starter-wrapper.profile
+++ b/etc/tb-starter-wrapper.profile
@@ -13,7 +13,5 @@ noblacklist ${HOME}/.tb
 mkdir ${HOME}/.tb
 whitelist ${HOME}/.tb
 
-x11 xorg
-
 # Redirect
 include torbrowser-launcher.profile


### PR DESCRIPTION
https://forums.whonix.org/t/automatically-firejailing-tor-browser/4767/29


If your PR isn't about profiles or you have no idea how to do one of these, skip the following and go ahead with this PR.

If you make a PR for new profiles or changeing profiles please do the following:
 - The ordering of options follow the rules descripted in [/usr/share/doc/firejail/profile.template](https://github.com/netblue30/firejail/blob/master/etc/templates/profile.template).  
   > Hint: The profile-template is very new, if you install firejail with your package-manager, it maybe missing, therefore, and to follow the latest rules, it is recommended to use the template from the repository.
 - Order the arguments of options alphabetical, you can easy do this with the [sort.py](https://github.com/netblue30/firejail/tree/master/contrib/sort.py).  
 The path to it depends on your distro:

   | Distro | Path |
   | ------ | ---- |
   | Arch/Fedora | `/usr/lib64/firejail/sort.py` |
   | Debian/Ubuntu/Mint | `/usr/lib/x86_64-linux-gnu/firejail/sort.py` |
   | local git clone | `contrib/sort.py` |

   Note also that the sort.py script exists only since firejail `0.9.61`.

See also [CONTRIBUTING.md](/CONTRIBUTING.md).
