### PR TITLE
Allow Tor Browser to run /usr/bin/id

### DIFF
--- a/etc/torbrowser-launcher.profile
+++ b/etc/torbrowser-launcher.profile
@@ -48,7 +48,7 @@ shell none
 #tracelog
 
 disable-mnt
-private-bin bash,cat,cp,cut,dirname,env,expr,file,gpg,grep,gxmessage,kdialog,ln,mkdir,mv,python*,rm,sed,sh,tail,tar,tclsh,test,tor-browser,tor-browser-en,torbrowser-launcher,update-desktop-database,xmessage,xz,zenity
+private-bin bash,cat,cp,cut,dirname,env,expr,file,gpg,grep,gxmessage,id,kdialog,ln,mkdir,mv,python*,rm,sed,sh,tail,tar,tclsh,test,tor-browser,tor-browser-en,torbrowser-launcher,update-desktop-database,xmessage,xz,zenity
 private-dev
 private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,ld.so.cache,machine-id,pki,pulse,resolv.conf,ssl
 private-tmp


### PR DESCRIPTION
The `start-tor-browser` script tries to run `/usr/bin/id` to check that
it isn't root before starting the browser. See
https://gitweb.torproject.org/builders/tor-browser-build.git/tree/projects/tor-browser/RelativeLink/start-tor-browser?id=41fd236bbb7d3d75a27473f927be31f7dd8fdc99#n94

If `id` is not in the `private-bin` directory, the test still works by
accident, but prints these error messages:
```
  ./Browser/start-tor-browser: line 94: id: command not found
  ./Browser/start-tor-browser: line 94: [: : integer expression expected
```
Add `id` to the `private-bin` directory to make it run as intended.