### PR TITLE
Improvements for syscalls.sh contib file

### DIFF
--- a/contrib/syscalls.sh
+++ b/contrib/syscalls.sh
@@ -8,26 +8,22 @@ SYSCALLS_OUTPUT_FILE="$(pwd)/syscalls.txt"
 
 if [ $# -eq 0 ]
 then
-echo
-echo "   *** No program specified!!! ***"
-echo
-echo -e "Make this file executable and execute it as:\\n"
-echo -e "\\e[96m   syscalls.sh /full/path/to/program\\n"
-echo -e "\\e[39mif you saved this script in a directory in your PATH (e.g., in ${HOME}/bin), otherwise as:\\n"
-echo -e "\\e[96m   ./syscalls.sh /full/path/to/program\\n"
-echo -e "\\e[39mUse the full path to the respective program to avoid executing it sandboxed with Firejail\\n(if a Firejail profile for it already exits and 'sudo firecfg' was executed earlier)\\nin order to determine the necessary system calls."
-echo
-exit 0
-
+  echo
+  echo "   *** No program specified!!! ***"
+  echo
+  echo -e "Make this file executable and execute it as:\\n"
+  echo -e "\\e[96m   syscalls.sh /full/path/to/program\\n"
+  echo -e "\\e[39mif you saved this script in a directory in your PATH (e.g., in ${HOME}/bin), otherwise as:\\n"
+  echo -e "\\e[96m   ./syscalls.sh /full/path/to/program\\n"
+  echo -e "\\e[39mUse the full path to the respective program to avoid executing it sandboxed with Firejail\\n(if a Firejail profile for it already exits and 'sudo firecfg' was executed earlier)\\nin order to determine the necessary system calls."
+  echo
+  exit 0
 else
-
-strace -cfo "$STRACE_OUTPUT_FILE" "$@" && awk '{print $NF}' "$STRACE_OUTPUT_FILE" | sed '/syscall\|-\|total/d' | sort -u | awk -vORS=, '{ print $1 }' | sed 's/,$/\n/' > "$SYSCALLS_OUTPUT_FILE"
-echo
-echo -e "\e[39mThese are the sorted syscalls:\n\e[93m"
-cat "$SYSCALLS_OUTPUT_FILE"
-echo
-echo -e "\e[39mThe sorted syscalls were saved to:\n\n\e[96m$SYSCALLS_OUTPUT_FILE"
-echo
-exit 0
-
+  strace -cfo "$STRACE_OUTPUT_FILE" "$@" && awk '{print $NF}' "$STRACE_OUTPUT_FILE" | sed '/syscall\|-\|total/d' | sort -u | awk -vORS=, '{ print $1 }' | sed 's/,$/\n/' > "$SYSCALLS_OUTPUT_FILE"
+  echo
+  echo -e "\e[39mThese are the sorted syscalls:\n\e[93m"
+  cat "$SYSCALLS_OUTPUT_FILE"
+  echo
+  echo -e "\e[39mThe sorted syscalls were saved to:\n\e[96m$SYSCALLS_OUTPUT_FILE\n\e[39m"
+  exit 0
 fi


### PR DESCRIPTION
Fixed the identation for copy/past problems and added a console character that returns the console to it's original colour after the SYSCALLS_OUTPUT_FILE param is printed.


If your PR isn't about profiles or you have no idea how to do one of these, skip the following and go ahead with this PR.

If you make a PR for new profiles or changeing profiles please do the following:
 - The ordering of options follow the rules descripted in [/usr/share/doc/firejail/profile.template](https://github.com/netblue30/firejail/blob/master/etc/templates/profile.template).  
   > Hint: The profile-template is very new, if you install firejail with your package-manager, it maybe missing, therefore, and to follow the latest rules, it is recommended to use the template from the repository.
 - Order the arguments of options alphabetical, you can easy do this with the [sort.py](https://github.com/netblue30/firejail/tree/master/contrib/sort.py).  
 The path to it depends on your distro:

   | Distro | Path |
   | ------ | ---- |
   | Arch/Fedora | `/usr/lib64/firejail/sort.py` |
   | Debian/Ubuntu/Mint | `/usr/lib/x86_64-linux-gnu/firejail/sort.py` |
   | local git clone | `contrib/sort.py` |

   Note also that the sort.py script exists only since firejail `0.9.61`.

See also [CONTRIBUTING.md](/CONTRIBUTING.md).
