### PR TITLE
Prevent quiet option output leakage

### DIFF
--- a/etc/Xephyr.profile
+++ b/etc/Xephyr.profile
@@ -1,6 +1,7 @@
 # Firejail profile for Xephyr
 # This file is overwritten after every install/update
 # Persistent local customizations
+quiet
 include Xephyr.local
 # Persistent global definitions
 include globals.local

--- a/etc/Xvfb.profile
+++ b/etc/Xvfb.profile
@@ -1,6 +1,7 @@
 # Firejail profile for Xvfb
 # Description: Virtual Framebuffer 'fake' X server
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include Xvfb.local
 # Persistent global definitions

--- a/etc/dnscrypt-proxy.profile
+++ b/etc/dnscrypt-proxy.profile
@@ -1,6 +1,7 @@
 # Firejail profile for dnscrypt-proxy
 # Description: Tool for securing communications between a client and a DNS resolver
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include dnscrypt-proxy.local
 # Persistent global definitions

--- a/etc/dnsmasq.profile
+++ b/etc/dnsmasq.profile
@@ -1,6 +1,7 @@
 # Firejail profile for dnsmasq
 # Description: Small caching DNS proxy and DHCP/TFTP server
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include dnsmasq.local
 # Persistent global definitions

--- a/etc/ffmpegthumbnailer.profile
+++ b/etc/ffmpegthumbnailer.profile
@@ -1,6 +1,7 @@
 # Firejail profile for ffmpegthumbnailer
 # Description: FFmpeg-based video thumbnailer
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include ffmpegthumbnailer.local
 # Persistent global definitions

--- a/etc/ffplay.profile
+++ b/etc/ffplay.profile
@@ -1,6 +1,7 @@
 # Firejail profile for ffplay
 # Description: FFmpeg-based media player
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include ffplay.local
 # Persistent global definitions

--- a/etc/ffprobe.profile
+++ b/etc/ffprobe.profile
@@ -1,6 +1,7 @@
 # Firejail profile for ffprobe
 # Description: FFmpeg-based media prober
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include ffprobe.local
 # Persistent global definitions

--- a/etc/nano.profile
+++ b/etc/nano.profile
@@ -1,6 +1,7 @@
 # Firejail profile for nano
 # Description: nano is an easy text editor for the terminal
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include nano.local
 # Persistent global definitions

--- a/etc/qt-faststart.profile
+++ b/etc/qt-faststart.profile
@@ -1,6 +1,7 @@
 # Firejail profile for qt-faststart
 # Description: FFmpeg-based media utility
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include qt-faststart.local
 # Persistent global definitions

--- a/etc/rnano.profile
+++ b/etc/rnano.profile
@@ -1,6 +1,7 @@
 # Firejail profile for rnano
 # Description: A restricted nano
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include rnano.local
 # Persistent global definitions

--- a/etc/scp.profile
+++ b/etc/scp.profile
@@ -1,6 +1,7 @@
 # Firejail profile for scp
 # Description: Secure shell copy
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include scp.local
 # Persistent global definitions

--- a/etc/seahorse-daemon.profile
+++ b/etc/seahorse-daemon.profile
@@ -1,6 +1,7 @@
 # Firejail profile for seahorse-daemon
 # Description: PGP encryption and signing
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include seahorse-daemon.local
 # Persistent global definitions

--- a/etc/sftp.profile
+++ b/etc/sftp.profile
@@ -1,6 +1,7 @@
 # Firejail profile for sftp
 # Description: Secure file transport protocol
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include sftp.local
 # Persistent global definitions

--- a/etc/transmission-create.profile
+++ b/etc/transmission-create.profile
@@ -1,6 +1,7 @@
 # Firejail profile for transmission-create
 # Description: CLI utility to create BitTorrent .torrent files
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include transmission-create.local
 # Persistent global definitions

--- a/etc/transmission-edit.profile
+++ b/etc/transmission-edit.profile
@@ -1,6 +1,7 @@
 # Firejail profile for transmission-edit
 # Description: CLI utility to modify BitTorrent .torrent files' announce URLs
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include transmission-edit.local
 # Persistent global definitions

--- a/etc/transmission-remote-cli.profile
+++ b/etc/transmission-remote-cli.profile
@@ -1,6 +1,7 @@
 # Firejail profile for transmission-remote-cli
 # Description: A remote control utility for transmission-daemon (CLI)
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include transmission-remote-cli.local
 # Persistent global definitions

--- a/etc/transmission-remote-gtk.profile
+++ b/etc/transmission-remote-gtk.profile
@@ -1,6 +1,7 @@
 # Firejail profile for transmission-remote-gtk
 # Description: A remote control utility for transmission-daemon (GTK GUI)
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include transmission-remote-gtk.local
 # Persistent global definitions

--- a/etc/xpra.profile
+++ b/etc/xpra.profile
@@ -1,6 +1,7 @@
 # Firejail profile for xpra
 # Description: Tool to detach/reattach running X programs
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include xpra.local
 # Persistent global definitions


### PR DESCRIPTION
https://github.com/netblue30/firejail/pull/2907 fixed the `quiet` option in archiver redirect profiles, preventing potential output leakage. This PR does the same for other relevant profiles.