### PR TITLE
Added compatibility with BetterDiscord

### DIFF
--- a/etc/discord-common.profile
+++ b/etc/discord-common.profile
@@ -15,6 +15,8 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 
 whitelist ${DOWNLOADS}
+whitelist ${HOME}/.config/BetterDiscord
+whitelist ${HOME}/.local/share/betterdiscordctl
 include whitelist-common.inc
 include whitelist-var-common.inc
 


### PR DESCRIPTION
BetterDiscord is a nice utility that allows direct modifications to Discord if the user wishes so. To make it work, dirs in .config and .local/share need to be whitelisted.

Signed-off-by: Atrate <Atrate@protonmail.com>