### PR TITLE
improve firejail's error messaging

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -237,7 +237,7 @@ static int extract_pid(const char *name, pid_t *pid) {
 	int retval = 0;
 	EUID_ASSERT();
 	if (!name || strlen(name) == 0) {
-		fprintf(stderr, "Error: invalid sandbox name\n");
+		fprintf(stderr, "[firejail] Error: invalid sandbox name\n");
 		exit(1);
 	}
 
@@ -269,7 +269,7 @@ static int read_pid(const char *name, pid_t *pid) {
 static pid_t require_pid(const char *name) {
 	pid_t pid;
 	if (read_pid(name,&pid)) {
-		fprintf(stderr, "Error: cannot find sandbox %s\n", name);
+		fprintf(stderr, "[firejail] Error: cannot find sandbox %s\n", name);
 		exit(1);
 	}
 	return pid;
@@ -291,7 +291,7 @@ static int has_link(const char *dir) {
 static void check_homedir(void) {
 	assert(cfg.homedir);
 	if (cfg.homedir[0] != '/') {
-		fprintf(stderr, "Error: invalid user directory \"%s\"\n", cfg.homedir);
+		fprintf(stderr, "[firejail] Error: invalid user directory \"%s\"\n", cfg.homedir);
 		exit(1);
 	}
 	// symlinks are rejected in many places
@@ -341,7 +341,7 @@ static void init_cfg(int argc, char **argv) {
 
 	// build home directory name
 	if (pw->pw_dir == NULL) {
-		fprintf(stderr, "Error: user %s doesn't have a user directory assigned\n", cfg.username);
+		fprintf(stderr, "[firejail] Error: user %s doesn't have a user directory assigned\n", cfg.username);
 		exit(1);
 	}
 	cfg.homedir = clean_pathname(pw->pw_dir);
@@ -425,7 +425,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 	else if (strcmp(argv[i], "--overlay-clean") == 0) {
 		if (checkcfg(CFG_OVERLAYFS)) {
 			if (remove_overlay_directory()) {
-				fprintf(stderr, "Error: cannot remove overlay directory\n");
+				fprintf(stderr, "[firejail] Error: cannot remove overlay directory\n");
 				exit(1);
 			}
 		}
@@ -475,12 +475,12 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 
 			// extract the command
 			if ((i + 1) == argc) {
-				fprintf(stderr, "Error: command expected after --bandwidth option\n");
+				fprintf(stderr, "[firejail] Error: command expected after --bandwidth option\n");
 				exit(1);
 			}
 			char *cmd = argv[i + 1];
 			if (strcmp(cmd, "status") && strcmp(cmd, "clear") && strcmp(cmd, "set")) {
-				fprintf(stderr, "Error: invalid --bandwidth command.\nValid commands: set, clear, status.\n");
+				fprintf(stderr, "[firejail] Error: invalid --bandwidth command.\nValid commands: set, clear, status.\n");
 				exit(1);
 			}
 
@@ -491,32 +491,32 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 			if (strcmp(cmd, "set") == 0 || strcmp(cmd, "clear") == 0) {
 				// extract device name
 				if ((i + 2) == argc) {
-					fprintf(stderr, "Error: network name expected after --bandwidth %s option\n", cmd);
+					fprintf(stderr, "[firejail] Error: network name expected after --bandwidth %s option\n", cmd);
 					exit(1);
 				}
 				dev = argv[i + 2];
 
 				// check device name
 				if (if_nametoindex(dev) == 0) {
-					fprintf(stderr, "Error: network device %s not found\n", dev);
+					fprintf(stderr, "[firejail] Error: network device %s not found\n", dev);
 					exit(1);
 				}
 
 				// extract bandwidth
 				if (strcmp(cmd, "set") == 0) {
 					if ((i + 4) >= argc) {
-						fprintf(stderr, "Error: invalid --bandwidth set command\n");
+						fprintf(stderr, "[firejail] Error: invalid --bandwidth set command\n");
 						exit(1);
 					}
 
 					down = atoi(argv[i + 3]);
 					if (down < 0) {
-						fprintf(stderr, "Error: invalid download speed\n");
+						fprintf(stderr, "[firejail] Error: invalid download speed\n");
 						exit(1);
 					}
 					up = atoi(argv[i + 4]);
 					if (up < 0) {
-						fprintf(stderr, "Error: invalid upload speed\n");
+						fprintf(stderr, "[firejail] Error: invalid upload speed\n");
 						exit(1);
 					}
 				}
@@ -606,7 +606,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 			errExit("asprintf");
 		FILE *fp = fopen(fname, "r");
 		if (!fp) {
-			fprintf(stderr, "Error: sandbox %s not found\n", argv[i] + 16);
+			fprintf(stderr, "[firejail] Error: sandbox %s not found\n", argv[i] + 16);
 			exit(1);
 		}
 #define MAXBUF 4096
@@ -709,19 +709,19 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 		if (checkcfg(CFG_FILE_TRANSFER)) {
 			logargs(argc, argv);
 			if (arg_private_cwd) {
-				fprintf(stderr, "Error: --get and --private-cwd options are mutually exclusive\n");
+				fprintf(stderr, "[firejail] Error: --get and --private-cwd options are mutually exclusive\n");
 				exit(1);
 			}
 
 			// verify path
 			if ((i + 2) != argc) {
-				fprintf(stderr, "Error: invalid --get option, path expected\n");
+				fprintf(stderr, "[firejail] Error: invalid --get option, path expected\n");
 				exit(1);
 			}
 			char *path = argv[i + 1];
 			 invalid_filename(path, 0); // no globbing
 			 if (strstr(path, "..")) {
-			 	fprintf(stderr, "Error: invalid file name %s\n", path);
+			 	fprintf(stderr, "[firejail] Error: invalid file name %s\n", path);
 			 	exit(1);
 			 }
 
@@ -737,25 +737,25 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 		if (checkcfg(CFG_FILE_TRANSFER)) {
 			logargs(argc, argv);
 			if (arg_private_cwd) {
-				fprintf(stderr, "Error: --put and --private-cwd options are mutually exclusive\n");
+				fprintf(stderr, "[firejail] Error: --put and --private-cwd options are mutually exclusive\n");
 				exit(1);
 			}
 
 			// verify path
 			if ((i + 3) != argc) {
-				fprintf(stderr, "Error: invalid --put option, 2 paths expected\n");
+				fprintf(stderr, "[firejail] Error: invalid --put option, 2 paths expected\n");
 				exit(1);
 			}
 			char *path1 = argv[i + 1];
 			 invalid_filename(path1, 0); // no globbing
 			 if (strstr(path1, "..")) {
-			 	fprintf(stderr, "Error: invalid file name %s\n", path1);
+			 	fprintf(stderr, "[firejail] Error: invalid file name %s\n", path1);
 			 	exit(1);
 			 }
 			char *path2 = argv[i + 2];
 			 invalid_filename(path2, 0); // no globbing
 			 if (strstr(path2, "..")) {
-			 	fprintf(stderr, "Error: invalid file name %s\n", path2);
+			 	fprintf(stderr, "[firejail] Error: invalid file name %s\n", path2);
 			 	exit(1);
 			 }
 
@@ -771,19 +771,19 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 		if (checkcfg(CFG_FILE_TRANSFER)) {
 			logargs(argc, argv);
 			if (arg_private_cwd) {
-				fprintf(stderr, "Error: --ls and --private-cwd options are mutually exclusive\n");
+				fprintf(stderr, "[firejail] Error: --ls and --private-cwd options are mutually exclusive\n");
 				exit(1);
 			}
 
 			// verify path
 			if ((i + 2) != argc) {
-				fprintf(stderr, "Error: invalid --ls option, path expected\n");
+				fprintf(stderr, "[firejail] Error: invalid --ls option, path expected\n");
 				exit(1);
 			}
 			char *path = argv[i + 1];
 			 invalid_filename(path, 0); // no globbing
 			 if (strstr(path, "..")) {
-			 	fprintf(stderr, "Error: invalid file name %s\n", path);
+			 	fprintf(stderr, "[firejail] Error: invalid file name %s\n", path);
 			 	exit(1);
 			 }
 
@@ -802,7 +802,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 
 			if (arg_shell_none) {
 				if (argc <= (i+1)) {
-					fprintf(stderr, "Error: --shell=none set, but no command specified\n");
+					fprintf(stderr, "[firejail] Error: --shell=none set, but no command specified\n");
 					exit(1);
 				}
 				cfg.original_program_index = i + 1;
@@ -828,7 +828,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 
 			if (arg_shell_none) {
 				if (argc <= (i+1)) {
-					fprintf(stderr, "Error: --shell=none set, but no command specified\n");
+					fprintf(stderr, "[firejail] Error: --shell=none set, but no command specified\n");
 					exit(1);
 				}
 				cfg.original_program_index = i + 1;
@@ -854,7 +854,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 			logargs(argc, argv);
 			arg_join_network = 1;
 			if (getuid() != 0) {
-				fprintf(stderr, "Error: --join-network is only available to root user\n");
+				fprintf(stderr, "[firejail] Error: --join-network is only available to root user\n");
 				exit(1);
 			}
 
@@ -874,7 +874,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 		logargs(argc, argv);
 		arg_join_filesystem = 1;
 		if (getuid() != 0) {
-			fprintf(stderr, "Error: --join-filesystem is only available to root user\n");
+			fprintf(stderr, "[firejail] Error: --join-filesystem is only available to root user\n");
 			exit(1);
 		}
 
@@ -1021,21 +1021,21 @@ int main(int argc, char **argv, char **envp) {
 
 	// argument count should be larger than 0
 	if (argc == 0 || !argv || strlen(argv[0]) == 0) {
-		fprintf(stderr, "Error: argv[0] is NULL\n");
+		fprintf(stderr, "[firejail] Error: argv[0] is NULL\n");
 		exit(1);
 	} else if (argc >= MAX_ARGS) {
-		fprintf(stderr, "Error: too many arguments\n");
+		fprintf(stderr, "[firejail] Error: too many arguments\n");
 		exit(1);
 	}
 
 	// sanity check for arguments
 	for (i = 0; i < argc; i++) {
 		if (*argv[i] == 0) {
-			fprintf(stderr, "Error: too short arguments\n");
+			fprintf(stderr, "[firejail] Error: too short arguments\n");
 			exit(1);
 		}
 		if (strlen(argv[i]) >= MAX_ARG_LEN) {
-			fprintf(stderr, "Error: too long arguments\n");
+			fprintf(stderr, "[firejail] Error: too long arguments\n");
 			exit(1);
 		}
 	}
@@ -1043,12 +1043,12 @@ int main(int argc, char **argv, char **envp) {
 	// sanity check for environment variables
 	for (i = 0, ptr = envp; ptr && *ptr && i < MAX_ENVS; i++, ptr++) {
 		if (strlen(*ptr) >= MAX_ENV_LEN) {
-			fprintf(stderr, "Error: too long environment variables\n");
+			fprintf(stderr, "[firejail] Error: too long environment variables\n");
 			exit(1);
 		}
 	}
 	if (i >= MAX_ENVS) {
-		fprintf(stderr, "Error: too many environment variables\n");
+		fprintf(stderr, "[firejail] Error: too many environment variables\n");
 		exit(1);
 	}
 
@@ -1092,11 +1092,11 @@ int main(int argc, char **argv, char **envp) {
 		int major;
 		int minor;
 		if (2 != sscanf(u.release, "%d.%d", &major, &minor)) {
-			fprintf(stderr, "Error: cannot extract Linux kernel version: %s\n", u.version);
+			fprintf(stderr, "[firejail] Error: cannot extract Linux kernel version: %s\n", u.version);
 			exit(1);
 		}
 		if (major < 4 || (major == 4 && minor < 8)) {
-			fprintf(stderr, "Error: --allow-debuggers is disabled on Linux kernels prior to 4.8. "
+			fprintf(stderr, "[firejail] Error: --allow-debuggers is disabled on Linux kernels prior to 4.8. "
 				"A bug in ptrace call allows a full bypass of the seccomp filter. "
 				"Your current kernel version is %d.%d.\n", major, minor);
 			exit(1);
@@ -1313,7 +1313,7 @@ int main(int argc, char **argv, char **envp) {
 		else if (strcmp(argv[i], "--seccomp") == 0) {
 			if (checkcfg(CFG_SECCOMP)) {
 				if (arg_seccomp) {
-					fprintf(stderr, "Error: seccomp already enabled\n");
+					fprintf(stderr, "[firejail] Error: seccomp already enabled\n");
 					exit(1);
 				}
 				arg_seccomp = 1;
@@ -1324,7 +1324,7 @@ int main(int argc, char **argv, char **envp) {
 		else if (strncmp(argv[i], "--seccomp=", 10) == 0) {
 			if (checkcfg(CFG_SECCOMP)) {
 				if (arg_seccomp) {
-					fprintf(stderr, "Error: seccomp already enabled\n");
+					fprintf(stderr, "[firejail] Error: seccomp already enabled\n");
 					exit(1);
 				}
 				arg_seccomp = 1;
@@ -1336,7 +1336,7 @@ int main(int argc, char **argv, char **envp) {
 		else if (strncmp(argv[i], "--seccomp.32=", 13) == 0) {
 			if (checkcfg(CFG_SECCOMP)) {
 				if (arg_seccomp32) {
-					fprintf(stderr, "Error: seccomp.32 already enabled\n");
+					fprintf(stderr, "[firejail] Error: seccomp.32 already enabled\n");
 					exit(1);
 				}
 				arg_seccomp32 = 1;
@@ -1348,7 +1348,7 @@ int main(int argc, char **argv, char **envp) {
 		else if (strncmp(argv[i], "--seccomp.drop=", 15) == 0) {
 			if (checkcfg(CFG_SECCOMP)) {
 				if (arg_seccomp) {
-					fprintf(stderr, "Error: seccomp already enabled\n");
+					fprintf(stderr, "[firejail] Error: seccomp already enabled\n");
 					exit(1);
 				}
 				arg_seccomp = 1;
@@ -1360,7 +1360,7 @@ int main(int argc, char **argv, char **envp) {
 		else if (strncmp(argv[i], "--seccomp.32.drop=", 18) == 0) {
 			if (checkcfg(CFG_SECCOMP)) {
 				if (arg_seccomp32) {
-					fprintf(stderr, "Error: seccomp.32 already enabled\n");
+					fprintf(stderr, "[firejail] Error: seccomp.32 already enabled\n");
 					exit(1);
 				}
 				arg_seccomp32 = 1;
@@ -1372,7 +1372,7 @@ int main(int argc, char **argv, char **envp) {
 		else if (strncmp(argv[i], "--seccomp.keep=", 15) == 0) {
 			if (checkcfg(CFG_SECCOMP)) {
 				if (arg_seccomp) {
-					fprintf(stderr, "Error: seccomp already enabled\n");
+					fprintf(stderr, "[firejail] Error: seccomp already enabled\n");
 					exit(1);
 				}
 				arg_seccomp = 1;
@@ -1384,7 +1384,7 @@ int main(int argc, char **argv, char **envp) {
 		else if (strncmp(argv[i], "--seccomp.32.keep=", 18) == 0) {
 			if (checkcfg(CFG_SECCOMP)) {
 				if (arg_seccomp32) {
-					fprintf(stderr, "Error: seccomp.32 already enabled\n");
+					fprintf(stderr, "[firejail] Error: seccomp.32 already enabled\n");
 					exit(1);
 				}
 				arg_seccomp32 = 1;
@@ -1396,7 +1396,7 @@ int main(int argc, char **argv, char **envp) {
 		else if (strcmp(argv[i], "--seccomp.block-secondary") == 0) {
 			if (checkcfg(CFG_SECCOMP)) {
 				if (arg_seccomp32) {
-					fprintf(stderr, "Error: seccomp.32 conflicts with block-secondary\n");
+					fprintf(stderr, "[firejail] Error: seccomp.32 conflicts with block-secondary\n");
 					exit(1);
 				}
 				arg_seccomp_block_secondary = 1;
@@ -1461,12 +1461,12 @@ int main(int argc, char **argv, char **envp) {
 			arg_trace = 1;
 			arg_tracefile = argv[i] + 8;
 			if (*arg_tracefile == '\0') {
-				fprintf(stderr, "Error: invalid trace option\n");
+				fprintf(stderr, "[firejail] Error: invalid trace option\n");
 				exit(1);
 			}
 			invalid_filename(arg_tracefile, 0); // no globbing
 			if (strstr(arg_tracefile, "..")) {
-				fprintf(stderr, "Error: invalid file name %s\n", arg_tracefile);
+				fprintf(stderr, "[firejail] Error: invalid file name %s\n", arg_tracefile);
 				exit(1);
 			}
 			// if the filename starts with ~, expand the home directory
@@ -1522,7 +1522,7 @@ int main(int argc, char **argv, char **envp) {
 		else if (strncmp(argv[i], "--cgroup=", 9) == 0) {
 			if (checkcfg(CFG_CGROUP)) {
 				if (option_cgroup) {
-					fprintf(stderr, "Error: only a cgroup can be defined\n");
+					fprintf(stderr, "[firejail] Error: only a cgroup can be defined\n");
 					exit(1);
 				}
 
@@ -1631,17 +1631,17 @@ int main(int argc, char **argv, char **envp) {
 		else if (strcmp(argv[i], "--overlay") == 0) {
 			if (checkcfg(CFG_OVERLAYFS)) {
 				if (arg_overlay) {
-					fprintf(stderr, "Error: only one overlay command is allowed\n");
+					fprintf(stderr, "[firejail] Error: only one overlay command is allowed\n");
 					exit(1);
 				}
 
 				if (cfg.chrootdir) {
-					fprintf(stderr, "Error: --overlay and --chroot options are mutually exclusive\n");
+					fprintf(stderr, "[firejail] Error: --overlay and --chroot options are mutually exclusive\n");
 					exit(1);
 				}
 				struct stat s;
 				if (stat("/proc/sys/kernel/grsecurity", &s) == 0) {
-					fprintf(stderr, "Error: --overlay option is not available on Grsecurity systems\n");
+					fprintf(stderr, "[firejail] Error: --overlay option is not available on Grsecurity systems\n");
 					exit(1);
 				}
 				arg_overlay = 1;
@@ -1660,16 +1660,16 @@ int main(int argc, char **argv, char **envp) {
 		else if (strncmp(argv[i], "--overlay-named=", 16) == 0) {
 			if (checkcfg(CFG_OVERLAYFS)) {
 				if (arg_overlay) {
-					fprintf(stderr, "Error: only one overlay command is allowed\n");
+					fprintf(stderr, "[firejail] Error: only one overlay command is allowed\n");
 					exit(1);
 				}
 				if (cfg.chrootdir) {
-					fprintf(stderr, "Error: --overlay and --chroot options are mutually exclusive\n");
+					fprintf(stderr, "[firejail] Error: --overlay and --chroot options are mutually exclusive\n");
 					exit(1);
 				}
 				struct stat s;
 				if (stat("/proc/sys/kernel/grsecurity", &s) == 0) {
-					fprintf(stderr, "Error: --overlay option is not available on Grsecurity systems\n");
+					fprintf(stderr, "[firejail] Error: --overlay option is not available on Grsecurity systems\n");
 					exit(1);
 				}
 				arg_overlay = 1;
@@ -1678,14 +1678,14 @@ int main(int argc, char **argv, char **envp) {
 
 				char *subdirname = argv[i] + 16;
 				if (*subdirname == '\0') {
-					fprintf(stderr, "Error: invalid overlay option\n");
+					fprintf(stderr, "[firejail] Error: invalid overlay option\n");
 					exit(1);
 				}
 
 				// check name
 				invalid_filename(subdirname, 0); // no globbing
 				if (strstr(subdirname, "..") || strstr(subdirname, "/")) {
-					fprintf(stderr, "Error: invalid overlay name\n");
+					fprintf(stderr, "[firejail] Error: invalid overlay name\n");
 					exit(1);
 				}
 				cfg.overlay_dir = fs_check_overlay_dir(subdirname, arg_overlay_reuse);
@@ -1696,16 +1696,16 @@ int main(int argc, char **argv, char **envp) {
 		else if (strcmp(argv[i], "--overlay-tmpfs") == 0) {
 			if (checkcfg(CFG_OVERLAYFS)) {
 				if (arg_overlay) {
-					fprintf(stderr, "Error: only one overlay command is allowed\n");
+					fprintf(stderr, "[firejail] Error: only one overlay command is allowed\n");
 					exit(1);
 				}
 				if (cfg.chrootdir) {
-					fprintf(stderr, "Error: --overlay and --chroot options are mutually exclusive\n");
+					fprintf(stderr, "[firejail] Error: --overlay and --chroot options are mutually exclusive\n");
 					exit(1);
 				}
 				struct stat s;
 				if (stat("/proc/sys/kernel/grsecurity", &s) == 0) {
-					fprintf(stderr, "Error: --overlay option is not available on Grsecurity systems\n");
+					fprintf(stderr, "[firejail] Error: --overlay option is not available on Grsecurity systems\n");
 					exit(1);
 				}
 				arg_overlay = 1;
@@ -1723,7 +1723,7 @@ int main(int argc, char **argv, char **envp) {
 			else if (access("/run/firetunnel/fts", R_OK) == 0)
 				profile_read("/run/firetunnel/fts");
 			else {
-				fprintf(stderr, "Error: no default firetunnel found, please specify it using --tunnel=devname option\n");
+				fprintf(stderr, "[firejail] Error: no default firetunnel found, please specify it using --tunnel=devname option\n");
 				exit(1);
 			}
 		}
@@ -1736,7 +1736,7 @@ int main(int argc, char **argv, char **envp) {
 			if (access(fname, R_OK) == 0)
 				profile_read(fname);
 			else {
-				fprintf(stderr, "Error: tunnel not found\n");
+				fprintf(stderr, "[firejail] Error: tunnel not found\n");
 				exit(1);
 			}
 		}
@@ -1745,7 +1745,7 @@ int main(int argc, char **argv, char **envp) {
 			// multiple profile files are allowed!
 
 			if (arg_noprofile) {
-				fprintf(stderr, "Error: --noprofile and --profile options are mutually exclusive\n");
+				fprintf(stderr, "[firejail] Error: --noprofile and --profile options are mutually exclusive\n");
 				exit(1);
 			}
 
@@ -1764,7 +1764,7 @@ int main(int argc, char **argv, char **envp) {
 				// profile path contains no / or . chars,
 				// assume its a profile name
 				if (*ptr != '\0') {
-					fprintf(stderr, "Error: inaccessible profile file: %s\n", ppath);
+					fprintf(stderr, "[firejail] Error: inaccessible profile file: %s\n", ppath);
 					exit(1);
 				}
 
@@ -1774,7 +1774,7 @@ int main(int argc, char **argv, char **envp) {
 					// do not fall through to default profile,
 					// because the user should be notified that
 					// given profile arg could not be used.
-					fprintf(stderr, "Error: no profile with name \"%s\" found.\n", ppath);
+					fprintf(stderr, "[firejail] Error: no profile with name \"%s\" found.\n", ppath);
 					exit(1);
 				}
 				else
@@ -1788,14 +1788,14 @@ int main(int argc, char **argv, char **envp) {
 		}
 		else if (strcmp(argv[i], "--noprofile") == 0) {
 			if (custom_profile) {
-				fprintf(stderr, "Error: --profile and --noprofile options are mutually exclusive\n");
+				fprintf(stderr, "[firejail] Error: --profile and --noprofile options are mutually exclusive\n");
 				exit(1);
 			}
 			arg_noprofile = 1;
 		}
 		else if (strncmp(argv[i], "--ignore=", 9) == 0) {
 			if (custom_profile) {
-				fprintf(stderr, "Error: please use --profile after --ignore\n");
+				fprintf(stderr, "[firejail] Error: please use --profile after --ignore\n");
 				exit(1);
 			}
 			profile_add_ignore(argv[i] + 9);
@@ -1804,19 +1804,19 @@ int main(int argc, char **argv, char **envp) {
 		else if (strncmp(argv[i], "--chroot=", 9) == 0) {
 			if (checkcfg(CFG_CHROOT)) {
 				if (arg_overlay) {
-					fprintf(stderr, "Error: --overlay and --chroot options are mutually exclusive\n");
+					fprintf(stderr, "[firejail] Error: --overlay and --chroot options are mutually exclusive\n");
 					exit(1);
 				}
 
 				struct stat s;
 				if (stat("/proc/sys/kernel/grsecurity", &s) == 0) {
-					fprintf(stderr, "Error: --chroot option is not available on Grsecurity systems\n");
+					fprintf(stderr, "[firejail] Error: --chroot option is not available on Grsecurity systems\n");
 					exit(1);
 				}
 				// extract chroot dirname
 				cfg.chrootdir = argv[i] + 9;
 				if (*cfg.chrootdir == '\0') {
-					fprintf(stderr, "Error: invalid chroot option\n");
+					fprintf(stderr, "[firejail] Error: invalid chroot option\n");
 					exit(1);
 				}
 				invalid_filename(cfg.chrootdir, 0); // no globbing
@@ -1837,7 +1837,7 @@ int main(int argc, char **argv, char **envp) {
 #endif
 		else if (strcmp(argv[i], "--writable-etc") == 0) {
 			if (cfg.etc_private_keep) {
-				fprintf(stderr, "Error: --private-etc and --writable-etc are mutually exclusive\n");
+				fprintf(stderr, "[firejail] Error: --private-etc and --writable-etc are mutually exclusive\n");
 				exit(1);
 			}
 			arg_writable_etc = 1;
@@ -1862,14 +1862,14 @@ int main(int argc, char **argv, char **envp) {
 		}
 		else if (strncmp(argv[i], "--private=", 10) == 0) {
 			if (cfg.home_private_keep) {
-				fprintf(stderr, "Error: a private list of files was already defined with --private-home option.\n");
+				fprintf(stderr, "[firejail] Error: a private list of files was already defined with --private-home option.\n");
 				exit(1);
 			}
 
 			// extract private home dirname
 			cfg.home_private = argv[i] + 10;
 			if (*cfg.home_private == '\0') {
-				fprintf(stderr, "Error: invalid private option\n");
+				fprintf(stderr, "[firejail] Error: invalid private option\n");
 				exit(1);
 			}
 			fs_check_private_dir();
@@ -1885,13 +1885,13 @@ int main(int argc, char **argv, char **envp) {
 		else if (strncmp(argv[i], "--private-home=", 15) == 0) {
 			if (checkcfg(CFG_PRIVATE_HOME)) {
 				if (cfg.home_private) {
-					fprintf(stderr, "Error: a private home directory was already defined with --private option.\n");
+					fprintf(stderr, "[firejail] Error: a private home directory was already defined with --private option.\n");
 					exit(1);
 				}
 
 				// extract private home dirname
 				if (*(argv[i] + 15) == '\0') {
-					fprintf(stderr, "Error: invalid private-home option\n");
+					fprintf(stderr, "[firejail] Error: invalid private-home option\n");
 					exit(1);
 				}
 				if (cfg.home_private_keep) {
@@ -1913,13 +1913,13 @@ int main(int argc, char **argv, char **envp) {
 		}
 		else if (strncmp(argv[i], "--private-etc=", 14) == 0) {
 			if (arg_writable_etc) {
-				fprintf(stderr, "Error: --private-etc and --writable-etc are mutually exclusive\n");
+				fprintf(stderr, "[firejail] Error: --private-etc and --writable-etc are mutually exclusive\n");
 				exit(1);
 			}
 
 			// extract private etc list
 			if (*(argv[i] + 14) == '\0') {
-				fprintf(stderr, "Error: invalid private-etc option\n");
+				fprintf(stderr, "[firejail] Error: invalid private-etc option\n");
 				exit(1);
 			}
 			if (cfg.etc_private_keep) {
@@ -1932,7 +1932,7 @@ int main(int argc, char **argv, char **envp) {
 		else if (strncmp(argv[i], "--private-opt=", 14) == 0) {
 			// extract private opt list
 			if (*(argv[i] + 14) == '\0') {
-				fprintf(stderr, "Error: invalid private-opt option\n");
+				fprintf(stderr, "[firejail] Error: invalid private-opt option\n");
 				exit(1);
 			}
 			if (cfg.opt_private_keep) {
@@ -1945,7 +1945,7 @@ int main(int argc, char **argv, char **envp) {
 		else if (strncmp(argv[i], "--private-srv=", 14) == 0) {
 			// extract private srv list
 			if (*(argv[i] + 14) == '\0') {
-				fprintf(stderr, "Error: invalid private-srv option\n");
+				fprintf(stderr, "[firejail] Error: invalid private-srv option\n");
 				exit(1);
 			}
 			if (cfg.srv_private_keep) {
@@ -1958,7 +1958,7 @@ int main(int argc, char **argv, char **envp) {
 		else if (strncmp(argv[i], "--private-bin=", 14) == 0) {
 			// extract private bin list
 			if (*(argv[i] + 14) == '\0') {
-				fprintf(stderr, "Error: invalid private-bin option\n");
+				fprintf(stderr, "[firejail] Error: invalid private-bin option\n");
 				exit(1);
 			}
 			if (cfg.bin_private_keep) {
@@ -1998,7 +1998,7 @@ int main(int argc, char **argv, char **envp) {
 		}
 		else if (strncmp(argv[i], "--private-cwd=", 14) == 0) {
 			if (*(argv[i] + 14) == '\0') {
-				fprintf(stderr, "Error: invalid private-cwd option\n");
+				fprintf(stderr, "[firejail] Error: invalid private-cwd option\n");
 				exit(1);
 			}
 
@@ -2012,14 +2012,14 @@ int main(int argc, char **argv, char **envp) {
 		else if (strncmp(argv[i], "--name=", 7) == 0) {
 			cfg.name = argv[i] + 7;
 			if (strlen(cfg.name) == 0) {
-				fprintf(stderr, "Error: please provide a name for sandbox\n");
+				fprintf(stderr, "[firejail] Error: please provide a name for sandbox\n");
 				return 1;
 			}
 		}
 		else if (strncmp(argv[i], "--hostname=", 11) == 0) {
 			cfg.hostname = argv[i] + 11;
 			if (strlen(cfg.hostname) == 0) {
-				fprintf(stderr, "Error: please provide a hostname for sandbox\n");
+				fprintf(stderr, "[firejail] Error: please provide a hostname for sandbox\n");
 				return 1;
 			}
 		}
@@ -2076,16 +2076,16 @@ int main(int argc, char **argv, char **envp) {
 			if (checkcfg(CFG_NETWORK)) {
 				// checks
 				if (arg_nonetwork) {
-					fprintf(stderr, "Error: --network=none and --interface are incompatible\n");
+					fprintf(stderr, "[firejail] Error: --network=none and --interface are incompatible\n");
 					exit(1);
 				}
 				if (strcmp(argv[i] + 12, "lo") == 0) {
-					fprintf(stderr, "Error: cannot use lo device in --interface command\n");
+					fprintf(stderr, "[firejail] Error: cannot use lo device in --interface command\n");
 					exit(1);
 				}
 				int ifindex = if_nametoindex(argv[i] + 12);
 				if (ifindex <= 0) {
-					fprintf(stderr, "Error: cannot find interface %s\n", argv[i] + 12);
+					fprintf(stderr, "[firejail] Error: cannot find interface %s\n", argv[i] + 12);
 					exit(1);
 				}
 
@@ -2099,7 +2099,7 @@ int main(int argc, char **argv, char **envp) {
 				else if (cfg.interface3.configured == 0)
 					intf = &cfg.interface3;
 				else {
-					fprintf(stderr, "Error: maximum 4 interfaces are allowed\n");
+					fprintf(stderr, "[firejail] Error: maximum 4 interfaces are allowed\n");
 					return 1;
 				}
 
@@ -2132,7 +2132,7 @@ int main(int argc, char **argv, char **envp) {
 				}
 
 				if (strcmp(argv[i] + 6, "lo") == 0) {
-					fprintf(stderr, "Error: cannot attach to lo device\n");
+					fprintf(stderr, "[firejail] Error: cannot attach to lo device\n");
 					exit(1);
 				}
 
@@ -2146,7 +2146,7 @@ int main(int argc, char **argv, char **envp) {
 				else if (cfg.bridge3.configured == 0)
 					br = &cfg.bridge3;
 				else {
-					fprintf(stderr, "Error: maximum 4 network devices are allowed\n");
+					fprintf(stderr, "[firejail] Error: maximum 4 network devices are allowed\n");
 					return 1;
 				}
 				br->dev = argv[i] + 6;
@@ -2160,14 +2160,14 @@ int main(int argc, char **argv, char **envp) {
 			if (checkcfg(CFG_NETWORK)) {
 				Bridge *br = last_bridge_configured();
 				if (br == NULL) {
-					fprintf(stderr, "Error: no network device configured\n");
+					fprintf(stderr, "[firejail] Error: no network device configured\n");
 					exit(1);
 				}
 				br->veth_name = strdup(argv[i] + 12);
 				if (br->veth_name == NULL)
 					errExit("strdup");
 				if (*br->veth_name == '\0') {
-					fprintf(stderr, "Error: no veth-name configured\n");
+					fprintf(stderr, "[firejail] Error: no veth-name configured\n");
 					exit(1);
 				}
 			}
@@ -2186,11 +2186,11 @@ int main(int argc, char **argv, char **envp) {
 			if (checkcfg(CFG_NETWORK)) {
 				Bridge *br = last_bridge_configured();
 				if (br == NULL) {
-					fprintf(stderr, "Error: no network device configured\n");
+					fprintf(stderr, "[firejail] Error: no network device configured\n");
 					return 1;
 				}
 				if (br->iprange_start || br->iprange_end) {
-					fprintf(stderr, "Error: cannot configure the IP range twice for the same interface\n");
+					fprintf(stderr, "[firejail] Error: cannot configure the IP range twice for the same interface\n");
 					return 1;
 				}
 
@@ -2203,7 +2203,7 @@ int main(int argc, char **argv, char **envp) {
 					secondip++;
 				}
 				if (*secondip == '\0') {
-					fprintf(stderr, "Error: invalid IP range\n");
+					fprintf(stderr, "[firejail] Error: invalid IP range\n");
 					return 1;
 				}
 				*secondip = '\0';
@@ -2212,7 +2212,7 @@ int main(int argc, char **argv, char **envp) {
 				// check addresses
 				if (atoip(firstip, &br->iprange_start) || atoip(secondip, &br->iprange_end) ||
 				    br->iprange_start >= br->iprange_end) {
-					fprintf(stderr, "Error: invalid IP range\n");
+					fprintf(stderr, "[firejail] Error: invalid IP range\n");
 					return 1;
 				}
 			}
@@ -2224,17 +2224,17 @@ int main(int argc, char **argv, char **envp) {
 			if (checkcfg(CFG_NETWORK)) {
 				Bridge *br = last_bridge_configured();
 				if (br == NULL) {
-					fprintf(stderr, "Error: no network device configured\n");
+					fprintf(stderr, "[firejail] Error: no network device configured\n");
 					exit(1);
 				}
 				if (mac_not_zero(br->macsandbox)) {
-					fprintf(stderr, "Error: cannot configure the MAC address twice for the same interface\n");
+					fprintf(stderr, "[firejail] Error: cannot configure the MAC address twice for the same interface\n");
 					exit(1);
 				}
 
 				// read the address
 				if (atomac(argv[i] + 6, br->macsandbox)) {
-					fprintf(stderr, "Error: invalid MAC address\n");
+					fprintf(stderr, "[firejail] Error: invalid MAC address\n");
 					exit(1);
 				}
 			}
@@ -2246,12 +2246,12 @@ int main(int argc, char **argv, char **envp) {
 			if (checkcfg(CFG_NETWORK)) {
 				Bridge *br = last_bridge_configured();
 				if (br == NULL) {
-					fprintf(stderr, "Error: no network device configured\n");
+					fprintf(stderr, "[firejail] Error: no network device configured\n");
 					exit(1);
 				}
 
 				if (sscanf(argv[i] + 6, "%d", &br->mtu) != 1 || br->mtu < 576 || br->mtu > 9198) {
-					fprintf(stderr, "Error: invalid mtu value\n");
+					fprintf(stderr, "[firejail] Error: invalid mtu value\n");
 					exit(1);
 				}
 			}
@@ -2263,11 +2263,11 @@ int main(int argc, char **argv, char **envp) {
 			if (checkcfg(CFG_NETWORK)) {
 				Bridge *br = last_bridge_configured();
 				if (br == NULL) {
-					fprintf(stderr, "Error: no network device configured\n");
+					fprintf(stderr, "[firejail] Error: no network device configured\n");
 					exit(1);
 				}
 				if (br->arg_ip_none || br->ipsandbox) {
-					fprintf(stderr, "Error: cannot configure the IP address twice for the same interface\n");
+					fprintf(stderr, "[firejail] Error: cannot configure the IP address twice for the same interface\n");
 					exit(1);
 				}
 
@@ -2279,7 +2279,7 @@ int main(int argc, char **argv, char **envp) {
 					br->arg_ip_dhcp = 1;
 				} else {
 					if (atoip(argv[i] + 5, &br->ipsandbox)) {
-						fprintf(stderr, "Error: invalid IP address\n");
+						fprintf(stderr, "[firejail] Error: invalid IP address\n");
 						exit(1);
 					}
 				}
@@ -2292,17 +2292,17 @@ int main(int argc, char **argv, char **envp) {
 			if (checkcfg(CFG_NETWORK)) {
 				Bridge *br = last_bridge_configured();
 				if (br == NULL) {
-					fprintf(stderr, "Error: no network device configured\n");
+					fprintf(stderr, "[firejail] Error: no network device configured\n");
 					exit(1);
 				}
 				if (br->arg_ip_none || br->mask) {
-					fprintf(stderr, "Error: cannot configure the network mask twice for the same interface\n");
+					fprintf(stderr, "[firejail] Error: cannot configure the network mask twice for the same interface\n");
 					exit(1);
 				}
 
 				// configure this network mask for the last bridge defined
 				if (atoip(argv[i] + 10, &br->mask)) {
-					fprintf(stderr, "Error: invalid  network mask\n");
+					fprintf(stderr, "[firejail] Error: invalid  network mask\n");
 					exit(1);
 				}
 			}
@@ -2314,11 +2314,11 @@ int main(int argc, char **argv, char **envp) {
 			if (checkcfg(CFG_NETWORK)) {
 				Bridge *br = last_bridge_configured();
 				if (br == NULL) {
-					fprintf(stderr, "Error: no network device configured\n");
+					fprintf(stderr, "[firejail] Error: no network device configured\n");
 					exit(1);
 				}
 				if (br->arg_ip6_dhcp || br->ip6sandbox) {
-					fprintf(stderr, "Error: cannot configure the IP address twice for the same interface\n");
+					fprintf(stderr, "[firejail] Error: cannot configure the IP address twice for the same interface\n");
 					exit(1);
 				}
 
@@ -2327,7 +2327,7 @@ int main(int argc, char **argv, char **envp) {
 					br->arg_ip6_dhcp = 1;
 				else {
 					if (check_ip46_address(argv[i] + 6) == 0) {
-						fprintf(stderr, "Error: invalid IPv6 address\n");
+						fprintf(stderr, "[firejail] Error: invalid IPv6 address\n");
 						exit(1);
 					}
 
@@ -2344,7 +2344,7 @@ int main(int argc, char **argv, char **envp) {
 		else if (strncmp(argv[i], "--defaultgw=", 12) == 0) {
 			if (checkcfg(CFG_NETWORK)) {
 				if (atoip(argv[i] + 12, &cfg.defaultgw)) {
-					fprintf(stderr, "Error: invalid IP address\n");
+					fprintf(stderr, "[firejail] Error: invalid IP address\n");
 					exit(1);
 				}
 			}
@@ -2354,7 +2354,7 @@ int main(int argc, char **argv, char **envp) {
 #endif
 		else if (strncmp(argv[i], "--dns=", 6) == 0) {
 			if (check_ip46_address(argv[i] + 6) == 0) {
-				fprintf(stderr, "Error: invalid DNS server IPv4 or IPv6 address\n");
+				fprintf(stderr, "[firejail] Error: invalid DNS server IPv4 or IPv6 address\n");
 				exit(1);
 			}
 			char *dns = strdup(argv[i] + 6);
@@ -2427,7 +2427,7 @@ int main(int argc, char **argv, char **envp) {
 		}
 		else if (strncmp(argv[i], "--audit=", 8) == 0) {
 			if (strlen(argv[i] + 8) == 0) {
-				fprintf(stderr, "Error: invalid audit program\n");
+				fprintf(stderr, "[firejail] Error: invalid audit program\n");
 				exit(1);
 			}
 			arg_audit_prog = strdup(argv[i] + 8);
@@ -2436,7 +2436,7 @@ int main(int argc, char **argv, char **envp) {
 
 			struct stat s;
 			if (stat(arg_audit_prog, &s) != 0) {
-				fprintf(stderr, "Error: cannot find the audit program %s\n", arg_audit_prog);
+				fprintf(stderr, "[firejail] Error: cannot find the audit program %s\n", arg_audit_prog);
 				exit(1);
 			}
 			arg_audit = 1;
@@ -2446,25 +2446,25 @@ int main(int argc, char **argv, char **envp) {
 		else if (strcmp(argv[i], "--shell=none") == 0) {
 			arg_shell_none = 1;
 			if (cfg.shell) {
-				fprintf(stderr, "Error: a shell was already specified\n");
+				fprintf(stderr, "[firejail] Error: a shell was already specified\n");
 				return 1;
 			}
 		}
 		else if (strncmp(argv[i], "--shell=", 8) == 0) {
 			if (arg_shell_none) {
-				fprintf(stderr, "Error: --shell=none was already specified.\n");
+				fprintf(stderr, "[firejail] Error: --shell=none was already specified.\n");
 				return 1;
 			}
 			invalid_filename(argv[i] + 8, 0); // no globbing
 
 			if (cfg.shell) {
-				fprintf(stderr, "Error: only one user shell can be specified\n");
+				fprintf(stderr, "[firejail] Error: only one user shell can be specified\n");
 				return 1;
 			}
 			cfg.shell = argv[i] + 8;
 
 			if (is_dir(cfg.shell) || strstr(cfg.shell, "..")) {
-				fprintf(stderr, "Error: invalid shell\n");
+				fprintf(stderr, "[firejail] Error: invalid shell\n");
 				exit(1);
 			}
 
@@ -2474,19 +2474,19 @@ int main(int argc, char **argv, char **envp) {
 				if (asprintf(&shellpath, "%s%s", cfg.chrootdir, cfg.shell) == -1)
 					errExit("asprintf");
 				if (access(shellpath, X_OK)) {
-					fprintf(stderr, "Error: cannot access shell file in chroot\n");
+					fprintf(stderr, "[firejail] Error: cannot access shell file in chroot\n");
 					exit(1);
 				}
 				free(shellpath);
 			} else if (access(cfg.shell, X_OK)) {
-				fprintf(stderr, "Error: cannot access shell file\n");
+				fprintf(stderr, "[firejail] Error: cannot access shell file\n");
 				exit(1);
 			}
 		}
 		else if (strcmp(argv[i], "-c") == 0) {
 			arg_command = 1;
 			if (i == (argc -  1)) {
-				fprintf(stderr, "Error: option -c requires an argument\n");
+				fprintf(stderr, "[firejail] Error: option -c requires an argument\n");
 				return 1;
 			}
 		}
@@ -2510,7 +2510,7 @@ int main(int argc, char **argv, char **envp) {
 			// set sandbox name and start normally
 			cfg.name = argv[i] + 16;
 			if (strlen(cfg.name) == 0) {
-				fprintf(stderr, "Error: please provide a name for sandbox\n");
+				fprintf(stderr, "[firejail] Error: please provide a name for sandbox\n");
 				return 1;
 			}
 		}
@@ -2523,13 +2523,13 @@ int main(int argc, char **argv, char **envp) {
 				arg_doubledash = 1;
 				i++;
 				if (i  >= argc) {
-					fprintf(stderr, "Error: program name not found\n");
+					fprintf(stderr, "[firejail] Error: program name not found\n");
 					exit(1);
 				}
 			}
 			// is this an invalid option?
 			else if (*argv[i] == '-') {
-				fprintf(stderr, "Error: invalid %s command line option\n", argv[i]);
+				fprintf(stderr, "[firejail] Error: invalid %s command line option\n", argv[i]);
 				return 1;
 			}
 
@@ -2561,7 +2561,7 @@ int main(int argc, char **argv, char **envp) {
 			opt = "chroot";
 
 		if (opt) {
-			fprintf(stderr, "Error: all capabilities are dropped for %s by default.\n"
+			fprintf(stderr, "[firejail] Error: all capabilities are dropped for %s by default.\n"
 				"Please remove --caps options from the command line.\n", opt);
 			exit(1);
 		}
@@ -2569,7 +2569,7 @@ int main(int argc, char **argv, char **envp) {
 
 	// prog_index could still be -1 if no program was specified
 	if (prog_index == -1 && arg_shell_none) {
-		fprintf(stderr, "Error: shell=none configured, but no program specified\n");
+		fprintf(stderr, "[firejail] Error: shell=none configured, but no program specified\n");
 		exit(1);
 	}
 
@@ -2608,7 +2608,7 @@ int main(int argc, char **argv, char **envp) {
 	if (!arg_shell_none && !cfg.shell) {
 		cfg.shell = guess_shell();
 		if (!cfg.shell) {
-			fprintf(stderr, "Error: unable to guess your shell, please set explicitly by using --shell option.\n");
+			fprintf(stderr, "[firejail] Error: unable to guess your shell, please set explicitly by using --shell option.\n");
 			exit(1);
 		}
 		if (arg_debug)
@@ -2631,7 +2631,7 @@ int main(int argc, char **argv, char **envp) {
 		build_cmdline(&cfg.command_line, &cfg.window_title, argc, argv, prog_index);
 	}
 /*	else {
-		fprintf(stderr, "Error: command must be specified when --shell=none used.\n");
+		fprintf(stderr, "[firejail] Error: command must be specified when --shell=none used.\n");
 		exit(1);
 	}*/
 
@@ -2656,7 +2656,7 @@ int main(int argc, char **argv, char **envp) {
 		custom_profile = profile_find_firejail(profile_name, 1);
 
 		if (!custom_profile) {
-			fprintf(stderr, "Error: no default.profile installed\n");
+			fprintf(stderr, "[firejail] Error: no default.profile installed\n");
 			exit(1);
 		}
 
@@ -2907,7 +2907,7 @@ int main(int argc, char **argv, char **envp) {
 		rv |= setuid(0);
 		rv |= setgid(0);
 		if (rv) {
-			fprintf(stderr, "Error: cannot start POSTMORTEM process\n");
+			fprintf(stderr, "[firejail] Error: cannot start POSTMORTEM process\n");
 			exit(1);
 		}
 


### PR DESCRIPTION
One of those days on a rolling release OS. Both kernel and systemd just got upgraded, together with a few dozen other packages. After a reboot frustration levels upped as my main dev machine was only barely alive. After taking a long outdoor reflective breather I started to rebuild a few mission-critical packages. `Error: too many environment variables`. Exit. No sender. No return adrress. No nothing.

This strangely mixed crystal clear and utterly cryptic message had apparently started to pop-up left and right. Sure, I use plenty of these env vars (134 according to `env`), but never had I been told I use too many :) After more digging it turned out I had been bitten by a newly introduced _sane maximum number of environment variables_. Going over the [commit in question](https://github.com/netblue30/firejail/commit/88258569cb5f455dd39447867e559bfba20d91c7) rapidly improved my mood. At last I had found something I could relate to: didn't pass the 'sanity check' :) Took care of upping the number to accomodate my 134 vars in my firejail-git PKGBUILD.

Nothing wrong with setting a limit, nor with drawing the line at 100. In fact probably a very wise thing to do as a sandbox application. All sarcasm aside, a slightly more contextual indication of the originator of the error message(s) would have helped. This WIP is a minimalistic first attempt to do just that, nothing more, nothing less. For now it only touched error messages directly followed by exit(1) that didn't already mention {F,f}irejail in the error text. I did notice the errExit("foo") defined in [common.h](https://github.com/netblue30/firejail/blob/master/src/include/common.h#L35) but decided to not touch that yet and **await comments/suggestions**.