### PR TITLE
tighten private-bin and etc for torbrowser-launcher.profile

### DIFF
--- a/etc/torbrowser-launcher.profile
+++ b/etc/torbrowser-launcher.profile
@@ -48,7 +48,7 @@ shell none
 #tracelog
 
 disable-mnt
-private-bin bash,cat,cp,cut,dirname,env,expr,file,getconf,gpg,grep,gxmessage,id,kdialog,ln,mkdir,mv,pwd,python*,readlink,realpath,rm,sed,sh,tail,tar,tclsh,test,tor-browser,tor-browser-en,torbrowser-launcher,update-desktop-database,xmessage,xz,zenity
+private-bin bash,cat,cp,cut,dirname,env,expr,file,gpg,grep,gxmessage,kdialog,ln,mkdir,mv,python*,rm,sed,sh,tail,tar,tclsh,test,tor-browser,tor-browser-en,torbrowser-launcher,update-desktop-database,xmessage,xz,zenity
 private-dev
-private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,hostname,hosts,ld.so.cache,machine-id,pki,pulse,resolv.conf,ssl
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,ld.so.cache,machine-id,pki,pulse,resolv.conf,ssl
 private-tmp


### PR DESCRIPTION
Tor Browser occupies a very interesting space with firejail, as ideally we would not only want to prevent further system compromise, but also to prevent further de-anonymization (beyond your ip address, which I assume is trivially easy to get if Tor Browser is compromised, regardless of firejail).

To aid in this, Tor Browser should not be able to gain access to the name of the user, and the name of the home directory. As such,

`id` can expose user name
`pwd` can expose name of host directory
`readlink` can expose name of host directory
`realpath` can expose name of host directory

should be removed from private-bin.

Ideally, Tor Browser should not be able to access `env` (also can leak user name and name of host directory), but the program will not work if it is removed (cannot access $PATH), so that is a task for another day. However, `getconf` is not necessary, and can leak environment variables, so that has been removed from private-bin.

`hosts` and `hostname` should be removed from private-etc, as it can leak the name of the user.

This change has been tested on Fedora 30/GNOME and Arch Linux/KDE, and works fine on both, using torbrowser-launcher (from repository) and AUR version, respectively. Used firejail compiled from master for testing.

It is possible to remove far more, for instance, on my computer (Arch/KDE) I am running:
```
private-bin bash,cp,dirname,env,expr,file,grep,ln,mkdir,python*,rm,sh,tor-browser,tor-browser-en,torbrowser-launcher,xz
private-etc machine-id
```
However, I decided to err on the side of caution for general use.