### PR TITLE
Blacklist .local/share/kxmlgui5 and allow access only for applications which use it.

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -613,7 +613,7 @@ blacklist ${HOME}/.local/share/ktorrent
 blacklist ${HOME}/.local/share/ktorrentrc
 blacklist ${HOME}/.local/share/ktouch
 blacklist ${HOME}/.local/share/kwrite
-blacklist ${HOME}/.local/share/kxmlgui5
+blacklist ${HOME}/.local/share/kxmlgui5/*
 blacklist ${HOME}/.local/share/liferea
 blacklist ${HOME}/.local/share/local-mail
 blacklist ${HOME}/.local/share/lollypop

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -613,6 +613,7 @@ blacklist ${HOME}/.local/share/ktorrent
 blacklist ${HOME}/.local/share/ktorrentrc
 blacklist ${HOME}/.local/share/ktouch
 blacklist ${HOME}/.local/share/kwrite
+blacklist ${HOME}/.local/share/kxmlgui5
 blacklist ${HOME}/.local/share/liferea
 blacklist ${HOME}/.local/share/local-mail
 blacklist ${HOME}/.local/share/lollypop

--- a/etc/inc/firefox-common-addons.inc
+++ b/etc/inc/firefox-common-addons.inc
@@ -17,6 +17,7 @@ noblacklist ${HOME}/.kde4/share/config/kgetrc
 noblacklist ${HOME}/.kde4/share/config/okularpartrc
 noblacklist ${HOME}/.kde4/share/config/okularrc
 noblacklist ${HOME}/.local/share/kget
+noblacklist ${HOME}/.local/share/kxmlgui5/okular
 noblacklist ${HOME}/.local/share/okular
 noblacklist ${HOME}/.local/share/qpdfview
 

--- a/etc/profile-a-l/akregator.profile
+++ b/etc/profile-a-l/akregator.profile
@@ -8,6 +8,7 @@ include globals.local
 
 noblacklist ${HOME}/.config/akregatorrc
 noblacklist ${HOME}/.local/share/akregator
+noblacklist ${HOME}/.local/share/kxmlgui5/akregator
 
 include disable-common.inc
 include disable-devel.inc
@@ -19,9 +20,11 @@ include disable-shell.inc
 
 mkfile ${HOME}/.config/akregatorrc
 mkdir ${HOME}/.local/share/akregator
+mkfile ${HOME}/.local/share/kxmlgui5/akregator
 whitelist ${HOME}/.config/akregatorrc
 whitelist ${HOME}/.local/share/akregator
 whitelist ${HOME}/.local/share/kssl
+whitelist ${HOME}/.local/share/kxmlgui5/akregator
 include whitelist-common.inc
 include whitelist-var-common.inc
 

--- a/etc/profile-a-l/akregator.profile
+++ b/etc/profile-a-l/akregator.profile
@@ -20,7 +20,7 @@ include disable-shell.inc
 
 mkfile ${HOME}/.config/akregatorrc
 mkdir ${HOME}/.local/share/akregator
-mkfile ${HOME}/.local/share/kxmlgui5/akregator
+mkdir ${HOME}/.local/share/kxmlgui5/akregator
 whitelist ${HOME}/.config/akregatorrc
 whitelist ${HOME}/.local/share/akregator
 whitelist ${HOME}/.local/share/kssl

--- a/etc/profile-a-l/ark.profile
+++ b/etc/profile-a-l/ark.profile
@@ -7,6 +7,7 @@ include ark.local
 include globals.local
 
 noblacklist ${HOME}/.config/arkrc
+noblacklist ${HOME}/.local/share/kxmlgui5/ark
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/profile-a-l/calligra.profile
+++ b/etc/profile-a-l/calligra.profile
@@ -6,6 +6,8 @@ include calligra.local
 # Persistent global definitions
 include globals.local
 
+noblacklist ${HOME}/.local/share/kxmlgui5/calligra
+
 include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc

--- a/etc/profile-a-l/calligraplan.profile
+++ b/etc/profile-a-l/calligraplan.profile
@@ -1,5 +1,7 @@
 # Firejail profile alias for calligra
 # This file is overwritten after every install/update
 
+noblacklist ${HOME}/.local/share/kxmlgui5/calligraplan
+
 # Redirect
 include calligra.profile

--- a/etc/profile-a-l/calligraplanwork.profile
+++ b/etc/profile-a-l/calligraplanwork.profile
@@ -1,5 +1,7 @@
 # Firejail profile alias for calligra
 # This file is overwritten after every install/update
 
+noblacklist ${HOME}/.local/share/kxmlgui5/calligraplanwork
+
 # Redirect
 include calligra.profile

--- a/etc/profile-a-l/calligrasheets.profile
+++ b/etc/profile-a-l/calligrasheets.profile
@@ -1,5 +1,7 @@
 # Firejail profile alias for calligra
 # This file is overwritten after every install/update
 
+noblacklist ${HOME}/.local/share/kxmlgui5/calligrasheets
+
 # Redirect
 include calligra.profile

--- a/etc/profile-a-l/calligrastage.profile
+++ b/etc/profile-a-l/calligrastage.profile
@@ -1,5 +1,7 @@
 # Firejail profile alias for calligra
 # This file is overwritten after every install/update
 
+noblacklist ${HOME}/.local/share/kxmlgui5/calligrastage
+
 # Redirect
 include calligra.profile

--- a/etc/profile-a-l/calligrawords.profile
+++ b/etc/profile-a-l/calligrawords.profile
@@ -1,5 +1,7 @@
 # Firejail profile alias for calligra
 # This file is overwritten after every install/update
 
+noblacklist ${HOME}/.local/share/kxmlgui5/calligrawords
+
 # Redirect
 include calligra.profile

--- a/etc/profile-a-l/gwenview.profile
+++ b/etc/profile-a-l/gwenview.profile
@@ -15,6 +15,7 @@ noblacklist ${HOME}/.kde/share/config/gwenviewrc
 noblacklist ${HOME}/.kde4/share/apps/gwenview
 noblacklist ${HOME}/.kde4/share/config/gwenviewrc
 noblacklist ${HOME}/.local/share/gwenview
+noblacklist ${HOME}/.local/share/kxmlgui5/gwenview
 noblacklist ${HOME}/.local/share/org.kde.gwenview
 
 include disable-common.inc

--- a/etc/profile-a-l/k3b.profile
+++ b/etc/profile-a-l/k3b.profile
@@ -9,6 +9,7 @@ include globals.local
 noblacklist ${HOME}/.config/k3brc
 noblacklist ${HOME}/.kde/share/config/k3brc
 noblacklist ${HOME}/.kde4/share/config/k3brc
+noblacklist ${HOME}/.local/share/kxmlgui5/k3b
 noblacklist ${MUSIC}
 
 include disable-common.inc

--- a/etc/profile-a-l/karbon.profile
+++ b/etc/profile-a-l/karbon.profile
@@ -1,5 +1,7 @@
 # Firejail profile alias for krita
 # This file is overwritten after every install/update
 
+noblacklist ${HOME}/.local/share/kxmlgui5/karbon
+
 # Redirect
 include krita.profile

--- a/etc/profile-a-l/kate.profile
+++ b/etc/profile-a-l/kate.profile
@@ -15,6 +15,13 @@ noblacklist ${HOME}/.config/kateschemarc
 noblacklist ${HOME}/.config/katesyntaxhighlightingrc
 noblacklist ${HOME}/.config/katevirc
 noblacklist ${HOME}/.local/share/kate
+noblacklist ${HOME}/.local/share/kxmlgui5/kate
+noblacklist ${HOME}/.local/share/kxmlgui5/katefiletree
+noblacklist ${HOME}/.local/share/kxmlgui5/katekonsole
+noblacklist ${HOME}/.local/share/kxmlgui5/kateopenheaderplugin
+noblacklist ${HOME}/.local/share/kxmlgui5/katepart
+noblacklist ${HOME}/.local/share/kxmlgui5/kateproject
+noblacklist ${HOME}/.local/share/kxmlgui5/katesearch
 
 include disable-common.inc
 # include disable-devel.inc

--- a/etc/profile-a-l/kcalc.profile
+++ b/etc/profile-a-l/kcalc.profile
@@ -6,6 +6,7 @@ include kcalc.local
 # Persistent global definitions
 include globals.local
 
+noblacklist ${HOME}/.local/share/kxmlgui5/kcalc
 
 include disable-common.inc
 include disable-devel.inc
@@ -15,12 +16,14 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-shell.inc
 
+mkdir ${HOME}/.local/share/kxmlgui5/kcalc
 mkfile ${HOME}/.config/kcalcrc
 mkfile ${HOME}/.kde/share/config/kcalcrc
 mkfile ${HOME}/.kde4/share/config/kcalcrc
 whitelist ${HOME}/.config/kcalcrc
 whitelist ${HOME}/.kde/share/config/kcalcrc
 whitelist ${HOME}/.kde4/share/config/kcalcrc
+whitelist ${HOME}/.local/share/kxmlgui5/kcalc
 include whitelist-common.inc
 include whitelist-var-common.inc
 

--- a/etc/profile-a-l/kdenlive.profile
+++ b/etc/profile-a-l/kdenlive.profile
@@ -11,6 +11,7 @@ ignore noexec ${HOME}
 noblacklist ${HOME}/.cache/kdenlive
 noblacklist ${HOME}/.config/kdenliverc
 noblacklist ${HOME}/.local/share/kdenlive
+noblacklist ${HOME}/.local/share/kxmlgui5/kdenlive
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/profile-a-l/kget.profile
+++ b/etc/profile-a-l/kget.profile
@@ -12,6 +12,7 @@ noblacklist ${HOME}/.kde/share/config/kgetrc
 noblacklist ${HOME}/.kde4/share/apps/kget
 noblacklist ${HOME}/.kde4/share/config/kgetrc
 noblacklist ${HOME}/.local/share/kget
+noblacklist ${HOME}/.local/share/kxmlgui5/kget
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/profile-a-l/kid3.profile
+++ b/etc/profile-a-l/kid3.profile
@@ -8,6 +8,7 @@ include globals.local
 
 noblacklist ${MUSIC}
 noblacklist ${HOME}/.config/kid3rc
+noblacklist ${HOME}/.local/share/kxmlgui5/kid3
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/profile-a-l/kmail.profile
+++ b/etc/profile-a-l/kmail.profile
@@ -25,6 +25,8 @@ noblacklist ${HOME}/.local/share/apps/korganizer
 noblacklist ${HOME}/.local/share/contacts
 noblacklist ${HOME}/.local/share/emailidentities
 noblacklist ${HOME}/.local/share/kmail2
+noblacklist ${HOME}/.local/share/kxmlgui5/kmail
+noblacklist ${HOME}/.local/share/kxmlgui5/kmail2
 noblacklist ${HOME}/.local/share/local-mail
 noblacklist ${HOME}/.local/share/notes
 noblacklist /tmp/akonadi-*

--- a/etc/profile-a-l/knotes.profile
+++ b/etc/profile-a-l/knotes.profile
@@ -12,6 +12,7 @@ include knotes.local
 
 noblacklist ${HOME}/.config/knotesrc
 noblacklist ${HOME}/.local/share/knotes
+noblacklist ${HOME}/.local/share/kxmlgui5/knotes
 
 # Redirect
 include kmail.profile

--- a/etc/profile-a-l/konversation.profile
+++ b/etc/profile-a-l/konversation.profile
@@ -10,6 +10,7 @@ noblacklist ${HOME}/.config/konversationrc
 noblacklist ${HOME}/.config/konversation.notifyrc
 noblacklist ${HOME}/.kde/share/config/konversationrc
 noblacklist ${HOME}/.kde4/share/config/konversationrc
+noblacklist ${HOME}/.local/share/kxmlgui5/konversation
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/profile-a-l/kopete.profile
+++ b/etc/profile-a-l/kopete.profile
@@ -10,6 +10,7 @@ noblacklist ${HOME}/.kde/share/apps/kopete
 noblacklist ${HOME}/.kde/share/config/kopeterc
 noblacklist ${HOME}/.kde4/share/apps/kopete
 noblacklist ${HOME}/.kde4/share/config/kopeterc
+noblacklist ${HOME}/.local/share/kxmlgui5/kopete
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/profile-a-l/ktorrent.profile
+++ b/etc/profile-a-l/ktorrent.profile
@@ -12,6 +12,7 @@ noblacklist ${HOME}/.kde/share/config/ktorrentrc
 noblacklist ${HOME}/.kde4/share/apps/ktorrent
 noblacklist ${HOME}/.kde4/share/config/ktorrentrc
 noblacklist ${HOME}/.local/share/ktorrent
+noblacklist ${HOME}/.local/share/kxmlgui5/ktorrent
 
 include disable-common.inc
 include disable-devel.inc
@@ -24,6 +25,7 @@ include disable-shell.inc
 mkdir ${HOME}/.kde/share/apps/ktorrent
 mkdir ${HOME}/.kde4/share/apps/ktorrent
 mkdir ${HOME}/.local/share/ktorrent
+mkdir ${HOME}/.local/share/kxmlgui5/ktorrent
 mkfile ${HOME}/.config/ktorrentrc
 mkfile ${HOME}/.kde/share/config/ktorrentrc
 mkfile ${HOME}/.kde4/share/config/ktorrentrc
@@ -34,6 +36,7 @@ whitelist ${HOME}/.kde/share/config/ktorrentrc
 whitelist ${HOME}/.kde4/share/apps/ktorrent
 whitelist ${HOME}/.kde4/share/config/ktorrentrc
 whitelist ${HOME}/.local/share/ktorrent
+whitelist ${HOME}/.local/share/kxmlgui5/ktorrent
 include whitelist-common.inc
 include whitelist-var-common.inc
 

--- a/etc/profile-a-l/kwrite.profile
+++ b/etc/profile-a-l/kwrite.profile
@@ -13,6 +13,7 @@ noblacklist ${HOME}/.config/katesyntaxhighlightingrc
 noblacklist ${HOME}/.config/katevirc
 noblacklist ${HOME}/.config/kwriterc
 noblacklist ${HOME}/.local/share/kwrite
+noblacklist ${HOME}/.local/share/kxmlgui5/kwrite
 noblacklist ${DOCUMENTS}
 
 include disable-common.inc

--- a/etc/profile-m-z/okular.profile
+++ b/etc/profile-m-z/okular.profile
@@ -15,6 +15,7 @@ noblacklist ${HOME}/.kde/share/config/okularrc
 noblacklist ${HOME}/.kde4/share/apps/okular
 noblacklist ${HOME}/.kde4/share/config/okularpartrc
 noblacklist ${HOME}/.kde4/share/config/okularrc
+noblacklist ${HOME}/.local/share/kxmlgui5/okular
 noblacklist ${HOME}/.local/share/okular
 noblacklist ${DOCUMENTS}
 


### PR DESCRIPTION
Multiple KDE applications store their keyboard shortcut and toolbar config in subdirectories of `.local/share/kxmlgui5`. This pull request blacklists these directories in `disable-programs.inc`, and then noblacklists them in the profiles of the applications which require access to them.