### PR TITLE
Move more whitelisting into firefox-common.profile

### DIFF
--- a/etc/firefox-common.profile
+++ b/etc/firefox-common.profile
@@ -6,6 +6,7 @@ include firefox-common.local
 # added by caller profile
 #include globals.local
 
+
 # noexec ${HOME} breaks DRM binaries.
 ?BROWSER_ALLOW_DRM: ignore noexec ${HOME}
 
@@ -21,6 +22,9 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 
+whitelist /usr/share/mozilla
+whitelist /usr/share/webext
+
 mkdir ${HOME}/.pki
 mkdir ${HOME}/.local/share/pki
 whitelist ${DOWNLOADS}
@@ -28,6 +32,7 @@ whitelist ${HOME}/.pki
 whitelist ${HOME}/.local/share/pki
 include whitelist-common.inc
 include whitelist-var-common.inc
+include whitelist-usr-share-common.inc
 
 apparmor
 caps.drop all

--- a/etc/firefox.profile
+++ b/etc/firefox.profile
@@ -14,10 +14,6 @@ mkdir ${HOME}/.mozilla
 whitelist ${HOME}/.cache/mozilla/firefox
 whitelist ${HOME}/.mozilla
 
-whitelist /usr/share/mozilla
-whitelist /usr/share/webext
-include whitelist-usr-share-common.inc
-
 # firefox requires a shell to launch on Arch.
 #private-bin bash,dbus-launch,dbus-send,env,firefox,sh,which
 # Fedora use shell scripts to launch firefox, at least this is required


### PR DESCRIPTION
A few relatively recent changes modified `firefox.profile`, but these affect all Firefox versions---stable, beta, esr, etc.---and so should have gone into `firefox-common.profile`.

This patch does so.