### PR TITLE
Allow python3 in totem profile

### DIFF
--- a/etc/profile-m-z/totem.profile
+++ b/etc/profile-m-z/totem.profile
@@ -8,6 +8,8 @@ include globals.local
 
 # Allow lua (required for youtube video)
 include allow-lua.inc
+# Allow python (blacklisted by disable-interpreters.inc)
+include allow-python3.inc
 
 noblacklist ${HOME}/.config/totem
 noblacklist ${HOME}/.local/share/totem


### PR DESCRIPTION
Totem crashes because it can't access python:

```
Could not find platform independent libraries <prefix>
Could not find platform dependent libraries <exec_prefix>
Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
Python path configuration:
  PYTHONHOME = (not set)
  PYTHONPATH = (not set)
  program name = 'python3'
  isolated = 0
  environment = 1
  user site = 1
  import site = 1
  sys._base_executable = ''
  sys.base_prefix = '/usr'
  sys.base_exec_prefix = '/usr'
  sys.executable = ''
  sys.prefix = '/usr'
  sys.exec_prefix = '/usr'
  sys.path = [
    '/usr/lib/python38.zip',
    '/usr/lib/python3.8',
    '/usr/lib/lib-dynload',
  ]
Fatal Python error: init_fs_encoding: failed to get the Python codec of the filesystem encoding
Python runtime state: core initialized
ModuleNotFoundError: No module named 'encodings'

Current thread 0x00007f57df153980 (most recent call first):
<no Python frame>

Parent is shutting down, bye...
```

Totem works if python3 is enabled in the profile.

Details of my Totem version:

```
Name            : totem
Version         : 3.34.1-2
Description     : Movie player for the GNOME desktop based on GStreamer
Architecture    : x86_64
URL             : https://wiki.gnome.org/Apps/Videos
Licenses        : GPL2  custom
Groups          : gnome
Provides        : None
Depends On      : totem-plparser  iso-codes  libpeas  clutter-gtk  clutter-gst
                  grilo  gsettings-desktop-schemas  dconf  python-gobject
                  python-xdg  gnome-desktop  gst-plugins-base  gst-plugins-good
                  gst-plugins-bad
Optional Deps   : gst-plugins-ugly: Extra media codecs
                  gst-libav: Extra media codecs [installed]
                  grilo-plugins: Media discovery [installed]
                  python-dbus: MPRIS plugin [installed]
Required By     : None
Optional For    : None
Conflicts With  : totem-plugin
Replaces        : totem-plugin
Installed Size  : 6.88 MiB
Packager        : Jan Alexander Steffens (heftig) <jan.steffens@gmail.com>
Build Date      : Sun Mar 8 07:26:39 2020
Install Date    : Tue Mar 10 20:30:28 2020
Install Reason  : Explicitly installed
Install Script  : No
Validated By    : Signature
```
