### PR TITLE
zoom.profile: fix zoom SSO workflow

### DIFF
--- a/etc/zoom.profile
+++ b/etc/zoom.profile
@@ -27,7 +27,7 @@ nodvd
 nonewprivs
 noroot
 notv
-protocol unix,inet,inet6
-seccomp
+protocol unix,inet,inet6,netlink
+seccomp !chroot
 
 private-tmp


### PR DESCRIPTION
The zoom SSO workflow launches an embedded sandboxed browser
(QtWebEngineProcess) which requires chroot and netlink to work.

Fixes #3272
