### PR TITLE
add join timeout and make it configurable

### DIFF
--- a/etc/firejail.config
+++ b/etc/firejail.config
@@ -62,6 +62,11 @@
 # root user can always join sandboxes.
 # join yes
 
+# Timeout when joining a sandbox, default five seconds. Wait up to
+# the specified period of time to allow sandbox setup to finish.
+# It is not possible to join a sandbox while it is still starting up.
+# join-timeout 5
+
 # Enable or disable sandbox name change, default enabled.
 # name-change yes
 

--- a/src/firejail/caps.c
+++ b/src/firejail/caps.c
@@ -404,21 +404,8 @@ void caps_print_filter(pid_t pid) {
 	// in case the pid is that of a firejail process, use the pid of the first child process
 	pid = switch_to_child(pid);
 
-	// now check if the pid belongs to a firejail sandbox
-	if (invalid_sandbox(pid)) {
-		fprintf(stderr, "Error: no valid sandbox\n");
-		exit(1);
-	}
-
-	// check privileges for non-root users
-	uid_t uid = getuid();
-	if (uid != 0) {
-		uid_t sandbox_uid = pid_get_uid(pid);
-		if (uid != sandbox_uid) {
-			fprintf(stderr, "Error: permission denied.\n");
-			exit(1);
-		}
-	}
+	// exit if no permission to join the sandbox
+	check_join_permission(pid);
 
 	uint64_t caps = extract_caps(pid);
 	int i;

--- a/src/firejail/checkcfg.c
+++ b/src/firejail/checkcfg.c
@@ -31,7 +31,7 @@ char *xpra_extra_params = "";
 char *xvfb_screen = "800x600x24";
 char *xvfb_extra_params = "";
 char *netfilter_default = NULL;
-unsigned join_timeout = 50; // 5 sec (unit is 0.1 sec)
+unsigned long join_timeout = 5000000; // microseconds
 
 int checkcfg(int val) {
 	assert(val < CFG_MAX);
@@ -217,7 +217,7 @@ int checkcfg(int val) {
 
 			// timeout for join option
 			else if (strncmp(ptr, "join-timeout ", 13) == 0)
-				join_timeout = strtoul(ptr + 13, NULL, 10) * 10;
+				join_timeout = strtoul(ptr + 13, NULL, 10) * 1000000; // seconds to microseconds
 
 			else
 				goto errout;

--- a/src/firejail/checkcfg.c
+++ b/src/firejail/checkcfg.c
@@ -31,6 +31,7 @@ char *xpra_extra_params = "";
 char *xvfb_screen = "800x600x24";
 char *xvfb_extra_params = "";
 char *netfilter_default = NULL;
+unsigned join_timeout = 50; // 5 sec (unit is 0.1 sec)
 
 int checkcfg(int val) {
 	assert(val < CFG_MAX);
@@ -213,6 +214,11 @@ int checkcfg(int val) {
 				if (setenv("FIREJAIL_FILE_COPY_LIMIT", ptr + 16, 1) == -1)
 					errExit("setenv");
 			}
+
+			// timeout for join option
+			else if (strncmp(ptr, "join-timeout ", 13) == 0)
+				join_timeout = strtoul(ptr + 13, NULL, 10) * 10;
+
 			else
 				goto errout;
 

--- a/src/firejail/cpu.c
+++ b/src/firejail/cpu.c
@@ -170,12 +170,10 @@ void cpu_print_filter(pid_t pid) {
 	pid = switch_to_child(pid);
 
 	// now check if the pid belongs to a firejail sandbox
-	if (invalid_sandbox(pid)) {
+	if (is_ready_for_join(pid) == 0) {
 		fprintf(stderr, "Error: no valid sandbox\n");
 		exit(1);
 	}
-
-
 
 	print_cpu(pid);
 	exit(0);

--- a/src/firejail/cpu.c
+++ b/src/firejail/cpu.c
@@ -170,7 +170,7 @@ void cpu_print_filter(pid_t pid) {
 	pid = switch_to_child(pid);
 
 	// now check if the pid belongs to a firejail sandbox
-	if (is_ready_for_join(pid) == 0) {
+	if (is_ready_for_join(pid) == false) {
 		fprintf(stderr, "Error: no valid sandbox\n");
 		exit(1);
 	}

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -738,6 +738,7 @@ extern char *xpra_extra_params;
 extern char *xvfb_screen;
 extern char *xvfb_extra_params;
 extern char *netfilter_default;
+extern unsigned join_timeout;
 int checkcfg(int val);
 void print_compiletime_support(void);
 

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -426,6 +426,7 @@ void usage(void);
 
 // join.c
 void join(pid_t pid, int argc, char **argv, int index);
+int invalid_sandbox(const pid_t pid);
 pid_t switch_to_child(pid_t pid);
 
 // shutdown.c
@@ -491,7 +492,6 @@ unsigned extract_timeout(const char *str);
 void disable_file_or_dir(const char *fname);
 void disable_file_path(const char *path, const char *file);
 int safe_fd(const char *path, int flags);
-int invalid_sandbox(const pid_t pid);
 int has_handler(pid_t pid, int signal);
 void enter_network_namespace(pid_t pid);
 

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -426,7 +426,8 @@ void usage(void);
 
 // join.c
 void join(pid_t pid, int argc, char **argv, int index);
-int invalid_sandbox(const pid_t pid);
+int is_ready_for_join(const pid_t pid);
+void check_join_permission(pid_t pid);
 pid_t switch_to_child(pid_t pid);
 
 // shutdown.c

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -738,7 +738,7 @@ extern char *xpra_extra_params;
 extern char *xvfb_screen;
 extern char *xvfb_extra_params;
 extern char *netfilter_default;
-extern unsigned join_timeout;
+extern unsigned long join_timeout;
 int checkcfg(int val);
 void print_compiletime_support(void);
 

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -426,7 +426,7 @@ void usage(void);
 
 // join.c
 void join(pid_t pid, int argc, char **argv, int index);
-int is_ready_for_join(const pid_t pid);
+bool is_ready_for_join(const pid_t pid);
 void check_join_permission(pid_t pid);
 pid_t switch_to_child(pid_t pid);
 

--- a/src/firejail/join.c
+++ b/src/firejail/join.c
@@ -318,15 +318,16 @@ int is_ready_for_join(const pid_t pid) {
 	return 1;
 }
 
+#define SNOOZE 100000 // sleep interval in microseconds
 void check_join_permission(pid_t pid) {
 	// check if pid belongs to a fully set up firejail sandbox
-	unsigned i;
-	for (i = 0; is_ready_for_join(pid) == 0; i++) { // give sandbox some time to start up
+	unsigned long i;
+	for (i = 0; is_ready_for_join(pid) == 0; i += SNOOZE) { // give sandbox some time to start up
 		if (i >= join_timeout) {
 			fprintf(stderr, "Error: no valid sandbox\n");
 			exit(1);
 		}
-		usleep(100000); // 0.1 sec
+		usleep(SNOOZE);
 	}
 	// check privileges for non-root users
 	uid_t uid = getuid();

--- a/src/firejail/join.c
+++ b/src/firejail/join.c
@@ -322,7 +322,7 @@ void check_join_permission(pid_t pid) {
 	// check if pid belongs to a fully set up firejail sandbox
 	unsigned i;
 	for (i = 0; is_ready_for_join(pid) == 0; i++) { // give sandbox some time to start up
-		if (i >= 50) {
+		if (i >= join_timeout) {
 			fprintf(stderr, "Error: no valid sandbox\n");
 			exit(1);
 		}

--- a/src/firejail/ls.c
+++ b/src/firejail/ls.c
@@ -215,21 +215,8 @@ void sandboxfs(int op, pid_t pid, const char *path1, const char *path2) {
 	// in case the pid is that of a firejail process, use the pid of the first child process
 	pid = switch_to_child(pid);
 
-	// now check if the pid belongs to a firejail sandbox
-	if (invalid_sandbox(pid)) {
-		fprintf(stderr, "Error: no valid sandbox\n");
-		exit(1);
-	}
-
-	// check privileges for non-root users
-	uid_t uid = getuid();
-	if (uid != 0) {
-		uid_t sandbox_uid = pid_get_uid(pid);
-		if (uid != sandbox_uid) {
-			fprintf(stderr, "Error: permission denied.\n");
-			exit(1);
-		}
-	}
+	// exit if no permission to join the sandbox
+	check_join_permission(pid);
 
 	// expand paths
 	char *fname1 = expand_path(path1);;

--- a/src/firejail/network_main.c
+++ b/src/firejail/network_main.c
@@ -272,21 +272,8 @@ void net_dns_print(pid_t pid) {
 	// in case the pid is that of a firejail process, use the pid of the first child process
 	pid = switch_to_child(pid);
 
-	// now check if the pid belongs to a firejail sandbox
-	if (invalid_sandbox(pid)) {
-		fprintf(stderr, "Error: no valid sandbox\n");
-		exit(1);
-	}
-
-	// check privileges for non-root users
-	uid_t uid = getuid();
-	if (uid != 0) {
-		uid_t sandbox_uid = pid_get_uid(pid);
-		if (uid != sandbox_uid) {
-			fprintf(stderr, "Error: permission denied.\n");
-			exit(1);
-		}
-	}
+	// exit if no permission to join the sandbox
+	check_join_permission(pid);
 
 	EUID_ROOT();
 	if (join_namespace(pid, "mnt"))

--- a/src/firejail/protocol.c
+++ b/src/firejail/protocol.c
@@ -67,21 +67,8 @@ void protocol_print_filter(pid_t pid) {
 	// in case the pid is that of a firejail process, use the pid of the first child process
 	pid = switch_to_child(pid);
 
-	// now check if the pid belongs to a firejail sandbox
-	if (invalid_sandbox(pid)) {
-		fprintf(stderr, "Error: no valid sandbox\n");
-		exit(1);
-	}
-
-	// check privileges for non-root users
-	uid_t uid = getuid();
-	if (uid != 0) {
-		uid_t sandbox_uid = pid_get_uid(pid);
-		if (uid != sandbox_uid) {
-			fprintf(stderr, "Error: permission denied.\n");
-			exit(1);
-		}
-	}
+	// exit if no permission to join the sandbox
+	check_join_permission(pid);
 
 	// find the seccomp filter
 	EUID_ROOT();

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -444,7 +444,7 @@ void start_application(int no_sandbox, FILE *fp) {
 	}
 	// restore original umask
 	umask(orig_umask);
-	//sleep(10);
+
 	if (arg_debug) {
 		printf("starting application\n");
 		printf("LD_PRELOAD=%s\n", getenv("LD_PRELOAD"));

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -444,7 +444,7 @@ void start_application(int no_sandbox, FILE *fp) {
 	}
 	// restore original umask
 	umask(orig_umask);
-
+	//sleep(10);
 	if (arg_debug) {
 		printf("starting application\n");
 		printf("LD_PRELOAD=%s\n", getenv("LD_PRELOAD"));

--- a/src/firejail/seccomp.c
+++ b/src/firejail/seccomp.c
@@ -332,21 +332,8 @@ void seccomp_print_filter(pid_t pid) {
 	// in case the pid is that of a firejail process, use the pid of the first child process
 	pid = switch_to_child(pid);
 
-	// now check if the pid belongs to a firejail sandbox
-	if (invalid_sandbox(pid)) {
-		fprintf(stderr, "Error: no valid sandbox\n");
-		exit(1);
-	}
-
-	// check privileges for non-root users
-	uid_t uid = getuid();
-	if (uid != 0) {
-		uid_t sandbox_uid = pid_get_uid(pid);
-		if (uid != sandbox_uid) {
-			fprintf(stderr, "Error: permission denied.\n");
-			exit(1);
-		}
-	}
+	// exit if no permission to join the sandbox
+	check_join_permission(pid);
 
 	// find the seccomp list file
 	EUID_ROOT();

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -1200,69 +1200,6 @@ errexit:
 	exit(1);
 }
 
-
-// return 1 if the sandbox identified by pid is not fully set up yet or if
-// it is no firejail sandbox at all, return 0 if the sandbox is complete
-int invalid_sandbox(const pid_t pid) {
-	// check if a file "ready-for-join" exists
-	char *fname;
-	if (asprintf(&fname, "/proc/%d/root%s", pid, RUN_READY_FOR_JOIN) == -1)
-		errExit("asprintf");
-	EUID_ROOT();
-	FILE *fp = fopen(fname, "re");
-	EUID_USER();
-	free(fname);
-	if (!fp)
-		return 1;
-	// regular file owned by root
-	int fd = fileno(fp);
-	if (fd == -1)
-		errExit("fileno");
-	struct stat s;
-	if (fstat(fd, &s) == -1)
-		errExit("fstat");
-	if (!S_ISREG(s.st_mode) || s.st_uid != 0) {
-		fclose(fp);
-		return 1;
-	}
-	// check if it is non-empty
-	char buf[BUFLEN];
-	if (fgets(buf, BUFLEN, fp) == NULL) {
-		fclose(fp);
-		return 1;
-	}
-	fclose(fp);
-	// confirm "ready" string was written
-	if (strncmp(buf, "ready\n", 6) != 0)
-		return 1;
-
-	// walk down the process tree a few nodes, there should be no firejail leaf
-#define MAXNODES 5
-	pid_t current = pid, next;
-	int i;
-	for (i = 0; i < MAXNODES; i++) {
-		if (find_child(current, &next) == 1) {
-			// found a leaf
-			EUID_ROOT();
-			char *comm = pid_proc_comm(current);
-			EUID_USER();
-			if (!comm) {
-				fprintf(stderr, "Error: cannot read /proc file\n");
-				exit(1);
-			}
-			if (strcmp(comm, "firejail") == 0) {
-				free(comm);
-				return 1;
-			}
-			free(comm);
-			break;
-		}
-		current = next;
-	}
-
-	return 0;
-}
-
 int has_handler(pid_t pid, int signal) {
 	if (signal > 0 && signal <= SIGRTMAX) {
 		char *fname;

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -1234,21 +1234,8 @@ void enter_network_namespace(pid_t pid) {
 	// in case the pid is that of a firejail process, use the pid of the first child process
 	pid_t child = switch_to_child(pid);
 
-	// now check if the pid belongs to a firejail sandbox
-	if (invalid_sandbox(child)) {
-		fprintf(stderr, "Error: no valid sandbox\n");
-		exit(1);
-	}
-
-	// check privileges for non-root users
-	uid_t uid = getuid();
-	if (uid != 0) {
-		uid_t sandbox_uid = pid_get_uid(pid);
-		if (uid != sandbox_uid) {
-			fprintf(stderr, "Error: permission is denied to join a sandbox created by a different user.\n");
-			exit(1);
-		}
-	}
+	// exit if no permission to join the sandbox
+	check_join_permission(child);
 
 	// check network namespace
 	char *name;


### PR DESCRIPTION
per this patch, firejail tries for 5 seconds to join a sandbox, and only then exits with an error. I'm not sure if the defaults are chosen wisely, you may want to adjust both the default timeout and the frequency of the checks (every 100 msec currently)

see #2139 