### PR TITLE
fix test catchsignal-master.sh

### DIFF
--- a/test/utils/catchsignal-master.sh
+++ b/test/utils/catchsignal-master.sh
@@ -4,4 +4,4 @@
 # License GPL v2
 
 ./catchsignal.sh &
-./catchsignal.sh &
+./catchsignal2.sh &


### PR DESCRIPTION
While moving copyright to 2020 I noticed that _catchsignal2.sh_ was never being run. Being totally unfamiliar with the test codebase, I could be wrong here. I'd appreciate a review before breaking stuff.