### PR TITLE
profiles: whitelist transmission-daemon config directory

### DIFF
--- a/etc/transmission-daemon.profile
+++ b/etc/transmission-daemon.profile
@@ -7,6 +7,8 @@ include transmission-daemon.local
 # Persistent global definitions
 include globals.local
 
+mkdir ${HOME}/.config/transmission-daemon
+whitelist ${HOME}/.config/transmission-daemon
 whitelist /var/lib/transmission
 
 caps.keep ipc_lock,net_bind_service,setgid,setuid,sys_chroot


### PR DESCRIPTION
Reported at: https://bugs.debian.org/948993