### PR TITLE
enable apparmor support by default in update_deb.sh

### DIFF
--- a/contrib/update_deb.sh
+++ b/contrib/update_deb.sh
@@ -6,11 +6,19 @@
 # Purpose: Fetch, compile, and install firejail from GitHub source. For
 # Debian-based distros only (Ubuntu, Mint, etc).
 set -e
+
 git clone --depth=1 https://github.com/netblue30/firejail.git
 cd firejail
 ./configure --enable-apparmor --prefix=/usr
+
+# Fix https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=916920
+sed -i \
+    -e "s/# cgroup .*/cgroup no/" \
+    -e "s/# restricted-network .*/restricted-network yes/" \
+    etc/firejail.config
+
 make deb
 sudo dpkg -i firejail*.deb
-echo "Firejail was updated!"
+echo "Firejail updated."
 cd ..
 rm -rf firejail

--- a/contrib/update_deb.sh
+++ b/contrib/update_deb.sh
@@ -8,7 +8,7 @@
 set -e
 git clone --depth=1 https://github.com/netblue30/firejail.git
 cd firejail
-./configure --prefix=/usr
+./configure --enable-apparmor --prefix=/usr
 make deb
 sudo dpkg -i firejail*.deb
 echo "Firejail was updated!"


### PR DESCRIPTION
IMO enabling apparmor support by default here ensures a git installation that is compatible with the OS repository and PPA packages (see the firejail-from-git wiki page).

One thing I'm not sure of is how we can patch firejail.config to accomodate https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=916920.