### PR TITLE
update --build

### DIFF
--- a/src/fbuilder/build_fs.c
+++ b/src/fbuilder/build_fs.c
@@ -165,10 +165,12 @@ void build_var(const char *fname, FILE *fp) {
 
 	process_files(fname, "/var", var_callback);
 
-	if (var_out == NULL)
+	if (var_out == NULL) {
 		fprintf(fp, "blacklist /var\n");
-	else
+	} else {
 		filedb_print(var_out, "whitelist ", fp);
+		fprintf(fp, "include whitelist-var-common.inc\n");
+	}
 }
 
 
@@ -202,10 +204,12 @@ void build_share(const char *fname, FILE *fp) {
 
 	process_files(fname, "/usr/share", share_callback);
 
-	if (share_out == NULL)
+	if (share_out == NULL) {
 		fprintf(fp, "blacklist /usr/share\n");
-	else
+	} else {
 		filedb_print(share_out, "whitelist ", fp);
+		fprintf(fp, "include whitelist-usr-share-common.inc\n");
+	}
 }
 
 //*******************************************

--- a/src/fbuilder/build_home.c
+++ b/src/fbuilder/build_home.c
@@ -32,9 +32,9 @@ static void load_whitelist_common(void) {
 
 	char buf[MAX_BUF];
 	while (fgets(buf, MAX_BUF, fp)) {
-		if (strncmp(buf, "whitelist ~/", 12) != 0)
+		if (strncmp(buf, "whitelist ${HOME}/", 18) != 0)
 			continue;
-		char *fn = buf + 12;
+		char *fn = buf + 18;
 		char *ptr = strchr(buf, '\n');
 		if (!ptr)
 			continue;
@@ -190,8 +190,8 @@ void build_home(const char *fname, FILE *fp) {
 
 	// print the out list if any
 	if (db_out) {
-		filedb_print(db_out, "whitelist ~/", fp);
-		fprintf(fp, "include /etc/firejail/whitelist-common.inc\n");
+		filedb_print(db_out, "whitelist ${HOME}/", fp);
+		fprintf(fp, "include whitelist-common.inc\n");
 	}
 	else
 		fprintf(fp, "private\n");

--- a/src/fbuilder/build_profile.c
+++ b/src/fbuilder/build_profile.c
@@ -131,18 +131,21 @@ void build_profile(int argc, char **argv, int index, FILE *fp) {
 	if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
 		if (fp == stdout)
 			printf("--- Built profile beings after this line ---\n");
-		fprintf(fp, "############################################\n");
-		fprintf(fp, "# %s profile\n", argv[index]);
-		fprintf(fp, "############################################\n");
+		fprintf(fp, "# Firejail profile for %s\n", argv[index]);
+		fprintf(fp, "# Persistent local customizations\n");
+		fprintf(fp, "#include %s.local\n", argv[index]);
 		fprintf(fp, "# Persistent global definitions\n");
-		fprintf(fp, "# include /etc/firejail/globals.local\n");
+		fprintf(fp, "#include globals.local\n");
 		fprintf(fp, "\n");
 
 		fprintf(fp, "### basic blacklisting\n");
-		fprintf(fp, "include /etc/firejail/disable-common.inc\n");
-		fprintf(fp, "# include /etc/firejail/disable-devel.inc\n");
-		fprintf(fp, "include /etc/firejail/disable-passwdmgr.inc\n");
-		fprintf(fp, "# include /etc/firejail/disable-programs.inc\n");
+		fprintf(fp, "include disable-common.inc\n");
+		fprintf(fp, "# include disable-devel.inc\n");
+		fprintf(fp, "# include disable-exec.inc\n");
+		fprintf(fp, "# include disable-interpreters.inc\n");
+		fprintf(fp, "include disable-passwdmgr.inc\n");
+		fprintf(fp, "# include disable-programs.inc\n");
+		fprintf(fp, "# include disable-xdg.inc\n");
 		fprintf(fp, "\n");
 
 		fprintf(fp, "### home directory whitelisting\n");
@@ -150,12 +153,19 @@ void build_profile(int argc, char **argv, int index, FILE *fp) {
 		fprintf(fp, "\n");
 
 		fprintf(fp, "### filesystem\n");
-		build_tmp(trace_output, fp);
-		build_dev(trace_output, fp);
-		build_etc(trace_output, fp);
-		build_var(trace_output, fp);
-		build_bin(trace_output, fp);
+		fprintf(fp, "# /usr/share:\n");
 		build_share(trace_output, fp);
+		fprintf(fp, "# /var:\n");
+		build_var(trace_output, fp);
+		fprintf(fp, "\n");
+		fprintf(fp, "# $PATH:\n");
+		build_bin(trace_output, fp);
+		fprintf(fp, "# /dev:\n");
+		build_dev(trace_output, fp);
+		fprintf(fp, "# /etc:\n");
+		build_etc(trace_output, fp);
+		fprintf(fp, "# /tmp:\n");
+		build_tmp(trace_output, fp);
 		fprintf(fp, "\n");
 
 		fprintf(fp, "### security filters\n");


### PR DESCRIPTION
The profile generated by --build are quite outdated. There are still a
lot of things left to do.

 - fix #2150 (whitelist-common.inc is still opened from /etc/firejail)
 - include wusc and wvc (todo: remove whitelists in wusc/wvc from the
   generated profile.)
 - fix parsing wc / use ${HOME} macro instead of ~
 - update profile headers
 - include all disable includes (mustly commented) in the output
 - reorder the filesystem section