### PR TITLE
remount hardening: move to file descriptor based mounts

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -394,6 +394,7 @@ typedef enum {
 	MOUNT_TMPFS,
 	MOUNT_NOEXEC,
 	MOUNT_RDWR,
+	MOUNT_RDWR_NOCHECK, // no check of ownership
 	OPERATION_MAX
 } OPERATION;
 
@@ -402,8 +403,7 @@ void fs_blacklist(void);
 // mount a writable tmpfs
 void fs_tmpfs(const char *dir, unsigned check_owner);
 // remount noexec/nodev/nosuid or read-only or read-write
-void fs_remount(const char *dir, OPERATION op, unsigned check_mnt);
-void fs_remount_rec(const char *dir, OPERATION op, unsigned check_mnt);
+void fs_remount(const char *dir, OPERATION op, int rec);
 // mount /proc and /sys directories
 void fs_proc_sys_dev_boot(void);
 // blacklist firejail configuration and runtime directories

--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -478,10 +478,8 @@ static void fs_remount_simple(const char *path, OPERATION op) {
 
 	// open path without following symbolic links
 	int fd = safe_fd(path, O_PATH|O_NOFOLLOW|O_CLOEXEC);
-	if (fd == -1) {
-		fwarning("cannot open %s, skipping the remount...\n", path);
-		return;
-	}
+	if (fd == -1)
+		errExit("open");
 	// identify file owner
 	struct stat s;
 	if (fstat(fd, &s) == -1)


### PR DESCRIPTION
Harden `noexec`, `read-only`, `read-write` options by moving entirely to file descriptor based mounts.

Along the way fix long-time broken `writable-var-log` option, which didn't work any more because of an ownership check.