### PR TITLE
Streamline file manager profiles

### DIFF
--- a/etc/Thunar.profile
+++ b/etc/Thunar.profile
@@ -10,5 +10,3 @@ include globals.local
 
 # Redirect
 include file-manager-common.profile
-
-join-or-start thunar

--- a/etc/Thunar.profile
+++ b/etc/Thunar.profile
@@ -6,28 +6,9 @@ include Thunar.local
 # Persistent global definitions
 include globals.local
 
-noblacklist ${HOME}/.local/share/Trash
-noblacklist ${HOME}/.config/Thunar
-noblacklist ${HOME}/.config/xfce4/xfconf/xfce-perchannel-xml/thunar.xml
+# Put 'ignore noroot' in your pcmanfm.local if you use MPV+Vulkan (see issue #3012)
 
-include disable-common.inc
-include disable-devel.inc
-include disable-interpreters.inc
-include disable-passwdmgr.inc
-# include disable-programs.inc
+# Redirect
+include file-manager-common.profile
 
-allusers
-caps.drop all
-netfilter
-no3d
-nodvd
-nogroups
-nonewprivs
-noroot
-nosound
-notv
-novideo
-protocol unix
-seccomp
-shell none
-tracelog
+join-or-start thunar

--- a/etc/caja.profile
+++ b/etc/caja.profile
@@ -13,5 +13,3 @@ include globals.local
 
 # Redirect
 include file-manager-common.profile
-
-join-or-start caja

--- a/etc/caja.profile
+++ b/etc/caja.profile
@@ -9,35 +9,9 @@ include globals.local
 # Caja is started by systemd on most systems. Therefore it is not firejailed by default. Since there
 # is already a caja process running on MATE desktops firejail will have no effect.
 
-noblacklist ${HOME}/.local/share/Trash
-# noblacklist ${HOME}/.config/caja - disable-programs.inc is disabled, see below
-# noblacklist ${HOME}/.local/share/caja-python
+# Put 'ignore noroot' in your caja.local if you use MPV+Vulkan (see issue #3012)
 
-# Allow python (blacklisted by disable-interpreters.inc)
-include allow-python2.inc
-include allow-python3.inc
+# Redirect
+include file-manager-common.profile
 
-include disable-common.inc
-include disable-devel.inc
-include disable-interpreters.inc
-include disable-passwdmgr.inc
-# include disable-programs.inc
-
-allusers
-caps.drop all
-netfilter
-nodvd
-nogroups
-nonewprivs
-noroot
-notv
-novideo
-protocol unix
-seccomp
-shell none
-tracelog
-
-# caja needs to be able to start arbitrary applications so we cannot blacklist their files
-# private-bin caja
-# private-dev
-# private-tmp
+join-or-start caja

--- a/etc/dolphin.profile
+++ b/etc/dolphin.profile
@@ -6,37 +6,9 @@ include dolphin.local
 # Persistent global definitions
 include globals.local
 
-noblacklist ${HOME}/.local/share/Trash
-# noblacklist ${HOME}/.cache/dolphin - disable-programs.inc is disabled, see below
-# noblacklist ${HOME}/.config/dolphinrc
-# noblacklist ${HOME}/.local/share/dolphin
+# Put 'ignore noroot' in your dolphin.local if you use MPV+Vulkan (see issue #3012)
 
-# Allow lua (blacklisted by disable-interpreters.inc)
-include allow-lua.inc
-
-include disable-common.inc
-include disable-devel.inc
-include disable-interpreters.inc
-include disable-passwdmgr.inc
-# dolphin needs to be able to start arbitrary applications so we cannot blacklist their files
-# include disable-programs.inc
-
-allusers
-caps.drop all
-# net none
-netfilter
-nodvd
-nogroups
-nonewprivs
-# Comment the next line (or put 'ignore noroot' in your dolphin.local) if you use MPV+Vulkan (see issue #3012)
-noroot
-notv
-novideo
-protocol unix,inet,inet6,netlink
-seccomp
-shell none
-
-private-dev
-# private-tmp
+# Redirect
+include file-manager-common.profile
 
 join-or-start dolphin

