### PR TITLE
add element-desktop redirect profile

### DIFF
--- a/RELNOTES
+++ b/RELNOTES
@@ -7,7 +7,7 @@ firejail (0.9.63) baseline; urgency=low
     /etc/firejail/firejail.config file.
   * Fine-grained D-Bus sandboxing with xdg-dbus-proxy.
     xdg-dbus-proxy must be installed, if not D-Bus access will be allowed.
-    With this version Nodbus is deprecated, in favor of dbus-user none and
+    With this version nodbus is deprecated, in favor of dbus-user none and
     dbus-system none and will be removed in a future version.
   * DHCP client support
   * firecfg only fix dektop-files if started with sudo
@@ -37,7 +37,7 @@ firejail (0.9.63) baseline; urgency=low
   * new profiles: swell-foop, fdns, five-or-more, steam-runtime, jitsi-meet-desktop
   * new profiles: nicotine, plv, mocp, apostrophe, quadrapassel, dino-im, strawberry
   * new profiles: hitori, bijiben, gnote, gnubik, ZeGrapher, xonotic-sdl-wrapper
-  * new profiles: gapplication, openarena_ded
+  * new profiles: gapplication, openarena_ded, element-desktop
  -- netblue30 <netblue30@yahoo.com>  Tue, 21 Apr 2020 08:00:00 -0500
 
 firejail (0.9.62) baseline; urgency=low

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -81,6 +81,8 @@ blacklist ${HOME}/.config/Code Industry
 blacklist ${HOME}/.config/Cryptocat
 blacklist ${HOME}/.config/Debauchee/Barrier.conf
 blacklist ${HOME}/.config/Dharkael
+blacklist ${HOME}/.config/Element
+blacklist ${HOME}/.config/Element (Riot)
 blacklist ${HOME}/.config/Enox
 blacklist ${HOME}/.config/Ferdi
 blacklist ${HOME}/.config/Franz

--- a/etc/profile-a-l/element-desktop.profile
+++ b/etc/profile-a-l/element-desktop.profile
@@ -1,0 +1,22 @@
+# Firejail profile for element-desktop
+# Description: All-in-one secure chat app for teams, friends and organisations
+# This file is overwritten after every install/update
+# Persistent local customizations
+include element-desktop.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+noblacklist ${HOME}/.config/Element
+noblacklist ${HOME}/.config/Element (Riot)
+
+mkdir ${HOME}/.config/Element
+mkdir ${HOME}/.config/Element (Riot)
+whitelist ${HOME}/.config/Element
+whitelist ${HOME}/.config/Element (Riot)
+whitelist /opt/Element
+
+private-opt Element
+
+# Redirect
+include riot-desktop.profile

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -178,6 +178,7 @@ easystroke
 ebook-viewer
 electron-mail
 electrum
+element-desktop
 elinks
 empathy
 enchant


### PR DESCRIPTION
This PR accomodates the [name change](https://element.io/blog/welcome-to-element/) from Riot to Element.