### PR TITLE
noblacklist a config file in konversation profile

### DIFF
--- a/etc/profile-a-l/konversation.profile
+++ b/etc/profile-a-l/konversation.profile
@@ -7,6 +7,7 @@ include konversation.local
 include globals.local
 
 noblacklist ${HOME}/.config/konversationrc
+noblacklist ${HOME}/.config/konversation.notifyrc
 noblacklist ${HOME}/.kde/share/config/konversationrc
 noblacklist ${HOME}/.kde4/share/config/konversationrc
 


### PR DESCRIPTION
Without this, konversation doesn't remember the settings for notifications.