### PR TITLE
print rejected character in invalid filenames

### DIFF
--- a/src/firejail/macros.c
+++ b/src/firejail/macros.c
@@ -258,6 +258,28 @@ char *expand_macros(const char *path) {
 	return rv;
 }
 
+// replace control characters with a '?'
+static char *fix_control_chars(const char *fname) {
+	assert(fname);
+
+	size_t len = strlen(fname);
+	char *rv = malloc(len + 1);
+	if (!rv)
+		errExit("malloc");
+
+	size_t i = 0;
+	while (fname[i] != '\0') {
+		if (iscntrl((unsigned char) fname[i]))
+			rv[i] = '?';
+		else
+			rv[i] = fname[i];
+		i++;
+	}
+	rv[i] = '\0';
+
+	return rv;
+}
+
 void invalid_filename(const char *fname, int globbing) {
 //	EUID_ASSERT();
 	assert(fname);
@@ -275,12 +297,14 @@ void invalid_filename(const char *fname, int globbing) {
 			return;
 	}
 
-	size_t i;
-	for (i = 0; ptr[i]; i++) {
+	size_t i = 0;
+	while (ptr[i] != '\0') {
 		if (iscntrl((unsigned char) ptr[i])) {
-			fprintf(stderr, "Error: invalid filename: contains a control character\n");
+			fprintf(stderr, "Error: \"%s\" is an invalid filename: no control characters allowed\n",
+				fix_control_chars(fname));
 			exit(1);
 		}
+		i++;
 	}
 	
 	char *reject;
@@ -290,7 +314,7 @@ void invalid_filename(const char *fname, int globbing) {
 		reject = "\\&!?\"'<>%^(){};,*[]";
 	char *c = strpbrk(ptr, reject);
 	if (c) {
-		fprintf(stderr, "Error: \"%s\" is an invalid filename: rejected character: \"%c\"\n", ptr, *c);
+		fprintf(stderr, "Error: \"%s\" is an invalid filename: rejected character: \"%c\"\n", fname, *c);
 		exit(1);
 	}
 }

--- a/src/firejail/macros.c
+++ b/src/firejail/macros.c
@@ -309,9 +309,9 @@ void invalid_filename(const char *fname, int globbing) {
 	
 	char *reject;
 	if (globbing)
-		reject = "\\&!\"'<>%^(){};,"; // file globbing ('*?[]') is allowed
+		reject = "\\&!\"'<>%^{};,"; // file globbing ('*?[]') is allowed
 	else
-		reject = "\\&!?\"'<>%^(){};,*[]";
+		reject = "\\&!?\"'<>%^{};,*[]";
 	char *c = strpbrk(ptr, reject);
 	if (c) {
 		fprintf(stderr, "Error: \"%s\" is an invalid filename: rejected character: \"%c\"\n", fname, *c);

--- a/src/firejail/macros.c
+++ b/src/firejail/macros.c
@@ -275,19 +275,15 @@ void invalid_filename(const char *fname, int globbing) {
 			return;
 	}
 
-	int len = strlen(ptr);
+	char *reject;
+	if (globbing)
+		reject = "\\&!\"'<>%^(){};,"; // file globbing ('*?[]') is allowed
+	else
+		reject = "\\&!?\"'<>%^(){};,*[]";
 
-	if (globbing) {
-		// file globbing ('*?[]') is allowed
-		if (strcspn(ptr, "\\&!\"'<>%^(){};,") != (size_t)len) {
-			fprintf(stderr, "Error: \"%s\" is an invalid filename\n", ptr);
-			exit(1);
-		}
-	}
-	else {
-		if (strcspn(ptr, "\\&!?\"'<>%^(){};,*[]") != (size_t)len) {
-			fprintf(stderr, "Error: \"%s\" is an invalid filename\n", ptr);
-			exit(1);
-		}
+	char *c = strpbrk(ptr, reject);
+	if (c) {
+		fprintf(stderr, "Error: \"%s\" is an invalid filename: rejected character: \"%c\"\n", ptr, *c);
+		exit(1);
 	}
 }

--- a/src/firejail/macros.c
+++ b/src/firejail/macros.c
@@ -275,12 +275,19 @@ void invalid_filename(const char *fname, int globbing) {
 			return;
 	}
 
+	size_t i;
+	for (i = 0; ptr[i]; i++) {
+		if (iscntrl((unsigned char) ptr[i])) {
+			fprintf(stderr, "Error: invalid filename: contains a control character\n");
+			exit(1);
+		}
+	}
+	
 	char *reject;
 	if (globbing)
 		reject = "\\&!\"'<>%^(){};,"; // file globbing ('*?[]') is allowed
 	else
 		reject = "\\&!?\"'<>%^(){};,*[]";
-
 	char *c = strpbrk(ptr, reject);
 	if (c) {
 		fprintf(stderr, "Error: \"%s\" is an invalid filename: rejected character: \"%c\"\n", ptr, *c);


### PR DESCRIPTION
provide feedback about why a filename was rejected; see issue #3001 