### PR TITLE
Fixed Blender profile being unable to import numpy

### DIFF
--- a/etc/profile-a-l/blender.profile
+++ b/etc/profile-a-l/blender.profile
@@ -33,7 +33,8 @@ noroot
 notv
 nou2f
 protocol unix,inet,inet6,netlink
-seccomp
+# numpy, used by many add-ons, requires the mbind syscall
+seccomp !mbind
 shell none
 
 private-dev


### PR DESCRIPTION
Many Blender add-ons make use of `numpy`, and with the default `seccomp` filter, the whole program crashes. `numpy` requires the `mbind` `seccomp` filter to be disabled, so this pull request should fix that issue