--- a/etc/file-manager-common.profile
+++ b/etc/file-manager-common.profile
@@ -1,0 +1,44 @@
+# Firejail profile for file managers
+# Description: Common profile for GUI file managers
+# This file is overwritten after every install/update
+# Persistent local customizations
+include file-manager-common.local
+# Persistent global definitions
+# added by caller profile
+#include globals.local
+
+# File managers need to be able to see everything under ${HOME}
+# and be able to start arbitrary applications
+
+ignore noexec ${HOME}
+
+# Allow lua (blacklisted by disable-interpreters.inc)
+include allow-lua.inc
+
+# Allow perl
+include allow-perl.inc
+
+# Allow python (blacklisted by disable-interpreters.inc)
+include allow-python2.inc
+include allow-python3.inc
+
+#include disable-common.inc
+include disable-devel.inc
+include disable-interpreters.inc
+#include disable-passwdmgr.inc
+# include disable-programs.inc
+
+allusers
+caps.drop all
+netfilter
+nodvd
+nogroups
+nonewprivs
+noroot
+notv
+nou2f
+novideo
+protocol unix,inet,inet6,netlink
+seccomp
+shell none
+tracelog

--- a/etc/file-manager-common.profile
+++ b/etc/file-manager-common.profile
@@ -42,3 +42,6 @@ protocol unix,inet,inet6,netlink
 seccomp
 shell none
 tracelog
+
+#dbus-user none
+#dbus-system none

--- a/etc/file-manager-common.profile
+++ b/etc/file-manager-common.profile
@@ -25,7 +25,7 @@ include allow-python3.inc
 #include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc
-#include disable-passwdmgr.inc
+include disable-passwdmgr.inc
 # include disable-programs.inc
 
 allusers
@@ -42,6 +42,8 @@ protocol unix,inet,inet6,netlink
 seccomp
 shell none
 tracelog
+
+private-dev
 
 #dbus-user none
 #dbus-system none

--- a/etc/nautilus.profile
+++ b/etc/nautilus.profile
@@ -9,36 +9,7 @@ include globals.local
 # Nautilus is started by systemd on most systems. Therefore it is not firejailed by default. Since there
 # is already a nautilus process running on gnome desktops firejail will have no effect.
 
-noblacklist ${HOME}/.config/nautilus
-noblacklist ${HOME}/.local/share/Trash
-noblacklist ${HOME}/.local/share/nautilus
-noblacklist ${HOME}/.local/share/nautilus-python
+# Redirect
+include file-manager-common.profile
 
-# Allow python (blacklisted by disable-interpreters.inc)
-include allow-python2.inc
-include allow-python3.inc
-
-include disable-common.inc
-include disable-devel.inc
-include disable-interpreters.inc
-include disable-passwdmgr.inc
-# include disable-programs.inc
-
-allusers
-caps.drop all
-netfilter
-nodvd
-nogroups
-nonewprivs
-noroot
-notv
-novideo
-protocol unix
-seccomp
-shell none
-tracelog
-
-# nautilus needs to be able to start arbitrary applications so we cannot blacklist their files
-# private-bin nautilus
-# private-dev
-# private-tmp
+join-or-start nautilus

--- a/etc/nautilus.profile
+++ b/etc/nautilus.profile
@@ -13,5 +13,3 @@ include globals.local
 
 # Redirect
 include file-manager-common.profile
-
-join-or-start nautilus

--- a/etc/nautilus.profile
+++ b/etc/nautilus.profile
@@ -9,6 +9,8 @@ include globals.local
 # Nautilus is started by systemd on most systems. Therefore it is not firejailed by default. Since there
 # is already a nautilus process running on gnome desktops firejail will have no effect.
 
+# Put 'ignore noroot' in your nautilus.local if you use MPV+Vulkan (see issue #3012)
+
 # Redirect
 include file-manager-common.profile
 

--- a/etc/nemo.profile
+++ b/etc/nemo.profile
@@ -10,5 +10,3 @@ include globals.local
 
 # Redirect
 include file-manager-common.profile
-
-join-or-start nemo

--- a/etc/nemo.profile
+++ b/etc/nemo.profile
@@ -6,33 +6,9 @@ include nemo.local
 # Persistent global definitions
 include globals.local
 
