### PR TITLE
profiles: whitelist firefox/thunderbird default directories

### DIFF
--- a/etc/firefox.profile
+++ b/etc/firefox.profile
@@ -15,6 +15,7 @@ whitelist ${HOME}/.cache/mozilla/firefox
 whitelist ${HOME}/.mozilla
 
 whitelist /usr/share/doc
+whitelist /usr/share/firefox
 whitelist /usr/share/gtk-doc/html
 whitelist /usr/share/mozilla
 whitelist /usr/share/webext

--- a/etc/thunderbird.profile
+++ b/etc/thunderbird.profile
@@ -47,6 +47,7 @@ whitelist ${HOME}/.thunderbird
 
 whitelist /usr/share/gnupg
 whitelist /usr/share/mozilla
+whitelist /usr/share/thunderbird
 whitelist /usr/share/webext
 include whitelist-usr-share-common.inc
 


### PR DESCRIPTION
Not whitelisting these directories causes firefox to not apply some settings on startup (e.g. it asks whether it should be default browser).

(See also: https://bugs.debian.org/948656)