### PR TITLE
blacklist ${RUNUSER}/wayland-* in every profile with blacklist /tmp/.X11-unix or x11 none

### DIFF
--- a/etc/7z.profile
+++ b/etc/7z.profile
@@ -7,6 +7,8 @@ include 7z.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/ar.profile
+++ b/etc/ar.profile
@@ -7,6 +7,8 @@ include ar.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/aria2c.profile
+++ b/etc/aria2c.profile
@@ -11,6 +11,7 @@ noblacklist ${HOME}/.config/aria2
 noblacklist ${HOME}/.netrc
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/artha.profile
+++ b/etc/artha.profile
@@ -11,6 +11,7 @@ noblacklist ${HOME}/.config/artha.log
 noblacklist ${HOME}/.config/enchant
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/atool.profile
+++ b/etc/atool.profile
@@ -7,6 +7,8 @@ include atool.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 # Allow perl (blacklisted by disable-interpreters.inc)
 include allow-perl.inc
 

--- a/etc/audio-recorder.profile
+++ b/etc/audio-recorder.profile
@@ -7,6 +7,8 @@ include audio-recorder.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 noblacklist ${MUSIC}
 
 include disable-common.inc

--- a/etc/bsdtar.profile
+++ b/etc/bsdtar.profile
@@ -6,6 +6,8 @@ include bsdtar.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 include disable-common.inc
 # include disable-devel.inc
 include disable-exec.inc

--- a/etc/checkbashisms.profile
+++ b/etc/checkbashisms.profile
@@ -7,6 +7,8 @@ include checkbashisms.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 noblacklist ${DOCUMENTS}
 
 # Allow perl (blacklisted by disable-interpreters.inc)

--- a/etc/clamav.profile
+++ b/etc/clamav.profile
@@ -7,6 +7,8 @@ include clamav.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 include disable-exec.inc
 
 caps.drop all

--- a/etc/cpio.profile
+++ b/etc/cpio.profile
@@ -7,6 +7,8 @@ include cpio.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 noblacklist /sbin
 noblacklist /usr/sbin
 

--- a/etc/dconf.profile
+++ b/etc/dconf.profile
@@ -6,6 +6,8 @@ include dconf.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/ddgtk.profile
+++ b/etc/ddgtk.profile
@@ -6,6 +6,8 @@ include ddgtk.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 # Allow python (blacklisted by disable-interpreters.inc)
 include allow-python2.inc
 include allow-python3.inc

--- a/etc/devilspie.profile
+++ b/etc/devilspie.profile
@@ -6,6 +6,8 @@ include devilspie.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 noblacklist ${HOME}/.devilspie
 
 include disable-common.inc

--- a/etc/devilspie2.profile
+++ b/etc/devilspie2.profile
@@ -6,6 +6,8 @@ include devilspie2.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 noblacklist ${HOME}/.config/devilspie2
 
 # Allow lua (blacklisted by disable-interpreters.inc)

--- a/etc/dnsmasq.profile
+++ b/etc/dnsmasq.profile
@@ -11,6 +11,7 @@ noblacklist /sbin
 noblacklist /usr/sbin
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/elinks.profile
+++ b/etc/elinks.profile
@@ -9,6 +9,7 @@ include globals.local
 noblacklist ${HOME}/.elinks
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/enchant.profile
+++ b/etc/enchant.profile
@@ -6,6 +6,8 @@ include enchant.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 noblacklist ${HOME}/.config/enchant
 
 include disable-common.inc

--- a/etc/exiftool.profile
+++ b/etc/exiftool.profile
@@ -6,6 +6,8 @@ include exiftool.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 # Allow perl (blacklisted by disable-interpreters.inc)
 include allow-perl.inc
 

--- a/etc/file.profile
+++ b/etc/file.profile
@@ -7,6 +7,8 @@ include file.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 include disable-common.inc
 include disable-exec.inc
 include disable-passwdmgr.inc

--- a/etc/gconf-editor.profile
+++ b/etc/gconf-editor.profile
@@ -8,6 +8,7 @@ include gconf-editor.local
 #include globals.local
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 ignore net none
 ignore x11 none

--- a/etc/gconf.profile
+++ b/etc/gconf.profile
@@ -6,6 +6,8 @@ include gconf.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 noblacklist ${HOME}/.config/gconf
 
 # Allow python (blacklisted by disable-interpreters.inc)

--- a/etc/gist.profile
+++ b/etc/gist.profile
@@ -8,6 +8,7 @@ include gist.local
 include globals.local
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 noblacklist ${HOME}/.gist
 