-noblacklist ${HOME}/.config/nemo
-noblacklist ${HOME}/.local/share/Trash
-noblacklist ${HOME}/.local/share/nemo
-noblacklist ${HOME}/.local/share/nemo-python
+# Put 'ignore noroot' in your nemo.local if you use MPV+Vulkan (see issue #3012)
 
-# Allow python (blacklisted by disable-interpreters.inc)
-include allow-python2.inc
-include allow-python3.inc
+# Redirect
+include file-manager-common.profile
 
-include disable-common.inc
-include disable-devel.inc
-include disable-exec.inc
-include disable-interpreters.inc
-include disable-passwdmgr.inc
-
-allusers
-caps.drop all
-netfilter
-no3d
-nodvd
-nogroups
-nonewprivs
-noroot
-nosound
-notv
-novideo
-protocol unix,inet,inet6
-seccomp
-shell none
-
+join-or-start nemo

--- a/etc/pcmanfm.profile
+++ b/etc/pcmanfm.profile
@@ -6,30 +6,9 @@ include pcmanfm.local
 # Persistent global definitions
 include globals.local
 
-noblacklist ${HOME}/.local/share/Trash
-# noblacklist ${HOME}/.config/libfm - disable-programs.inc is disabled, see below
-# noblacklist ${HOME}/.config/pcmanfm
+# Put 'ignore noroot' in your pcmanfm.local if you use MPV+Vulkan (see issue #3012)
 
-include disable-common.inc
-include disable-devel.inc
-include disable-interpreters.inc
-include disable-passwdmgr.inc
-# include disable-programs.inc
+# Redirect
+include file-manager-common.profile
 
-allusers
-caps.drop all
-# net none - see issue #1467, computer:/// location broken
-no3d
-nodvd
-nonewprivs
-noroot
-nosound
-notv
-novideo
-protocol unix
-seccomp
-shell none
-tracelog
-
-# dbus-user none
-# dbus-system none
+join-or-start pcmanfm

--- a/etc/pcmanfm.profile
+++ b/etc/pcmanfm.profile
@@ -10,5 +10,3 @@ include globals.local
 
 # Redirect
 include file-manager-common.profile
-
-join-or-start pcmanfm

--- a/etc/ranger.profile
+++ b/etc/ranger.profile
@@ -10,5 +10,3 @@ include globals.local
 
 # Redirect
 include file-manager-common.profile
-
-join-or-start ranger

--- a/etc/ranger.profile
+++ b/etc/ranger.profile
@@ -6,39 +6,9 @@ include ranger.local
 # Persistent global definitions
 include globals.local
 
-noblacklist ${HOME}/.config/nano
-noblacklist ${HOME}/.config/ranger
-noblacklist ${HOME}/.nanorc
+# Put 'ignore noroot' in your ranger.local if you use MPV+Vulkan (see issue #3012)
 
-# Allow python (blacklisted by disable-interpreters.inc)
-include allow-python2.inc
-include allow-python3.inc
+# Redirect
+include file-manager-common.profile
 
-# Allow perl
-include allow-perl.inc
-
-include disable-common.inc
-include disable-devel.inc
-include disable-interpreters.inc
-include disable-passwdmgr.inc
-include disable-programs.inc
-
-allusers
-caps.drop all
-net none
-nodvd
-nogroups
-nonewprivs
-noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix
-seccomp
-#x11 none
-
-private-dev
-
-dbus-user none
-dbus-system none
+join-or-start ranger

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -162,6 +162,7 @@ display
 dnox
 dnscrypt-proxy
 dnsmasq
+dolphin
 dooble
 dooble-qt4
 dosbox

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -162,7 +162,6 @@ display
 dnox
 dnscrypt-proxy
 dnsmasq
-dolphin
 dooble
 dooble-qt4
 dosbox


### PR DESCRIPTION
Thought it might be a good idea to bring some sanity in the file manager profiles. Some allow Python, some Perl, some need Lua and then there's the more important issue of what we want those applications to see or not, do we allow/deny D-Bus, sound, etc.

This will need some decisions I suppose. For now I've just tried to incorporate options we already had in some but not in others and assumed we want file managers to at least see everything under ${HOME}.