### PR TITLE
Fix qt5ct colour schemes and QSS

### DIFF
--- a/etc/inc/whitelist-usr-share-common.inc
+++ b/etc/inc/whitelist-usr-share-common.inc
@@ -48,6 +48,7 @@ whitelist /usr/share/publicsuffix
 whitelist /usr/share/qt
 whitelist /usr/share/qt4
 whitelist /usr/share/qt5
+whitelist /usr/share/qt5ct
 whitelist /usr/share/sounds
 whitelist /usr/share/tcl8.6
 whitelist /usr/share/tcltk


### PR DESCRIPTION
Applications using Qt5 need this to be whitelisted if the user is using a qt5ct colour scheme (such as "darker") or custom QSS.