### PR TITLE
add xournal.profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,4 +151,4 @@ We also keep a list of profile fixes for previous released versions in [etc-fixe
 
 ### New profiles:
 
-gfeeds, firefox-x11, tvbrowser, rtv, clipgrab, gnome-passwordsafe, bibtex, gummi, latex, pdflatex, tex, wpp, wpspdf, wps, et, multimc, gnome-hexgl, com.github.johnfactotum.Foliate, desktopeditors, impressive, mupdf-gl, mupdf-x11, mupdf-x11-curl, muraster, mutool, planmaker18, planmaker18free, presentations18, presentations18free, textmaker18, textmaker18free, teams
+gfeeds, firefox-x11, tvbrowser, rtv, clipgrab, gnome-passwordsafe, bibtex, gummi, latex, pdflatex, tex, wpp, wpspdf, wps, et, multimc, gnome-hexgl, com.github.johnfactotum.Foliate, desktopeditors, impressive, mupdf-gl, mupdf-x11, mupdf-x11-curl, muraster, mutool, planmaker18, planmaker18free, presentations18, presentations18free, textmaker18, textmaker18free, teams, xournal

--- a/RELNOTES
+++ b/RELNOTES
@@ -8,7 +8,7 @@ firejail (0.9.63) baseline; urgency=low
   * new profiles: gnome-hexgl, com.github.johnfactotum.Foliate, mupdf-gl, mutool
   * new profiles: desktopeditors, impressive, planmaker18, planmaker18free
   * new profiles: presentations18, presentations18free, textmaker18, teams
-  * new profiles: textmaker18free
+  * new profiles: textmaker18free, xournal
 
 firejail (0.9.62) baseline; urgency=low
   * added file-copy-limit in /etc/firejail/firejail.config

--- a/etc/xournal.profile
+++ b/etc/xournal.profile
@@ -1,0 +1,47 @@
+# Firejail profile for xournal
+# Description: Note taking and PDF editing
+# This file is overwritten after every install/update
+# Persistent local customizations
+include xournal.local
+# Persistent global definitions
+include globals.local
+
+noblacklist ${DOCUMENTS}
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
+include disable-xdg.inc
+
+whitelist /usr/share/xournal
+whitelist /usr/share/poppler
+include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
+
+caps.drop all
+machine-id
+net none
+no3d
+nodbus
+nodvd
+nogroups
+nonewprivs
+noroot
+nosound
+notv
+nou2f
+novideo
+protocol unix
+seccomp
+shell none
+tracelog
+
+private-bin xournal
+private-cache
+private-dev
+private-etc alternatives,fonts,group,machine-id,passwd
+# TODO should use private-lib
+private-tmp

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -722,6 +722,7 @@ xmr-stak
 xonotic
 xonotic-glx
 xonotic-sdl
+xournal
 xpdf
 xplayer
 xplayer-audio-preview


### PR DESCRIPTION
xournal is a funny document editor that can do overlay edits on PDFs.  It is meant as a diary/journal note taking app.  It turns out it is a great app for overlaying images of signatures onto PDF contracts.  Since it means editing PDFs from outside sources, it should be firejailed.  Also, it needs very little access to work.

I'm new to this, so I didn't attempt _private-lib_ at all.  This should probably have a custom _private-lib_ entry. 