### PR TITLE
Fix missing lib libmfx.so.1 (standardnotes-desktop)

### DIFF
--- a/etc/standardnotes-desktop.profile
+++ b/etc/standardnotes-desktop.profile
@@ -39,5 +39,5 @@ seccomp !chroot
 disable-mnt
 private-dev
 private-tmp
-private-etc alternatives,ca-certificates,crypto-policies,fonts,host.conf,hostname,hosts,pki,resolv.conf,ssl,xdg
+private-etc alternatives,ca-certificates,crypto-policies,fonts,host.conf,hostname,hosts,ld.so.cache,pki,resolv.conf,ssl,xdg
 


### PR DESCRIPTION
To fix:
```shell
$ firejail --profile=/etc/firejail/standardnotes-desktop.profile /usr/bin/standardnotes-desktop
Reading profile /etc/firejail/standardnotes-desktop.profile
Reading profile /etc/firejail/standardnotes-desktop.local
Reading profile /etc/firejail/disable-common.inc
Reading profile /etc/firejail/disable-devel.inc
Reading profile /etc/firejail/disable-exec.inc
Reading profile /etc/firejail/disable-interpreters.inc
Reading profile /etc/firejail/disable-passwdmgr.inc
Reading profile /etc/firejail/disable-programs.inc
Reading profile /etc/firejail/whitelist-var-common.inc
Parent pid 292648, child pid 292675
Warning: skipping alternatives for private /etc
Warning: skipping crypto-policies for private /etc
Warning: skipping pki for private /etc
Private /etc installed in 47.93 ms
Warning: An abstract unix socket for session D-BUS might still be available. Use --net or remove unix from --protocol set.
Warning: /sbin directory link was not blacklisted
Warning: /usr/sbin directory link was not blacklisted
Post-exec seccomp protector enabled
Warning: Cannot confine the application using AppArmor.
Maybe firejail-default AppArmor profile is not loaded into the kernel.
As root, run "aa-enforce firejail-default" to load it.
Child process initialized in 146.13 ms
/usr/bin/electron: error while loading shared libraries: libmfx.so.1: cannot open shared object file: No such file or directory

Parent is shutting down, bye...
```