### PR TITLE
Fix seccomp for firefox, kate, and others

### DIFF
--- a/etc/ark.profile
+++ b/etc/ark.profile
@@ -31,7 +31,7 @@ notv
 nou2f
 novideo
 protocol unix
-seccomp
+seccomp !sched_setscheduler
 shell none
 
 private-bin 7z,ark,bash,lrzip,lsar,lz4,lzop,p7zip,rar,sh,tclsh,unar,unrar,unzip,zip,zipinfo

--- a/etc/feedreader.profile
+++ b/etc/feedreader.profile
@@ -36,7 +36,7 @@ notv
 nou2f
 novideo
 protocol unix,inet,inet6
-seccomp
+seccomp !sched_setscheduler,!sched_setaffinity
 shell none
 
 disable-mnt

--- a/etc/feedreader.profile
+++ b/etc/feedreader.profile
@@ -36,7 +36,7 @@ notv
 nou2f
 novideo
 protocol unix,inet,inet6
-seccomp !sched_setscheduler,!sched_setaffinity
+seccomp !sched_setscheduler,!sched_setaffinity,!fchown
 shell none
 
 disable-mnt

--- a/etc/firefox-common.profile
+++ b/etc/firefox-common.profile
@@ -46,7 +46,7 @@ notv
 ?BROWSER_DISABLE_U2F: nou2f
 protocol unix,inet,inet6,netlink
 # The below seccomp configuration still permits chroot syscall. See https://github.com/netblue30/firejail/issues/2506 for possible workarounds.
-seccomp !chroot
+seccomp !capset,!chroot,!quotactl,!sched_setaffinity,!sched_setscheduler,!setuid,!setuid32
 shell none
 # Disable tracelog, it breaks or causes major issues with many firefox based browsers, see https://github.com/netblue30/firejail/issues/1930.
 #tracelog

--- a/etc/kate.profile
+++ b/etc/kate.profile
@@ -39,7 +39,7 @@ notv
 nou2f
 novideo
 protocol unix
-seccomp
+seccomp !sched_setscheduler
 shell none
 tracelog
 

--- a/etc/mpv.profile
+++ b/etc/mpv.profile
@@ -39,7 +39,7 @@ nonewprivs
 noroot
 nou2f
 protocol unix,inet,inet6
-seccomp
+seccomp !sched_setscheduler,!sched_setaffinity
 shell none
 tracelog
 

--- a/etc/okular.profile
+++ b/etc/okular.profile
@@ -43,7 +43,7 @@ notv
 nou2f
 novideo
 protocol unix
-seccomp
+seccomp !sched_setscheduler
 shell none
 tracelog
 

--- a/etc/quiterss.profile
+++ b/etc/quiterss.profile
@@ -43,7 +43,7 @@ notv
 nou2f
 novideo
 protocol unix,inet,inet6
-seccomp
+seccomp !sched_setscheduler
 shell none
 tracelog
 

--- a/etc/teamspeak3.profile
+++ b/etc/teamspeak3.profile
@@ -33,7 +33,7 @@ notv
 nou2f
 novideo
 protocol unix,inet,inet6,netlink
-seccomp !chroot
+seccomp !chroot,!sched_setscheduler
 shell none
 
 disable-mnt

--- a/etc/transmission-common.profile
+++ b/etc/transmission-common.profile
@@ -35,7 +35,7 @@ notv
 nou2f
 novideo
 protocol unix,inet,inet6
-seccomp
+seccomp !quotactl,!sched_setscheduler
 shell none
 tracelog
 


### PR DESCRIPTION
See discussion at [issues/2936.](https://github.com/netblue30/firejail/issues/2936)

Tested on my computer running Arch/KDE with wayland. No errors regarding `seccomp` present in `sudo journalctl -f` while running each program.

Fixes firefox, thunderbird, kate, teamspeak, quiterss, transmission, ark, and okular.

All of these would not work, just hang without opening, before this change to seccomp.