### PR TITLE
include wvc to more profiles

### DIFF
--- a/etc/aria2c.profile
+++ b/etc/aria2c.profile
@@ -21,6 +21,7 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 caps.drop all
 ipc-namespace

--- a/etc/clawsker.profile
+++ b/etc/clawsker.profile
@@ -23,6 +23,7 @@ whitelist ${HOME}/.claws-mail
 whitelist /usr/share/perl5
 include whitelist-common.inc
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 apparmor
 caps.drop all

--- a/etc/conky.profile
+++ b/etc/conky.profile
@@ -17,6 +17,7 @@ include disable-programs.inc
 include disable-xdg.inc
 
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 caps.drop all
 ipc-namespace

--- a/etc/dconf-editor.profile
+++ b/etc/dconf-editor.profile
@@ -17,6 +17,7 @@ include disable-xdg.inc
 whitelist ${HOME}/.local/share/glib-2.0
 include whitelist-common.inc
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 apparmor
 caps.drop all

--- a/etc/dconf.profile
+++ b/etc/dconf.profile
@@ -20,6 +20,7 @@ whitelist ${HOME}/.local/share/glib-2.0
 # dconf paths are whitelisted by the following
 include whitelist-common.inc
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 apparmor
 caps.drop all

--- a/etc/exiftool.profile
+++ b/etc/exiftool.profile
@@ -21,6 +21,7 @@ include disable-programs.inc
 whitelist /usr/share/perl5
 whitelist /usr/share/perl-image-exiftool
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 apparmor
 caps.drop all

--- a/etc/font-manager.profile
+++ b/etc/font-manager.profile
@@ -28,6 +28,7 @@ whitelist ${HOME}/.config/font-manager
 whitelist /usr/share/font-manager
 include whitelist-common.inc
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 apparmor
 caps.drop all

--- a/etc/gconf.profile
+++ b/etc/gconf.profile
@@ -28,6 +28,7 @@ whitelist /usr/share/GConf
 whitelist /usr/share/gconf
 include whitelist-common.inc
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 apparmor
 caps.drop all

--- a/etc/git.profile
+++ b/etc/git.profile
@@ -33,6 +33,7 @@ whitelist /usr/share/gitgui
 whitelist /usr/share/gitweb
 whitelist /usr/share/nano
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 apparmor
 caps.drop all

--- a/etc/gjs.profile
+++ b/etc/gjs.profile
@@ -23,6 +23,7 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 caps.drop all
 netfilter

--- a/etc/gpg.profile
+++ b/etc/gpg.profile
@@ -22,6 +22,7 @@ whitelist /usr/share/gnupg
 whitelist /usr/share/gnupg2
 whitelist /usr/share/pacman/keyrings
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 caps.drop all
 netfilter

--- a/etc/img2txt.profile
+++ b/etc/img2txt.profile
@@ -20,6 +20,7 @@ include disable-xdg.inc
 
 whitelist /usr/share/imlib2
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 apparmor
 caps.drop all

--- a/etc/mediainfo.profile
+++ b/etc/mediainfo.profile
@@ -16,6 +16,7 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 apparmor
 caps.drop all

--- a/etc/mpd.profile
+++ b/etc/mpd.profile
@@ -20,6 +20,7 @@ include disable-programs.inc
 include disable-xdg.inc
 
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 caps.drop all
 netfilter

--- a/etc/nitroshare.profile
+++ b/etc/nitroshare.profile
@@ -21,6 +21,7 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 caps.drop all
 netfilter

--- a/etc/ocenaudio.profile
+++ b/etc/ocenaudio.profile
@@ -19,6 +19,7 @@ include disable-programs.inc
 include disable-xdg.inc
 
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 apparmor
 caps.drop all

--- a/etc/ping.profile
+++ b/etc/ping.profile
@@ -15,8 +15,9 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-xdg.inc
 
-include whitelist-usr-share-common.inc
 include whitelist-common.inc
+include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 caps.keep net_raw
 ipc-namespace

--- a/etc/simple-scan.profile
+++ b/etc/simple-scan.profile
@@ -18,6 +18,7 @@ include disable-xdg.inc
 
 whitelist /usr/share/simple-scan
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 caps.drop all
 netfilter

--- a/etc/simplescreenrecorder.profile
+++ b/etc/simplescreenrecorder.profile
@@ -18,6 +18,7 @@ include disable-xdg.inc
 
 whitelist /usr/share/simplescreenrecorder
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 apparmor
 caps.drop all

--- a/etc/sysprof.profile
+++ b/etc/sysprof.profile
@@ -15,6 +15,7 @@ include disable-programs.inc
 include disable-xdg.inc
 
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 apparmor
 caps.drop all

--- a/etc/tshark.profile
+++ b/etc/tshark.profile
@@ -17,6 +17,7 @@ include disable-xdg.inc
 whitelist /usr/share/wireshark
 include whitelist-common.inc
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 #caps.keep net_raw
 caps.keep dac_override,net_admin,net_raw

--- a/etc/uget-gtk.profile
+++ b/etc/uget-gtk.profile
@@ -17,6 +17,7 @@ whitelist ${DOWNLOADS}
 whitelist ${HOME}/.config/uGet
 include whitelist-common.inc
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 caps.drop all
 netfilter

--- a/etc/viewnior.profile
+++ b/etc/viewnior.profile
@@ -20,6 +20,7 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 apparmor
 caps.drop all

--- a/etc/weechat.profile
+++ b/etc/weechat.profile
@@ -13,6 +13,7 @@ include disable-programs.inc
 
 whitelist /usr/share/perl5
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 caps.drop all
 netfilter


### PR DESCRIPTION
Adding 'include whitelist-var-common.profile' to more profiles. Inspired by discussion in #3189 to avoid potential data sharing via /var.