### PR TITLE
Clarify that file globbing occurs only at start

### DIFF
--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -165,8 +165,9 @@ host filesystem. Each line describes a file/directory that is inaccessible
 (\fBblacklist\fR), a read-only file or directory (\fBread-only\fR),
 a tmpfs mounted on top of an existing directory (\fBtmpfs\fR),
 or mount-bind a directory or file on top of another directory or file (\fBbind\fR).
-Use \fBprivate\fR to set private mode.
-File globbing is supported, and PATH and HOME directories are searched.
+Use \fBprivate\fR to set private mode.  File globbing is supported, and PATH and
+HOME directories are searched, see the \fBfirejail\f(1) \fBFILE GLOBBING\fR section
+for more details.
 Examples:
 .TP
 \fBblacklist file_or_directory

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -2835,7 +2835,11 @@ List all sandboxed processes.
 
 .SH FILE GLOBBING
 .TP
-Globbing is the operation that expands a wildcard pattern into the list of pathnames matching the pattern. Matching is defined by:
+Globbing is the operation that expands a wildcard pattern into the
+list of pathnames matching the pattern.  This pattern is matched at
+firejail \fBstart\fR, and is NOT UPDATED at runtime.  \fBFiles matching
+a blacklist, but created after firejail start will be accessible within
+the jail.\fR Matching is defined by:
 .br
 
 .br
@@ -2846,12 +2850,15 @@ Globbing is the operation that expands a wildcard pattern into the list of pathn
 - '[' denotes a range of characters
 .br
 .TP
-The globbing feature is implemented using glibc glob command. For more information on the wildcard syntax see man 7 glob.
+The globbing feature is implemented using glibc glob command. For
+more information on the wildcard syntax see man 7 glob.
 .br
 
 .br
 .TP
-The following command line options are supported: \-\-blacklist, \-\-private-bin, \-\-noexec, \-\-read-only, \-\-read-write, \-\-tmpfs, and \-\-whitelist.
+The following command line options are supported: \-\-blacklist,
+\-\-private-bin, \-\-noexec, \-\-read-only, \-\-read-write,
+\-\-tmpfs, and \-\-whitelist.
 .br
 
 .br


### PR DESCRIPTION
firejail can blacklist (and now also whitelist) files based on glob pattern.  This pattern is evaluated at firejail start, and not updated at run time.  This patch documents this behavior.

# The problem

You should be able to reproduce this behavior by:

```bash
 firejail --blacklist="${HOME}/somedir/*" /bin/bash
```

Then, in another shell,

```bash
mkdir "${HOME}/somedir"
touch mkdir "${HOME}/somedir/something"
```

You can access this in the jailed shell. Stopping and restarting it gives the proper blacklisting.

# Alternatives

Ideally, the blacklist glob would be evaluated at runtime, but that doesn't seem compatible with the approach firejail uses.