### PR TITLE
Blacklisting openrc paths by defaults

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -151,6 +151,11 @@ blacklist /var/lib/systemd
 # blacklist /var/run/systemd
 # creates problems on Arch where /etc/resolv.conf is a symlink to /var/run/systemd/resolve/resolv.conf
 
+# openrc
+blacklist /etc/runlevels/
+blacklist /etc/init.d/
+blacklist /etc/rc.conf
+
 # VirtualBox
 blacklist ${HOME}/.VirtualBox
 blacklist ${HOME}/.config/VirtualBox


### PR DESCRIPTION
This PR blacklists openrc path that could be used to identify running services out of the sandbox, which could be used for information gathering.