### PR TITLE
Fine-grained DBus sandboxing

### DIFF
--- a/src/firejail/dbus.c
+++ b/src/firejail/dbus.c
@@ -18,52 +18,221 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 #include "firejail.h"
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <fcntl.h>
 
-static void dbus_block_user(void) {
-	char *path;
-	if (asprintf(&path, "/run/user/%d/bus", getuid()) == -1)
-		errExit("asprintf");
-	char *env_var;
-	if (asprintf(&env_var, "unix:path=%s", path) == -1)
-		errExit("asprintf");
+#define DBUS_SOCKET_PATH_PREFIX "unix:path="
+#define DBUS_USER_SOCKET_FORMAT "/run/user/%d/bus"
+#define DBUS_USER_SOCKET_PATH_FORMAT DBUS_SOCKET_PATH_PREFIX DBUS_USER_SOCKET_FORMAT
+#define DBUS_SYSTEM_SOCKET "/run/dbus/system_bus_socket"
+#define DBUS_SYSTEM_SOCKET_PATH DBUS_SOCKET_PATH_PREFIX DBUS_SYSTEM_SOCKET
+#define DBUS_SESSION_BUS_ADDRESS_ENV "DBUS_SESSION_BUS_ADDRESS"
+#define DBUS_USER_PROXY_SOCKET_FORMAT RUN_FIREJAIL_DBUS_DIR "/%d-user"
+#define DBUS_SYSTEM_PROXY_SOCKET_FORMAT RUN_FIREJAIL_DBUS_DIR "/%d-system"
 
-	// set a new environment variable: DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/<UID>/bus
-	if (setenv("DBUS_SESSION_BUS_ADDRESS", env_var, 1) == -1) {
-		fprintf(stderr, "Error: cannot modify DBUS_SESSION_BUS_ADDRESS required by --nodbus\n");
-		exit(1);
-	}
+static pid_t dbus_proxy_pid = 0;
+static int dbus_proxy_status_fd = -1;
+static char *dbus_user_proxy_socket = NULL;
+static char *dbus_system_proxy_socket = NULL;
 
-	// blacklist the path
-	disable_file_or_dir(path);
-	free(path);
-	free(env_var);
-
-	// blacklist the dbus-launch user directory
-	if (asprintf(&path, "%s/.dbus", cfg.homedir) == -1)
-		errExit("asprintf");
-	disable_file_or_dir(path);
-	free(path);
+static void write_arg(int fd, char const *format, ...) {
+	va_list ap;
+	va_start(ap, format);
+	char *arg;
+	int length = vasprintf(&arg, format, ap);
+	va_end(ap);
+	if (length == -1)
+		errExit("vasprintf");
+	length++;
+	if (arg_debug)
+		printf("xdg-dbus-proxy arg: %s\n", arg);
+	if (write(fd, arg, (size_t) length) != (ssize_t) length)
+		errExit("write");
+	free(arg);
 }
 
-static void dbus_block_system() {
-	// blacklist also system D-Bus socket
-	disable_file_or_dir("/run/dbus/system_bus_socket");
+void dbus_proxy_start(void) {
+	int status_pipe[2];
+	if (pipe(status_pipe) == -1)
+		errExit("pipe");
+	dbus_proxy_status_fd = status_pipe[0];
+
+	int args_pipe[2];
+	if (pipe(args_pipe) == -1)
+		errExit("pipe");
+
+	dbus_proxy_pid = fork();
+	if (dbus_proxy_pid == -1)
+		errExit("fork");
+	if (dbus_proxy_pid == 0) {
+		int i;
+		for (i = 3; i < FIREJAIL_MAX_FD; i++) {
+			if (i != status_pipe[1] && i != args_pipe[0])
+				close(i); // close open files
+		}
+		char *args[4] = {"/usr/bin/xdg-dbus-proxy", NULL, NULL, NULL};
+		if (asprintf(&args[1], "--fd=%d", status_pipe[1]) == -1
+			|| asprintf(&args[2], "--args=%d", args_pipe[0]) == -1)
+			errExit("asprintf");
+		if (arg_debug)
+			printf("starting xdg-dbus-proxy\n");
+		sbox_exec_v(SBOX_USER | SBOX_SECCOMP | SBOX_CAPS_NONE | SBOX_KEEP_FDS, args);
+	} else {
+		if (close(status_pipe[1]) == -1 || close(args_pipe[0]) == -1)
+			errExit("close");
+
+		if (arg_dbus_user == DBUS_POLICY_FILTER) {
+			char *dbus_user_path_env = getenv(DBUS_SESSION_BUS_ADDRESS_ENV);
+			if (dbus_user_path_env == NULL) {
+				write_arg(args_pipe[1], DBUS_USER_SOCKET_PATH_FORMAT, getuid());
+			} else {
+				write_arg(args_pipe[1], dbus_user_path_env);
+			}
+			if (asprintf(&dbus_user_proxy_socket, DBUS_USER_PROXY_SOCKET_FORMAT, (int) getpid()) == -1)
+				errExit("asprintf");
+			write_arg(args_pipe[1], dbus_user_proxy_socket);
+			write_arg(args_pipe[1], "--filter");
+			// TODO Write filter rules to pipe
+		}
+
+		if (arg_dbus_system == DBUS_POLICY_FILTER) {
+			write_arg(args_pipe[1], DBUS_SYSTEM_SOCKET_PATH);
+			if (asprintf(&dbus_system_proxy_socket, DBUS_SYSTEM_PROXY_SOCKET_FORMAT, (int) getpid()) == -1)
+				errExit("asprintf");
+			write_arg(args_pipe[1], dbus_system_proxy_socket);
+			write_arg(args_pipe[1], "--filter");
+			// TODO Write filter rules to pipe
+		}
+
+		if (close(args_pipe[1]) == -1)
+			errExit("close");
+		char buf[1];
+		ssize_t read_bytes = read(status_pipe[0], buf, 1);
+		switch (read_bytes) {
+		case -1:
+			errExit("read");
+			break;
+		case 0:
+			fprintf(stderr, "xdg-dbus-proxy closed pipe unexpectedly\n");
+			// Wait for the subordinate process to write any errors to stderr and exit.
+			waitpid(dbus_proxy_pid, NULL, 0);
+			exit(-1);
+			break;
+		case 1:
+			if (arg_debug)
+				printf("xdg-dbus-proxy initialized\n");
+			break;
+		default:
+			assert(0);
+		}
+	}
+}
+
+void dbus_proxy_stop(void) {
+	if (dbus_proxy_pid == 0)
+		return;
+	assert(dbus_proxy_status_fd >= 0);
+	if (close(dbus_proxy_status_fd) == -1)
+		errExit("close");
+	int status;
+	if (waitpid(dbus_proxy_pid, &status, 0) == -1)
+		errExit("waitpid");
+	if (WIFEXITED(status) && WEXITSTATUS(status) != 0)
+		fwarning("xdg-dbus-proxy returned %s\n", WEXITSTATUS(status));
+	dbus_proxy_pid = 0;
+	dbus_proxy_status_fd = -1;
+	if (dbus_user_proxy_socket != NULL) {
+		free(dbus_user_proxy_socket);
+		dbus_user_proxy_socket = NULL;
+	}
+	if (dbus_system_proxy_socket != NULL) {
+		free(dbus_system_proxy_socket);
+		dbus_system_proxy_socket = NULL;
+	}
+}
+
+static void socket_overlay(char *socket_path, char *proxy_path) {
+	if (mount(proxy_path, socket_path, NULL, MS_BIND, NULL) == -1)
+		errExit("mount");
+}
+
+static void disable_socket_dir(void) {
+	struct stat s;
+	if (stat(RUN_FIREJAIL_DBUS_DIR, &s) == 0)
+		disable_file_or_dir(RUN_FIREJAIL_DBUS_DIR);
 }
 
 void dbus_apply_policy(void) {
-	if (arg_dbus_user == DBUS_POLICY_ALLOW && arg_dbus_system == DBUS_POLICY_ALLOW)
+	EUID_ROOT();
+
+	if (arg_dbus_user == DBUS_POLICY_ALLOW && arg_dbus_system == DBUS_POLICY_ALLOW) {
+		disable_socket_dir();
 		return;
+	}
 
 	if (!checkcfg(CFG_DBUS)) {
+		disable_socket_dir();
 		fwarning("D-Bus handling is disabled in Firejail configuration file\n");
 		return;
 	}
 
-	if (arg_dbus_user != DBUS_POLICY_ALLOW)
-		dbus_block_user();
+	char *dbus_new_user_socket_path;
+	if (asprintf(&dbus_new_user_socket_path, DBUS_USER_SOCKET_PATH_FORMAT, getuid()) == -1)
+		errExit("asprintf");
+	char *dbus_new_user_socket = dbus_new_user_socket_path + strlen(DBUS_SOCKET_PATH_PREFIX);
+	char *dbus_user_path_env = getenv(DBUS_SESSION_BUS_ADDRESS_ENV);
+	char *dbus_orig_user_socket_path;
+	if (dbus_user_path_env != NULL
+		&& strncmp(DBUS_SOCKET_PATH_PREFIX, dbus_user_path_env, strlen(DBUS_SOCKET_PATH_PREFIX)) == 0) {
+		dbus_orig_user_socket_path = dbus_user_path_env;
+	} else {
+		dbus_orig_user_socket_path = dbus_new_user_socket_path;
+	}
+	char *dbus_orig_user_socket = dbus_user_path_env + strlen(DBUS_SOCKET_PATH_PREFIX);
 
-	if (arg_dbus_system != DBUS_POLICY_ALLOW)
-		dbus_block_system();
+	if (arg_dbus_user != DBUS_POLICY_ALLOW) {
+		if (arg_dbus_user == DBUS_POLICY_FILTER) {
+			assert(dbus_user_proxy_socket != NULL);
+			socket_overlay(dbus_new_user_socket, dbus_user_proxy_socket);
+			free(dbus_user_proxy_socket);
+		} else { // arg_dbus_user == DBUS_POLICY_BLOCK
+			disable_file_or_dir(dbus_new_user_socket);
+		}
+
+		if (strcmp(dbus_orig_user_socket, dbus_new_user_socket) != 0)
+			disable_file_or_dir(dbus_orig_user_socket);
+
+		// set a new environment variable:
+		// DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/<UID>/bus
+		if (setenv(DBUS_SESSION_BUS_ADDRESS_ENV, dbus_new_user_socket_path, 1) == -1) {
+			fprintf(stderr, "Error: cannot modify " DBUS_SESSION_BUS_ADDRESS_ENV " required by --dbus-user\n");
+			exit(1);
+		}
+
+		// blacklist the dbus-launch user directory
+		char *path;
+		if (asprintf(&path, "%s/.dbus", cfg.homedir) == -1)
+			errExit("asprintf");
+		disable_file_or_dir(path);
+		free(path);
+	}
+
+	free(dbus_new_user_socket_path);
+
+	if (arg_dbus_system == DBUS_POLICY_FILTER) {
+		assert(dbus_system_proxy_socket != NULL);
+		socket_overlay(DBUS_SYSTEM_SOCKET, dbus_system_proxy_socket);
+		free(dbus_system_proxy_socket);
+	} else if (arg_dbus_system == DBUS_POLICY_BLOCK) {
+		disable_file_or_dir(DBUS_SYSTEM_SOCKET);
+	}
+
+	// Only disable access to /run/firejail/dbus here, when the sockets have been bind-mounted.
+	disable_socket_dir();
 
 	// look for a possible abstract unix socket
 

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -846,6 +846,8 @@ void set_x11_run_file(pid_t pid, int display);
 void set_profile_run_file(pid_t pid, const char *fname);
 
 // dbus.c
+int dbus_check_name(const char *name);
+void dbus_check_profile(void);
 void dbus_proxy_start(void);
 void dbus_proxy_stop(void);
 void dbus_apply_policy(void);

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -340,8 +340,15 @@ extern int arg_memory_deny_write_execute;	// block writable and executable memor
 extern int arg_notv;	// --notv
 extern int arg_nodvd;	// --nodvd
 extern int arg_nou2f;   // --nou2f
-extern int arg_nodbus; // -nodbus
 extern int arg_deterministic_exit_code;	// always exit with first child's exit status
+
+typedef enum {
+	DBUS_POLICY_ALLOW,	// Allow unrestricted access to the bus
+	DBUS_POLICY_FILTER, // Filter with xdg-dbus-proxy
+	DBUS_POLICY_BLOCK   // Block access
+} DbusPolicy;
+extern DbusPolicy arg_dbus_user; // --dbus-user
+extern DbusPolicy arg_dbus_system; // --dbus-system
 
 extern int login_shell;
 extern int parent_to_child_fds[2];
@@ -836,7 +843,7 @@ void set_x11_run_file(pid_t pid, int display);
 void set_profile_run_file(pid_t pid, const char *fname);
 
 // dbus.c
-void dbus_disable(void);
+void dbus_apply_policy(void);
 
 // dhcp.c
 extern pid_t dhclient4_pid;

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -846,6 +846,8 @@ void set_x11_run_file(pid_t pid, int display);
 void set_profile_run_file(pid_t pid, const char *fname);
 
 // dbus.c
+void dbus_proxy_start(void);
+void dbus_proxy_stop(void);
 void dbus_apply_policy(void);
 
 // dhcp.c

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -830,10 +830,13 @@ void build_appimage_cmdline(char **command_line, char **window_title, int argc, 
 #define SBOX_STDIN_FROM_FILE (1 << 6)	// open file and redirect it to stdin
 #define SBOX_CAPS_HIDEPID (1 << 7)	// hidepid caps filter for running firemon
 #define SBOX_CAPS_NET_SERVICE (1 << 8) // caps filter for programs running network services
+#define SBOX_KEEP_FDS (1 << 9) // keep file descriptors open
+#define FIREJAIL_MAX_FD 20 // getdtablesize() is overkill for a firejail process
 
 // run sbox
 int sbox_run(unsigned filter, int num, ...);
 int sbox_run_v(unsigned filter, char * const arg[]);
+void sbox_exec_v(unsigned filter, char * const arg[]);
 
 // run_files.c
 void delete_run_files(pid_t pid);

--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -256,6 +256,7 @@ void fs_blacklist(void) {
 		// whitelist commands handled by fs_whitelist()
 		if (strncmp(entry->data, "whitelist ", 10) == 0 ||
 		    strncmp(entry->data, "nowhitelist ", 12) == 0 ||
+		    strncmp(entry->data, "dbus-", 5) == 0 ||
 		   *entry->data == '\0') {
 			entry = entry->next;
 			continue;

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -144,9 +144,10 @@ int arg_noprofile = 0; // use default.profile if none other found/specified
 int arg_memory_deny_write_execute = 0;		// block writable and executable memory
 int arg_notv = 0;	// --notv
 int arg_nodvd = 0; // --nodvd
-int arg_nodbus = 0; // -nodbus
 int arg_nou2f = 0; // --nou2f
 int arg_deterministic_exit_code = 0;	// always exit with first child's exit status
+DbusPolicy arg_dbus_user = DBUS_POLICY_ALLOW;	// --dbus-user
+DbusPolicy arg_dbus_system = DBUS_POLICY_ALLOW;	// --dbus-system
 int login_shell = 0;
 
 //**********************************************************************************
@@ -2053,8 +2054,34 @@ int main(int argc, char **argv, char **envp) {
 			arg_nodvd = 1;
 		else if (strcmp(argv[i], "--nou2f") == 0)
 			arg_nou2f = 1;
-		else if (strcmp(argv[i], "--nodbus") == 0)
-			arg_nodbus = 1;
+		else if (strcmp(argv[i], "--nodbus") == 0) {
+			arg_dbus_user = DBUS_POLICY_BLOCK;
+			arg_dbus_system = DBUS_POLICY_BLOCK;
+		}
+		else if (strncmp("--dbus-user=", argv[i], 12) == 0) {
+			if (strcmp("allow", argv[i] + 12) == 0) {
+				arg_dbus_user = DBUS_POLICY_ALLOW;
+			} else if (strcmp("filter", argv[i] + 12) == 0) {
+				arg_dbus_user = DBUS_POLICY_FILTER;
+			} else if (strcmp("none", argv[i] + 12) == 0) {
+				arg_dbus_user = DBUS_POLICY_BLOCK;
+			} else {
+				fprintf(stderr, "Unknown dbus-user policy: %s\n", argv[i] + 12);
+				exit(1);
+			}
+		}
+		else if (strncmp("--dbus-system=", argv[i], 14) == 0) {
+			if (strcmp("allow", argv[i] + 14) == 0) {
+				arg_dbus_system = DBUS_POLICY_ALLOW;
+			} else if (strcmp("filter", argv[i] + 14) == 0) {
+				arg_dbus_system = DBUS_POLICY_FILTER;
+			} else if (strcmp("none", argv[i] + 14) == 0) {
+				arg_dbus_system = DBUS_POLICY_BLOCK;
+			} else {
+				fprintf(stderr, "Unknown dbus-system policy: %s\n", argv[i] + 14);
+				exit(1);
+			}
+		}
 
 		//*************************************
 		// network

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -2767,6 +2767,13 @@ int main(int argc, char **argv, char **envp) {
 	}
 	EUID_USER();
 
+	if (checkcfg(CFG_DBUS) &&
+		(arg_dbus_user == DBUS_POLICY_FILTER || arg_dbus_system == DBUS_POLICY_FILTER)) {
+		EUID_ROOT();
+		dbus_proxy_start();
+		EUID_USER();
+	}
+
 	// clone environment
 	int flags = CLONE_NEWNS | CLONE_NEWPID | CLONE_NEWUTS | SIGCHLD;
 
@@ -2976,6 +2983,9 @@ printf("**********************************\n");
 
 	// end of signal-safe code
 	//*****************************
+
+	// stop dbus proxy (if any)
+	dbus_proxy_stop();
 
 	// free globals
 	if (cfg.profile) {

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -181,6 +181,7 @@ static void myexit(int rv) {
 
 
 	// delete sandbox files in shared memory
+	dbus_proxy_stop();
 	EUID_ROOT();
 	delete_run_files(sandbox_pid);
 	appimage_clear();
@@ -3022,9 +3023,6 @@ printf("**********************************\n");
 
 	// end of signal-safe code
 	//*****************************
-
-	// stop dbus proxy (if any)
-	dbus_proxy_stop();
 
 	// free globals
 	if (cfg.profile) {

--- a/src/firejail/preproc.c
+++ b/src/firejail/preproc.c
@@ -59,7 +59,17 @@ void preproc_build_firejail_dir(void) {
 	}
 
 	if (stat(RUN_FIREJAIL_DBUS_DIR, &s)) {
-		create_empty_dir_as_root(RUN_FIREJAIL_DBUS_DIR, 01777);
+		create_empty_dir_as_root(RUN_FIREJAIL_DBUS_DIR, 0755);
+		if (arg_debug)
+			printf("Remounting the " RUN_FIREJAIL_DBUS_DIR
+				   " directory as noexec\n");
+		if (mount(RUN_FIREJAIL_DBUS_DIR, RUN_FIREJAIL_DBUS_DIR, NULL,
+				  MS_BIND, NULL) == -1)
+			errExit("mounting " RUN_FIREJAIL_DBUS_DIR);
+		if (mount(NULL, RUN_FIREJAIL_DBUS_DIR, NULL,
+				  MS_REMOUNT | MS_BIND | MS_NOSUID | MS_NOEXEC | MS_NODEV,
+				  "mode=755,gid=0") == -1)
+			errExit("remounting " RUN_FIREJAIL_DBUS_DIR);
 	}
 
 	if (stat(RUN_FIREJAIL_APPIMAGE_DIR, &s)) {

--- a/src/firejail/preproc.c
+++ b/src/firejail/preproc.c
@@ -58,6 +58,10 @@ void preproc_build_firejail_dir(void) {
 		create_empty_dir_as_root(RUN_FIREJAIL_X11_DIR, 0755);
 	}
 
+	if (stat(RUN_FIREJAIL_DBUS_DIR, &s)) {
+		create_empty_dir_as_root(RUN_FIREJAIL_DBUS_DIR, 01777);
+	}
+
 	if (stat(RUN_FIREJAIL_APPIMAGE_DIR, &s)) {
 		create_empty_dir_as_root(RUN_FIREJAIL_APPIMAGE_DIR, 0755);
 	}

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -150,7 +150,7 @@ static int check_netoptions(void) {
 }
 
 static int check_nodbus(void) {
-	return arg_nodbus != 0;
+	return arg_dbus_user != DBUS_POLICY_ALLOW || arg_dbus_system != DBUS_POLICY_ALLOW;
 }
 
 static int check_nosound(void) {
@@ -432,11 +432,40 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		return 0;
 	}
 	else if (strcmp(ptr, "nodbus") == 0) {
-		arg_nodbus = 1;
+		arg_dbus_user = DBUS_POLICY_BLOCK;
+		arg_dbus_system = DBUS_POLICY_BLOCK;
+		return 0;
+	}
+	else if (strncmp("dbus-user ", ptr, 10) == 0) {
+		ptr += 10;
+		if (strcmp("allow", ptr) == 0) {
+			arg_dbus_user = DBUS_POLICY_ALLOW;
+		} else if (strcmp("filter", ptr) == 0) {
+			arg_dbus_user = DBUS_POLICY_FILTER;
+		} else if (strcmp("none", ptr) == 0) {
+			arg_dbus_user = DBUS_POLICY_BLOCK;
+		} else {
+			fprintf(stderr, "Unknown dbus-user policy: %s\n", ptr);
+			exit(1);
+		}
+		return 0;
+	}
+	else if (strncmp("dbus-system ", ptr, 12) == 0) {
+		ptr += 12;
+		if (strcmp("allow", ptr) == 0) {
+			arg_dbus_system = DBUS_POLICY_ALLOW;
+		} else if (strcmp("filter", ptr) == 0) {
+			arg_dbus_system = DBUS_POLICY_FILTER;
+		} else if (strcmp("none", ptr) == 0) {
+			arg_dbus_system = DBUS_POLICY_BLOCK;
+		} else {
+			fprintf(stderr, "Unknown dbus-system policy: %s\n", ptr);
+			exit(1);
+		}
 		return 0;
 	}
 	else if (strcmp(ptr, "nou2f") == 0) {
-	        arg_nou2f = 1;
+		arg_nou2f = 1;
 		return 0;
 	}
 	else if (strcmp(ptr, "netfilter") == 0) {

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -453,12 +453,6 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		return 0;
 	}
 	else if (strncmp(ptr, "dbus-user.talk ", 15) == 0) {
-		if (arg_dbus_user == DBUS_POLICY_ALLOW) {
-			fprintf(stderr, "Session DBus filtering (dbus-user filter) is "
-							"required for dbus-user.talk rules\n");
-			exit(1);
-		}
-
 		if (!dbus_check_name(ptr + 15)) {
 			printf("Invalid dbus-user.talk name: %s\n", ptr + 15);
 			exit(1);
@@ -466,12 +460,6 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		return 1;
 	}
 	else if (strncmp(ptr, "dbus-user.own ", 14) == 0) {
-		if (arg_dbus_user == DBUS_POLICY_ALLOW) {
-			fprintf(stderr, "Session DBus filtering (dbus-user filter) is "
-							"required for dbus-user.own rules\n");
-			exit(1);
-		}
-
 		if (!dbus_check_name(ptr + 14)) {
 			fprintf(stderr, "Invalid dbus-user.own name: %s\n", ptr + 14);
 			exit(1);
@@ -495,12 +483,6 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		return 0;
 	}
 	else if (strncmp(ptr, "dbus-system.talk ", 17) == 0) {
-		if (arg_dbus_system == DBUS_POLICY_ALLOW) {
-			fprintf(stderr, "System DBus filtering (dbus-system filter) is "
-							"required for dbus-system.talk rules\n");
-			exit(1);
-		}
-
 		if (!dbus_check_name(ptr + 17)) {
 			fprintf(stderr, "Invalid dbus-system.talk name: %s\n", ptr + 17);
 			exit(1);
@@ -508,12 +490,6 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		return 1;
 	}
 	else if (strncmp(ptr, "dbus-system.own ", 16) == 0) {
-		if (arg_dbus_system == DBUS_POLICY_ALLOW) {
-			fprintf(stderr, "System DBus filtering (dbus-system filter) is "
-							"required for dbus-system.own rules\n");
-			exit(1);
-		}
-
 		if (!dbus_check_name(ptr + 16)) {
 			fprintf(stderr, "Invalid dbus-system.own name: %s\n", ptr + 16);
 			exit(1);

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -438,9 +438,11 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 	}
 	else if (strncmp("dbus-user ", ptr, 10) == 0) {
 		ptr += 10;
-		if (strcmp("allow", ptr) == 0) {
-			arg_dbus_user = DBUS_POLICY_ALLOW;
-		} else if (strcmp("filter", ptr) == 0) {
+		if (strcmp("filter", ptr) == 0) {
+			if (arg_dbus_user == DBUS_POLICY_BLOCK) {
+				fprintf(stderr, "Error: Cannot relax dbus-user policy, it is already set to block\n");
+				exit(1);
+			}
 			arg_dbus_user = DBUS_POLICY_FILTER;
 		} else if (strcmp("none", ptr) == 0) {
 			arg_dbus_user = DBUS_POLICY_BLOCK;
@@ -450,11 +452,39 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		}
 		return 0;
 	}
+	else if (strncmp(ptr, "dbus-user.talk ", 15) == 0) {
+		if (arg_dbus_user == DBUS_POLICY_ALLOW) {
+			fprintf(stderr, "Session DBus filtering (dbus-user filter) is "
+							"required for dbus-user.talk rules\n");
+			exit(1);
+		}
+
+		if (!dbus_check_name(ptr + 15)) {
+			printf("Invalid dbus-user.talk name: %s\n", ptr + 15);
+			exit(1);
+		}
+		return 1;
+	}
+	else if (strncmp(ptr, "dbus-user.own ", 14) == 0) {
+		if (arg_dbus_user == DBUS_POLICY_ALLOW) {
+			fprintf(stderr, "Session DBus filtering (dbus-user filter) is "
+							"required for dbus-user.own rules\n");
+			exit(1);
+		}
+
+		if (!dbus_check_name(ptr + 14)) {
+			fprintf(stderr, "Invalid dbus-user.own name: %s\n", ptr + 14);
+			exit(1);
+		}
+		return 1;
+	}
 	else if (strncmp("dbus-system ", ptr, 12) == 0) {
 		ptr += 12;
-		if (strcmp("allow", ptr) == 0) {
-			arg_dbus_system = DBUS_POLICY_ALLOW;
-		} else if (strcmp("filter", ptr) == 0) {
+		if (strcmp("filter", ptr) == 0) {
+			if (arg_dbus_system == DBUS_POLICY_BLOCK) {
+				fprintf(stderr, "Error: Cannot relax dbus-system policy, it is already set to block\n");
+				exit(1);
+			}
 			arg_dbus_system = DBUS_POLICY_FILTER;
 		} else if (strcmp("none", ptr) == 0) {
 			arg_dbus_system = DBUS_POLICY_BLOCK;
@@ -463,6 +493,32 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 			exit(1);
 		}
 		return 0;
+	}
+	else if (strncmp(ptr, "dbus-system.talk ", 17) == 0) {
+		if (arg_dbus_system == DBUS_POLICY_ALLOW) {
+			fprintf(stderr, "System DBus filtering (dbus-system filter) is "
+							"required for dbus-system.talk rules\n");
+			exit(1);
+		}
+
+		if (!dbus_check_name(ptr + 17)) {
+			fprintf(stderr, "Invalid dbus-system.talk name: %s\n", ptr + 17);
+			exit(1);
+		}
+		return 1;
+	}
+	else if (strncmp(ptr, "dbus-system.own ", 16) == 0) {
+		if (arg_dbus_system == DBUS_POLICY_ALLOW) {
+			fprintf(stderr, "System DBus filtering (dbus-system filter) is "
+							"required for dbus-system.own rules\n");
+			exit(1);
+		}
+
+		if (!dbus_check_name(ptr + 16)) {
+			fprintf(stderr, "Invalid dbus-system.own name: %s\n", ptr + 16);
+			exit(1);
+		}
+		return 1;
 	}
 	else if (strcmp(ptr, "nou2f") == 0) {
 		arg_nou2f = 1;

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -932,8 +932,7 @@ int sandbox(void* sandbox_arg) {
 	//****************************
 	// Session D-BUS
 	//****************************
-	if (arg_nodbus)
-		dbus_disable();
+	dbus_apply_policy();
 
 
 	//****************************

--- a/src/firejail/sbox.c
+++ b/src/firejail/sbox.c
@@ -23,13 +23,217 @@
 #include <unistd.h>
 #include <net/if.h>
 #include <stdarg.h>
- #include <sys/wait.h>
+#include <sys/wait.h>
 #include "../include/seccomp.h"
 
 #include <fcntl.h>
 #ifndef O_PATH
 #define O_PATH 010000000
 #endif
+
+static int sbox_do_exec_v(unsigned filtermask, char * const arg[]) {
+	int env_index = 0;
+	char *new_environment[256] = { NULL };
+	// preserve firejail-specific env vars
+	char *cl = getenv("FIREJAIL_FILE_COPY_LIMIT");
+	if (cl) {
+		if (asprintf(&new_environment[env_index++], "FIREJAIL_FILE_COPY_LIMIT=%s", cl) == -1)
+			errExit("asprintf");
+	}
+	clearenv();
+	if (arg_quiet) // --quiet is passed as an environment variable
+		new_environment[env_index++] = "FIREJAIL_QUIET=yes";
+	if (arg_debug) // --debug is passed as an environment variable
+		new_environment[env_index++] = "FIREJAIL_DEBUG=yes";
+
+	if (filtermask & SBOX_STDIN_FROM_FILE) {
+		int fd;
+		if((fd = open(SBOX_STDIN_FILE, O_RDONLY)) == -1) {
+			fprintf(stderr,"Error: cannot open %s\n", SBOX_STDIN_FILE);
+			exit(1);
+		}
+		if (dup2(fd, STDIN_FILENO) == -1)
+			errExit("dup2");
+		close(fd);
+	}
+	else if ((filtermask & SBOX_ALLOW_STDIN) == 0) {
+		int fd = open("/dev/null",O_RDWR, 0);
+		if (fd != -1) {
+			if (dup2(fd, STDIN_FILENO) == -1)
+				errExit("dup2");
+			close(fd);
+		}
+		else // the user could run the sandbox without /dev/null
+			close(STDIN_FILENO);
+	}
+
+	// close all other file descriptors
+	if ((filtermask & SBOX_KEEP_FDS) == 0) {
+		int i;
+		for (i = 3; i < FIREJAIL_MAX_FD; i++)
+			close(i); // close open files
+	}
+
+	umask(027);
+
+	// apply filters
+	if (filtermask & SBOX_CAPS_NONE) {
+		caps_drop_all();
+	} else {
+		uint64_t set = 0;
+		if (filtermask & SBOX_CAPS_NETWORK) {
+#ifndef HAVE_GCOV // the following filter will prevent GCOV from saving info in .gcda files
+			set |= ((uint64_t) 1) << CAP_NET_ADMIN;
+			set |= ((uint64_t) 1) << CAP_NET_RAW;
+#endif
+		}
+		if (filtermask & SBOX_CAPS_HIDEPID) {
+#ifndef HAVE_GCOV // the following filter will prevent GCOV from saving info in .gcda files
+			set |= ((uint64_t) 1) << CAP_SYS_PTRACE;
+			set |= ((uint64_t) 1) << CAP_SYS_PACCT;
+#endif
+		}
+		if (filtermask & SBOX_CAPS_NET_SERVICE) {
+#ifndef HAVE_GCOV // the following filter will prevent GCOV from saving info in .gcda files
+			set |= ((uint64_t) 1) << CAP_NET_BIND_SERVICE;
+			set |= ((uint64_t) 1) << CAP_NET_BROADCAST;
+#endif
+		}
+		if (set != 0) { // some SBOX_CAPS_ flag was specified, drop all other capabilities
+#ifndef HAVE_GCOV // the following filter will prevent GCOV from saving info in .gcda files
+			caps_set(set);
+#endif
+		}
+	}
+
+	if (filtermask & SBOX_SECCOMP) {
+		struct sock_filter filter[] = {
+			VALIDATE_ARCHITECTURE,
+			EXAMINE_SYSCALL,
+
+#if defined(__x86_64__)
+#define X32_SYSCALL_BIT 0x40000000
+			// handle X32 ABI
+			BPF_JUMP(BPF_JMP + BPF_JGE + BPF_K, X32_SYSCALL_BIT, 1, 0),
+			BPF_JUMP(BPF_JMP + BPF_JGE + BPF_K, 0, 1, 0),
+			RETURN_ERRNO(EPERM),
+#endif
+
+		// syscall list
+#ifdef SYS_mount
+			BLACKLIST(SYS_mount), // mount/unmount filesystems
+#endif
+#ifdef SYS_umount2
+			BLACKLIST(SYS_umount2),
+#endif
+#ifdef SYS_ptrace
+			BLACKLIST(SYS_ptrace), // trace processes
+#endif
+#ifdef SYS_process_vm_readv
+			BLACKLIST(SYS_process_vm_readv),
+#endif
+#ifdef SYS_process_vm_writev
+			BLACKLIST(SYS_process_vm_writev),
+#endif
+#ifdef SYS_kexec_file_load
+			BLACKLIST(SYS_kexec_file_load), // loading a different kernel
+#endif
+#ifdef SYS_kexec_load
+			BLACKLIST(SYS_kexec_load),
+#endif
+#ifdef SYS_name_to_handle_at
+			BLACKLIST(SYS_name_to_handle_at),
+#endif
+#ifdef SYS_open_by_handle_at
+			BLACKLIST(SYS_open_by_handle_at), // open by handle
+#endif
+#ifdef SYS_init_module
+			BLACKLIST(SYS_init_module), // kernel module handling
+#endif
+#ifdef SYS_finit_module // introduced in 2013
+			BLACKLIST(SYS_finit_module),
+#endif
+#ifdef SYS_create_module
+			BLACKLIST(SYS_create_module),
+#endif
+#ifdef SYS_delete_module
+			BLACKLIST(SYS_delete_module),
+#endif
+#ifdef SYS_iopl
+			BLACKLIST(SYS_iopl), // io permissions
+#endif
+#ifdef SYS_ioperm
+			BLACKLIST(SYS_ioperm),
+#endif
+#ifdef SYS_ioprio_set
+			BLACKLIST(SYS_ioprio_set),
+#endif
+#ifdef SYS_ni_syscall // new io permissions call on arm devices
+			BLACKLIST(SYS_ni_syscall),
+#endif
+#ifdef SYS_swapon
+			BLACKLIST(SYS_swapon), // swap on/off
+#endif
+#ifdef SYS_swapoff
+			BLACKLIST(SYS_swapoff),
+#endif
+#ifdef SYS_syslog
+			BLACKLIST(SYS_syslog), // kernel printk control
+#endif
+			RETURN_ALLOW
+		};
+
+		struct sock_fprog prog = {
+			.len = (unsigned short)(sizeof(filter) / sizeof(filter[0])),
+			.filter = filter,
+		};
+
+		if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)) {
+			perror("prctl(NO_NEW_PRIVS)");
+		}
+		if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog)) {
+			perror("prctl(PR_SET_SECCOMP)");
+		}
+	}
+
+	if (filtermask & SBOX_ROOT) {
+		// elevate privileges in order to get grsecurity working
+		if (setreuid(0, 0))
+			errExit("setreuid");
+		if (setregid(0, 0))
+			errExit("setregid");
+	}
+	else if (filtermask & SBOX_USER)
+		drop_privs(1);
+
+	if (arg[0]) { // get rid of scan-build warning
+		int fd = open(arg[0], O_PATH | O_CLOEXEC);
+		if (fd == -1) {
+			if (errno == ENOENT) {
+				fprintf(stderr, "Error: %s does not exist\n", arg[0]);
+				exit(1);
+			} else {
+				errExit("open");
+			}
+		}
+		struct stat s;
+		if (fstat(fd, &s) == -1)
+			errExit("fstat");
+		if (s.st_uid != 0 && s.st_gid != 0) {
+			fprintf(stderr, "Error: %s is not owned by root, refusing to execute\n", arg[0]);
+			exit(1);
+		}
+		if (s.st_mode & 00002) {
+			fprintf(stderr, "Error: %s is world writable, refusing to execute\n", arg[0]);
+			exit(1);
+		}
+		fexecve(fd, arg, new_environment);
+	} else {
+		assert(0);
+	}
+	perror("fexecve");
+	_exit(1);
+}
 
 int sbox_run(unsigned filtermask, int num, ...) {
 	va_list valist;
@@ -39,7 +243,7 @@ int sbox_run(unsigned filtermask, int num, ...) {
 	char **arg = malloc((num + 1) * sizeof(char *));
 	int i;
 	for (i = 0; i < num; i++)
-		arg[i] = va_arg(valist, char*);
+		arg[i] = va_arg(valist, char *);
 	arg[i] = NULL;
 	va_end(valist);
 
@@ -51,87 +255,6 @@ int sbox_run(unsigned filtermask, int num, ...) {
 }
 
 int sbox_run_v(unsigned filtermask, char * const arg[]) {
-	struct sock_filter filter[] = {
-	VALIDATE_ARCHITECTURE,
-	EXAMINE_SYSCALL,
-
-#if defined(__x86_64__)
-#define X32_SYSCALL_BIT 0x40000000
-	// handle X32 ABI
-	BPF_JUMP(BPF_JMP+BPF_JGE+BPF_K, X32_SYSCALL_BIT, 1, 0),
-	BPF_JUMP(BPF_JMP+BPF_JGE+BPF_K, 0, 1, 0),
-	RETURN_ERRNO(EPERM),
-#endif
-
-	// syscall list
-#ifdef SYS_mount
-	BLACKLIST(SYS_mount),  // mount/unmount filesystems
-#endif
-#ifdef SYS_umount2
-	BLACKLIST(SYS_umount2),
-#endif
-#ifdef SYS_ptrace
-	BLACKLIST(SYS_ptrace), // trace processes
-#endif
-#ifdef SYS_process_vm_readv
-	BLACKLIST(SYS_process_vm_readv),
-#endif
-#ifdef SYS_process_vm_writev
-	BLACKLIST(SYS_process_vm_writev),
-#endif
-#ifdef SYS_kexec_file_load
-	BLACKLIST(SYS_kexec_file_load), // loading a different kernel
-#endif
-#ifdef SYS_kexec_load
-	BLACKLIST(SYS_kexec_load),
-#endif
-#ifdef SYS_name_to_handle_at
-	BLACKLIST(SYS_name_to_handle_at),
-#endif
-#ifdef SYS_open_by_handle_at
-	BLACKLIST(SYS_open_by_handle_at), // open by handle
-#endif
-#ifdef SYS_init_module
-	BLACKLIST(SYS_init_module), // kernel module handling
-#endif
-#ifdef SYS_finit_module // introduced in 2013
-	BLACKLIST(SYS_finit_module),
-#endif
-#ifdef SYS_create_module
-	BLACKLIST(SYS_create_module),
-#endif
-#ifdef SYS_delete_module
-	BLACKLIST(SYS_delete_module),
-#endif
-#ifdef SYS_iopl
-	BLACKLIST(SYS_iopl), // io permissions
-#endif
-#ifdef 	SYS_ioperm
-	BLACKLIST(SYS_ioperm),
-#endif
-#ifdef 	SYS_ioprio_set
-	BLACKLIST(SYS_ioprio_set),
-#endif
-#ifdef SYS_ni_syscall // new io permissions call on arm devices
-	BLACKLIST(SYS_ni_syscall),
-#endif
-#ifdef SYS_swapon
-	BLACKLIST(SYS_swapon), // swap on/off
-#endif
-#ifdef SYS_swapoff
-	BLACKLIST(SYS_swapoff),
-#endif
-#ifdef SYS_syslog
-	BLACKLIST(SYS_syslog), // kernel printk control
-#endif
-	RETURN_ALLOW
-	};
-
-	struct sock_fprog prog = {
-		.len = (unsigned short)(sizeof(filter) / sizeof(filter[0])),
-		.filter = filter,
-	};
-
 	EUID_ROOT();
 
 	if (arg_debug) {
@@ -144,132 +267,14 @@ int sbox_run_v(unsigned filtermask, char * const arg[]) {
 		printf("\n");
 	}
 
+	// KEEP_FDS only makes sense with sbox_exec_v
+	assert((filtermask & SBOX_KEEP_FDS) == 0);
+
 	pid_t child = fork();
 	if (child < 0)
 		errExit("fork");
 	if (child == 0) {
-		int env_index = 0;
-		char *new_environment[256] = { NULL };
-		// preserve firejail-specific env vars
-		char *cl = getenv("FIREJAIL_FILE_COPY_LIMIT");
-		if (cl) {
-			if (asprintf(&new_environment[env_index++], "FIREJAIL_FILE_COPY_LIMIT=%s", cl) == -1)
-				errExit("asprintf");
-		}
-		clearenv();
-		if (arg_quiet) // --quiet is passed as an environment variable
-			new_environment[env_index++] = "FIREJAIL_QUIET=yes";
-		if (arg_debug) // --debug is passed as an environment variable
-			new_environment[env_index++] = "FIREJAIL_DEBUG=yes";
-		if (cfg.seccomp_error_action)
-			if (asprintf(&new_environment[env_index++], "FIREJAIL_SECCOMP_ERROR_ACTION=%s", cfg.seccomp_error_action) == -1)
-				errExit("asprintf");
-
-		if (filtermask & SBOX_STDIN_FROM_FILE) {
-			int fd;
-			if((fd = open(SBOX_STDIN_FILE, O_RDONLY)) == -1) {
-				fprintf(stderr,"Error: cannot open %s\n", SBOX_STDIN_FILE);
-				exit(1);
-			}
-			if (dup2(fd, STDIN_FILENO) == -1)
-				errExit("dup2");
-			close(fd);
-		}
-		else if ((filtermask & SBOX_ALLOW_STDIN) == 0) {
-			int fd = open("/dev/null",O_RDWR, 0);
-			if (fd != -1) {
-				if (dup2(fd, STDIN_FILENO) == -1)
-					errExit("dup2");
-				close(fd);
-			}
-			else // the user could run the sandbox without /dev/null
-				close(STDIN_FILENO);
-		}
-
-		// close all other file descriptors
-		int max = 20; // getdtablesize() is overkill for a firejail process
-		int i = 3;
-		for (i = 3; i < max; i++)
-			close(i); // close open files
-
-		umask(027);
-
-		// apply filters
-		if (filtermask & SBOX_CAPS_NONE) {
-			caps_drop_all();
-		} else {
-			uint64_t set = 0;
-			if (filtermask & SBOX_CAPS_NETWORK) {
-#ifndef HAVE_GCOV // the following filter will prevent GCOV from saving info in .gcda files
-				set |= ((uint64_t) 1) << CAP_NET_ADMIN;
-				set |= ((uint64_t) 1) << CAP_NET_RAW;
-#endif
-			}
-			if (filtermask & SBOX_CAPS_HIDEPID) {
-#ifndef HAVE_GCOV // the following filter will prevent GCOV from saving info in .gcda files
-				set |= ((uint64_t) 1) << CAP_SYS_PTRACE;
-				set |= ((uint64_t) 1) << CAP_SYS_PACCT;
-#endif
-			}
-			if (filtermask & SBOX_CAPS_NET_SERVICE) {
-#ifndef HAVE_GCOV // the following filter will prevent GCOV from saving info in .gcda files
-				set |= ((uint64_t) 1) << CAP_NET_BIND_SERVICE;
-				set |= ((uint64_t) 1) << CAP_NET_BROADCAST;
-#endif
-			}
-			if (set != 0) { // some SBOX_CAPS_ flag was specified, drop all other capabilities
-#ifndef HAVE_GCOV // the following filter will prevent GCOV from saving info in .gcda files
-				caps_set(set);
-#endif
-			}
-		}
-
-		if (filtermask & SBOX_SECCOMP) {
-			if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)) {
-				perror("prctl(NO_NEW_PRIVS)");
-			}
-			if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog)) {
-				perror("prctl(PR_SET_SECCOMP)");
-			}
-		}
-
-		if (filtermask & SBOX_ROOT) {
-			// elevate privileges in order to get grsecurity working
-			if (setreuid(0, 0))
-				errExit("setreuid");
-			if (setregid(0, 0))
-				errExit("setregid");
-		}
-		else if (filtermask & SBOX_USER)
-			drop_privs(1);
-
-		if (arg[0]) { // get rid of scan-build warning
-			int fd = open(arg[0], O_PATH | O_CLOEXEC);
-			if (fd == -1) {
-				if (errno == ENOENT) {
-					fprintf(stderr, "Error: %s does not exist\n", arg[0]);
-					exit(1);
-				} else {
-					errExit("open");
-				}
-			}
-			struct stat s;
-			if (fstat(fd, &s) == -1)
-				errExit("fstat");
-			if (s.st_uid != 0 && s.st_gid != 0) {
-				fprintf(stderr, "Error: %s is not owned by root, refusing to execute\n", arg[0]);
-				exit(1);
-			}
-			if (s.st_mode & 00002) {
-				fprintf(stderr, "Error: %s is world writable, refusing to execute\n", arg[0]);
-				exit(1);
-			}
-			fexecve(fd, arg, new_environment);
-		} else {
-			assert(0);
-		}
-		perror("fexecve");
-		_exit(1);
+		sbox_do_exec_v(filtermask, arg);
 	}
 
 	int status;
@@ -282,4 +287,20 @@ int sbox_run_v(unsigned filtermask, char * const arg[]) {
 	}
 
 	return status;
+}
+
+void sbox_exec_v(unsigned filtermask, char * const arg[]) {
+	EUID_ROOT();
+
+	if (arg_debug) {
+		printf("sbox exec: ");
+		int i = 0;
+		while (arg[i]) {
+			printf("%s ", arg[i]);
+			i++;
+		}
+		printf("\n");
+	}
+
+	sbox_do_exec_v(filtermask, arg);
 }

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -53,6 +53,12 @@ static char *usage_str =
 #endif
 	"    --cpu=cpu-number,cpu-number - set cpu affinity.\n"
 	"    --cpu.print=name|pid - print the cpus in use.\n"
+	"    --dbus-system=filter|none - set system DBus access policy.\n"
+	"    --dbus-system.own=name - allow ownership of name on the system DBus.\n"
+	"    --dbus-system.talk-name - allow talking to name on the system DBus.\n"
+	"    --dbus-user=filter|none - set session DBus access policy.\n"
+	"    --dbus-user.own=name - allow ownership of name on the session DBus.\n"
+	"    --dbus-user.talk-name - allow talking to name on the session DBus.\n"
 	"    --debug - print sandbox debug messages.\n"
 	"    --debug-blacklists - debug blacklisting.\n"
 	"    --debug-caps - print all recognized capabilities.\n"

--- a/src/include/rundefs.h
+++ b/src/include/rundefs.h
@@ -30,6 +30,7 @@
 #define RUN_FIREJAIL_NETWORK_DIR	RUN_FIREJAIL_DIR "/network"
 #define RUN_FIREJAIL_BANDWIDTH_DIR	RUN_FIREJAIL_DIR "/bandwidth"
 #define RUN_FIREJAIL_PROFILE_DIR	RUN_FIREJAIL_DIR "/profile"
+#define RUN_FIREJAIL_DBUS_DIR RUN_FIREJAIL_DIR "/dbus"
 #define RUN_NETWORK_LOCK_FILE		RUN_FIREJAIL_DIR "/firejail-network.lock"
 #define RUN_DIRECTORY_LOCK_FILE		RUN_FIREJAIL_DIR "/firejail-run.lock"
 #define RUN_RO_DIR			RUN_FIREJAIL_DIR "/firejail.ro.dir"

--- a/src/include/rundefs.h
+++ b/src/include/rundefs.h
@@ -57,6 +57,9 @@
 #define RUN_DHCLIENT_4_LEASES_FILE		RUN_DHCLIENT_DIR "/dhclient.leases"
 #define RUN_DHCLIENT_4_PID_FILE			RUN_DHCLIENT_DIR "/dhclient.pid"
 #define RUN_DHCLIENT_6_PID_FILE			RUN_DHCLIENT_DIR "/dhclient6.pid"
+#define RUN_DBUS_DIR        RUN_MNT_DIR "/dbus"
+#define RUN_DBUS_USER_SOCKET        RUN_DBUS_DIR "/user"
+#define RUN_DBUS_SYSTEM_SOCKET      RUN_DBUS_DIR "/system"
 
 #define RUN_SECCOMP_DIR			RUN_MNT_DIR "/seccomp"
 #define RUN_SECCOMP_LIST		RUN_SECCOMP_DIR "/seccomp.list"		// list of seccomp files installed

--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -494,7 +494,7 @@ Allow the application to own the name org.gnome.ghex and all names underneath in
 \fBdbus-user.talk org.freedesktop.Notifications
 Allow the application to talk to the name org.freedesktop.Notifications on the session DBus.
 .TP
-\fBnodbus
+\fBnodbus \fR(deprecated)
 Disable D-Bus access (both system and session buses). Equivalent to dbus-system none and dbus-user none.
 
 .SH Resource limits, CPU affinity, Control Groups

--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -447,7 +447,55 @@ xephyr-screen 640x480
 .br
 x11 xephyr
 
+.SH DBus filtering
 
+Access to the session and system DBus UNIX sockets can be allowed, filtered or
+disabled. To disable the abstract sockets (and force applications to use the
+filtered UNIX socket) you would need to request a new network namespace using
+\-\-net command. Another option is to remove unix from the \-\-protocol set.
+.br
+
+.br
+Filtering requires installing the xdg-dbus-proxy utility. Filter rules can be
+specified for well-known DBus names, but they are also propagated to the owning
+unique name, too. The permissions are "sticky" and are kept even if the
+corresponding well-know name is released (however, applications rarely release
+well-known names in practice). Names may have a .* suffix to match all names
+underneath them, including themselves (e.g. "foo.bar.*" matches "foo.bar",
+"foo.bar.baz" and "foo.bar.baz.quux", but not "foobar"). For more information,
+see xdg-dbus-proxy(1).
+.br
+
+.br
+Examples:
+
+.TP
+\fBdbus-system filter
+Enable filtered access to the system DBus. Filters can be specified with the dbus-system.talk and dbus-system.own commands.
+.TP
+\fBdbus-system none
+Disable access to the system DBus. Once access is disabled, it cannot be relaxed to filtering.
+.TP
+\fBdbus-system.own org.gnome.ghex.*
+Allow the application to own the name org.gnome.ghex and all names underneath in on the system DBus.
+.TP
+\fBdbus-system.talk org.freedesktop.Notifications
+Allow the application to talk to the name org.freedesktop.Notifications on the system DBus.
+.TP
+\fBdbus-user filter
+Enable filtered access to the session DBus. Filters can be specified with the dbus-user.talk and dbus-user.own commands.
+.TP
+\fBdbus-user none
+Disable access to the session DBus. Once access is disabled, it cannot be relaxed to filtering.
+.TP
+\fBdbus-user.own org.gnome.ghex.*
+Allow the application to own the name org.gnome.ghex and all names underneath in on the session DBus.
+.TP
+\fBdbus-user.talk org.freedesktop.Notifications
+Allow the application to talk to the name org.freedesktop.Notifications on the session DBus.
+.TP
+\fBnodbus
+Disable D-Bus access (both system and session buses). Equivalent to dbus-system none and dbus-user none.
 
 .SH Resource limits, CPU affinity, Control Groups
 These profile entries define the limits on system resources (rlimits) for the processes inside the sandbox.
@@ -521,12 +569,6 @@ Disable 3D hardware acceleration.
 \fBnoautopulse
 Disable automatic ~/.config/pulse init, for complex setups such as remote
 pulse servers or non-standard socket paths.
-.TP
-\fBnodbus
-Disable D-Bus access. Only the regular UNIX socket is handled by
-this command. To disable the abstract socket, you would need to
-request a new network namespace using the net command. Another
-option is to remove unix from protocol set.
 .TP
 \fBnodvd
 Disable DVD and audio CD devices.

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -326,6 +326,112 @@ $ firejail \-\-list
 $ firejail \-\-cpu.print=3272
 
 .TP
+\fB\-\-dbus-system=filter|none
+Set system DBus sandboxing policy. 
+.br
+
+.br
+The \fBfilter\fR policy enables the system DBus filter. This option requires
+installing the xdg-dbus-proxy utility. Permissions for well-known can be
+specified with the --dbus-system.talk and --dbus-system.own options.
+.br
+
+.br
+The \fBnone\fR policy disables access to the system DBus.
+.br
+
+.br
+Only the regular system DBus UNIX socket is handled by this option. To disable
+the abstract sockets (and force applications to use the filtered UNIX socket)
+you would need to request a new network namespace using \-\-net command. Another
+option is to remove unix from the \-\-protocol set.
+.br
+
+.br
+Example:
+.br
+$ firejail \-\-dbus-system=none
+
+.TP
+\fB\-\-dbus-system.own=name
+Allows the application to own the specified well-known name on the system DBus.
+The name may have a .* suffix to match all names underneath it, including itself
+(e.g. "foo.bar.*" matches "foo.bar", "foo.bar.baz" and "foo.bar.baz.quux", but
+not "foobar").
+.br
+
+.br
+Example:
+.br
+$ firejail --dbus-system=filter --dbus-system.own=org.gnome.ghex.*
+
+.TP
+\fB\-\-dbus-system.talk=name
+Allows the application to talk to the specified well-known name on the system DBus.
+The name may have a .* suffix to match all names underneath it, including itself
+(e.g. "foo.bar.*" matches "foo.bar", "foo.bar.baz" and "foo.bar.baz.quux", but
+not "foobar").
+.br
+
+.br
+Example:
+.br
+$ firejail --dbus-system=filter --dbus-system.talk=org.freedesktop.Notifications
+
+.TP
+\fB\-\-dbus-user=filter|none
+Set session DBus sandboxing policy.
+.br
+
+.br
+The \fBfilter\fR policy enables the session DBus filter. This option requires
+installing the xdg-dbus-proxy utility. Permissions for well-known names can be
+added with the --dbus-user.talk and --dbus-user.own options.
+.br
+
+.br
+The \fBnone\fR policy disables access to the session DBus.
+.br
+
+.br
+Only the regular session DBus UNIX socket is handled by this option. To disable
+the abstract sockets (and force applications to use the filtered UNIX socket)
+you would need to request a new network namespace using \-\-net command. Another
+option is to remove unix from the \-\-protocol set.
+.br
+
+.br
+Example:
+.br
+$ firejail \-\-dbus-user=none
+
+.TP
+\fB\-\-dbus-user.own=name
+Allows the application to own the specified well-known name on the session DBus.
+The name may have a .* suffix to match all names underneath it, including itself
+(e.g. "foo.bar.*" matches "foo.bar", "foo.bar.baz" and "foo.bar.baz.quux", but
+not "foobar").
+.br
+
+.br
+Example:
+.br
+$ firejail --dbus-user=filter --dbus-user.own=org.gnome.ghex.*
+
+.TP
+\fB\-\-dbus-user.talk=name
+Allows the application to talk to the specified well-known name on the session DBus.
+The name may have a .* suffix to match all names underneath it, including itself
+(e.g. "foo.bar.*" matches "foo.bar", "foo.bar.baz" and "foo.bar.baz.quux", but
+not "foobar").
+.br
+
+.br
+Example:
+.br
+$ firejail --dbus-user=filter --dbus-user.talk=org.freedesktop.Notifications
+
+.TP
 \fB\-\-debug\fR
 Print debug messages.
 .br
@@ -1171,11 +1277,7 @@ $ nc dict.org 2628
 .br
 .TP
 \fB\-\-nodbus
-Disable D-Bus access (both system and session buses). Only the regular
-UNIX sockets are handled by this command. To disable the abstract
-sockets you would need to request a new network namespace using
-\-\-net command. Another option is to remove unix from \-\-protocol
-set.
+Disable D-Bus access (both system and session buses). Equivalent to --dbus-system=none --dbus-user=none.
 .br
 
 .br

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -1276,7 +1276,7 @@ $ nc dict.org 2628
 220 pan.alephnull.com dictd 1.12.1/rf on Linux 3.14-1-amd64
 .br
 .TP
-\fB\-\-nodbus
+\fB\-\-nodbus \fR(deprecated)
 Disable D-Bus access (both system and session buses). Equivalent to --dbus-system=none --dbus-user=none.
 .br
 


### PR DESCRIPTION
This PR adds the `dbus-user` and `dbus-system` options to individually control access to the session and system DBus buses, as per #3184. Access policies to the buses can be `allow`, which completely allows the bus, `filter`, which runs [`xdg-dbus-proxy`](https://github.com/flatpak/xdg-dbus-proxy), and `none`, which disables access. The `nodbus` options, which is equivalent to `dbus-user none` `dbus-system none` is kept for compatibility.

Filter rules for `xdg-dbus-proxy` can be specified with the `dbus-user.talk`, `dbus-user.own`, `dbus-system.talk`, and `dbus-system.own` options. While `xdg-dbus-proxy` implements finer-grained rules, these four should hopefully be enough to convert filter rules from Flatpak manifests.

On the implementation side:
- The new filter rules are added to the profile similarly to `blacklist` and `whitelist` commands.
- `xdg-dbus-proxy` runs outside the sandbox namespace (to maintain access to the original DBus sockets), but contained by a modified version of `sbox_run`. It is linked to the parent firejail process by a pipe fd, closing which triggers its exit, so it (hopefully) quits when the parent firejail process exits for any reason.
- Filtered DBus sockets are in `/run/firejail/dbus` and are bind-mounted to their usual locations inside the sandbox. Even the system DBus socket is owned the user running the sandbox, not root, because if we `chown` it to root, xdg-dbus-proxy cannot clean them up when it exits (an the parent firejail process might not be around to clean the up instead). So inside the sandbox, the system DBus socket is owned by a normal user. This does not cause any problems when connecting to the bus, but might be used to detect the sandbox.

This PR does not contain any profile changes, so all profiles remain to constrain DBus access in a coarse-grained way. Hopefully, in the future, profiles can be updated to take advantage of DBus filtering, but that might require a hard dependency on xdg-dbus-proxy, or some auto-detection mechanism.