### PR TITLE
Whitelist /usr/share/hplip for simple-scan

### DIFF
--- a/etc/profile-m-z/simple-scan.profile
+++ b/etc/profile-m-z/simple-scan.profile
@@ -16,6 +16,7 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-xdg.inc
 
+whitelist /usr/share/hplip
 whitelist /usr/share/simple-scan
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc


### PR DESCRIPTION
hplip is required for scanning using HP printer/scanners.