### PR TITLE
Removed disable-interpreters.inc from w3m.profile

### DIFF
--- a/etc/w3m.profile
+++ b/etc/w3m.profile
@@ -10,10 +10,11 @@ noblacklist ${HOME}/.w3m
 
 blacklist /tmp/.X11-unix
 
+include allow-perl.inc
+
 include disable-common.inc
 include disable-devel.inc
-# Breaks the help screen
-#include disable-interpreters.inc
+include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-xdg.inc

--- a/etc/w3m.profile
+++ b/etc/w3m.profile
@@ -12,7 +12,8 @@ blacklist /tmp/.X11-unix
 
 include disable-common.inc
 include disable-devel.inc
-include disable-interpreters.inc
+# Breaks the help screen
+#include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-xdg.inc


### PR DESCRIPTION
Including disable-interpreters.inc consistently prevents the help screen from loading within w3m.