### PR TITLE
clarify dropping python2 support in meld.profile

### DIFF
--- a/etc/meld.profile
+++ b/etc/meld.profile
@@ -23,7 +23,7 @@ noblacklist ${HOME}/.subversion
 
 # Allow python (blacklisted by disable-interpreters.inc)
 # Python 2 is EOL (see #3164). Uncomment the next line (or put it into your meld.local) if you understand the risks but want python 2 support for older meld versions.
-include allow-python3.inc
+#include allow-python3.inc
 
 # Uncomment the next line (or put it into your meld.local) if you don't need to compare files in disable-common.inc.
 #include disable-common.inc

--- a/etc/meld.profile
+++ b/etc/meld.profile
@@ -22,6 +22,7 @@ noblacklist ${HOME}/.ssh
 noblacklist ${HOME}/.subversion
 
 # Allow python (blacklisted by disable-interpreters.inc)
+# Python 2 is EOL (see #3164). Uncomment the next line (or put it into your meld.local) if you understand the risks but want python 2 support for older meld versions.
 include allow-python3.inc
 
 # Uncomment the next line (or put it into your meld.local) if you don't need to compare files in disable-common.inc.


### PR DESCRIPTION
This is just a suggestion relating to the discussion on dropping support for python2 in https://github.com/netblue30/firejail/issues/3164.