### PR TITLE
KeePassXC: Added a warning regarding tray icon

### DIFF
--- a/etc/keepassxc.profile
+++ b/etc/keepassxc.profile
@@ -29,8 +29,9 @@ machine-id
 net none
 no3d
 nodvd
-# Breaks 'Lock database when session is locked or lid is closed' (#2899),
-# you can safely uncomment it or add to keepassxc.local if you don't need this feature.
+# Breaks 'Lock database when session is locked or lid is closed' (#2899).
+# Also breaks (Plasma) tray icon,
+# you can safely uncomment it or add to keepassxc.local if you don't need these features.
 #nodbus
 nogroups
 nonewprivs


### PR DESCRIPTION
nodbus also breaks the (minimize to-) system tray feature of KeePassXC. Users should be aware of that.