### PR TITLE
DHCP client code quality fixes

### DIFF
--- a/src/firejail/dhcp.c
+++ b/src/firejail/dhcp.c
@@ -29,130 +29,133 @@ pid_t dhclient4_pid = 0;
 pid_t dhclient6_pid = 0;
 
 typedef struct {
-  char *version_arg;
-  char *pid_file;
-  char *leases_file;
-  uint8_t generate_duid;
-  char *duid_leases_file;
-  pid_t *pid;
-  ptrdiff_t arg_offset;
+	char *version_arg;
+	char *pid_file;
+	char *leases_file;
+	uint8_t generate_duid;
+	char *duid_leases_file;
+	pid_t *pid;
+	ptrdiff_t arg_offset;
 } Dhclient;
 
-static const Dhclient dhclient4 = { .version_arg = "-4",
-                                    .pid_file = RUN_DHCLIENT_4_PID_FILE,
-                                    .leases_file = RUN_DHCLIENT_4_LEASES_FILE,
-                                    .generate_duid = 1,
-                                    .pid = &dhclient4_pid,
-                                    .arg_offset = offsetof(Bridge, arg_ip_dhcp)
+static const Dhclient dhclient4 = {
+	.version_arg = "-4",
+	.pid_file = RUN_DHCLIENT_4_PID_FILE,
+	.leases_file = RUN_DHCLIENT_4_LEASES_FILE,
+	.generate_duid = 1,
+	.pid = &dhclient4_pid,
+	.arg_offset = offsetof(Bridge, arg_ip_dhcp)
 };
 
-static const Dhclient dhclient6 = { .version_arg = "-6",
-                                    .pid_file = RUN_DHCLIENT_6_PID_FILE,
-                                    .leases_file = RUN_DHCLIENT_6_LEASES_FILE,
-                                    .duid_leases_file = RUN_DHCLIENT_4_LEASES_FILE,
-                                    .pid = &dhclient6_pid,
-                                    .arg_offset = offsetof(Bridge, arg_ip6_dhcp)
+static const Dhclient dhclient6 = {
+	.version_arg = "-6",
+	.pid_file = RUN_DHCLIENT_6_PID_FILE,
+	.leases_file = RUN_DHCLIENT_6_LEASES_FILE,
+	.duid_leases_file = RUN_DHCLIENT_4_LEASES_FILE,
+	.pid = &dhclient6_pid,
+	.arg_offset = offsetof(Bridge, arg_ip6_dhcp)
 };
 
 static void dhcp_run_dhclient(const Dhclient *client) {
-  char *argv[256] = { "dhclient",
-                      client->version_arg,
-                      "-pf", client->pid_file,
-                      "-lf", client->leases_file,
-  };
-  int i = 6;
-  if (client->generate_duid)
-    argv[i++] = "-i";
-  if (client->duid_leases_file) {
-    argv[i++] = "-df";
-    argv[i++] = client->duid_leases_file;
-  }
-  if (arg_debug)
-    argv[i++] = "-v";
-  if (*(uint8_t *) ((char *) &cfg.bridge0 + client->arg_offset))
-    argv[i++] = cfg.bridge0.devsandbox;
-  if (*(uint8_t *) ((char *) &cfg.bridge1 + client->arg_offset))
-    argv[i++] = cfg.bridge1.devsandbox;
-  if (*(uint8_t *) ((char *) &cfg.bridge2 + client->arg_offset))
-    argv[i++] = cfg.bridge2.devsandbox;
-  if (*(uint8_t *) ((char *) &cfg.bridge3 + client->arg_offset))
-    argv[i++] = cfg.bridge3.devsandbox;
+	char *argv[256] = {
+		"dhclient",
+		client->version_arg,
+		"-pf", client->pid_file,
+		"-lf", client->leases_file,
+	};
+	int i = 6;
+	if (client->generate_duid)
+		argv[i++] = "-i";
+	if (client->duid_leases_file) {
+		argv[i++] = "-df";
+		argv[i++] = client->duid_leases_file;
+	}
+	if (arg_debug)
+		argv[i++] = "-v";
+	if (*(uint8_t *)((char *)&cfg.bridge0 + client->arg_offset))
+		argv[i++] = cfg.bridge0.devsandbox;
+	if (*(uint8_t *)((char *)&cfg.bridge1 + client->arg_offset))
+		argv[i++] = cfg.bridge1.devsandbox;
+	if (*(uint8_t *)((char *)&cfg.bridge2 + client->arg_offset))
+		argv[i++] = cfg.bridge2.devsandbox;
+	if (*(uint8_t *)((char *)&cfg.bridge3 + client->arg_offset))
+		argv[i++] = cfg.bridge3.devsandbox;
 
-  sbox_run_v(SBOX_ROOT | SBOX_CAPS_NETWORK | SBOX_CAPS_NET_SERVICE | SBOX_SECCOMP, argv);
+	sbox_run_v(SBOX_ROOT | SBOX_CAPS_NETWORK | SBOX_CAPS_NET_SERVICE | SBOX_SECCOMP, argv);
 }
 
 static pid_t dhcp_read_pidfile(const Dhclient *client) {
-  // We have to run dhclient as a forking daemon (not pass the -d option),
-  // because we want to be notified of a successful DHCP lease by the parent process exit.
-  // However, try to be extra paranoid with race conditions,
-  // because dhclient only writes the daemon pid into the pidfile
-  // after its parent process has exited.
-  int tries = 0;
-  pid_t found = 0;
-  while (found == 0 && tries < 10) {
-    if (tries >= 1)
-      usleep(100000);
-    FILE *pidfile = fopen(client->pid_file, "r");
-    if (pidfile) {
-      long pid;
-      if (fscanf(pidfile, "%ld", &pid) == 1) {
-        char *pidname = pid_proc_comm((pid_t) pid);
-        if (pidname && strcmp(pidname, "dhclient") == 0)
-          found = (pid_t) pid;
-      }
-      fclose(pidfile);
-    }
-    ++tries;
-  }
-  if (found == 0) {
-    fprintf(stderr, "Error: Cannot get dhclient %s PID from %s\n",
-            client->version_arg, client->pid_file);
-    exit(1);
-  }
-  return found;
+	// We have to run dhclient as a forking daemon (not pass the -d option),
+	// because we want to be notified of a successful DHCP lease by the parent process exit.
+	// However, try to be extra paranoid with race conditions,
+	// because dhclient only writes the daemon pid into the pidfile
+	// after its parent process has exited.
+	int tries = 0;
+	pid_t found = 0;
+	while (found == 0 && tries < 10) {
+		if (tries >= 1)
+			usleep(100000);
+		FILE *pidfile = fopen(client->pid_file, "r");
+		if (pidfile) {
+			long pid;
+			if (fscanf(pidfile, "%ld", &pid) == 1) {
+				char *pidname = pid_proc_comm((pid_t) pid);
+				if (pidname && strcmp(pidname, "dhclient") == 0)
+					found = (pid_t) pid;
+			}
+			fclose(pidfile);
+		}
+		++tries;
+	}
+	if (found == 0) {
+		fprintf(stderr, "Error: Cannot get dhclient %s PID from %s\n",
+						client->version_arg, client->pid_file);
+		exit(1);
+	}
+	return found;
 }
 
 static void dhcp_start_dhclient(const Dhclient *client) {
-  dhcp_run_dhclient(client);
-  *(client->pid) = dhcp_read_pidfile(client);
+	dhcp_run_dhclient(client);
+	*(client->pid) = dhcp_read_pidfile(client);
 }
 
 static void dhcp_waitll(const char *ifname) {
-  sbox_run(SBOX_ROOT | SBOX_CAPS_NETWORK | SBOX_SECCOMP, 3, PATH_FNET, "waitll", ifname);
+	sbox_run(SBOX_ROOT | SBOX_CAPS_NETWORK | SBOX_SECCOMP, 3, PATH_FNET, "waitll", ifname);
 }
 
 static void dhcp_waitll_all() {
-  if (cfg.bridge0.arg_ip6_dhcp)
-    dhcp_waitll(cfg.bridge0.devsandbox);
-  if (cfg.bridge1.arg_ip6_dhcp)
-    dhcp_waitll(cfg.bridge1.devsandbox);
-  if (cfg.bridge2.arg_ip6_dhcp)
-    dhcp_waitll(cfg.bridge2.devsandbox);
-  if (cfg.bridge3.arg_ip6_dhcp)
-    dhcp_waitll(cfg.bridge3.devsandbox);
+	if (cfg.bridge0.arg_ip6_dhcp)
+		dhcp_waitll(cfg.bridge0.devsandbox);
+	if (cfg.bridge1.arg_ip6_dhcp)
+		dhcp_waitll(cfg.bridge1.devsandbox);
+	if (cfg.bridge2.arg_ip6_dhcp)
+		dhcp_waitll(cfg.bridge2.devsandbox);
+	if (cfg.bridge3.arg_ip6_dhcp)
+		dhcp_waitll(cfg.bridge3.devsandbox);
 }
 
 void dhcp_start(void) {
-  if (!any_dhcp())
-    return;
+	if (!any_dhcp())
+		return;
 
-  EUID_ROOT();
-  if (mkdir(RUN_DHCLIENT_DIR, 0700))
-    errExit("mkdir");
+	EUID_ROOT();
+	if (mkdir(RUN_DHCLIENT_DIR, 0700))
+		errExit("mkdir");
 
-  if (any_ip_dhcp()) {
-    dhcp_start_dhclient(&dhclient4);
-    if (arg_debug)
-      printf("Running dhclient -4 in the background as pid %ld\n", (long) dhclient4_pid);
-  }
-  if (any_ip6_dhcp()) {
-    dhcp_waitll_all();
-    dhcp_start_dhclient(&dhclient6);
-    if (arg_debug)
-      printf("Running dhclient -6 in the background as pid %ld\n", (long) dhclient6_pid);
-    if (dhclient4_pid == dhclient6_pid) {
-      fprintf(stderr, "Error: dhclient -4 and -6 have the same PID: %ld\n", (long) dhclient4_pid);
-      exit(1);
-    }
-  }
+	if (any_ip_dhcp()) {
+		dhcp_start_dhclient(&dhclient4);
+		if (arg_debug)
+			printf("Running dhclient -4 in the background as pid %ld\n", (long) dhclient4_pid);
+	}
+	if (any_ip6_dhcp()) {
+		dhcp_waitll_all();
+		dhcp_start_dhclient(&dhclient6);
+		if (arg_debug)
+			printf("Running dhclient -6 in the background as pid %ld\n", (long) dhclient6_pid);
+		if (dhclient4_pid == dhclient6_pid) {
+			fprintf(stderr, "Error: dhclient -4 and -6 have the same PID: %ld\n", (long) dhclient4_pid);
+			exit(1);
+		}
+	}
 }

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -103,8 +103,8 @@ typedef struct bridge_t {
 
 	// flags
 	uint8_t arg_ip_none;	// --ip=none
-  uint8_t arg_ip_dhcp;
-  uint8_t arg_ip6_dhcp;
+	uint8_t arg_ip_dhcp;
+	uint8_t arg_ip6_dhcp;
 	uint8_t macvlan;	// set by --net=eth0 (or eth1, ...); reset by --net=br0 (or br1, ...)
 	uint8_t configured;
 	uint8_t scan;		// set by --scan

--- a/src/firejail/fs_hostname.c
+++ b/src/firejail/fs_hostname.c
@@ -171,10 +171,10 @@ void fs_resolvconf(void) {
 	}
 
 	if (cfg.dns1) {
-    if (any_dhcp())
-      fwarning("network setup uses DHCP, nameservers will likely be overwritten\n");
+		if (any_dhcp())
+			fwarning("network setup uses DHCP, nameservers will likely be overwritten\n");
 		fprintf(fp, "nameserver %s\n", cfg.dns1);
-  }
+	}
 	if (cfg.dns2)
 		fprintf(fp, "nameserver %s\n", cfg.dns2);
 	if (cfg.dns3)

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -2193,18 +2193,18 @@ int main(int argc, char **argv) {
 				}
 
 				// configure this IP address for the last bridge defined
-        if (strcmp(argv[i] + 6, "dhcp") == 0)
-          br->arg_ip6_dhcp = 1;
-        else {
-          if (check_ip46_address(argv[i] + 6) == 0) {
-            fprintf(stderr, "Error: invalid IPv6 address\n");
-            exit(1);
-          }
+				if (strcmp(argv[i] + 6, "dhcp") == 0)
+					br->arg_ip6_dhcp = 1;
+				else {
+					if (check_ip46_address(argv[i] + 6) == 0) {
+						fprintf(stderr, "Error: invalid IPv6 address\n");
+						exit(1);
+					}
 
-          br->ip6sandbox = strdup(argv[i] + 6);
-          if (br->ip6sandbox == NULL)
-            errExit("strdup");
-        }
+					br->ip6sandbox = strdup(argv[i] + 6);
+					if (br->ip6sandbox == NULL)
+						errExit("strdup");
+				}
 			}
 			else
 				exit_err_feature("networking");

--- a/src/firejail/network_main.c
+++ b/src/firejail/network_main.c
@@ -246,10 +246,10 @@ void net_check_cfg(void) {
 	if (cfg.defaultgw)
 		check_default_gw(cfg.defaultgw);
 	else {
-    // if the first network has no assigned address,
-    // do not try to set up a gateway, because it will fail
-    if (cfg.bridge0.arg_ip_none)
-      return;
+		// if the first network has no assigned address,
+		// do not try to set up a gateway, because it will fail
+		if (cfg.bridge0.arg_ip_none)
+			return;
 		// first network is a regular bridge
 		if (cfg.bridge0.macvlan == 0)
 			cfg.defaultgw = cfg.bridge0.ip;

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -701,19 +701,19 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 				exit(1);
 			}
 
-      // configure this IP address for the last bridge defined
-      if (strcmp(ptr + 4, "dhcp") == 0)
-        br->arg_ip6_dhcp = 1;
-      else {
-        if (check_ip46_address(ptr + 4) == 0) {
-          fprintf(stderr, "Error: invalid IPv6 address\n");
-          exit(1);
-        }
+			// configure this IP address for the last bridge defined
+			if (strcmp(ptr + 4, "dhcp") == 0)
+				br->arg_ip6_dhcp = 1;
+			else {
+				if (check_ip46_address(ptr + 4) == 0) {
+					fprintf(stderr, "Error: invalid IPv6 address\n");
+					exit(1);
+				}
 
-        br->ip6sandbox = strdup(ptr + 4);
-        if (br->ip6sandbox == NULL)
-          errExit("strdup");
-      }
+				br->ip6sandbox = strdup(ptr + 4);
+				if (br->ip6sandbox == NULL)
+					errExit("strdup");
+			}
 		}
 		else
 			warning_feature_disabled("networking");

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -337,8 +337,8 @@ static int monitor_application(pid_t app_pid) {
 				continue;
 			if (pid == 1)
 				continue;
-      if (pid == dhclient4_pid || pid == dhclient6_pid)
-        continue;
+			if (pid == dhclient4_pid || pid == dhclient6_pid)
+				continue;
 
 			// todo: make this generic
 			// Dillo browser leaves a dpid process running, we need to shut it down
@@ -995,7 +995,7 @@ int sandbox(void* sandbox_arg) {
 		fs_dev_disable_dvd();
 
 	if (arg_nou2f)
-	        fs_dev_disable_u2f();
+		fs_dev_disable_u2f();
 
 	if (arg_novideo)
 		fs_dev_disable_video();
@@ -1020,7 +1020,7 @@ int sandbox(void* sandbox_arg) {
 	//****************************
 	// start dhcp client
 	//****************************
-  dhcp_start();
+	dhcp_start();
 
 	//****************************
 	// set application environment

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -337,7 +337,7 @@ static int monitor_application(pid_t app_pid) {
 				continue;
 			if (pid == 1)
 				continue;
-			if (pid == dhclient4_pid || pid == dhclient6_pid)
+			if ((pid_t) pid == dhclient4_pid || (pid_t) pid == dhclient6_pid)
 				continue;
 
 			// todo: make this generic

--- a/src/firejail/sbox.c
+++ b/src/firejail/sbox.c
@@ -182,7 +182,8 @@ int sbox_run_v(unsigned filtermask, char * const arg[]) {
 
 		// close all other file descriptors
 		int max = 20; // getdtablesize() is overkill for a firejail process
-		for (int i = 3; i < max; i++)
+		int i = 3;
+		for (i = 3; i < max; i++)
 			close(i); // close open files
 
 		umask(027);

--- a/src/firejail/sbox.c
+++ b/src/firejail/sbox.c
@@ -128,11 +128,11 @@ int sbox_run_v(unsigned filtermask, char * const arg[]) {
 
 	if (arg_debug) {
 		printf("sbox run: ");
-    int i = 0;
-    while (arg[i]) {
+		int i = 0;
+		while (arg[i]) {
 			printf("%s ", arg[i]);
-      i++;
-    }
+			i++;
+		}
 		printf("\n");
 	}
 
@@ -191,33 +191,33 @@ int sbox_run_v(unsigned filtermask, char * const arg[]) {
 		if (filtermask & SBOX_CAPS_NONE) {
 			caps_drop_all();
 		} else {
-      uint64_t set = 0;
-      if (filtermask & SBOX_CAPS_NETWORK) {
+			uint64_t set = 0;
+			if (filtermask & SBOX_CAPS_NETWORK) {
 #ifndef HAVE_GCOV // the following filter will prevent GCOV from saving info in .gcda files
-        set |= ((uint64_t) 1) << CAP_NET_ADMIN;
-        set |= ((uint64_t) 1) << CAP_NET_RAW;
+				set |= ((uint64_t) 1) << CAP_NET_ADMIN;
+				set |= ((uint64_t) 1) << CAP_NET_RAW;
 #endif
-      }
-      if (filtermask & SBOX_CAPS_HIDEPID) {
+			}
+			if (filtermask & SBOX_CAPS_HIDEPID) {
 #ifndef HAVE_GCOV // the following filter will prevent GCOV from saving info in .gcda files
-        set |= ((uint64_t) 1) << CAP_SYS_PTRACE;
-        set |= ((uint64_t) 1) << CAP_SYS_PACCT;
+				set |= ((uint64_t) 1) << CAP_SYS_PTRACE;
+				set |= ((uint64_t) 1) << CAP_SYS_PACCT;
 #endif
-      }
-      if (filtermask & SBOX_CAPS_NET_SERVICE) {
+			}
+			if (filtermask & SBOX_CAPS_NET_SERVICE) {
 #ifndef HAVE_GCOV // the following filter will prevent GCOV from saving info in .gcda files
-        set |= ((uint64_t) 1) << CAP_NET_BIND_SERVICE;
-        set |= ((uint64_t) 1) << CAP_NET_BROADCAST;
+				set |= ((uint64_t) 1) << CAP_NET_BIND_SERVICE;
+				set |= ((uint64_t) 1) << CAP_NET_BROADCAST;
 #endif
-      }
-      if (set != 0) { // some SBOX_CAPS_ flag was specified, drop all other capabilities
+			}
+			if (set != 0) { // some SBOX_CAPS_ flag was specified, drop all other capabilities
 #ifndef HAVE_GCOV // the following filter will prevent GCOV from saving info in .gcda files
-        caps_set(set);
+				caps_set(set);
 #endif
-      }
-    }
+			}
+		}
 
-    if (filtermask & SBOX_SECCOMP) {
+		if (filtermask & SBOX_SECCOMP) {
 			if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)) {
 				perror("prctl(NO_NEW_PRIVS)");
 			}

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -82,7 +82,9 @@ static char *usage_str =
 	"    --interface=name - move interface in sandbox.\n"
 	"    --ip=address - set interface IP address.\n"
 	"    --ip=none - no IP address and no default gateway are configured.\n"
+	"    --ip=dhcp - acquire IP address by running dhclient.\n"
 	"    --ip6=address - set interface IPv6 address.\n"
+	"    --ip6=dhcp - acquire IPv6 address by running dhclient.\n"
 	"    --iprange=address,address - configure an IP address in this range.\n"
 #endif
 	"    --ipc-namespace - enable a new IPC namespace.\n"

--- a/src/fnet/interface.c
+++ b/src/fnet/interface.c
@@ -374,81 +374,81 @@ void net_if_ip6(const char *ifname, const char *addr6) {
 }
 
 static int net_netlink_address_tentative(struct nlmsghdr *current_header) {
-  struct ifaddrmsg *msg = NLMSG_DATA(current_header);
-  struct rtattr *rta = IFA_RTA(msg);
-  size_t msg_len = IFA_PAYLOAD(current_header);
-  int has_flags = 0;
-  while (RTA_OK(rta, msg_len)) {
-    if (rta->rta_type == IFA_FLAGS) {
-      has_flags = 1;
-      uint32_t *flags = RTA_DATA(rta);
-      if (*flags & IFA_F_TENTATIVE)
-        return 1;
-    }
-    rta = RTA_NEXT(rta, msg_len);
-  }
-  // According to <linux/if_addr.h>, if an IFA_FLAGS attribute is present,
-  // the field ifa_flags should be ignored.
-  return !has_flags && (msg->ifa_flags & IFA_F_TENTATIVE);
+	struct ifaddrmsg *msg = NLMSG_DATA(current_header);
+	struct rtattr *rta = IFA_RTA(msg);
+	size_t msg_len = IFA_PAYLOAD(current_header);
+	int has_flags = 0;
+	while (RTA_OK(rta, msg_len)) {
+		if (rta->rta_type == IFA_FLAGS) {
+			has_flags = 1;
+			uint32_t *flags = RTA_DATA(rta);
+			if (*flags & IFA_F_TENTATIVE)
+				return 1;
+		}
+		rta = RTA_NEXT(rta, msg_len);
+	}
+	// According to <linux/if_addr.h>, if an IFA_FLAGS attribute is present,
+	// the field ifa_flags should be ignored.
+	return !has_flags && (msg->ifa_flags & IFA_F_TENTATIVE);
 }
 
 static int net_netlink_if_has_ll(int sock, int index) {
-  struct {
-    struct nlmsghdr header;
-    struct ifaddrmsg message;
-  } req;
-  memset(&req, 0, sizeof(req));
-  req.header.nlmsg_len = NLMSG_LENGTH(sizeof(req.message));
-  req.header.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
-  req.header.nlmsg_type = RTM_GETADDR;
-  req.message.ifa_family = AF_INET6;
-  if (send(sock, &req, req.header.nlmsg_len, 0) != req.header.nlmsg_len)
-    errExit("send");
+	struct {
+		struct nlmsghdr header;
+		struct ifaddrmsg message;
+	} req;
+	memset(&req, 0, sizeof(req));
+	req.header.nlmsg_len = NLMSG_LENGTH(sizeof(req.message));
+	req.header.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+	req.header.nlmsg_type = RTM_GETADDR;
+	req.message.ifa_family = AF_INET6;
+	if (send(sock, &req, req.header.nlmsg_len, 0) != req.header.nlmsg_len)
+		errExit("send");
 
-  int found = 0;
-  int all_parts_processed = 0;
-  while (!all_parts_processed) {
-    char buf[16384];
-    ssize_t len = recv(sock, buf, sizeof(buf), 0);
-    if (len < 0)
-      errExit("recv");
-    if (len < sizeof(struct nlmsghdr)) {
-      fprintf(stderr, "Received incomplete netlink message\n");
-      exit(1);
-    }
+	int found = 0;
+	int all_parts_processed = 0;
+	while (!all_parts_processed) {
+		char buf[16384];
+		ssize_t len = recv(sock, buf, sizeof(buf), 0);
+		if (len < 0)
+			errExit("recv");
+		if (len < sizeof(struct nlmsghdr)) {
+			fprintf(stderr, "Received incomplete netlink message\n");
+			exit(1);
+		}
 
-    struct nlmsghdr *current_header = (struct nlmsghdr *) buf;
-    while (NLMSG_OK(current_header, len)) {
-      switch (current_header->nlmsg_type) {
-      case RTM_NEWADDR: {
-        struct ifaddrmsg *msg = NLMSG_DATA(current_header);
-        if (!found && msg->ifa_index == index && msg->ifa_scope == RT_SCOPE_LINK &&
-            !net_netlink_address_tentative(current_header))
-          found = 1;
-      }
-        break;
-      case NLMSG_NOOP:
-        break;
-      case NLMSG_DONE:
-        all_parts_processed = 1;
-        break;
-      case NLMSG_ERROR: {
-        struct nlmsgerr *err = NLMSG_DATA(current_header);
-        fprintf(stderr, "Netlink error: %d\n", err->error);
-        exit(1);
-      }
-        break;
-      default:
-        fprintf(stderr, "Unknown netlink message type: %u\n", current_header->nlmsg_type);
-        exit(1);
-        break;
-      }
+		struct nlmsghdr *current_header = (struct nlmsghdr *) buf;
+		while (NLMSG_OK(current_header, len)) {
+			switch (current_header->nlmsg_type) {
+			case RTM_NEWADDR: {
+				struct ifaddrmsg *msg = NLMSG_DATA(current_header);
+				if (!found && msg->ifa_index == index && msg->ifa_scope == RT_SCOPE_LINK &&
+						!net_netlink_address_tentative(current_header))
+					found = 1;
+			}
+				break;
+			case NLMSG_NOOP:
+				break;
+			case NLMSG_DONE:
+				all_parts_processed = 1;
+				break;
+			case NLMSG_ERROR: {
+				struct nlmsgerr *err = NLMSG_DATA(current_header);
+				fprintf(stderr, "Netlink error: %d\n", err->error);
+				exit(1);
+			}
+				break;
+			default:
+				fprintf(stderr, "Unknown netlink message type: %u\n", current_header->nlmsg_type);
+				exit(1);
+				break;
+			}
 
-      current_header = NLMSG_NEXT(current_header, len);
-    }
-  }
+			current_header = NLMSG_NEXT(current_header, len);
+		}
+	}
 
-  return found;
+	return found;
 }
 
 // wait for a link-local IPv6 address for DHCPv6
@@ -468,27 +468,27 @@ void net_if_waitll(const char *ifname) {
 		perror("ioctl SIOGIFINDEX");
 		exit(1);
 	}
-  close(inet6_sock);
-  int index = ifr.ifr_ifindex;
+	close(inet6_sock);
+	int index = ifr.ifr_ifindex;
 
 	// poll for link-local address
-  int netlink_sock = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
-  if (netlink_sock < 0)
-    errExit("socket");
-  int tries = 0;
-  int found = 0;
-  while (tries < 60 && !found) {
-    if (tries >= 1)
-      usleep(500000);
+	int netlink_sock = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+	if (netlink_sock < 0)
+		errExit("socket");
+	int tries = 0;
+	int found = 0;
+	while (tries < 60 && !found) {
+		if (tries >= 1)
+			usleep(500000);
 
-    found = net_netlink_if_has_ll(netlink_sock, index);
+		found = net_netlink_if_has_ll(netlink_sock, index);
 
-    tries++;
-  }
-  close(netlink_sock);
+		tries++;
+	}
+	close(netlink_sock);
 
-  if (!found) {
-    fprintf(stderr, "Waiting for link-local IPv6 address of %s timed out\n", ifname);
-    exit(1);
-  }
+	if (!found) {
+		fprintf(stderr, "Waiting for link-local IPv6 address of %s timed out\n", ifname);
+		exit(1);
+	}
 }

--- a/src/include/rundefs.h
+++ b/src/include/rundefs.h
@@ -49,11 +49,12 @@
 #define RUN_LIB_DIR			RUN_MNT_DIR "/lib"
 #define RUN_LIB_FILE			RUN_MNT_DIR "/libfiles"
 #define RUN_DNS_ETC			RUN_MNT_DIR "/dns-etc"
-#define RUN_DHCLIENT_DIR      RUN_MNT_DIR "/dhclient"
-#define RUN_DHCLIENT_4_LEASES_FILE      RUN_DHCLIENT_DIR "/dhclient.leases"
-#define RUN_DHCLIENT_6_LEASES_FILE      RUN_DHCLIENT_DIR "/dhclient6.leases"
-#define RUN_DHCLIENT_4_PID_FILE      RUN_DHCLIENT_DIR "/dhclient.pid"
-#define RUN_DHCLIENT_6_PID_FILE      RUN_DHCLIENT_DIR "/dhclient6.pid"
+#define RUN_DHCLIENT_DIR			RUN_MNT_DIR "/dhclient"
+#define RUN_DHCLIENT_4_LEASES_FILE		RUN_DHCLIENT_DIR "/dhclient.leases"
+#define RUN_DHCLIENT_6_LEASES_FILE		RUN_DHCLIENT_DIR "/dhclient6.leases"
+#define RUN_DHCLIENT_4_LEASES_FILE		RUN_DHCLIENT_DIR "/dhclient.leases"
+#define RUN_DHCLIENT_4_PID_FILE			RUN_DHCLIENT_DIR "/dhclient.pid"
+#define RUN_DHCLIENT_6_PID_FILE			RUN_DHCLIENT_DIR "/dhclient6.pid"
 
 #define RUN_SECCOMP_DIR			RUN_MNT_DIR "/seccomp"
 #define RUN_SECCOMP_LIST		RUN_SECCOMP_DIR "/seccomp.list"		// list of seccomp files installed

--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -582,6 +582,33 @@ net eth0
 ip none
 
 .TP
+\fBip dhcp
+Acquire an IP address and default gateway for the last interface defined by a
+net command, as well as set the DNS servers according to the DHCP response.
+This command requires the ISC dhclient DHCP client to be installed and will start
+it automatically inside the sandbox.
+.br
+
+.br
+Example:
+.br
+net br0
+.br
+ip dhcp
+.br
+
+.br
+This command should not be used in conjunction with the dns command if the
+DHCP server is set to configure DNS servers for the clients, because the
+manually specified DNS servers will be overwritten.
+
+.br
+The DHCP client will NOT release the DHCP lease when the sandbox terminates.
+If your DHCP server requires leases to be explicitly released, consider running
+a DHCP client and releasing the lease manually in conjunction with the
+net none command.
+
+.TP
 \fBip6 address
 Assign IPv6 addresses to the last network interface defined by a net command.
 .br
@@ -592,6 +619,32 @@ Example:
 net eth0
 .br
 ip6 2001:0db8:0:f101::1/64
+
+.TP
+\fBip6 dhcp
+Acquire an IPv6 address and default gateway for the last interface defined by a
+net command, as well as set the DNS servers according to the DHCP response.
+This command requires the ISC dhclient DHCP client to be installed and will start
+it automatically inside the sandbox.
+.br
+
+.br
+Example:
+.br
+net br0
+.br
+ip6 dhcp
+.br
+
+.br
+This command should not be used in conjunction with the dns command if the
+DHCP server is set to configure DNS servers for the clients, because the
+manually specified DNS servers will be overwritten.
+
+.br
+The DHCP client will NOT release the DHCP lease when the sandbox terminates.
+If your DHCP server requires leases to be explicitly released, consider running
+a DHCP client and releasing the lease manually.
 
 .TP
 \fBiprange address,address

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -567,6 +567,31 @@ If the corresponding interface doesn't have an IP address configured, this
 option is enabled by default.
 
 .TP
+\fB\-\-ip=dhcp
+Acquire an IP address and default gateway for the last interface defined by a
+\-\-net option, as well as set the DNS servers according to the DHCP response.
+This option requires the ISC dhclient DHCP client to be installed and will start
+it automatically inside the sandbox.
+.br
+
+.br
+Example:
+.br
+$ firejail \-\-net=br0 \-\-ip=dhcp
+.br
+
+.br
+This option should not be used in conjunction with the \-\-dns option if the
+DHCP server is set to configure DNS servers for the clients, because the
+manually specified DNS servers will be overwritten.
+
+.br
+The DHCP client will NOT release the DHCP lease when the sandbox terminates.
+If your DHCP server requires leases to be explicitly released, consider running
+a DHCP client and releasing the lease manually in conjunction with the
+\-\-net=none option.
+
+.TP
 \fB\-\-ip6=address
 Assign IPv6 addresses to the last network interface defined by a \-\-net option.
 .br
@@ -577,6 +602,30 @@ Example:
 $ firejail \-\-net=eth0 \-\-ip6=2001:0db8:0:f101::1/64 firefox
 
 Note: you don't need this option if you obtain your ip6 address from router via SLAAC (your ip6 address and default route will be configured by kernel automatically).
+
+.TP
+\fB\-\-ip6=dhcp
+Acquire an IPv6 address and default gateway for the last interface defined by a
+\-\-net option, as well as set the DNS servers according to the DHCP response.
+This option requires the ISC dhclient DHCP client to be installed and will start
+it automatically inside the sandbox.
+.br
+
+.br
+Example:
+.br
+$ firejail \-\-net=br0 \-\-ip6=dhcp
+.br
+
+.br
+This option should not be used in conjunction with the \-\-dns option if the
+DHCP server is set to configure DNS servers for the clients, because the
+manually specified DNS servers will be overwritten.
+
+.br
+The DHCP client will NOT release the DHCP lease when the sandbox terminates.
+If your DHCP server requires leases to be explicitly released, consider running
+a DHCP client and releasing the lease manually.
 
 .TP
 \fB\-\-iprange=address,address


### PR DESCRIPTION
I finally had some time to fix up my implementation for DHCP client support. Sorry for the delay!
* Unfortunately, I used spaces instead of tabs for my code in #3102  (I messed up something in Emacs, I think), which resulted in inconsistent indentation at least on GIthub. My first commit replaces the spaces with tabs, however, it does mess up `git blame` output a bit, so it is debatable whether we should merge it.
* I fixed the unsigned comparison warning in #3174 that made the build fail due to `-Werror`.
* Updated documentation (usage, firejail(1) and firejail-profile(5) manpages) with the new options.
By the way, there seem to be some differences between default CFLAGS produces by `./configure` on my machine and on Travis. ~Compiling with `-Wall -Wextra -Werror` seems prudent, but does not happen for me locally.~ Thanks for @Vincent43 for pointing out the `./configure --enable-fatal-warnings` option! On the other hand, on Travis, C99 support is not enabled. Travis also uses older netlink headers, I think, for example, it does not define `IFA_FLAGS`.