### PR TITLE
Update QOwnNotes.profile

### DIFF
--- a/etc/QOwnNotes.profile
+++ b/etc/QOwnNotes.profile
@@ -49,6 +49,6 @@ tracelog
 disable-mnt
 private-bin gio,QOwnNotes
 private-dev
-private-etc alternatives,ca-certificates,crypto-policies,fonts,host.conf,hosts,ld.so.cache,nsswitch.conf,pki,pulse,resolv.conf,ssl,machine-id
+private-etc alternatives,ca-certificates,crypto-policies,fonts,host.conf,hosts,ld.so.cache,machine-id,nsswitch.conf,pki,pulse,resolv.conf,ssl
 private-tmp
 

--- a/etc/QOwnNotes.profile
+++ b/etc/QOwnNotes.profile
@@ -49,6 +49,6 @@ tracelog
 disable-mnt
 private-bin gio,QOwnNotes
 private-dev
-private-etc alternatives,ca-certificates,crypto-policies,fonts,host.conf,hosts,ld.so.cache,nsswitch.conf,pki,pulse,resolv.conf,ssl
+private-etc alternatives,ca-certificates,crypto-policies,fonts,host.conf,hosts,ld.so.cache,nsswitch.conf,pki,pulse,resolv.conf,ssl,machine-id
 private-tmp
 


### PR DESCRIPTION
Fix startup problem in Ubuntu 19.10:

"bus[17]: D-Bus library appears to be incorrectly set up: see the manual page for dbus-uuidgen to correct this issue. (Failed to open "/var/lib/dbus/machine-id": Datei oder Verzeichnis nicht gefunden; Failed to open "/etc/machine-id": Datei oder Verzeichnis nicht gefunden)
  D-Bus not built with -rdynamic so unable to print a backtrace"