### PR TITLE
DHCP client support

### DIFF
--- a/src/firejail/dhcp.c
+++ b/src/firejail/dhcp.c
@@ -117,6 +117,21 @@ static void dhcp_start_dhclient(const Dhclient *client) {
   *(client->pid) = dhcp_read_pidfile(client);
 }
 
+static void dhcp_waitll(const char *ifname) {
+  sbox_run(SBOX_ROOT | SBOX_CAPS_NETWORK | SBOX_SECCOMP, 3, PATH_FNET, "waitll", ifname);
+}
+
+static void dhcp_waitll_all() {
+  if (cfg.bridge0.arg_ip6_dhcp)
+    dhcp_waitll(cfg.bridge0.devsandbox);
+  if (cfg.bridge1.arg_ip6_dhcp)
+    dhcp_waitll(cfg.bridge1.devsandbox);
+  if (cfg.bridge2.arg_ip6_dhcp)
+    dhcp_waitll(cfg.bridge2.devsandbox);
+  if (cfg.bridge3.arg_ip6_dhcp)
+    dhcp_waitll(cfg.bridge3.devsandbox);
+}
+
 void dhcp_start(void) {
   if (!any_dhcp())
     return;
@@ -131,6 +146,7 @@ void dhcp_start(void) {
       printf("Running dhclient -4 in the background as pid %ld\n", (long) dhclient4_pid);
   }
   if (any_ip6_dhcp()) {
+    dhcp_waitll_all();
     dhcp_start_dhclient(&dhclient6);
     if (arg_debug)
       printf("Running dhclient -6 in the background as pid %ld\n", (long) dhclient6_pid);

--- a/src/firejail/dhcp.c
+++ b/src/firejail/dhcp.c
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2014-2019 Firejail Authors
+ *
+ * This file is part of firejail project
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include "firejail.h"
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+pid_t dhclient4_pid = 0;
+pid_t dhclient6_pid = 0;
+
+typedef struct {
+  char *version_arg;
+  char *pid_file;
+  char *leases_file;
+  uint8_t generate_duid;
+  char *duid_leases_file;
+  pid_t *pid;
+  ptrdiff_t arg_offset;
+} Dhclient;
+
+static const Dhclient dhclient4 = { .version_arg = "-4",
+                                    .pid_file = RUN_DHCLIENT_4_PID_FILE,
+                                    .leases_file = RUN_DHCLIENT_4_LEASES_FILE,
+                                    .generate_duid = 1,
+                                    .pid = &dhclient4_pid,
+                                    .arg_offset = offsetof(Bridge, arg_ip_dhcp)
+};
+
+static const Dhclient dhclient6 = { .version_arg = "-6",
+                                    .pid_file = RUN_DHCLIENT_6_PID_FILE,
+                                    .leases_file = RUN_DHCLIENT_6_LEASES_FILE,
+                                    .duid_leases_file = RUN_DHCLIENT_4_LEASES_FILE,
+                                    .pid = &dhclient6_pid,
+                                    .arg_offset = offsetof(Bridge, arg_ip6_dhcp)
+};
+
+static void dhcp_run_dhclient(const Dhclient *client) {
+  char *argv[256] = { "dhclient",
+                      client->version_arg,
+                      "-pf", client->pid_file,
+                      "-lf", client->leases_file,
+  };
+  int i = 6;
+  if (client->generate_duid)
+    argv[i++] = "-i";
+  if (client->duid_leases_file) {
+    argv[i++] = "-df";
+    argv[i++] = client->duid_leases_file;
+  }
+  if (arg_debug)
+    argv[i++] = "-v";
+  if (*(uint8_t *) ((char *) &cfg.bridge0 + client->arg_offset))
+    argv[i++] = cfg.bridge0.devsandbox;
+  if (*(uint8_t *) ((char *) &cfg.bridge1 + client->arg_offset))
+    argv[i++] = cfg.bridge1.devsandbox;
+  if (*(uint8_t *) ((char *) &cfg.bridge2 + client->arg_offset))
+    argv[i++] = cfg.bridge2.devsandbox;
+  if (*(uint8_t *) ((char *) &cfg.bridge3 + client->arg_offset))
+    argv[i++] = cfg.bridge3.devsandbox;
+
+  sbox_run_v(SBOX_ROOT | SBOX_CAPS_NETWORK | SBOX_CAPS_NET_SERVICE | SBOX_SECCOMP, argv);
+}
+
+static pid_t dhcp_read_pidfile(const Dhclient *client) {
+  // We have to run dhclient as a forking daemon (not pass the -d option),
+  // because we want to be notified of a successful DHCP lease by the parent process exit.
+  // However, try to be extra paranoid with race conditions,
+  // because dhclient only writes the daemon pid into the pidfile
+  // after its parent process has exited.
+  int tries = 0;
+  pid_t found = 0;
+  while (found == 0 && tries < 10) {
+    if (tries >= 1)
+      usleep(100000);
+    FILE *pidfile = fopen(client->pid_file, "r");
+    if (pidfile) {
+      long pid;
+      if (fscanf(pidfile, "%ld", &pid) == 1) {
+        char *pidname = pid_proc_comm((pid_t) pid);
+        if (pidname && strcmp(pidname, "dhclient") == 0)
+          found = (pid_t) pid;
+      }
+      fclose(pidfile);
+    }
+    ++tries;
+  }
+  if (found == 0) {
+    fprintf(stderr, "Error: Cannot get dhclient %s PID from %s\n",
+            client->version_arg, client->pid_file);
+    exit(1);
+  }
+  return found;
+}
+
+static void dhcp_start_dhclient(const Dhclient *client) {
+  dhcp_run_dhclient(client);
+  *(client->pid) = dhcp_read_pidfile(client);
+}
+
+void dhcp_start(void) {
+  if (!any_dhcp())
+    return;
+
+  EUID_ROOT();
+  if (mkdir(RUN_DHCLIENT_DIR, 0700))
+    errExit("mkdir");
+
+  if (any_ip_dhcp()) {
+    dhcp_start_dhclient(&dhclient4);
+    if (arg_debug)
+      printf("Running dhclient -4 in the background as pid %ld\n", (long) dhclient4_pid);
+  }
+  if (any_ip6_dhcp()) {
+    dhcp_start_dhclient(&dhclient6);
+    if (arg_debug)
+      printf("Running dhclient -6 in the background as pid %ld\n", (long) dhclient6_pid);
+    if (dhclient4_pid == dhclient6_pid) {
+      fprintf(stderr, "Error: dhclient -4 and -6 have the same PID: %ld\n", (long) dhclient4_pid);
+      exit(1);
+    }
+  }
+}

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -812,6 +812,7 @@ void build_appimage_cmdline(char **command_line, char **window_title, int argc, 
 #define SBOX_ALLOW_STDIN (1 << 5)		// don't close stdin
 #define SBOX_STDIN_FROM_FILE (1 << 6)	// open file and redirect it to stdin
 #define SBOX_CAPS_HIDEPID (1 << 7)	// hidepid caps filter for running firemon
+#define SBOX_CAPS_NET_SERVICE (1 << 8) // caps filter for programs running network services
 
 // run sbox
 int sbox_run(unsigned filter, int num, ...);
@@ -826,5 +827,10 @@ void set_profile_run_file(pid_t pid, const char *fname);
 
 // dbus.c
 void dbus_disable(void);
+
+// dhcp.c
+extern pid_t dhclient4_pid;
+extern pid_t dhclient6_pid;
+void dhcp_start(void);
 
 #endif

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -239,6 +239,24 @@ static inline int any_interface_configured(void) {
 		return 0;
 }
 
+static inline int any_ip_dhcp(void) {
+	if (cfg.bridge0.arg_ip_dhcp || cfg.bridge1.arg_ip_dhcp || cfg.bridge2.arg_ip_dhcp || cfg.bridge3.arg_ip_dhcp)
+		return 1;
+	else
+		return 0;
+}
+
+static inline int any_ip6_dhcp(void) {
+	if (cfg.bridge0.arg_ip6_dhcp || cfg.bridge1.arg_ip6_dhcp || cfg.bridge2.arg_ip6_dhcp || cfg.bridge3.arg_ip6_dhcp)
+		return 1;
+	else
+		return 0;
+}
+
+static inline int any_dhcp(void) {
+  return any_ip_dhcp() || any_ip6_dhcp();
+}
+
 extern int arg_private;		// mount private /home
 extern int arg_private_cache;	// private home/.cache
 extern int arg_debug;		// print debug messages

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -815,6 +815,7 @@ void build_appimage_cmdline(char **command_line, char **window_title, int argc, 
 
 // run sbox
 int sbox_run(unsigned filter, int num, ...);
+int sbox_run_v(unsigned filter, char * const arg[]);
 
 // run_files.c
 void delete_run_files(pid_t pid);

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -103,6 +103,8 @@ typedef struct bridge_t {
 
 	// flags
 	uint8_t arg_ip_none;	// --ip=none
+  uint8_t arg_ip_dhcp;
+  uint8_t arg_ip6_dhcp;
 	uint8_t macvlan;	// set by --net=eth0 (or eth1, ...); reset by --net=br0 (or br1, ...)
 	uint8_t configured;
 	uint8_t scan;		// set by --scan

--- a/src/firejail/fs_hostname.c
+++ b/src/firejail/fs_hostname.c
@@ -89,7 +89,7 @@ errexit:
 }
 
 void fs_resolvconf(void) {
-	if (cfg.dns1 == NULL)
+	if (cfg.dns1 == NULL && !any_dhcp())
 		return;
 
 	if (arg_debug)
@@ -108,7 +108,8 @@ void fs_resolvconf(void) {
 		if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
 			continue;
 		// for resolv.conf we create a brand new file
-		if (strcmp(entry->d_name, "resolv.conf") == 0)
+		if (strcmp(entry->d_name, "resolv.conf") == 0 ||
+        strcmp(entry->d_name, "resolv.conf.dhclient-new") == 0)
 			continue;
 //		printf("linking %s\n", entry->d_name);
 
@@ -169,8 +170,11 @@ void fs_resolvconf(void) {
 		exit(1);
 	}
 
-	if (cfg.dns1)
+	if (cfg.dns1) {
+    if (any_dhcp())
+      fwarning("network setup uses DHCP, nameservers will likely be overwritten\n");
 		fprintf(fp, "nameserver %s\n", cfg.dns1);
+  }
 	if (cfg.dns2)
 		fprintf(fp, "nameserver %s\n", cfg.dns2);
 	if (cfg.dns3)

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -2144,7 +2144,10 @@ int main(int argc, char **argv) {
 				// configure this IP address for the last bridge defined
 				if (strcmp(argv[i] + 5, "none") == 0)
 					br->arg_ip_none = 1;
-				else {
+				else if (strcmp(argv[i] + 5, "dhcp") == 0) {
+					br->arg_ip_none = 1;
+					br->arg_ip_dhcp = 1;
+				} else {
 					if (atoip(argv[i] + 5, &br->ipsandbox)) {
 						fprintf(stderr, "Error: invalid IP address\n");
 						exit(1);
@@ -2184,20 +2187,24 @@ int main(int argc, char **argv) {
 					fprintf(stderr, "Error: no network device configured\n");
 					exit(1);
 				}
-				if (br->ip6sandbox) {
+				if (br->arg_ip6_dhcp || br->ip6sandbox) {
 					fprintf(stderr, "Error: cannot configure the IP address twice for the same interface\n");
 					exit(1);
 				}
 
 				// configure this IP address for the last bridge defined
-				if (check_ip46_address(argv[i] + 6) == 0) {
-					fprintf(stderr, "Error: invalid IPv6 address\n");
-					exit(1);
-				}
+        if (strcmp(argv[i] + 6, "dhcp") == 0)
+          br->arg_ip6_dhcp = 1;
+        else {
+          if (check_ip46_address(argv[i] + 6) == 0) {
+            fprintf(stderr, "Error: invalid IPv6 address\n");
+            exit(1);
+          }
 
-				br->ip6sandbox = strdup(argv[i] + 6);
-				if (br->ip6sandbox == NULL)
-					errExit("strdup");
+          br->ip6sandbox = strdup(argv[i] + 6);
+          if (br->ip6sandbox == NULL)
+            errExit("strdup");
+        }
 			}
 			else
 				exit_err_feature("networking");

--- a/src/firejail/network_main.c
+++ b/src/firejail/network_main.c
@@ -246,6 +246,10 @@ void net_check_cfg(void) {
 	if (cfg.defaultgw)
 		check_default_gw(cfg.defaultgw);
 	else {
+    // if the first network has no assigned address,
+    // do not try to set up a gateway, because it will fail
+    if (cfg.bridge0.arg_ip_none)
+      return;
 		// first network is a regular bridge
 		if (cfg.bridge0.macvlan == 0)
 			cfg.defaultgw = cfg.bridge0.ip;

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -672,7 +672,10 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 			// configure this IP address for the last bridge defined
 			if (strcmp(ptr + 3, "none") == 0)
 				br->arg_ip_none = 1;
-			else {
+			else if (strcmp(ptr + 3, "dhcp") == 0) {
+				br->arg_ip_none = 1;
+				br->arg_ip_dhcp = 1;
+			} else {
 				if (atoip(ptr + 3, &br->ipsandbox)) {
 					fprintf(stderr, "Error: invalid IP address\n");
 					exit(1);
@@ -693,21 +696,24 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 				fprintf(stderr, "Error: no network device configured\n");
 				exit(1);
 			}
-			if (br->ip6sandbox) {
+			if (br->arg_ip6_dhcp || br->ip6sandbox) {
 				fprintf(stderr, "Error: cannot configure the IP address twice for the same interface\n");
 				exit(1);
 			}
 
-			// configure this IP address for the last bridge defined
-			if (check_ip46_address(ptr + 4) == 0) {
-				fprintf(stderr, "Error: invalid IPv6 address\n");
-				exit(1);
-			}
+      // configure this IP address for the last bridge defined
+      if (strcmp(ptr + 4, "dhcp") == 0)
+        br->arg_ip6_dhcp = 1;
+      else {
+        if (check_ip46_address(ptr + 4) == 0) {
+          fprintf(stderr, "Error: invalid IPv6 address\n");
+          exit(1);
+        }
 
-			br->ip6sandbox = strdup(ptr + 4);
-			if (br->ip6sandbox == NULL)
-				errExit("strdup");
-
+        br->ip6sandbox = strdup(ptr + 4);
+        if (br->ip6sandbox == NULL)
+          errExit("strdup");
+      }
 		}
 		else
 			warning_feature_disabled("networking");

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -337,6 +337,8 @@ static int monitor_application(pid_t app_pid) {
 				continue;
 			if (pid == 1)
 				continue;
+      if (pid == dhclient4_pid || pid == dhclient6_pid)
+        continue;
 
 			// todo: make this generic
 			// Dillo browser leaves a dpid process running, we need to shut it down
@@ -1014,6 +1016,11 @@ int sandbox(void* sandbox_arg) {
 	//****************************
 	fs_logger_print();
 	fs_logger_change_owner();
+
+	//****************************
+	// start dhcp client
+	//****************************
+  dhcp_start();
 
 	//****************************
 	// set application environment

--- a/src/firejail/sbox.c
+++ b/src/firejail/sbox.c
@@ -190,23 +190,34 @@ int sbox_run_v(unsigned filtermask, char * const arg[]) {
 		// apply filters
 		if (filtermask & SBOX_CAPS_NONE) {
 			caps_drop_all();
-		}
-		else if (filtermask & SBOX_CAPS_NETWORK) {
+		} else {
+      uint64_t set = 0;
+      if (filtermask & SBOX_CAPS_NETWORK) {
 #ifndef HAVE_GCOV // the following filter will prevent GCOV from saving info in .gcda files
-			uint64_t set = ((uint64_t) 1) << CAP_NET_ADMIN;
-			set |=  ((uint64_t) 1) << CAP_NET_RAW;
-			caps_set(set);
+        set |= ((uint64_t) 1) << CAP_NET_ADMIN;
+        set |= ((uint64_t) 1) << CAP_NET_RAW;
 #endif
-		}
-		else if (filtermask & SBOX_CAPS_HIDEPID) {
+      }
+      if (filtermask & SBOX_CAPS_HIDEPID) {
 #ifndef HAVE_GCOV // the following filter will prevent GCOV from saving info in .gcda files
-			uint64_t set = ((uint64_t) 1) << CAP_SYS_PTRACE;
-			set |=  ((uint64_t) 1) << CAP_SYS_PACCT;
-			caps_set(set);
+        set |= ((uint64_t) 1) << CAP_SYS_PTRACE;
+        set |= ((uint64_t) 1) << CAP_SYS_PACCT;
 #endif
-		}
+      }
+      if (filtermask & SBOX_CAPS_NET_SERVICE) {
+#ifndef HAVE_GCOV // the following filter will prevent GCOV from saving info in .gcda files
+        set |= ((uint64_t) 1) << CAP_NET_BIND_SERVICE;
+        set |= ((uint64_t) 1) << CAP_NET_BROADCAST;
+#endif
+      }
+      if (set != 0) { // some SBOX_CAPS_ flag was specified, drop all other capabilities
+#ifndef HAVE_GCOV // the following filter will prevent GCOV from saving info in .gcda files
+        caps_set(set);
+#endif
+      }
+    }
 
-		if (filtermask & SBOX_SECCOMP) {
+    if (filtermask & SBOX_SECCOMP) {
 			if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)) {
 				perror("prctl(NO_NEW_PRIVS)");
 			}

--- a/src/firejail/sbox.c
+++ b/src/firejail/sbox.c
@@ -105,23 +105,34 @@ static struct sock_fprog prog = {
 };
 
 int sbox_run(unsigned filtermask, int num, ...) {
-	EUID_ROOT();
-
-	int i;
 	va_list valist;
 	va_start(valist, num);
 
 	// build argument list
-	char *arg[num + 1];
+  char **arg = malloc((num + 1) * sizeof(char *));
+  int i;
 	for (i = 0; i < num; i++)
 		arg[i] = va_arg(valist, char*);
 	arg[i] = NULL;
 	va_end(valist);
 
+  int status = sbox_run_v(filtermask, arg); 
+
+  free(arg);
+
+  return status;
+}
+
+int sbox_run_v(unsigned filtermask, char * const arg[]) {
+	EUID_ROOT();
+
 	if (arg_debug) {
 		printf("sbox run: ");
-		for (i = 0; i <= num; i++)
+    int i = 0;
+    while (arg[i]) {
 			printf("%s ", arg[i]);
+      i++;
+    }
 		printf("\n");
 	}
 
@@ -171,7 +182,7 @@ int sbox_run(unsigned filtermask, int num, ...) {
 
 		// close all other file descriptors
 		int max = 20; // getdtablesize() is overkill for a firejail process
-		for (i = 3; i < max; i++)
+		for (int i = 3; i < max; i++)
 			close(i); // close open files
 
 		umask(027);

--- a/src/fnet/fnet.h
+++ b/src/fnet/fnet.h
@@ -47,6 +47,7 @@ int net_get_mac(const char *ifname, unsigned char mac[6]);
 void net_if_ip(const char *ifname, uint32_t ip, uint32_t mask, int mtu);
 int net_if_mac(const char *ifname, const unsigned char mac[6]);
 void net_if_ip6(const char *ifname, const char *addr6);
+void net_if_waitll(const char *ifname);
 
 
 // arp.c

--- a/src/fnet/main.c
+++ b/src/fnet/main.c
@@ -47,6 +47,7 @@ static void usage(void) {
 	printf("\tfnet config mac addr\n");
 	printf("\tfnet config ipv6 dev ip\n");
 	printf("\tfnet ifup dev\n");
+  printf("\tfnet waitll dev\n");
 }
 
 int main(int argc, char **argv) {
@@ -141,6 +142,9 @@ printf("\n");
 	else if (argc == 5 && strcmp(argv[1], "config") == 0 && strcmp(argv[2], "ipv6") == 0) {
 		net_if_ip6(argv[3], argv[4]);
 	}
+  else if (argc == 3 && strcmp(argv[1], "waitll") == 0) {
+    net_if_waitll(argv[2]);
+  }
 	else {
 		fprintf(stderr, "Error fnet: invalid arguments\n");
 		return 1;

--- a/src/include/rundefs.h
+++ b/src/include/rundefs.h
@@ -49,6 +49,11 @@
 #define RUN_LIB_DIR			RUN_MNT_DIR "/lib"
 #define RUN_LIB_FILE			RUN_MNT_DIR "/libfiles"
 #define RUN_DNS_ETC			RUN_MNT_DIR "/dns-etc"
+#define RUN_DHCLIENT_DIR      RUN_MNT_DIR "/dhclient"
+#define RUN_DHCLIENT_4_LEASES_FILE      RUN_DHCLIENT_DIR "/dhclient.leases"
+#define RUN_DHCLIENT_6_LEASES_FILE      RUN_DHCLIENT_DIR "/dhclient6.leases"
+#define RUN_DHCLIENT_4_PID_FILE      RUN_DHCLIENT_DIR "/dhclient.pid"
+#define RUN_DHCLIENT_6_PID_FILE      RUN_DHCLIENT_DIR "/dhclient6.pid"
 
 #define RUN_SECCOMP_DIR			RUN_MNT_DIR "/seccomp"
 #define RUN_SECCOMP_LIST		RUN_SECCOMP_DIR "/seccomp.list"		// list of seccomp files installed


### PR DESCRIPTION
As per my issue in #3026, I was trying to use DHCP to configure network interfaces in firejail. This patch implements integration with the ISC dhclient for both IPv4 and IPv6.

I left the commits as-is so that they can be reviewed individually, but I can squash them if that is preferred.

* Added the options `--ip=dhcp` and `--ip6=dhcp` for IPv4 and IPv6 configuration by DHCP.
* `--ip=dhcp` is handled similarly to `--ip=none`. In particular, firejail does not do any network configuration on its own, not even setting up routing.
* dhclient is invoked in forking mode. Its main process exits when it successfully acquired a lease, while the daemon keeps running in the background. This ensures that firejail only proceeds when the network is working inside the container (running dhclient as a foreground process and getting notified about leases would be a bit trickier).
* I added a capability filter for `CAP_NET_BIND_SERVICE` so that dhclient can bind to low ports.
* PID files and lease files are written to `/run/firejail/mnt/dhclient`. The PID file is read (hopefully without race conditions) to find the PID of the dhclient daemon process. The sandbox may terminate if only the dhlient daemons are running.
* No effort is made to properly terminate (`-x`) dhlient or release the DHCP lease (`-r`), as neither is required by the DHCP protocol. The dclient processes just die when the sandbox terminates. It would be possible to release the lease properly (this is allegedly required by some ISPs, but not in the more common situation when the sandboxes are connected to a local virtual bridged network, such as libvirt), but would require keeping some privileges until container termination (either in the firejail main process, or an auxiliary process just for communicating with dhclient).
* Especially when used solely for DHCPv6, dhclient may fail to bind to the network interface if it has no link-local IPv6 address (or the LL address is only tentative). When both DHCPv4 and DHCPv6 is in use, the delay caused by waiting for the DHCPv4 lease is virtually always enough for IPv6 LL address to become active. I added a subcommand to `fnet` to wait for IPv6 LL addresses. Unfortunately, I had to use the rather complex rtnetlink interface, because this is the only way to access the tenative flag of an address.