### PR TITLE
fixes for /var/mail in mail clients

### DIFF
--- a/etc/profile-a-l/email-common.profile
+++ b/etc/profile-a-l/email-common.profile
@@ -63,6 +63,8 @@ read-only ${HOME}/.config/mimeapps.list
 writable-run-user
 
 # If you want to read local mail stored in /var/mail, add the following to email-common.local:
-# whitelist /var/mail
-# whitelist /var/spool/mail
-# writable-var
+#noblacklist /var/mail
+#noblacklist /var/spool/mail
+#whitelist /var/mail
+#whitelist /var/spool/mail
+#writable-var

--- a/etc/profile-a-l/evolution.profile
+++ b/etc/profile-a-l/evolution.profile
@@ -43,5 +43,4 @@ shell none
 
 private-dev
 private-tmp
-
 writable-var

--- a/etc/profile-a-l/evolution.profile
+++ b/etc/profile-a-l/evolution.profile
@@ -44,3 +44,4 @@ shell none
 private-dev
 private-tmp
 
+writable-var

--- a/etc/profile-m-z/mutt.profile
+++ b/etc/profile-m-z/mutt.profile
@@ -59,3 +59,4 @@ shell none
 
 private-dev
 writable-run-user
+writable-var


### PR DESCRIPTION
Streamlined some fixes in mail client profiles for accessing /var/mail. IMO the most complete comment is that in the thunderbird.profile, so I based these changes on that.