### PR TITLE
Add new profile: nicotine

### DIFF
--- a/etc/disable-programs.inc
+++ b/etc/disable-programs.inc
@@ -653,6 +653,7 @@ blacklist ${HOME}/.netactview
 blacklist ${HOME}/.neverball
 blacklist ${HOME}/.newsbeuter
 blacklist ${HOME}/.newsboat
+blacklist ${HOME}/.nicotine
 blacklist ${HOME}/.nv
 blacklist ${HOME}/.nylas-mail
 blacklist ${HOME}/.openarena

--- a/etc/nicotine.profile
+++ b/etc/nicotine.profile
@@ -1,0 +1,55 @@
+# Firejail profile for Nicotine Plus
+# Description: Soulseek music-sharing client
+# This file is overwritten after every install/update
+# Persistent local customizations
+include nicotine.local
+# Persistent global definitions
+include globals.local
+
+noblacklist ${HOME}/.nicotine
+
+include allow-python2.inc
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
+include disable-xdg.inc
+
+mkdir ${HOME}/.nicotine
+whitelist ${DOWNLOADS}
+whitelist ${HOME}/.nicotine
+whitelist /usr/share/GeoIP
+include whitelist-common.inc
+include whitelist-runuser-common.inc
+include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
+
+apparmor
+caps.drop all
+#ipc-namespace
+netfilter
+no3d
+nodvd
+nogroups
+nonewprivs
+noroot
+nosound
+notv
+nou2f
+novideo
+protocol unix,inet,inet6
+seccomp
+shell none
+tracelog
+
+disable-mnt
+private-bin nicotine,python2*
+private-cache
+private-dev
+private-tmp
+
+dbus-user none
+dbus-system none

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -492,6 +492,7 @@ neverputt
 newsbeuter
 newsboat
 nheko
+nicotine
 nitroshare
 nitroshare-cli
 nitroshare-nmh


### PR DESCRIPTION
New profile for Nicotine Plus Soulseek client. 
I realized you were asking contribution for another Soulseek client (soulseekqt), but this is the one I use.
The profile is heavily based on Amule profile and I tried to follow your contribution guidelines.

Tested in Arch Linux with Nicotine Plus 1.4.1-4 and Firejail 0.9.62-1.