### PR TITLE
Add allow-debuggers to steam.profile

### DIFF
--- a/etc/steam.profile
+++ b/etc/steam.profile
@@ -38,6 +38,8 @@ include disable-programs.inc
 
 include whitelist-var-common.inc
 
+# allow-debuggers needed for running some games with proton
+allow-debuggers
 caps.drop all
 #ipc-namespace
 netfilter


### PR DESCRIPTION
With the default steam profile, steam runs fine, but several games (all running via proton) do not open or open to a black screen. Checking `journalctl`, each segfaulted with firejail reporting they tried to access syscall 101, which is `ptrace`.

Games: Twilight Struggle, ZeroK, Supreme Commander 2

Adding `seccomp !ptrace` or `allow-debuggers` seemed to fix the problem, and now the games run fine.

I added `allow-debuggers` to the profile, as I think that was the preferred method of allowing `ptrace`, but I can change it to `seccomp !ptrace` instead.

Just checked now, and seems like other people are having this problem: [Issue 2860](https://github.com/netblue30/firejail/issues/2860) 