### PR TITLE
Harden sbox_run by using fexecve instead of execvp

### DIFF
--- a/src/firejail/dhcp.c
+++ b/src/firejail/dhcp.c
@@ -143,10 +143,6 @@ void dhcp_start(void) {
 			exit(1);
 		}
 	}
-	if (s.st_uid != 0 && s.st_gid != 0) {
-		fprintf(stderr, "Error: invalid dhclient executable\n");
-		exit(1);
-	}
 
 	EUID_ROOT();
 	if (mkdir(RUN_DHCLIENT_DIR, 0700))


### PR DESCRIPTION
Based on the discussion in #3239, this patch aims to make `sbox_run` less likely to execute malicious binaries as root.

* The `execvp` call is replaces with `fexecve`, which does not perform PATH resolution. Because the environment was already cleared, this already wasn't a serious problem. But now, by passing absolute paths only to sbox_run, we get a bit more control.
* We check the binary to be owned by root (either the user or the group) and not be world-writable. As we are running system utilities, not having these would indicate a serious and dangerous misconfiguration, or some kind of an attack.
* The use of `open` with `O_PATH` and `fexecve` prevents TOCTOU errors with the permission check. This prevents a situation when the containing folder is somehow owned by a normal user (maybe by abusing some other setuid functionality to mount a tmpfs over it), and the binary we wish to run is replaced by a malicious one after we check its permissions.
