### PR TITLE
Drop CLI archivers from firecfg

### DIFF
--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -37,7 +37,7 @@ amuled
 android-studio
 anydesk
 apktool
-ar
+# ar - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
 arch-audit
 archaudit-report
 ardour4
@@ -51,7 +51,7 @@ assogiate
 asunder
 # atom
 # atom-beta
-atool
+# atool - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
 atril
 atril-previewer
 atril-thumbnailer
@@ -87,10 +87,10 @@ brave-browser-beta
 brave-browser-dev
 brave-browser-nightly
 brave-browser-stable
-bunzip2
-bzcat
+# bunzip2 - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+# bzcat - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
 bzflag
-bzip2
+# bzip2 - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
 calibre
 calligra
 calligraauthor
@@ -368,12 +368,12 @@ lollypop
 lomath
 loweb
 lowriter
-lrunzip
-lrz
-lrzcat
-lrzip
-lrztar
-lrzuntar
+# lrunzip - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+# lrz - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+# lrzcat - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+# lrzip - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+# lrztar - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+# lrzuntar - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
 luminance-hdr
 lximage-qt
 lxmusic
@@ -504,7 +504,7 @@ psi-plus
 pybitmessage
 # pycharm-community - FB note: may enable later
 # pycharm-professional
-pzstd
+# pzstd - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
 qbittorrent
 qemu-launcher
 qgis
@@ -647,7 +647,7 @@ uget-gtk
 unbound
 unf
 unknown-horizons
-unzstd
+# unzstd - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
 utox
 uudeview
 uzbl-browser
@@ -713,10 +713,10 @@ zart
 zathura
 zeal
 zoom
-zpaq
-zstd
-zstdcat
-zstdgrep
-zstdless
-zstdmt
+# zpaq - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+# zstd - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+# zstdcat - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+# zstdgrep - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+# zstdless - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+# zstdmt - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
 zulip


### PR DESCRIPTION
More research/testing is needed to make CLI-based archivers work with makepkg on Arch (based distributions). See ongoing discussion in #3095.