### PR TITLE
steam.profile: correctly blacklist unneeded directories in user's home

### DIFF
--- a/etc/steam.profile
+++ b/etc/steam.profile
@@ -36,6 +36,34 @@ include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
 
+mkdir ${HOME}/.killingfloor
+mkdir ${HOME}/.local/share/3909/PapersPlease
+mkdir ${HOME}/.local/share/aspyr-media
+mkdir ${HOME}/.local/share/cdprojektred
+mkdir ${HOME}/.local/share/feral-interactive
+mkdir ${HOME}/.local/share/Steam
+mkdir ${HOME}/.local/share/SuperHexagon
+mkdir ${HOME}/.local/share/Terraria
+mkdir ${HOME}/.local/share/vpltd
+mkdir ${HOME}/.local/share/vulkan
+mkdir ${HOME}/.steam
+mkfile ${HOME}/.steampath
+mkfile ${HOME}/.steampid
+whitelist ${HOME}/.killingfloor
+whitelist ${HOME}/.local/share/3909/PapersPlease
+whitelist ${HOME}/.local/share/aspyr-media
+whitelist ${HOME}/.local/share/cdprojektred
+whitelist ${HOME}/.local/share/feral-interactive
+whitelist ${HOME}/.local/share/Steam
+whitelist ${HOME}/.local/share/SuperHexagon
+whitelist ${HOME}/.local/share/Terraria
+whitelist ${HOME}/.local/share/vpltd
+whitelist ${HOME}/.local/share/vulkan
+whitelist ${HOME}/.steam
+whitelist ${HOME}/.steampath
+whitelist ${HOME}/.steampid
+whitelist ${HOME}/.steampid
+include whitelist-common.inc
 include whitelist-var-common.inc
 
 caps.drop all


### PR DESCRIPTION
`noblacklist` directives prevent following ones from blacklisting the specified directory/file.

The profile currently has a `noblacklist` directive for each directory used by Steam and/or its games, which is fine.

However, there are no directives blacklisting the user's home, thus all directories and files inside it are accessible by Steam.

This pull request fixes the issue by adding `whitelist` directives, which automatically blacklist the parent directory (in this case the user's home).

`mkdir` and `mkfile` directives are added so that the directories/files are created if they don't exist.

Thanks to @SkewedZeppelin for suggesting to keep `noblacklist` and use `mkdir` and `mkfile`.