### PR TITLE
Add steam-runtime alias

### DIFF
--- a/etc/profile-m-z/steam-runtime.profile
+++ b/etc/profile-m-z/steam-runtime.profile
@@ -1,0 +1,5 @@
+# Firejail profile alias for steam
+# This file is overwritten after every install/update
+
+# Redirect
+include steam.profile

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -630,6 +630,7 @@ standardnotes-desktop
 start-tor-browser
 steam
 steam-native
+steam-runtime
 stellarium
 strings
 studio.sh


### PR DESCRIPTION
Simple alias as the desktop file calls it by default on Arch.