### PR TITLE
Wusc fixes for profiles allowing perl

### DIFF
--- a/etc/checkbashisms.profile
+++ b/etc/checkbashisms.profile
@@ -20,6 +20,7 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-xdg.inc
 
+whitelist /usr/share/perl5
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 

--- a/etc/clawsker.profile
+++ b/etc/clawsker.profile
@@ -20,6 +20,7 @@ include disable-programs.inc
 
 mkdir ${HOME}/.claws-mail
 whitelist ${HOME}/.claws-mail
+whitelist /usr/share/perl5
 include whitelist-common.inc
 include whitelist-usr-share-common.inc
 

--- a/etc/conplay.profile
+++ b/etc/conplay.profile
@@ -12,5 +12,7 @@ include conplay.local
 # Allow perl (blacklisted by disable-interpreters.inc)
 include allow-perl.inc
 
+whitelist /usr/share/perl5
+
 # Redirect
 include mpg123.profile

--- a/etc/exiftool.profile
+++ b/etc/exiftool.profile
@@ -16,6 +16,7 @@ include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
 
+whitelist /usr/share/perl5
 include whitelist-usr-share-common.inc
 
 apparmor

--- a/etc/spectre-meltdown-checker.profile
+++ b/etc/spectre-meltdown-checker.profile
@@ -20,6 +20,7 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-xdg.inc
 
+whitelist /usr/share/perl5
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 


### PR DESCRIPTION
These were overlooked previously. If someone could confirm /usr/share/perl5 is the correct path on Fedora that would be nice.