### PR TITLE
add lua support for mpv

### DIFF
--- a/etc/allow-lua.inc
+++ b/etc/allow-lua.inc
@@ -4,5 +4,6 @@ include allow-lua.local
 
 noblacklist ${PATH}/lua*
 noblacklist /usr/include/lua*
+noblacklist /usr/lib/liblua*
 noblacklist /usr/lib/lua
 noblacklist /usr/share/lua

--- a/etc/disable-interpreters.inc
+++ b/etc/disable-interpreters.inc
@@ -13,6 +13,7 @@ blacklist /usr/lib64/libgjs*
 # Lua
 blacklist ${PATH}/lua*
 blacklist /usr/include/lua*
+blacklist /usr/lib/liblua*
 blacklist /usr/lib/lua
 blacklist /usr/share/lua
 

--- a/etc/mpv.profile
+++ b/etc/mpv.profile
@@ -11,6 +11,8 @@ noblacklist ${HOME}/.config/mpv
 noblacklist ${HOME}/.config/youtube-dl
 noblacklist ${HOME}/.netrc
 
+# Allow lua (blacklisted by disable-interpreters.inc)
+include allow-lua.inc
 # Allow python (blacklisted by disable-interpreters.inc)
 include allow-python2.inc
 include allow-python3.inc


### PR DESCRIPTION
On Arch mpv needs access to lua:

```
$ pacman -Q mpv
mpv 1:0.32.0-1
$ firejail /usr/bin/mpv ~/Downloads/video.mp4
/usr/bin/mpv: error while loading shared libraries: liblua5.2.so.5.2: cannot open shared object file: Permission denied
```

On a side-note, Python support (enabled in the mpv profile) doesn't seem to be needed, at least not on Arch. Need to check on a Ubuntu machine to confirm.