### PR TITLE
Add profile for offical Linux Teams application

### DIFF
--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -244,6 +244,7 @@ blacklist ${HOME}/.config/mate/mate-dictionary
 blacklist ${HOME}/.config/meld
 blacklist ${HOME}/.config/meteo-qt
 blacklist ${HOME}/.config/mfusion
+blacklist ${HOME}/.config/Microsoft
 blacklist ${HOME}/.config/midori
 blacklist ${HOME}/.config/mono
 blacklist ${HOME}/.config/mpDris2
@@ -305,6 +306,7 @@ blacklist ${HOME}/.config/sqlitebrowser
 blacklist ${HOME}/.config/stellarium
 blacklist ${HOME}/.config/supertuxkart
 blacklist ${HOME}/.config/synfig
+blacklist ${HOME}/.config/teams
 blacklist ${HOME}/.config/telepathy-account-widgets
 blacklist ${HOME}/.config/torbrowser
 blacklist ${HOME}/.config/totem

--- a/etc/teams.profile
+++ b/etc/teams.profile
@@ -18,6 +18,9 @@ include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
 
+mkdir ${HOME}/.config/teams
+mkdir ${HOME}/.config/Microsoft
+
 whitelist ${HOME}/.config/teams
 whitelist ${HOME}/.config/Microsoft
 whitelist ${DOWNLOADS}

--- a/etc/teams.profile
+++ b/etc/teams.profile
@@ -4,6 +4,8 @@
 # Persistent local customizations
 include teams.local
 # Persistent global definitions
+# added by included profile
+#include globals.local
 
 # TODO add these 2 paths as blacklist to disable-programs.inc
 noblacklist ${HOME}/.config/teams

--- a/etc/teams.profile
+++ b/etc/teams.profile
@@ -7,7 +7,6 @@ include teams.local
 # added by included profile
 #include globals.local
 
-# TODO add these 2 paths as blacklist to disable-programs.inc
 noblacklist ${HOME}/.config/teams
 noblacklist ${HOME}/.config/Microsoft
 
@@ -21,13 +20,10 @@ whitelist ${HOME}/.config/teams
 whitelist ${HOME}/.config/Microsoft
 include whitelist-common.inc
 include whitelist-var-common.inc
-# TODO Check if can we enable wusc - if so, do we need to whitelist something in /usr/share/?
-#include whitelist-usr-share-common.inc
 
 nou2f
 shell none
-# TODO Check if can we enable tracelog?
-#tracelog
+tracelog
 
 disable-mnt
 private-cache

--- a/etc/teams.profile
+++ b/etc/teams.profile
@@ -1,48 +1,37 @@
-# Firejail profile for offical Teams application
-#
-# Description: Teams is an application for Microsoft's team collaboration and chat program
-# URL:         https://teams.microsoft.com/downloads
-#
+# Firejail profile for teams
+# Description: Official Microsoft Teams client for Linux using Electron.
 # This file is overwritten after every install/update
 # Persistent local customizations
 include teams.local
 # Persistent global definitions
-include globals.local
 
+# TODO add these 2 paths as blacklist to disable-programs.inc
 noblacklist ${HOME}/.config/teams
+noblacklist ${HOME}/.config/Microsoft
 
-include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
-include disable-passwdmgr.inc
-include disable-programs.inc
 
 mkdir ${HOME}/.config/teams
 mkdir ${HOME}/.config/Microsoft
-
 whitelist ${HOME}/.config/teams
 whitelist ${HOME}/.config/Microsoft
 whitelist ${DOWNLOADS}
 include whitelist-common.inc
 include whitelist-var-common.inc
+# TODO Check if can we enable wusc - if so, do we need to whitelist something in /usr/share/?
+#include whitelist-usr-share-common.inc
 
-caps.drop all
-netfilter
-nodvd
-nogroups
-nonewprivs
-noroot
-notv
 nou2f
-novideo
-protocol unix,inet,inet6,netlink
-seccomp
 shell none
+# TODO Check if can we enable tracelog?
+#tracelog
 
 disable-mnt
