### PR TITLE
Increase MAX_ENVS to 256

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -649,7 +649,7 @@ int check_namespace_virt(void);
 int check_kernel_procs(void);
 void run_no_sandbox(int argc, char **argv);
 
-#define MAX_ENVS 100			// some sane maximum number of environment variables
+#define MAX_ENVS 256			// some sane maximum number of environment variables
 #define MAX_ENV_LEN (PATH_MAX + 32)	// FOOBAR=SOME_PATH
 // env.c
 typedef enum {


### PR DESCRIPTION
Some applications like Byobu, tmux and screen like to use environment
and then 100 environment variables may be too few.

Closes #3350
