### PR TITLE
profiles: whitelist /usr/share/doc

### DIFF
--- a/etc/devhelp.profile
+++ b/etc/devhelp.profile
@@ -16,6 +16,8 @@ include disable-programs.inc
 include disable-xdg.inc
 
 whitelist /usr/share/devhelp
+whitelist /usr/share/doc
+whitelist /usr/share/gtk-doc/html
 include whitelist-common.inc
 include whitelist-usr-share-common.inc
 

--- a/etc/evince.profile
+++ b/etc/evince.profile
@@ -17,6 +17,7 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-xdg.inc
 
+whitelist /usr/share/doc
 whitelist /usr/share/evince
 whitelist /usr/share/poppler
 whitelist /usr/share/tracker

--- a/etc/firefox.profile
+++ b/etc/firefox.profile
@@ -14,6 +14,8 @@ mkdir ${HOME}/.mozilla
 whitelist ${HOME}/.cache/mozilla/firefox
 whitelist ${HOME}/.mozilla
 
+whitelist /usr/share/doc
+whitelist /usr/share/gtk-doc/html
 whitelist /usr/share/mozilla
 whitelist /usr/share/webext
 include whitelist-usr-share-common.inc

--- a/etc/yelp.profile
+++ b/etc/yelp.profile
@@ -18,6 +18,7 @@ include disable-xdg.inc
 
 mkdir ${HOME}/.config/yelp
 whitelist ${HOME}/.config/yelp
+whitelist /usr/share/doc
 whitelist /usr/share/help
 whitelist /usr/share/yelp
 whitelist /usr/share/yelp-xsl

--- a/etc/zathura.profile
+++ b/etc/zathura.profile
@@ -20,6 +20,7 @@ include disable-xdg.inc
 
 mkdir ${HOME}/.config/zathura
 mkdir ${HOME}/.local/share/zathura
+whitelist /usr/share/doc
 whitelist /usr/share/zathura
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc


### PR DESCRIPTION
It contains documentation and example files for installed programs and libraries.

I'm not sure if it should be allowed here globally, or in individual profiles, where it makes sense.
(For example in browsers, which are often used for reading documentation from there.)

Reported at: https://bugs.debian.org/950007