### PR TITLE
aria2c fixes

### DIFF
--- a/etc/aria2c.profile
+++ b/etc/aria2c.profile
@@ -7,6 +7,8 @@ include aria2c.local
 include globals.local
 
 noblacklist ${HOME}/.aria2
+noblacklist ${HOME}/.config/aria2
+noblacklist ${HOME}/.netrc
 
 blacklist /tmp/.X11-unix
 
@@ -37,6 +39,7 @@ seccomp
 shell none
 
 # disable-mnt
+# Add your custom event hook commands to 'private-bin' in your aria2c.local
 private-bin aria2c,gzip
 # Uncomment the next line (or put 'private-cache' in your aria2c.local) if you don't use Lutris/winetricks (see issue #2772)
 #private-cache

--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -118,6 +118,7 @@ blacklist ${HOME}/.config/akonadi*
 blacklist ${HOME}/.config/akregatorrc
 blacklist ${HOME}/.config/ardour4
 blacklist ${HOME}/.config/ardour5
+blacklist ${HOME}/.config/aria2
 blacklist ${HOME}/.config/arkrc
 blacklist ${HOME}/.config/artha.conf
 blacklist ${HOME}/.config/artha.log


### PR DESCRIPTION
Until now we only supported the legacy ${HOME}/.aria2 path. Let's include support for ${HOME}/.config/aria2 too (cfr. https://aria2.github.io/manual/en/html/aria2c.html#files). Fixes https://github.com/netblue30/firejail/issues/3142.

Additionally add a comment to inform users that have [custom event hooks](https://aria2.github.io/manual/en/html/aria2c.html#event-hook) to add these to private-bin.