### PR TITLE
Whitelist more /usr/share for okular and others

### DIFF
--- a/etc/okular.profile
+++ b/etc/okular.profile
@@ -26,8 +26,9 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-xdg.inc
 
-whitelist /usr/share/poppler
+whitelist /usr/share/config.kcfg
 whitelist /usr/share/okular
+whitelist /usr/share/poppler
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 

--- a/etc/whitelist-usr-share-common.inc
+++ b/etc/whitelist-usr-share-common.inc
@@ -50,6 +50,8 @@ whitelist /usr/share/qt5
 whitelist /usr/share/sounds
 whitelist /usr/share/tcl8.6
 whitelist /usr/share/terminfo
+whitelist /usr/share/texlive
+whitelist /usr/share/texmf
 whitelist /usr/share/themes
 whitelist /usr/share/thumbnail.so
 whitelist /usr/share/X11


### PR DESCRIPTION
Some distributions include fonts in the `/usr/share/texmf` and `/usr/share/texlive`. This makes those fonts accessible, addressing buggy behavior in okular where some text fails to render.

This also whitelists `/usr/share/config.kcfg` which, on Debian, contains some default settings.
