### PR TITLE
add name or private directory being used to the window title when xpra is being used

### DIFF
--- a/src/firejail/x11.c
+++ b/src/firejail/x11.c
@@ -641,6 +641,10 @@ static char * get_title_arg_str() {
 	if ((cfg.name != NULL) && (strlen(cfg.name) > 0)) {
 
 		title_arg_str = malloc(strlen(title_start) + strlen(title_sep) + strlen(cfg.name) + 1);
+		if (title_arg_str == NULL) {
+			fprintf(stderr, "Error: malloc() failed to allocate memory\n");
+			exit(1);
+		}
 
 		strcpy(title_arg_str, title_start);
 		strcat(title_arg_str, title_sep);
@@ -650,10 +654,13 @@ static char * get_title_arg_str() {
 	// use the "--private" argument if it was explicitly specified
 	else if ((cfg.home_private != NULL) && (strlen(cfg.home_private) > 0)) {
 
-		char * tmp_in = strdupa(cfg.home_private);
-		char * base_out = strdupa(basename(tmp_in));
+		const char * base_out = gnu_basename(cfg.home_private);
 
 		title_arg_str = malloc(strlen(title_start) + strlen(title_sep) + strlen(base_out) + 1);
+		if (title_arg_str == NULL) {
+			fprintf(stderr, "Error: malloc() failed to allocate memory\n");
+			exit(1);
+		}
 
 		strcpy(title_arg_str, title_start);
 		strcat(title_arg_str, title_sep);
@@ -663,6 +670,10 @@ static char * get_title_arg_str() {
 	// default
 	else {
 		title_arg_str = malloc(strlen(title_start) + 1);
+		if (title_arg_str == NULL) {
+			fprintf(stderr, "Error: malloc() failed to allocate memory\n");
+			exit(1);
+		}
 
 		strcpy(title_arg_str, title_start);
 	}

--- a/src/firejail/x11.c
+++ b/src/firejail/x11.c
@@ -625,6 +625,52 @@ void x11_start_xephyr(int argc, char **argv) {
 }
 
 
+// this function returns the string that will appear in the window title when xpra is being used
+// this string may include one of these items:
+// *  the "--name" argument, if specified
+// *  the basename portion of the "--private" directory, if specified
+// note: the malloc() is leaking, but this is a small string allocated one time only during startup, so don't care
+static char * get_title_arg_str() {
+
+	char * title_arg_str = NULL;
+
+	const char * title_start = "--title=firejail x11 sandbox";
+	const char * title_sep = " ";
+
+	// use the "--name" argument if it was explicitly specified
+	if ((cfg.name != NULL) && (strlen(cfg.name) > 0)) {
+
+		title_arg_str = malloc(strlen(title_start) + strlen(title_sep) + strlen(cfg.name) + 1);
+
+		strcpy(title_arg_str, title_start);
+		strcat(title_arg_str, title_sep);
+		strcat(title_arg_str, cfg.name);
+	}
+
+	// use the "--private" argument if it was explicitly specified
+	else if ((cfg.home_private != NULL) && (strlen(cfg.home_private) > 0)) {
+
+		char * tmp_in = strdupa(cfg.home_private);
+		char * base_out = strdupa(basename(tmp_in));
+
+		title_arg_str = malloc(strlen(title_start) + strlen(title_sep) + strlen(base_out) + 1);
+
+		strcpy(title_arg_str, title_start);
+		strcat(title_arg_str, title_sep);
+		strcat(title_arg_str, base_out);
+	}
+
+	// default
+	else {
+		title_arg_str = malloc(strlen(title_start) + 1);
+
+		strcpy(title_arg_str, title_start);
+	}
+
+	return title_arg_str;
+}
+
+
 void x11_start_xpra_old(int argc, char **argv, int display, char *display_str) {
 	EUID_ASSERT();
 	int i;
@@ -752,7 +798,10 @@ void x11_start_xpra_old(int argc, char **argv, int display, char *display_str) {
 	free(fname);
 
 	// build attach command
-	char *attach_argv[] = { "xpra", "--title=\"firejail x11 sandbox\"", "attach", display_str, NULL };
+
+	char * title_arg_str = get_title_arg_str();
+
+	char *attach_argv[] = { "xpra", title_arg_str, "attach", display_str, NULL };
 
 	// run attach command
 	client = fork();


### PR DESCRIPTION
First, thanks for making firejail available.  It is outstanding.

I use a number of different private directories, and wanted some kind of visual indication of which private directory was being used by each instance of a running firefox.  This PR adds this information to the window title when xpra is being used.  I find this to be very valuable for me, and maybe others will as well.

This PR may be related to at least some of this prior issues (in no particular order):
https://github.com/netblue30/firejail/issues/1983
https://github.com/netblue30/firejail/issues/1350
https://github.com/netblue30/firejail/issues/1308
https://github.com/netblue30/firejail/issues/281
https://github.com/netblue30/firejail/issues/303
https://github.com/netblue30/firejail/issues/424
https://github.com/netblue30/firejail/issues/242
