### PR TITLE
support netcat variants

### DIFF
--- a/etc/disable-common.inc
+++ b/etc/disable-common.inc
@@ -391,6 +391,8 @@ blacklist ${PATH}/ksu
 blacklist ${PATH}/mount
 blacklist ${PATH}/mount.ecryptfs_private
 blacklist ${PATH}/nc
+blacklist ${PATH}/nc.openbsd
+blacklist ${PATH}/nc.traditional
 blacklist ${PATH}/ncat
 blacklist ${PATH}/newgidmap
 blacklist ${PATH}/newgrp

--- a/etc/playonlinux.profile
+++ b/etc/playonlinux.profile
@@ -12,8 +12,11 @@ noblacklist ${HOME}/.local/share/steam
 noblacklist ${HOME}/.steam
 noblacklist ${HOME}/.PlayOnLinux
 
-# nc is needed to run playonlinux
+# netcat is needed to run playonlinux
 noblacklist ${PATH}/nc
+noblacklist ${PATH}/nc.openbsd
+noblacklist ${PATH}/nc.traditional
+noblacklist ${PATH}/ncat
 
 # Allow python (blacklisted by disable-interpreters.inc)
 include allow-python2.inc

--- a/etc/ssh.profile
+++ b/etc/ssh.profile
@@ -10,8 +10,11 @@ include globals.local
 noblacklist /etc/ssh
 noblacklist /tmp/ssh-*
 noblacklist ${HOME}/.ssh
-# nc can be used as ProxyCommand, e.g. when using tor
+# netcat can be used as ProxyCommand, e.g. when using tor
 noblacklist ${PATH}/nc
+noblacklist ${PATH}/nc.openbsd
+noblacklist ${PATH}/nc.traditional
+noblacklist ${PATH}/ncat
 
 include disable-common.inc
 include disable-exec.inc


### PR DESCRIPTION
Currently we only use ${PATH}/nc and ${PATH}/ncat to refer to `netcat`. Due to packaging philosophy this binary can be available under several other disguises. E.g. on Debian/Ubuntu it also exists as ${PATH}/nc.openbsd and ${PATH}/nc.traditional. Let's play safe with such a tool and add support for these known variants. Not sure if we would prefer to have it sandboxed via firecfg by default, so I left that aspect out of this PR.

I'll keep this open for a while to give people a chance to suggest other variants if they exist.
