### PR TITLE
Add Comment Mentioning that `nodbus` Breaks Native Notifications

### DIFF
--- a/etc/firefox-common.profile
+++ b/etc/firefox-common.profile
@@ -35,7 +35,7 @@ caps.drop all
 #machine-id
 netfilter
 # nodbus breaks various desktop integration features
-# among other things global menus, Gnome connector, KDE connect and power management on KDE Plasma
+# among other things global menus, native notifications, Gnome connector, KDE connect and power management on KDE Plasma
 nodbus
 nodvd
 nogroups


### PR DESCRIPTION
After installing a notification daemon yesterday, I realized that `nodus` in the `firefox-common.profile` also breaks native notifications.
So I extended the comment to mention that, so that users have an easier time discovering this issue in the future.