### PR TITLE
Add Ubuntu's renamed version of dino

### DIFF
--- a/etc/profile-a-l/dino-im.profile
+++ b/etc/profile-a-l/dino-im.profile
@@ -1,0 +1,14 @@
+# Firejail profile for dino-im
+# Description: Modern XMPP Chat Client using GTK+/Vala, Ubuntu specific bin name
+# This file is overwritten after every install/update
+##quiet
+# Persistent local customizations
+include dino-im.local
+# Persistent global definitions
+include globals.local
+
+# Add Ubuntu specific binary name
+private-bin dino-im
+
+# Redirect
+include dino.profile

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -156,6 +156,7 @@ dig
 digikam
 dillo
 dino
+dino-im
 discord
 discord-canary
 display


### PR DESCRIPTION
Ubuntu ships the dino instant messenger as ``dino-im``, so I added a profile for it, which adds the name to the private-bin parameter and then redirects to the dino profile. Also it's added to firecfg.
