### PR TITLE
cmus: allow access to resolv.conf

### DIFF
--- a/etc/cmus.profile
+++ b/etc/cmus.profile
@@ -27,4 +27,4 @@ seccomp
 shell none
 
 private-bin cmus
-private-etc alternatives,asound.conf,ca-certificates,crypto-policies,group,machine-id,pki,pulse,ssl
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,group,machine-id,pki,pulse,resolv.conf,ssl


### PR DESCRIPTION
DNS resolution is useful in case streams are referenced by DNS.