### PR TITLE
man: minor clarifications to man pages

### DIFF
--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -268,6 +268,8 @@ Use directory as user home.
 .TP
 \fBprivate-bin file,file
 Build a new /bin in a temporary filesystem, and copy the programs in the list.
+The files in the list must be expressed as relative to the /bin,
+/sbin, /usr/bin, /usr/sbin, or /usr/local/bin directories.
 The same directory is also bind-mounted over /sbin, /usr/bin and /usr/sbin.
 .TP
 \fBprivate-cache
@@ -289,26 +291,37 @@ Use the options no3d, nodvd, nosound, notv, nou2f and novideo for additional res
 \fBprivate-etc file,directory
 Build a new /etc in a temporary
 filesystem, and copy the files and directories in the list.
+The files and directories in the list must be expressed as relative to
+the /etc directory.
 All modifications are discarded when the sandbox is closed.
 .TP
 \fBprivate-home file,directory
 Build a new user home in a temporary
 filesystem, and copy the files and directories in the list in the
-new home. All modifications are discarded when the sandbox is
+new home.
+The files and directories in the list must be expressed as relative to
+the current user's home directory.
+All modifications are discarded when the sandbox is
 closed.
 .TP
 \fBprivate-lib file,directory
 Build a new /lib directory and bring in the libraries required by the application to run.
+The files and directories in the list must be expressed as relative to
+the /lib directory.
 This feature is still under development, see \fBman 1 firejail\fR for some examples.
 .TP
 \fBprivate-opt file,directory
 Build a new /opt in a temporary
 filesystem, and copy the files and directories in the list.
+The files and directories in the list must be expressed as relative to
+the /opt directory.
 All modifications are discarded when the sandbox is closed.
 .TP
 \fBprivate-srv file,directory
 Build a new /srv in a temporary
 filesystem, and copy the files and directories in the list.
+The files and directories in the list must be expressed as relative to
+the /srv directory.
 All modifications are discarded when the sandbox is closed.
 .TP
 \fBprivate-tmp

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -1696,7 +1696,9 @@ $ firejail \-\-private=/home/netblue/firefox-home firefox
 .TP
 \fB\-\-private-bin=file,file
 Build a new /bin in a temporary filesystem, and copy the programs in the list.
-If no listed file is found, /bin directory will be empty.
+The files in the list must be expressed as relative to the /bin,
+/sbin, /usr/bin, /usr/sbin, or /usr/local/bin directories.
+If no listed files are found, /bin directory will be empty.
 The same directory is also bind-mounted over /sbin, /usr/bin, /usr/sbin and /usr/local/bin.
 All modifications are discarded when the sandbox is closed. File globbing is supported,
 see \fBFILE GLOBBING\fR section for more details.
@@ -1792,6 +1794,8 @@ $
 \fB\-\-private-etc=file,directory
 Build a new /etc in a temporary
 filesystem, and copy the files and directories in the list.
+The files and directories in the list must be expressed as relative to
+the /etc directory.
 If no listed file is found, /etc directory will be empty.
 All modifications are discarded when the sandbox is closed.
 .br
@@ -1801,13 +1805,16 @@ Example:
 .br
 $ firejail --private-etc=group,hostname,localtime, \\
 .br
-nsswitch.conf,passwd,resolv.conf
+nsswitch.conf,passwd,resolv.conf,default/motd-news
 
 .TP
 \fB\-\-private-home=file,directory
 Build a new user home in a temporary
 filesystem, and copy the files and directories in the list in the
-new home. All modifications are discarded when the sandbox is
+new home.
+The files and directories in the list must be expressed as relative to
+the current user's home directory.
+All modifications are discarded when the sandbox is
 closed.
 .br
 
@@ -1819,6 +1826,8 @@ $ firejail \-\-private-home=.mozilla firefox
 .TP
 \fB\-\-private-lib=file,directory
 This feature is currently under heavy development. Only amd64 platforms are supported at this moment.
+The files and directories in the list must be expressed as relative to
+the /lib directory.
 The idea is to build a new /lib in a temporary filesystem,
 with only the library files necessary to run the application.
 It could be as simple as:
@@ -1870,6 +1879,8 @@ $
 \fB\-\-private-opt=file,directory
 Build a new /opt in a temporary
 filesystem, and copy the files and directories in the list.
+The files and directories in the list must be expressed as relative to
+the /opt directory.
 If no listed file is found, /opt directory will be empty.
 All modifications are discarded when the sandbox is closed.
 .br
@@ -1883,6 +1894,8 @@ $ firejail --private-opt=firefox /opt/firefox/firefox
 \fB\-\-private-srv=file,directory
 Build a new /srv in a temporary
 filesystem, and copy the files and directories in the list.
+The files and directories in the list must be expressed as relative to
+the /srv directory.
 If no listed file is found, /srv directory will be empty.
 All modifications are discarded when the sandbox is closed.
 .br


### PR DESCRIPTION
Add verbiage to the man pages clarifying that the files/directories in the lists given to options such as --private-bin must be relative to the directory that is being limited (e.g., --private-bin requires a list of files/directories that are relative to /bin).

Signed-off-by: Jeff Squyres <jeff@squyres.com>

I made this PR because it took me a while to figure out why I couldn't properly restrict things with `--private-opt`.  Adding this verbiage will hopefully save another newbie like me some time in the future!