### PR TITLE
seccomp fix: allow numeric syscalls

### DIFF
--- a/src/firejail/seccomp.c
+++ b/src/firejail/seccomp.c
@@ -48,7 +48,8 @@ char *seccomp_check_list(const char *str) {
 	const char *ptr1 = str;
 	char *ptr2 = rv;
 	while (*ptr1 != '\0') {
-		if (isalnum(*ptr1) || *ptr1 == '_' || *ptr1 == ',' || *ptr1 == ':' || *ptr1 == '@' || *ptr1 == '-')
+		if (isalnum(*ptr1) || *ptr1 == '_' || *ptr1 == ',' || *ptr1 == ':'
+				   || *ptr1 == '@' || *ptr1 == '-' || *ptr1 == '$')
 			*ptr2++ = *ptr1++;
 		else {
 			fprintf(stderr, "Error: invalid syscall list\n");


### PR DESCRIPTION
as per man page, numeric syscall is indicated by the dollar sign '$'

Somehow, this seems to be broken for a few years,
since introduction of seccomp_check_list() function in
commit 322ce2cdc
Nov 6, 2016
"seccomp rework"

