### PR TITLE
Disable browser drm by default.

### DIFF
--- a/src/firejail/checkcfg.c
+++ b/src/firejail/checkcfg.c
@@ -55,6 +55,7 @@ int checkcfg(int val) {
 		cfg_val[CFG_ARP_PROBES] = DEFAULT_ARP_PROBES;
 		cfg_val[CFG_XPRA_ATTACH] = 0;
 		cfg_val[CFG_SECCOMP_ERROR_ACTION] = -1;
+		cfg_val[CFG_BROWSER_ALLOW_DRM] = 0;
 
 		// open configuration file
 		const char *fname = SYSCONFDIR "/firejail.config";


### PR DESCRIPTION
Browser DRM was not disabled by default, even though etc/firejail/firejail.config stated that it was.
