### PR TITLE
Add configure options when building rpm

### DIFF
--- a/platform/rpm/firejail.spec
+++ b/platform/rpm/firejail.spec
@@ -19,7 +19,7 @@ using Linux namespaces. It includes a sandbox profile for Mozilla Firefox.
 %setup -q
 
 %build
-%configure --disable-userns --disable-contrib-install
+%configure __CONFIG_OPT__
 make %{?_smp_mflags}
 
 %install

--- a/platform/rpm/mkrpm.sh
+++ b/platform/rpm/mkrpm.sh
@@ -3,7 +3,7 @@
 # Copyright (C) 2014-2020 Firejail Authors
 # License GPL v2
 #
-# Usage: ./platform/rpm/mkrpm.sh firejail <version>
+# Usage: ./platform/rpm/mkrpm.sh firejail <version> "<config options>"
 #
 # Builds rpms in a temporary directory then places the result in the
 # current working directory.
@@ -11,6 +11,7 @@
 name=$1
 # Strip any trailing prefix from the version like -rc1 etc
 version=$(echo "$2" | sed 's/\-.*//g')
+config_opt=$3
 
 if [[ ! -f platform/rpm/${name}.spec ]]; then
     echo error: spec file not found for name \"${name}\"
@@ -20,6 +21,10 @@ fi
 if [[ -z "${version}" ]]; then
     echo error: version must be given
     exit 1
+fi
+
+if [[ -z "${config_opt}" ]]; then
+    config_opt="--disable-userns --disable-contrib-install"
 fi
 
 # Make a temporary directory and arrange to clean up on exit
@@ -32,7 +37,10 @@ trap cleanup EXIT
 
 # Create the spec file
 tmp_spec_file=${tmpdir}/SPECS/${name}.spec
-sed -e "s/__NAME__/${name}/g" -e "s/__VERSION__/${version}/g" platform/rpm/${name}.spec >${tmp_spec_file}
+sed -e "s/__NAME__/${name}/g" \
+    -e "s/__VERSION__/${version}/g" \
+    -e "s/__CONFIG_OPT__/${config_opt}/g" \
+    platform/rpm/${name}.spec >${tmp_spec_file}
 # FIXME: We could parse RELNOTES and create a %changelog section here
 
 # Copy the source to build into a tarball


### PR DESCRIPTION
It seems configure options are hard-coded when building the RPM. I wish to use different config options with RPM, so I added a third argument to `platform/rpm/mkrpm.sh`, which can change the configure options in firejail.spec file.