### PR TITLE
clarify writing to /var/mail and /var/spool/mail in apparmor

### DIFF
--- a/etc/apparmor/firejail-default
+++ b/etc/apparmor/firejail-default
@@ -51,7 +51,7 @@ owner /{,run/firejail/mnt/oroot/}{run,dev}/shm/** w,
 
 # Allow writing to /var/mail and /var/spool/mail (for mail clients)
 # Uncomment to enable
-#owner /{,var/}{mail,spool/mail}/** w,
+#owner /var/{mail,spool/mail}/** w,
 
 # Allow writing to removable media
 owner /{,var/}run/media/** w,

--- a/etc/apparmor/firejail-default
+++ b/etc/apparmor/firejail-default
@@ -49,6 +49,10 @@ owner /{,run/firejail/mnt/oroot/}{,var/}run/firejail/mnt/trace w,
 owner /{,run/firejail/mnt/oroot/}{,var/}run/user/[0-9]*/** w,
 owner /{,run/firejail/mnt/oroot/}{run,dev}/shm/** w,
 
+# Allow writing to /var/mail and /var/spool/mail (for mail clients)
+# Uncomment to enable
+#owner /{,var/}{mail,spool/mail}/** w,
+
 # Allow writing to removable media
 owner /{,var/}run/media/** w,
 


### PR DESCRIPTION
Thunderbird seems to be our only mail client profile that enables the `apparmor` option. Users need this when they follow instructions on how to allow reading local mail.

@Vincent43 Could you take a look at the rule I added please? Not sure if it is the correct syntax...