### PR TITLE
Man pages: were missing info about .profile .local resolution

### DIFF
--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -842,5 +842,7 @@ Homepage: https://firejail.wordpress.com
 \&\flfirejail\fR\|(1),
 \&\flfiremon\fR\|(1),
 \&\flfirecfg\fR\|(1),
-\&\flfirejail-login\fR\|(5)
-\&\flfirejail-users\fR\|(5)
+\&\flfirejail-login\fR\|(5),
+\&\flfirejail-users\fR\|(5),
+.UR https://github.com/netblue30/firejail/wiki/Creating-Profiles 
+.UE 

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -66,8 +66,8 @@ command line options. The default Firejail filesystem is based on the host files
 system directories mounted read-only. These directories are /etc, /var, /usr, /bin, /sbin, /lib, /lib32,
 /libx32 and /lib64. Only /home and /tmp are writable.
 .PP
-Upon execution Firejail first looks in ~/.config/firejail/ for a profile and if it doesn't find one, it looks in /etc/firejail/ .
-For profile resolution detail see https://github.com/netblue30/firejail/wiki/Creating-Profiles#locations-and-types .
+Upon execution Firejail first looks in ~/.config/firejail/ for a profile and if it doesn't find one, it looks in /etc/firejail/.
+For profile resolution detail see https://github.com/netblue30/firejail/wiki/Creating-Profiles#locations-and-types.
 If an appropriate profile is not found, Firejail will use a default profile.
 The default profile is quite restrictive. In case the application doesn't work, use --noprofile option
 to disable it. For more information, please see \fBSECURITY PROFILES\fR section below.

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -66,7 +66,8 @@ command line options. The default Firejail filesystem is based on the host files
 system directories mounted read-only. These directories are /etc, /var, /usr, /bin, /sbin, /lib, /lib32,
 /libx32 and /lib64. Only /home and /tmp are writable.
 .PP
-Upon execution Firejail first looks in ~/.config/firejail/ for a profile and if it doesn't find one, it looks in /etc/firejail. For profile resolution detail see https://github.com/netblue30/firejail/wiki/Creating-Profiles#locations-and-types .
+Upon execution Firejail first looks in ~/.config/firejail/ for a profile and if it doesn't find one, it looks in /etc/firejail/ .
+For profile resolution detail see https://github.com/netblue30/firejail/wiki/Creating-Profiles#locations-and-types .
 If an appropriate profile is not found, Firejail will use a default profile.
 The default profile is quite restrictive. In case the application doesn't work, use --noprofile option
 to disable it. For more information, please see \fBSECURITY PROFILES\fR section below.

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -66,7 +66,7 @@ command line options. The default Firejail filesystem is based on the host files
 system directories mounted read-only. These directories are /etc, /var, /usr, /bin, /sbin, /lib, /lib32,
 /libx32 and /lib64. Only /home and /tmp are writable.
 .PP
-As it starts up, Firejail tries to find a security profile based on the name of the application.
+Upon execution Firejail first looks in ~/.config/firejail/ for a profile and if it doesn't find one, it looks in /etc/firejail. For profile resolution detail see https://github.com/netblue30/firejail/wiki/Creating-Profiles#locations-and-types .
 If an appropriate profile is not found, Firejail will use a default profile.
 The default profile is quite restrictive. In case the application doesn't work, use --noprofile option
 to disable it. For more information, please see \fBSECURITY PROFILES\fR section below.
@@ -3107,5 +3107,9 @@ Homepage: https://firejail.wordpress.com
 \&\flfiremon\fR\|(1),
 \&\flfirecfg\fR\|(1),
 \&\flfirejail-profile\fR\|(5),
-\&\flfirejail-login\fR\|(5)
-\&\flfirejail-users\fR\|(5)
+\&\flfirejail-login\fR\|(5),
+\&\flfirejail-users\fR\|(5),
+.UR https://github.com/netblue30/firejail/wiki 
+.UE ,
+.UR https://github.com/netblue30/firejail 
+.UE


### PR DESCRIPTION
Kind of hot fix to explained how .profile/.local resolution works. This was something I was confused about as someone who goes for man pages at first shot.

Partial info is copy pasted and linked from https://github.com/netblue30/firejail/wiki/Creating-Profiles#locations-and-types

This addresses larger issue that documentation is currently scattered cross man, github and web.

I have added links to SEE ALSO paragraph to somehow make user see that there is some more info.