### PR TITLE
fsec-print: print address of BPF_JA jump in hex

### DIFF
--- a/src/fsec-print/print.c
+++ b/src/fsec-print/print.c
@@ -250,7 +250,7 @@ static void bpf_decode_args(const struct sock_filter *bpf, unsigned int line) {
 		break;
 	case BPF_JMP:
 		if (BPF_OP(bpf->code) == BPF_JA) {
-			printf("%.4u", (line + 1) + bpf->k);
+			printf("%.4x", (line + 1) + bpf->k);
 		}
 		else {
 			const char *name = NULL;


### PR DESCRIPTION
Since target addresses for other (conditional) jumps are in hex, it's
very confusing to have one jump address in decimal.