### PR TITLE
RFC: profiles: allow nc in ssh profile by default

### DIFF
--- a/etc/ssh.profile
+++ b/etc/ssh.profile
@@ -10,8 +10,8 @@ include globals.local
 noblacklist /etc/ssh
 noblacklist /tmp/ssh-*
 noblacklist ${HOME}/.ssh
-# If you want to use tor, uncomment the next line or put it in your ssh.local
-#noblacklist ${PATH}/nc
+# nc can be used as ProxyCommand, e.g. when using tor
+noblacklist ${PATH}/nc
 
 include disable-common.inc
 include disable-exec.inc


### PR DESCRIPTION
nc is currently disallowed in the ssh profile.
I think it could be allowed by default, as it can not only be used for tor, but has more general uses (see ProxyCommand in ssh_config(5)). And I think it's also not harmful to allow it.

Not blacklisting nc would allow a smoother out-of-the-box experience for tor users that use nc in ProxyCommand.

But I'm interested in other opinions if it's a sensible change, or if the profile should be kept more closed.