### PR TITLE
allow chroot syscall where apps depend on QtWebengine

### DIFF
--- a/etc/anki.profile
+++ b/etc/anki.profile
@@ -42,7 +42,8 @@ notv
 nou2f
 novideo
 protocol unix,inet,inet6
-seccomp
+# QtWebengine needs chroot to set up its own sandbox
+seccomp !chroot
 shell none
 tracelog
 

--- a/etc/digikam.profile
+++ b/etc/digikam.profile
@@ -32,7 +32,8 @@ nonewprivs
 noroot
 notv
 protocol unix,inet,inet6,netlink
-seccomp
+# QtWebengine needs chroot to set up its own sandbox
+seccomp !chroot
 shell none
 
 # private-dev - prevents libdc1394 loading; this lib is used to connect to a camera device

--- a/etc/musescore.profile
+++ b/etc/musescore.profile
@@ -33,7 +33,8 @@ noroot
 notv
 novideo
 protocol unix,inet,inet6
-seccomp
+# QtWebengine needs chroot to set up its own sandbox
+seccomp !chroot
 shell none
 tracelog
 

--- a/etc/psi-plus.profile
+++ b/etc/psi-plus.profile
@@ -36,10 +36,10 @@ notv
 nou2f
 novideo
 protocol unix,inet,inet6
-seccomp
+# QtWebengine needs chroot to set up its own sandbox
+seccomp !chroot
 shell none
 
 disable-mnt
 private-dev
 private-tmp
-

--- a/etc/quassel.profile
+++ b/etc/quassel.profile
@@ -19,7 +19,8 @@ nonewprivs
 noroot
 notv
 protocol unix,inet,inet6
-seccomp
+# QtWebengine needs chroot to set up its own sandbox
+seccomp !chroot
 
 private-cache
 private-tmp


### PR DESCRIPTION
If unprivileged user namespaces are enabled, [QtWebengine](https://doc.qt.io/qt-5/qtwebengine-overview.html) needs chroot to set up its own sandbox. We adapted a number of profiles already, see for instance the Qutebrowser, Akregator, Bibletime, Calibre, Falkon or Kmail profiles.

This pull request adds the same exception to the Anki, Digikam, MuseScore, Psi+ and Quassel profiles. Note that this is mostly untested, and based only on [reverse dependencies](https://www.archlinux.org/packages/extra/x86_64/qt5-webengine) in Arch and some coarse understanding of the use of QtWebengine in respective apps.

fixes #3124

