### PR TITLE
Allow google-chrome access to the custom flags files in ~/.config.

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -161,6 +161,12 @@ blacklist ${HOME}/.config/cantata
 blacklist ${HOME}/.config/catfish
 blacklist ${HOME}/.config/celluloid
 blacklist ${HOME}/.config/cherrytree
+blacklist ${HOME}/.config/chrome-flags.conf
+blacklist ${HOME}/.config/chrome-flags.config
+blacklist ${HOME}/.config/chrome-beta-flags.conf
+blacklist ${HOME}/.config/chrome-beta-flags.config
+blacklist ${HOME}/.config/chrome-unstable-flags.conf
+blacklist ${HOME}/.config/chrome-unstable-flags.config
 blacklist ${HOME}/.config/chromium
 blacklist ${HOME}/.config/chromium-dev
 blacklist ${HOME}/.config/chromium-flags.conf

--- a/etc/profile-a-l/google-chrome-beta.profile
+++ b/etc/profile-a-l/google-chrome-beta.profile
@@ -8,10 +8,16 @@ include globals.local
 noblacklist ${HOME}/.cache/google-chrome-beta
 noblacklist ${HOME}/.config/google-chrome-beta
 
+noblacklist ${HOME}/.config/chrome-beta-flags.conf
+noblacklist ${HOME}/.config/chrome-beta-flags.config
+
 mkdir ${HOME}/.cache/google-chrome-beta
 mkdir ${HOME}/.config/google-chrome-beta
 whitelist ${HOME}/.cache/google-chrome-beta
 whitelist ${HOME}/.config/google-chrome-beta
+
+whitelist ${HOME}/.config/chrome-beta-flags.conf
+whitelist ${HOME}/.config/chrome-beta-flags.config
 
 # Redirect
 include chromium-common.profile

--- a/etc/profile-a-l/google-chrome-unstable.profile
+++ b/etc/profile-a-l/google-chrome-unstable.profile
@@ -8,10 +8,16 @@ include globals.local
 noblacklist ${HOME}/.cache/google-chrome-unstable
 noblacklist ${HOME}/.config/google-chrome-unstable
 
+noblacklist ${HOME}/.config/chrome-unstable-flags.conf
+noblacklist ${HOME}/.config/chrome-unstable-flags.config
+
 mkdir ${HOME}/.cache/google-chrome-unstable
 mkdir ${HOME}/.config/google-chrome-unstable
 whitelist ${HOME}/.cache/google-chrome-unstable
 whitelist ${HOME}/.config/google-chrome-unstable
+
+whitelist ${HOME}/.config/chrome-unstable-flags.conf
+whitelist ${HOME}/.config/chrome-unstable-flags.config
 
 # Redirect
 include chromium-common.profile

--- a/etc/profile-a-l/google-chrome.profile
+++ b/etc/profile-a-l/google-chrome.profile
@@ -13,5 +13,8 @@ mkdir ${HOME}/.config/google-chrome
 whitelist ${HOME}/.cache/google-chrome
 whitelist ${HOME}/.config/google-chrome
 
+whitelist ${HOME}/.config/chrome-flags.conf
+whitelist ${HOME}/.config/chrome-flags.config
+
 # Redirect
 include chromium-common.profile

--- a/etc/profile-a-l/google-chrome.profile
+++ b/etc/profile-a-l/google-chrome.profile
@@ -8,6 +8,9 @@ include globals.local
 noblacklist ${HOME}/.cache/google-chrome
 noblacklist ${HOME}/.config/google-chrome
 
+noblacklist ${HOME}/.config/chrome-flags.conf
+noblacklist ${HOME}/.config/chrome-flags.config
+
 mkdir ${HOME}/.cache/google-chrome
 mkdir ${HOME}/.config/google-chrome
 whitelist ${HOME}/.cache/google-chrome


### PR DESCRIPTION
This PR modifies the google-chrome.profile to allow chrome access to its custom flag files in ~/.config.