### PR TITLE
firecfg: Only use fix_desktop_files automatically when run through sudo

### DIFF
--- a/src/firecfg/main.c
+++ b/src/firecfg/main.c
@@ -370,7 +370,6 @@ int main(int argc, char **argv) {
 			return 0;
 		}
 		else if (strcmp(argv[i], "--fix") == 0) {
-			// fix .desktop files in ~/.local/share/applications directory
 			fix_desktop_files(home);
 			return 0;
 		}
@@ -486,6 +485,10 @@ int main(int argc, char **argv) {
 
 	if (arg_debug)
 		printf("%s %d %d %d %d\n", user, getuid(), getgid(), geteuid(), getegid());
+
+	// if runs as regular user, fix .desktop files in ~/.local/share/applications directory
+	if (getuid() != 0)
+		fix_desktop_files(home);
 
 	return 0;
 }

--- a/src/firecfg/main.c
+++ b/src/firecfg/main.c
@@ -370,6 +370,7 @@ int main(int argc, char **argv) {
 			return 0;
 		}
 		else if (strcmp(argv[i], "--fix") == 0) {
+			// fix .desktop files in ~/.local/share/applications directory
 			fix_desktop_files(home);
 			return 0;
 		}
@@ -485,9 +486,6 @@ int main(int argc, char **argv) {
 
 	if (arg_debug)
 		printf("%s %d %d %d %d\n", user, getuid(), getgid(), geteuid(), getegid());
-
-	// fix .desktop files in ~/.local/share/applications directory
-	fix_desktop_files(home);
 
 	return 0;
 }


### PR DESCRIPTION
It also fixes this error when running `firecfg` as root:
```
Error: this option is not supported for root user; please run as a regular user.
```