### PR TITLE
Add barrier profile

### DIFF
--- a/etc/barrier.profile
+++ b/etc/barrier.profile
@@ -1,5 +1,5 @@
 # Firejail profile for barrier
-# Keyboard and mouse sharing application
+# Description: Keyboard and mouse sharing application
 # This file is overwritten after every install/update
 
 # Persistent local customizations

--- a/etc/barrier.profile
+++ b/etc/barrier.profile
@@ -19,7 +19,6 @@ include disable-xdg.inc
 
 include whitelist-var-common.inc
 
-
 caps.drop all
 machine-id
 netfilter

--- a/etc/barrier.profile
+++ b/etc/barrier.profile
@@ -1,0 +1,41 @@
+# Firejail profile for barrier
+# Keyboard and mouse sharing application
+# This file is overwritten after every install/update
+
+# Persistent local customizations
+include barrier.local
+
+# Persistent global definitions
+include globals.local 
+
+noblacklist ${HOME}/.config/Debauchee/Barrier.conf
+noblacklist ${HOME}/.local/share/barrier/SSL/Barrier.pem
+noblacklist /etc/xdg/Debauchee/Barrier.conf
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
+include disable-xdg.inc
+
+caps.drop all
+netfilter
+no3d
+nodvd
+nogroups
+nonewprivs
+noroot
+nosound
+notv
+nou2f
+novideo
+protocol unix,inet,inet6,netlink
+seccomp
+shell none
+
+private-dev
+private-cache
+private-tmp
+memory-deny-write-execute

--- a/etc/barrier.profile
+++ b/etc/barrier.profile
@@ -35,6 +35,7 @@ protocol unix,inet,inet6,netlink
 seccomp
 shell none
 
+disable-mnt
 private-dev
 private-cache
 private-tmp

--- a/etc/barrier.profile
+++ b/etc/barrier.profile
@@ -8,6 +8,7 @@ include globals.local
 
 noblacklist ${HOME}/.config/Debauchee/Barrier.conf
 noblacklist ${HOME}/.local/share/barrier
+noblacklist ${PATH}/openssl
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/barrier.profile
+++ b/etc/barrier.profile
@@ -38,4 +38,5 @@ shell none
 private-dev
 private-cache
 private-tmp
+
 memory-deny-write-execute

--- a/etc/barrier.profile
+++ b/etc/barrier.profile
@@ -1,16 +1,13 @@
 # Firejail profile for barrier
 # Description: Keyboard and mouse sharing application
 # This file is overwritten after every install/update
-
 # Persistent local customizations
 include barrier.local
-
 # Persistent global definitions
 include globals.local 
 
 noblacklist ${HOME}/.config/Debauchee/Barrier.conf
-noblacklist ${HOME}/.local/share/barrier/SSL/Barrier.pem
-noblacklist /etc/xdg/Debauchee/Barrier.conf
+noblacklist ${HOME}/.local/share/barrier
 
 include disable-common.inc
 include disable-devel.inc
@@ -20,7 +17,11 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-xdg.inc
 
+include whitelist-var-common.inc
+
+
 caps.drop all
+machine-id
 netfilter
 no3d
 nodvd
@@ -34,6 +35,7 @@ novideo
 protocol unix,inet,inet6,netlink
 seccomp
 shell none
+tracelog
 
 disable-mnt
 private-dev

--- a/etc/barrier.profile
+++ b/etc/barrier.profile
@@ -42,3 +42,5 @@ private-cache
 private-tmp
 
 memory-deny-write-execute
+noexec ${HOME}
+noexec /tmp

--- a/etc/barrier.profile
+++ b/etc/barrier.profile
@@ -43,5 +43,3 @@ private-cache
 private-tmp
 
 memory-deny-write-execute
-noexec ${HOME}
-noexec /tmp

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -71,6 +71,7 @@ blacklist ${HOME}/.config/Code
 blacklist ${HOME}/.config/Code - OSS
 blacklist ${HOME}/.config/Code Industry
 blacklist ${HOME}/.config/Cryptocat
+blacklist ${HOME}/.config/Debauchee/Barrier.conf
 blacklist ${HOME}/.config/Enox
 blacklist ${HOME}/.config/Franz
 blacklist ${HOME}/.config/FreeCAD
@@ -488,6 +489,7 @@ blacklist ${HOME}/.local/share/apps/korganizer
 blacklist ${HOME}/.local/share/aspyr-media
 blacklist ${HOME}/.local/share/autokey
 blacklist ${HOME}/.local/share/baloo
+blacklist ${HOME}/.local/share/barrier
 blacklist ${HOME}/.local/share/bibletime
 blacklist ${HOME}/.local/share/caja-python
 blacklist ${HOME}/.local/share/cantata

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -67,6 +67,7 @@ aweather
 baloo_file
 baloo_filemetadata_temp_extractor
 baobab
+barrier
 basilisk
 beaker
 bibletime


### PR DESCRIPTION
Barrier is a keyboard and mouse sharing application that can be used across multiple networked computers. Here is a profile for it. 

I tried to make a whitelist for it but it was taking a huge amount of time. So here it is as a blacklist. It needs dbus, netlink, and doesn't work with a private /etc or private binary.