### PR TITLE
Speedup the buildsystem

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -128,13 +128,12 @@ endif
 	install -c -m 0644 RELNOTES $(DESTDIR)/$(DOCDIR)/.
 	install -c -m 0644 etc/templates/* $(DESTDIR)/$(DOCDIR)/.
 	# etc files
-	./mketc.sh $(sysconfdir) $(BUSYBOX_WORKAROUND)
+ifeq ($(BUSYBOX_WORKAROUND),yes)
+	./mketc.sh
+endif
 	install -m 0755 -d $(DESTDIR)/$(sysconfdir)/firejail
-	for file in .etc/* etc/firejail.config; do \
-		install -c -m 0644 $$file $(DESTDIR)/$(sysconfdir)/firejail; \
-	done
+	install -m 0644 -t $(DESTDIR)/$(sysconfdir)/firejail etc/{*.profile,*.inc,*.net,firejail.config}
 	sh -c "if [ ! -f $(DESTDIR)/$(sysconfdir)/firejail/login.users ]; then install -c -m 0644 etc/login.users $(DESTDIR)/$(sysconfdir)/firejail/.; fi;"
-	rm -fr .etc
 ifeq ($(HAVE_APPARMOR),-DHAVE_APPARMOR)
 	# install apparmor profile
 	sh -c "if [ ! -d $(DESTDIR)/$(sysconfdir)/apparmor.d ]; then install -d -m 755 $(DESTDIR)/$(sysconfdir)/apparmor.d; fi;"

--- a/mketc.sh
+++ b/mketc.sh
@@ -3,16 +3,6 @@
 # Copyright (C) 2014-2020 Firejail Authors
 # License GPL v2
 
-rm -fr .etc
-mkdir .etc
-
-for file in etc/*.profile etc/*.inc etc/*.net;
-do
-	sed "s;/etc/firejail;$1/firejail;g" $file > .$file
-done
-
-if [ "x$2" = "xyes" ]
-then
 sed -i -e '
 1i# Workaround for systems where common UNIX utilities are symlinks to busybox.\
 # If this is not your case you can remove --enable-busybox-workaround from\
@@ -23,5 +13,4 @@ noblacklist \${PATH}/su\
 noblacklist \${PATH}/sudo\
 noblacklist \${PATH}/nc\
 noblacklist \${PATH}/crontab\
-' .etc/disable-common.inc
-fi
+' etc/disable-common.inc


### PR DESCRIPTION
 - replaing 'include /etc/firejail/foobar.inc' with
   'include $(sysconfdir)/firejail/foobar.inc' is useless since 0.9.58
 - onetime calling install with globbing is faster the a loop calling
   install nearly 1000 times