### PR TITLE
Profiles: add I2P

### DIFF
--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -3,6 +3,7 @@
 include disable-programs.local
 
 blacklist ${HOME}/Arduino
+blacklist ${HOME}/i2p
 blacklist ${HOME}/Monero/wallets
 blacklist ${HOME}/Nextcloud/Notes
 blacklist ${HOME}/SoftMaker
@@ -190,6 +191,7 @@ blacklist ${HOME}/.config/gpicview
 blacklist ${HOME}/.config/gthumb
 blacklist ${HOME}/.config/gwenviewrc
 blacklist ${HOME}/.config/hexchat
+blacklist ${HOME}/.config/i2p
 blacklist ${HOME}/.config/inkscape
 blacklist ${HOME}/.config/inox
 blacklist ${HOME}/.config/iridium
@@ -366,6 +368,7 @@ blacklist ${HOME}/.guayadeque
 blacklist ${HOME}/.hashcat
 blacklist ${HOME}/.hedgewars
 blacklist ${HOME}/.hugin
+blacklist ${HOME}/.i2p
 blacklist ${HOME}/.icedove
 blacklist ${HOME}/.imagej
 blacklist ${HOME}/.inkscape
@@ -505,6 +508,7 @@ blacklist ${HOME}/.local/share/gnome-twitch
 blacklist ${HOME}/.local/share/godot
 blacklist ${HOME}/.local/share/gradio
 blacklist ${HOME}/.local/share/gwenview
+blacklist ${HOME}/.local/share/i2p
 blacklist ${HOME}/.local/share/kaffeine
 blacklist ${HOME}/.local/share/kate
 blacklist ${HOME}/.local/share/kdenlive

--- a/etc/i2prouter.profile
+++ b/etc/i2prouter.profile
@@ -54,7 +54,7 @@ notv
 nou2f
 novideo
 protocol unix,inet,inet6
-seccomp.drop @default-nodebuggers
+seccomp
 shell none
 
 disable-mnt

--- a/etc/i2prouter.profile
+++ b/etc/i2prouter.profile
@@ -1,0 +1,64 @@
+# Firejail profile for I2P
+# Description: A distributed anonymous network
+# This file is overwritten after every install/update
+# Persistent local customizations
+include i2prouter.local
+# Persistent global definitions
+include globals.local
+
+# Notice: default browser will not be able to automatically open, due to sandbox.
+# Auto-opening default browser can be disabled in the I2P router console.
+# This profile will not currently work with any Arch User Repository i2p packages,
+# use the distro-independent official java installer instead
+
+# Only needed if i2prouter binary is not in home directory, ubuntu official ppa package does this
+ignore noexec ${HOME}
+
+noblacklist ${HOME}/.config/i2p
+noblacklist ${HOME}/.i2p
+noblacklist ${HOME}/.local/share/i2p
+noblacklist ${HOME}/i2p
+# Only needed if wrapper is placed in /usr/sbin/, ubuntu official ppa package does this
+noblacklist /usr/sbin
+
+# Allow java (blacklisted by disable-devel.inc)
+include allow-java.inc
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
+include disable-xdg.inc
+
+whitelist ${HOME}/.config/I2P
+whitelist ${HOME}/.i2p
+whitelist ${HOME}/.local/share/I2P
+whitelist ${HOME}/i2p
+# Only needed if wrapper is placed in /usr/sbin/, ubuntu official ppa package does this
+whitelist /usr/sbin/wrapper*
+
+# May break I2P if wrapper is placed in the home directory
+# If using ubuntu official ppa, this should be fine to uncomment, as it puts wrapper in /usr/sbin/
+#apparmor
+caps.drop all
+ipc-namespace
+machine-id
+netfilter
+no3d
+nodvd
+nogroups
+nonewprivs
+nosound
+notv
+nou2f
+novideo
+protocol unix,inet,inet6
+seccomp.drop @default-nodebuggers
+shell none
+
+disable-mnt
+private-cache
+private-dev
+private-etc alternatives,ca-certificates,crypto-policies,pki,ssl,java-8-openjdk,i2p
+private-tmp

--- a/etc/i2prouter.profile
+++ b/etc/i2prouter.profile
@@ -11,7 +11,7 @@ include globals.local
 # This profile will not currently work with any Arch User Repository i2p packages,
 # use the distro-independent official java installer instead
 
-# Only needed if i2prouter binary is not in home directory, ubuntu official ppa package does this
+# Only needed if i2prouter binary is in home directory, java installer does this
 ignore noexec ${HOME}
 
 noblacklist ${HOME}/.config/i2p
@@ -23,6 +23,7 @@ noblacklist /usr/sbin
 
 # Allow java (blacklisted by disable-devel.inc)
 include allow-java.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
@@ -31,12 +32,18 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-xdg.inc
 
-whitelist ${HOME}/.config/I2P
+mkdir ${HOME}/.config/i2p
+mkdir ${HOME}/.i2p
+mkdir ${HOME}/.local/share/i2p
+mkdir ${HOME}/i2p
+whitelist ${HOME}/.config/i2p
 whitelist ${HOME}/.i2p
-whitelist ${HOME}/.local/share/I2P
+whitelist ${HOME}/.local/share/i2p
 whitelist ${HOME}/i2p
 # Only needed if wrapper is placed in /usr/sbin/, ubuntu official ppa package does this
 whitelist /usr/sbin/wrapper*
+
+include whitelist-common.inc
 
 # May break I2P if wrapper is placed in the home directory
 # If using ubuntu official ppa, this should be fine to uncomment, as it puts wrapper in /usr/sbin/

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -278,6 +278,7 @@ hedgewars
 hexchat
 highlight
 hugin
+i2prouter
 icecat
 icedove
 iceweasel


### PR DESCRIPTION
Added an I2P profile.

This was tested with Arch/KDE, installing I2P using the official distro-independent java installer and  Xubuntu, installing I2P using the official PPA. 

This does not support the AUR packages for I2P, as they install it really funky and require root privileges to run I2P. Didn't see the point of supporting that when there is an official distro-independent java installer, that only requires normal user privileges to run I2P.

Was not able to create a private-bin for I2P, unfortunately. I'm sure it is possible, but it uses a java wrapper shell script to start I2P, and I thought I copied all the necessary binaries to get it running, but no luck. Are there some debugging tools for firejail that simplifies the process of creating a private-bin?

By default, after starting up I2P opens your default browser to the I2P router console at http://127.0.0.1:7657/home. I couldn't get this to work, so currently it just shows some error messages that it can't open the browser. Luckily, this can be turned off in the I2P settings. I don't think it is that much of an inconvenience to manually open your browser and go to http://127.0.0.1:7657/home instead.