-#private-bin bash,cut,echo,egrep,grep,head,sed,sh,teams,tr,xdg-mime,xdg-open,zsh,readlink,dirname,mkdir,nohup,pulseaudio,awk,mv,dash,kde-config,wget
 private-cache
 private-dev
-#private-etc ca-certificates,crypto-policies,fonts,ld.so.cache,localtime,machine-id,pki,resolv.conf,ssl,alsa,asound.conf,pulse,alternatives,ld.so.preload,selinux,ld.so.conf,ld.so.conf.d,locale,locale.alias,locale.conf,xdg,gtk-3.0,hosts,resolve.conf,host.conf,hostname,protocols,config,dconf,gconf,gtk-2.0,gnutls,mime.types,locale.alias,magic,magic.mgc,group,login.defs,password,X11,nsswitch.conf
 private-tmp
+
+# Redirect
+include electron.profile

--- a/etc/teams.profile
+++ b/etc/teams.profile
@@ -1,0 +1,45 @@
+# Firejail profile for offical Teams application
+#
+# Description: Teams is an application for Microsoft's team collaboration and chat program
+# URL:         https://teams.microsoft.com/downloads
+#
+# This file is overwritten after every install/update
+# Persistent local customizations
+include teams.local
+# Persistent global definitions
+include globals.local
+
+noblacklist ${HOME}/.config/teams
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
+
+whitelist ${HOME}/.config/teams
+whitelist ${HOME}/.config/Microsoft
+whitelist ${DOWNLOADS}
+include whitelist-common.inc
+include whitelist-var-common.inc
+
+caps.drop all
+netfilter
+nodvd
+nogroups
+nonewprivs
+noroot
+notv
+nou2f
+novideo
+protocol unix,inet,inet6,netlink
+seccomp
+shell none
+
+disable-mnt
+#private-bin bash,cut,echo,egrep,grep,head,sed,sh,teams,tr,xdg-mime,xdg-open,zsh,readlink,dirname,mkdir,nohup,pulseaudio,awk,mv,dash,kde-config,wget
+private-cache
+private-dev
+#private-etc ca-certificates,crypto-policies,fonts,ld.so.cache,localtime,machine-id,pki,resolv.conf,ssl,alsa,asound.conf,pulse,alternatives,ld.so.preload,selinux,ld.so.conf,ld.so.conf.d,locale,locale.alias,locale.conf,xdg,gtk-3.0,hosts,resolve.conf,host.conf,hostname,protocols,config,dconf,gconf,gtk-2.0,gnutls,mime.types,locale.alias,magic,magic.mgc,group,login.defs,password,X11,nsswitch.conf
+private-tmp

--- a/etc/teams.profile
+++ b/etc/teams.profile
@@ -19,7 +19,6 @@ mkdir ${HOME}/.config/teams
 mkdir ${HOME}/.config/Microsoft
 whitelist ${HOME}/.config/teams
 whitelist ${HOME}/.config/Microsoft
-whitelist ${DOWNLOADS}
 include whitelist-common.inc
 include whitelist-var-common.inc
 # TODO Check if can we enable wusc - if so, do we need to whitelist something in /usr/share/?

--- a/etc/teams.profile
+++ b/etc/teams.profile
@@ -1,6 +1,8 @@
 # Firejail profile for teams
 # Description: Official Microsoft Teams client for Linux using Electron.
 # This file is overwritten after every install/update
+# Known issues:
+#  * if Teams crashes on startup try using "ignore apparmor" in your local config
 # Persistent local customizations
 include teams.local
 # Persistent global definitions

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -581,6 +581,7 @@ synfigstudio
 sysprof
 sysprof-cli
 tb-starter-wrapper
+teams
 teams-for-linux
 teamspeak3
 teeworlds


### PR DESCRIPTION
Based on the existing teams-for-linux profile here's the profile which matches with Microsoft's official Teams application for Linux.

Currently I had to disable private-bin and private-etc because of immediate crashes after start but it's worth having it in the repo nevertheless so others can contribute to that profile to enhance it if someone come up with the fix for private-bin and private-etc.