### PR TITLE
Allow mbind syscall for GIMP

### DIFF
--- a/etc/gimp.profile
+++ b/etc/gimp.profile
@@ -45,7 +45,7 @@ nosound
 notv
 nou2f
 protocol unix
-seccomp
+seccomp !mbind
 shell none
 tracelog
 


### PR DESCRIPTION
Fixes #2681.