### PR TITLE
Set quiet in w3m profile

### DIFF
--- a/etc/profile-m-z/w3m.profile
+++ b/etc/profile-m-z/w3m.profile
@@ -1,6 +1,7 @@
 # Firejail profile for w3m
 # Description: WWW browsable pager with excellent tables/frames support
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include w3m.local
 # Persistent global definitions


### PR DESCRIPTION
w3m is a text-based web browser as well as a pager like `more' or `less'. With w3m you can browse web pages through a terminal emulator window (xterm, rxvt or something like that).

As it outputs I suppose setting quiet in its profile is appropriate.