### PR TITLE
nvim

### DIFF
--- a/etc/nvim.profile
+++ b/etc/nvim.profile
@@ -1,4 +1,4 @@
-# Firejail profile for vim
+# Firejail profile for neovim
 # This file is overwritten after every install/update
 # Persistent local customizations
 include /etc/firejail/vim.local

--- a/etc/nvim.profile
+++ b/etc/nvim.profile
@@ -8,6 +8,9 @@ include globals.local
 noblacklist ${HOME}/.config/nvim
 noblacklist ${HOME}/.local/share/nvim
 
+# Allows files commonly used by IDEs
+include allow-common-devel.inc
+
 include disable-common.inc
 include disable-passwdmgr.inc
 include disable-programs.inc

--- a/etc/nvim.profile
+++ b/etc/nvim.profile
@@ -8,9 +8,9 @@ include globals.local
 noblacklist ${HOME}/.config/nvim
 noblacklist ${HOME}/.local/share/nvim
 
-include /etc/firejail/disable-common.inc
-include /etc/firejail/disable-passwdmgr.inc
-include /etc/firejail/disable-programs.inc
+include disable-common.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
 
 caps.drop all
 netfilter

--- a/etc/nvim.profile
+++ b/etc/nvim.profile
@@ -1,0 +1,26 @@
+# Firejail profile for vim
+# This file is overwritten after every install/update
+# Persistent local customizations
+include /etc/firejail/vim.local
+# Persistent global definitions
+include /etc/firejail/globals.local
+
+noblacklist ${HOME}/.config/nvim
+noblacklist ${HOME}/.local/share/nvim
+
+include /etc/firejail/disable-common.inc
+include /etc/firejail/disable-passwdmgr.inc
+include /etc/firejail/disable-programs.inc
+
+caps.drop all
+netfilter
+nodvd
+nogroups
+nonewprivs
+noroot
+notv
+novideo
+protocol unix,inet,inet6
+seccomp
+
+private-dev

--- a/etc/nvim.profile
+++ b/etc/nvim.profile
@@ -3,7 +3,7 @@
 # Persistent local customizations
 include /etc/firejail/vim.local
 # Persistent global definitions
-include /etc/firejail/globals.local
+include globals.local
 
 noblacklist ${HOME}/.config/nvim
 noblacklist ${HOME}/.local/share/nvim


### PR DESCRIPTION
according to there : # https://old.reddit.com/r/neovim/comments/5con51/where_is_neovims_viminfo_located/

neovim uses something else than .viminfo files, they are inside .local

also I don't know if the --appimage was necessary, it was the case for my setup


If your PR isn't about profiles or you have no idea how to do one of these, skip the following and go ahead with this PR.

If you make a PR for new profiles or changeing profiles please do the following:
 - The ordering of options follow the rules descripted in [/usr/share/doc/firejail/profile.template](https://github.com/netblue30/firejail/blob/master/etc/templates/profile.template).  
   > Hint: The profile-template is very new, if you install firejail with your package-manager, it maybe missing, therefore, and to follow the latest rules, it is recommended to use the template from the repository.
 - Order the arguments of options alphabetical, you can easy do this with the [sort.py](https://github.com/netblue30/firejail/tree/master/contrib/sort.py).  
 The path to it depends on your distro:

   | Distro | Path |
   | ------ | ---- |
   | Arch/Fedora | `/usr/lib64/firejail/sort.py` |
   | Debian/Ubuntu/Mint | `/usr/lib/x86_64-linux-gnu/firejail/sort.py` |
   | local git clone | `contrib/sort.py` |

   Note also that the sort.py script exists only since firejail `0.9.61`.

See also [CONTRIBUTING.md](/CONTRIBUTING.md).
