### PR TITLE
blacklist gjs in disable-interpreters

### DIFF
--- a/etc/allow-gjs.inc
+++ b/etc/allow-gjs.inc
@@ -1,0 +1,6 @@
+noblacklist ${PATH}/gjs
+noblacklist ${PATH}/gjs-console
+noblacklist /usr/lib/gjs
+noblacklist /usr/lib64/gjs
+noblacklist /usr/lib/libgjs*
+noblacklist /usr/lib64/libgjs*

--- a/etc/disable-interpreters.inc
+++ b/etc/disable-interpreters.inc
@@ -2,6 +2,12 @@
 # Persistent customizations should go in a .local file.
 include disable-interpreters.local
 
+# gjs
+blacklist ${PATH}/gjs
+blacklist ${PATH}/gjs-console
+blacklist /usr/lib/gjs
+blacklist /usr/lib64/gjs
+
 # Lua
 blacklist ${PATH}/lua*
 blacklist /usr/include/lua*

--- a/etc/disable-interpreters.inc
+++ b/etc/disable-interpreters.inc
@@ -7,6 +7,8 @@ blacklist ${PATH}/gjs
 blacklist ${PATH}/gjs-console
 blacklist /usr/lib/gjs
 blacklist /usr/lib64/gjs
+blacklist /usr/lib/libgjs*
+blacklist /usr/lib64/libgjs*
 
 # Lua
 blacklist ${PATH}/lua*

--- a/etc/gjs.profile
+++ b/etc/gjs.profile
@@ -13,6 +13,9 @@ noblacklist ${HOME}/.cache/org.gnome.Books
 noblacklist ${HOME}/.config/libreoffice
 noblacklist ${HOME}/.local/share/gnome-photos
 
+# Allow gjs (blacklisted by disable-interpreters.inc)
+include allow-gjs.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc

--- a/etc/gnome-books.profile
+++ b/etc/gnome-books.profile
@@ -10,6 +10,9 @@ include globals.local
 noblacklist ${HOME}/.cache/org.gnome.Books
 noblacklist ${DOCUMENTS}
 
+# Allow gjs (blacklisted by disable-interpreters.inc)
+include allow-gjs.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/gnome-characters.profile
+++ b/etc/gnome-characters.profile
@@ -6,6 +6,9 @@ include gnome-characters.local
 # Persistent global definitions
 include globals.local
 
+# Allow gjs (blacklisted by disable-interpreters.inc)
+include allow-gjs.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/gnome-documents.profile
+++ b/etc/gnome-documents.profile
@@ -11,6 +11,9 @@ include globals.local
 noblacklist ${HOME}/.config/libreoffice
 noblacklist ${DOCUMENTS}
 
+# Allow gjs (blacklisted by disable-interpreters.inc)
+include allow-gjs.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/gnome-maps.profile
+++ b/etc/gnome-maps.profile
@@ -13,6 +13,9 @@ noblacklist ${HOME}/.cache/org.gnome.Maps
 noblacklist ${HOME}/.local/share/flatpak
 noblacklist ${HOME}/.local/share/maps-places.json
 
+# Allow gjs (blacklisted by disable-interpreters.inc)
+include allow-gjs.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/gnome-sound-recorder.profile
+++ b/etc/gnome-sound-recorder.profile
@@ -10,6 +10,9 @@ noblacklist ${MUSIC}
 noblacklist ${HOME}/.local/share/flatpak
 noblacklist ${HOME}/.local/share/Trash
 
+# Allow gjs (blacklisted by disable-interpreters.inc)
+include allow-gjs.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/gnome-weather.profile
+++ b/etc/gnome-weather.profile
@@ -10,6 +10,9 @@ include globals.local
 
 noblacklist ${HOME}/.cache/libgweather
 
+# Allow gjs (blacklisted by disable-interpreters.inc)
+include allow-gjs.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/polari.profile
+++ b/etc/polari.profile
@@ -6,6 +6,8 @@ include polari.local
 # Persistent global definitions
 include globals.local
 
+# Allow gjs (blacklisted by disable-interpreters.inc)
+include allow-gjs.inc
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -93,6 +93,9 @@ include globals.local
 # Allow ruby (blacklisted by disable-interpreters.inc)
 #include allow-ruby.inc
 
+# Allow gjs (blacklisted by disable-interpreters.inc)
+#include allow-gjs.inc
+
 # Allows files commonly used by IDEs
 #include allow-common-devel.inc
 


### PR DESCRIPTION
TODO: reverse dependencies check on more distros (actually only Fedora).