### PR TITLE
remove read access from fs log file

### DIFF
--- a/src/firejail/fs_logger.c
+++ b/src/firejail/fs_logger.c
@@ -97,7 +97,7 @@ void fs_logger_print(void) {
 		perror("fopen");
 		return;
 	}
-	SET_PERMS_STREAM_NOERR(fp, getuid(), getgid(), 0644);
+	SET_PERMS_STREAM_NOERR(fp, getuid(), getgid(), 0600);
 
 	FsMsg *ptr = head;
 	while (ptr) {


### PR DESCRIPTION
Removing read access from the fs log file should make it slightly more difficult to gather information about the sandbox