### PR TITLE
Add several games to steam and disable-programs

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -553,6 +553,7 @@ blacklist ${HOME}/.local/share/dolphin
 blacklist ${HOME}/.local/share/emailidentities
 blacklist ${HOME}/.local/share/epiphany
 blacklist ${HOME}/.local/share/evolution
+blacklist ${HOME}/.local/share/FasterThanLight
 blacklist ${HOME}/.local/share/feedreader
 blacklist ${HOME}/.local/share/feral-interactive
 blacklist ${HOME}/.local/share/five-or-more
@@ -581,6 +582,7 @@ blacklist ${HOME}/.local/share/godot
 blacklist ${HOME}/.local/share/gradio
 blacklist ${HOME}/.local/share/gwenview
 blacklist ${HOME}/.local/share/i2p
+blacklist ${HOME}/.local/share/IntoTheBreach
 blacklist ${HOME}/.local/share/kaffeine
 blacklist ${HOME}/.local/share/kalgebra
 blacklist ${HOME}/.local/share/kate
@@ -621,6 +623,7 @@ blacklist ${HOME}/.local/share/okular
 blacklist ${HOME}/.local/share/onlyoffice
 blacklist ${HOME}/.local/share/orage
 blacklist ${HOME}/.local/share/org.kde.gwenview
+blacklist ${HOME}/.local/share/Paradox Interactive
 blacklist ${HOME}/.local/share/pix
 blacklist ${HOME}/.local/share/plasma_notes
 blacklist ${HOME}/.local/share/profanity
@@ -654,6 +657,7 @@ blacklist ${HOME}/.local/share/zathura
 blacklist ${HOME}/.lv2
 blacklist ${HOME}/.magicor
 blacklist ${HOME}/.masterpdfeditor
+blacklist ${HOME}/.mbwarband
 blacklist ${HOME}/.mcabber
 blacklist ${HOME}/.mcabberrc
 blacklist ${HOME}/.mediathek3
@@ -686,6 +690,7 @@ blacklist ${HOME}/.openttd
 blacklist ${HOME}/.opera
 blacklist ${HOME}/.opera-beta
 blacklist ${HOME}/.ostrichriders
+blacklist ${HOME}/.paradoxinteractive
 blacklist ${HOME}/.parallelrealities/blobwars
 blacklist ${HOME}/.penguin-command
 blacklist ${HOME}/.pingus

--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -10,12 +10,17 @@ noblacklist ${HOME}/.killingfloor
 noblacklist ${HOME}/.local/share/3909/PapersPlease
 noblacklist ${HOME}/.local/share/aspyr-media
 noblacklist ${HOME}/.local/share/cdprojektred
+noblacklist ${HOME}/.local/share/FasterThanLight
 noblacklist ${HOME}/.local/share/feral-interactive
+noblacklist ${HOME}/.local/share/IntoTheBreach
+noblacklist ${HOME}/.local/share/Paradox Interactive
 noblacklist ${HOME}/.local/share/Steam
 noblacklist ${HOME}/.local/share/SuperHexagon
 noblacklist ${HOME}/.local/share/Terraria
 noblacklist ${HOME}/.local/share/vpltd
 noblacklist ${HOME}/.local/share/vulkan
+noblacklist ${HOME}/.mbwarband
+noblacklist ${HOME}/.paradoxinteractive
 noblacklist ${HOME}/.steam
 noblacklist ${HOME}/.steampath
 noblacklist ${HOME}/.steampid
@@ -41,7 +46,9 @@ mkdir ${HOME}/.killingfloor
 mkdir ${HOME}/.local/share/3909/PapersPlease
 mkdir ${HOME}/.local/share/aspyr-media
 mkdir ${HOME}/.local/share/cdprojektred
+mkdir ${HOME}/.local/share/FasterThanLight
 mkdir ${HOME}/.local/share/feral-interactive
+mkdir ${HOME}/.local/share/IntoTheBreach
 mkdir ${HOME}/.local/share/Paradox Interactive
 mkdir ${HOME}/.local/share/Steam
 mkdir ${HOME}/.local/share/SuperHexagon
@@ -58,7 +65,9 @@ whitelist ${HOME}/.killingfloor
 whitelist ${HOME}/.local/share/3909/PapersPlease
 whitelist ${HOME}/.local/share/aspyr-media
 whitelist ${HOME}/.local/share/cdprojektred
+whitelist ${HOME}/.local/share/FasterThanLight
 whitelist ${HOME}/.local/share/feral-interactive
+whitelist ${HOME}/.local/share/IntoTheBreach
 whitelist ${HOME}/.local/share/Paradox Interactive
 whitelist ${HOME}/.local/share/Steam
 whitelist ${HOME}/.local/share/SuperHexagon
@@ -69,7 +78,6 @@ whitelist ${HOME}/.mbwarband
 whitelist ${HOME}/.paradoxinteractive
 whitelist ${HOME}/.steam
 whitelist ${HOME}/.steampath
-whitelist ${HOME}/.steampid
 whitelist ${HOME}/.steampid
 include whitelist-common.inc
 include whitelist-var-common.inc


### PR DESCRIPTION
Add Faster Than Light, Into the Breach, Paradox Interactive, and mbwarband
to disable-programs.inc.

Also, add Faster Than Light and Into the Breach into steam.profile. This
fixes saved games being lost when steam is closed, and also lets Steam
cloud sync work properly.

Lastly, remove a duplicate whitelist ${HOME}/.steampid from
steam.profile.