--- a/etc/git.profile
+++ b/etc/git.profile
@@ -20,6 +20,7 @@ noblacklist ${HOME}/.vim
 noblacklist ${HOME}/.viminfo
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-exec.inc

--- a/etc/gpg-agent.profile
+++ b/etc/gpg-agent.profile
@@ -10,6 +10,7 @@ include globals.local
 noblacklist ${HOME}/.gnupg
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/gpg.profile
+++ b/etc/gpg.profile
@@ -10,6 +10,7 @@ include globals.local
 noblacklist ${HOME}/.gnupg
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/gtk-update-icon-cache.profile
+++ b/etc/gtk-update-icon-cache.profile
@@ -7,6 +7,8 @@ include gtk-update-icon-cache.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/gzip.profile
+++ b/etc/gzip.profile
@@ -7,6 +7,8 @@ include gzip.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 # Arch Linux (based distributions) need access to /var/lib/pacman. As we drop all capabilities this is automatically read-only.
 noblacklist /var/lib/pacman
 

--- a/etc/hashcat.profile
+++ b/etc/hashcat.profile
@@ -7,6 +7,8 @@ include hashcat.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 noblacklist ${HOME}/.hashcat
 noblacklist /usr/include
 noblacklist ${DOCUMENTS}

--- a/etc/highlight.profile
+++ b/etc/highlight.profile
@@ -6,6 +6,8 @@ include highlight.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc

--- a/etc/img2txt.profile
+++ b/etc/img2txt.profile
@@ -5,6 +5,8 @@ include img2txt.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 noblacklist ${DOCUMENTS}
 noblacklist ${PICTURES}
 

--- a/etc/less.profile
+++ b/etc/less.profile
@@ -7,6 +7,8 @@ include less.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 noblacklist ${HOME}/.lesshst
 
 include disable-devel.inc

--- a/etc/links.profile
+++ b/etc/links.profile
@@ -9,6 +9,7 @@ include globals.local
 noblacklist ${HOME}/.links
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/lynx.profile
+++ b/etc/lynx.profile
@@ -7,6 +7,7 @@ include lynx.local
 include globals.local
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/mediainfo.profile
+++ b/etc/mediainfo.profile
@@ -6,6 +6,8 @@ include mediainfo.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/mp3splt.profile
+++ b/etc/mp3splt.profile
@@ -6,6 +6,8 @@ include mp3splt.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 noblacklist ${MUSIC}
 
 include disable-common.inc

--- a/etc/mutt.profile
+++ b/etc/mutt.profile
@@ -32,6 +32,7 @@ noblacklist ${HOME}/postponed
 noblacklist ${HOME}/sent
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/nano.profile
+++ b/etc/nano.profile
@@ -7,6 +7,8 @@ include nano.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 noblacklist ${HOME}/.config/nano
 noblacklist ${HOME}/.nanorc
 

--- a/etc/ncdu.profile
+++ b/etc/ncdu.profile
@@ -6,6 +6,8 @@ include ncdu.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 include disable-exec.inc
 
 caps.drop all

--- a/etc/odt2txt.profile
+++ b/etc/odt2txt.profile
@@ -6,6 +6,8 @@ include odt2txt.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 noblacklist ${DOCUMENTS}
 
 include disable-common.inc

--- a/etc/pandoc.profile
+++ b/etc/pandoc.profile
@@ -7,6 +7,8 @@ include pandoc.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 noblacklist ${DOCUMENTS}
 
 include disable-common.inc

--- a/etc/patch.profile
+++ b/etc/patch.profile
@@ -7,6 +7,8 @@ include patch.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 noblacklist ${DOCUMENTS}
 
 include disable-common.inc

--- a/etc/pdftotext.profile
+++ b/etc/pdftotext.profile
@@ -6,6 +6,8 @@ include pdftotext.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 noblacklist ${DOCUMENTS}
 
 include disable-common.inc

--- a/etc/pngquant.profile
+++ b/etc/pngquant.profile
@@ -7,6 +7,8 @@ include pngquant.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/rsync-download_only.profile
+++ b/etc/rsync-download_only.profile
@@ -13,6 +13,7 @@ include globals.local
 # Usage: firejail --profile=rsync-download_only rsync
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/seahorse.profile
+++ b/etc/seahorse.profile
@@ -7,6 +7,7 @@ include seahorse.local
 include globals.local
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 noblacklist ${HOME}/.gnupg
 noblacklist ${HOME}/.ssh

