### PR TITLE
fixes for 'blacklist ${RUNUSER}/wayland-*'

### DIFF
--- a/etc/audio-recorder.profile
+++ b/etc/audio-recorder.profile
@@ -7,8 +7,6 @@ include audio-recorder.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
-
 noblacklist ${MUSIC}
 
 include disable-common.inc
@@ -42,7 +40,6 @@ protocol unix
 seccomp
 shell none
 tracelog
-x11 none
 
 disable-mnt
 # private-bin audio-recorder

--- a/etc/ddgtk.profile
+++ b/etc/ddgtk.profile
@@ -6,8 +6,6 @@ include ddgtk.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
-
 # Allow python (blacklisted by disable-interpreters.inc)
 include allow-python2.inc
 include allow-python3.inc
@@ -45,7 +43,6 @@ protocol unix
 seccomp
 shell none
 tracelog
-x11 none
 
 disable-mnt
 private-bin bash,dd,ddgtk,grep,lsblk,python*,sed,sh,tr

--- a/etc/dnscrypt-proxy.profile
+++ b/etc/dnscrypt-proxy.profile
@@ -8,6 +8,7 @@ include dnscrypt-proxy.local
 include globals.local
 
 blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
 
 noblacklist /sbin
 noblacklist /usr/sbin

--- a/etc/gconf-editor.profile
+++ b/etc/gconf-editor.profile
@@ -8,9 +8,9 @@ include gconf-editor.local
 #include globals.local
 
 blacklist /tmp/.X11-unix
-blacklist ${RUNUSER}/wayland-*
 
-ignore net none
+whitelist /usr/share/gconf-editor
+
 ignore x11 none
 
 # Redirect

--- a/etc/seahorse.profile
+++ b/etc/seahorse.profile
@@ -7,7 +7,6 @@ include seahorse.local
 include globals.local
 
 blacklist /tmp/.X11-unix
-blacklist ${RUNUSER}/wayland-*
 
 noblacklist ${HOME}/.gnupg
 noblacklist ${HOME}/.ssh


### PR DESCRIPTION
We need to support both X11 and Wayland by default in GUI applications. See discussion in https://github.com/netblue30/firejail/commit/dead61dd2447a9583af8a0d240a4520aa692c79d.