### PR TITLE
Fix Brave's native sandbox

### DIFF
--- a/etc/brave.profile
+++ b/etc/brave.profile
@@ -20,5 +20,8 @@ whitelist ${HOME}/.config/brave
 whitelist ${HOME}/.config/BraveSoftware
 whitelist ${HOME}/.gnupg
 
+# Brave sandbox needs read access to /proc/config.gz
+noblacklist /proc/config.gz
+
 # Redirect
 include chromium-common.profile

--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -452,3 +452,6 @@ blacklist ${HOME}/Mail
 blacklist ${HOME}/mail
 blacklist ${HOME}/postponed
 blacklist ${HOME}/sent
+
+# kernel configuration
+blacklist /proc/config.gz

--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -642,6 +642,11 @@ void fs_proc_sys_dev_boot(void) {
 	// various /proc files
 	disable_file(BLACKLIST_FILE, "/proc/irq");
 	disable_file(BLACKLIST_FILE, "/proc/bus");
+	{ // allow user access to /proc/config.gz by specifying 'noblacklist' option
+		EUID_USER();
+		profile_add("blacklist /proc/config.gz");
+		EUID_ROOT();
+	}
 	disable_file(BLACKLIST_FILE, "/proc/config.gz");
 	disable_file(BLACKLIST_FILE, "/proc/sched_debug");
 	disable_file(BLACKLIST_FILE, "/proc/timer_list");

--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -642,12 +642,8 @@ void fs_proc_sys_dev_boot(void) {
 	// various /proc files
 	disable_file(BLACKLIST_FILE, "/proc/irq");
 	disable_file(BLACKLIST_FILE, "/proc/bus");
-	{ // allow user access to /proc/config.gz by specifying 'noblacklist' option
-		EUID_USER();
-		profile_add("blacklist /proc/config.gz");
-		EUID_ROOT();
-	}
-	disable_file(BLACKLIST_FILE, "/proc/config.gz");
+	// move /proc/config.gz to disable-common.inc
+	//disable_file(BLACKLIST_FILE, "/proc/config.gz");
 	disable_file(BLACKLIST_FILE, "/proc/sched_debug");
 	disable_file(BLACKLIST_FILE, "/proc/timer_list");
 	disable_file(BLACKLIST_FILE, "/proc/timer_stats");


### PR DESCRIPTION
**IMPORTANT**: leave this unmerged until collaborators have had ample opportunity to review.

This is a tentative fix for #2944. The patch enables using `noblacklist /proc/config.gz` in `/etc/firejail/brave.profile`. Momentarily this is only needed for that one profile, so I'm not entirely convinced this is the best way to fix #2914. Thoughts?