--- a/etc/server.profile
+++ b/etc/server.profile
@@ -14,6 +14,7 @@ noblacklist /usr/sbin
 # noblacklist /var/opt
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 # include disable-devel.inc

--- a/etc/shellcheck.profile
+++ b/etc/shellcheck.profile
@@ -7,6 +7,8 @@ include shellcheck.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 noblacklist ${DOCUMENTS}
 
 include disable-common.inc

--- a/etc/signal-cli.profile
+++ b/etc/signal-cli.profile
@@ -7,6 +7,7 @@ include signal-cli.local
 include globals.local
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 noblacklist ${HOME}/.local/share/signal-cli
 

--- a/etc/spectre-meltdown-checker.profile
+++ b/etc/spectre-meltdown-checker.profile
@@ -6,6 +6,8 @@ include spectre-meltdown-checker.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 noblacklist ${PATH}/mount
 noblacklist ${PATH}/umount
 

--- a/etc/ssh-agent.profile
+++ b/etc/ssh-agent.profile
@@ -11,6 +11,7 @@ noblacklist /tmp/ssh-*
 noblacklist ${HOME}/.ssh
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-passwdmgr.inc

--- a/etc/strings.profile
+++ b/etc/strings.profile
@@ -7,6 +7,8 @@ include strings.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 #include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/tar.profile
+++ b/etc/tar.profile
@@ -7,6 +7,8 @@ include tar.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 # Arch Linux (based distributions) need access to /var/lib/pacman. As we drop all capabilities this is automatically read-only.
 noblacklist /var/lib/pacman
 

--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -42,6 +42,7 @@
 #  ${HOME} (user's home)
 #  ${PATH} (contents of PATH envvar)
 #  ${MUSIC}
+#  ${RUNUSER} (/run/user/UID)
 #  ${VIDEOS}
 #
 # Check contents of ~/.config/user-dirs.dirs to see how they translate to actual paths.
@@ -59,6 +60,8 @@ include globals.local
 ##blacklist PATH
 # Disable X11 (CLI only), see also 'x11 none' below
 #blacklist /tmp/.X11-unix
+# Disable Wayland
+#blacklist ${RUNUSER}/wayland-*
 
 # It is common practice to add files/dirs containing program-specific configuration
 # (often ${HOME}/PROGRAMNAME or ${HOME}/.config/PROGRAMNAME) into disable-programs.inc

--- a/etc/tracker.profile
+++ b/etc/tracker.profile
@@ -9,6 +9,7 @@ include globals.local
 # Tracker is started by systemd on most systems. Therefore it is not firejailed by default
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/unbound.profile
+++ b/etc/unbound.profile
@@ -10,6 +10,7 @@ noblacklist /sbin
 noblacklist /usr/sbin
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/unf.profile
+++ b/etc/unf.profile
@@ -7,6 +7,8 @@ include unf.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/unrar.profile
+++ b/etc/unrar.profile
@@ -7,6 +7,8 @@ include unrar.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/unzip.profile
+++ b/etc/unzip.profile
@@ -7,6 +7,8 @@ include unzip.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 # GNOME Shell integration (chrome-gnome-shell)
 noblacklist ${HOME}/.local/share/gnome-shell
 

--- a/etc/uudeview.profile
+++ b/etc/uudeview.profile
@@ -7,6 +7,8 @@ include uudeview.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/w3m.profile
+++ b/etc/w3m.profile
@@ -9,6 +9,7 @@ include globals.local
 noblacklist ${HOME}/.w3m
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 include allow-perl.inc
 

--- a/etc/wget.profile
+++ b/etc/wget.profile
@@ -12,6 +12,7 @@ noblacklist ${HOME}/.wget-hsts
 noblacklist ${HOME}/.wgetrc
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/whois.profile
+++ b/etc/whois.profile
@@ -8,6 +8,7 @@ include whois.local
 include globals.local
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/xzdec.profile
+++ b/etc/xzdec.profile
@@ -7,6 +7,8 @@ include xzdec.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/youtube-dl.profile
+++ b/etc/youtube-dl.profile
@@ -21,6 +21,7 @@ include allow-python2.inc
 include allow-python3.inc
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/zstd.profile
+++ b/etc/zstd.profile
@@ -7,6 +7,8 @@ include zstd.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc


### PR DESCRIPTION
This PR adds `blacklist ${RUNUSER}/wayland-*` (the default location for wayland-sockets) to every profile with `blacklist /tmp/.X11-unix` or `x11 none`