### PR TITLE
Okular profile fixes

### DIFF
--- a/etc/inc/firefox-common-addons.inc
+++ b/etc/inc/firefox-common-addons.inc
@@ -17,7 +17,6 @@ noblacklist ${HOME}/.kde4/share/config/kgetrc
 noblacklist ${HOME}/.kde4/share/config/okularpartrc
 noblacklist ${HOME}/.kde4/share/config/okularrc
 noblacklist ${HOME}/.local/share/kget
-noblacklist ${HOME}/.local/share/kxmlgui5/okular
 noblacklist ${HOME}/.local/share/okular
 noblacklist ${HOME}/.local/share/qpdfview
 

--- a/etc/inc/firefox-common-addons.inc
+++ b/etc/inc/firefox-common-addons.inc
@@ -17,8 +17,8 @@ noblacklist ${HOME}/.kde4/share/config/kgetrc
 noblacklist ${HOME}/.kde4/share/config/okularpartrc
 noblacklist ${HOME}/.kde4/share/config/okularrc
 noblacklist ${HOME}/.local/share/kget
-noblacklist ${HOME}/.local/share/okular
 noblacklist ${HOME}/.local/share/kxmlgui5/okular
+noblacklist ${HOME}/.local/share/okular
 noblacklist ${HOME}/.local/share/qpdfview
 
 whitelist ${HOME}/.cache/gnome-mplayer/plugin
@@ -42,8 +42,8 @@ whitelist ${HOME}/.kde4/share/config/okularrc
 whitelist ${HOME}/.keysnail.js
 whitelist ${HOME}/.lastpass
 whitelist ${HOME}/.local/share/kget
-whitelist ${HOME}/.local/share/okular
 whitelist ${HOME}/.local/share/kxmlgui5/okular
+whitelist ${HOME}/.local/share/okular
 whitelist ${HOME}/.local/share/qpdfview
 whitelist ${HOME}/.local/share/tridactyl
 whitelist ${HOME}/.pentadactyl

--- a/etc/inc/firefox-common-addons.inc
+++ b/etc/inc/firefox-common-addons.inc
@@ -18,6 +18,7 @@ noblacklist ${HOME}/.kde4/share/config/okularpartrc
 noblacklist ${HOME}/.kde4/share/config/okularrc
 noblacklist ${HOME}/.local/share/kget
 noblacklist ${HOME}/.local/share/okular
+noblacklist ${HOME}/.local/share/kxmlgui5/okular
 noblacklist ${HOME}/.local/share/qpdfview
 
 whitelist ${HOME}/.cache/gnome-mplayer/plugin
@@ -42,6 +43,7 @@ whitelist ${HOME}/.keysnail.js
 whitelist ${HOME}/.lastpass
 whitelist ${HOME}/.local/share/kget
 whitelist ${HOME}/.local/share/okular
+whitelist ${HOME}/.local/share/kxmlgui5/okular
 whitelist ${HOME}/.local/share/qpdfview
 whitelist ${HOME}/.local/share/tridactyl
 whitelist ${HOME}/.pentadactyl

--- a/etc/profile-m-z/okular.profile
+++ b/etc/profile-m-z/okular.profile
@@ -15,8 +15,8 @@ noblacklist ${HOME}/.kde/share/config/okularrc
 noblacklist ${HOME}/.kde4/share/apps/okular
 noblacklist ${HOME}/.kde4/share/config/okularpartrc
 noblacklist ${HOME}/.kde4/share/config/okularrc
-noblacklist ${HOME}/.local/share/okular
 noblacklist ${HOME}/.local/share/kxmlgui5/okular
+noblacklist ${HOME}/.local/share/okular
 noblacklist ${DOCUMENTS}
 
 include disable-common.inc
@@ -29,9 +29,9 @@ include disable-shell.inc
 include disable-xdg.inc
 
 whitelist /usr/share/config.kcfg
+whitelist /usr/share/kxmlgui5/okular
 whitelist /usr/share/okular
 whitelist /usr/share/poppler
-whitelist /usr/share/kxmlgui5/okular
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 

--- a/etc/profile-m-z/okular.profile
+++ b/etc/profile-m-z/okular.profile
@@ -16,6 +16,7 @@ noblacklist ${HOME}/.kde4/share/apps/okular
 noblacklist ${HOME}/.kde4/share/config/okularpartrc
 noblacklist ${HOME}/.kde4/share/config/okularrc
 noblacklist ${HOME}/.local/share/okular
+noblacklist ${HOME}/.local/share/kxmlgui5/okular
 noblacklist ${DOCUMENTS}
 
 include disable-common.inc
@@ -30,6 +31,7 @@ include disable-xdg.inc
 whitelist /usr/share/config.kcfg
 whitelist /usr/share/okular
 whitelist /usr/share/poppler
+whitelist /usr/share/kxmlgui5/okular
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 

--- a/etc/profile-m-z/okular.profile
+++ b/etc/profile-m-z/okular.profile
@@ -15,7 +15,6 @@ noblacklist ${HOME}/.kde/share/config/okularrc
 noblacklist ${HOME}/.kde4/share/apps/okular
 noblacklist ${HOME}/.kde4/share/config/okularpartrc
 noblacklist ${HOME}/.kde4/share/config/okularrc
-noblacklist ${HOME}/.local/share/kxmlgui5/okular
 noblacklist ${HOME}/.local/share/okular
 noblacklist ${DOCUMENTS}
 


### PR DESCRIPTION
The default okular profile doesn't whitelist some config files which are used to store keyboard shortcuts and toolbar configuration. This pull request whitelists those files in `okular.profile` and `firefox-common-addons.inc`