### PR TITLE
integrate join(-or-start) with dbus options (partial fix)

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -854,6 +854,8 @@ int dbus_check_call_rule(const char *name);
 void dbus_check_profile(void);
 void dbus_proxy_start(void);
 void dbus_proxy_stop(void);
+void dbus_set_session_bus_env(void);
+void dbus_set_system_bus_env(void);
 void dbus_apply_policy(void);
 
 // dhcp.c

--- a/src/firejail/join.c
+++ b/src/firejail/join.c
@@ -579,6 +579,13 @@ void join(pid_t pid, int argc, char **argv, int index) {
 			free(display_str);
 		}
 
+		// set D-Bus environment variables
+		struct stat s;
+		if (stat(RUN_DBUS_USER_SOCKET, &s) == 0)
+			dbus_set_session_bus_env();
+		if (stat(RUN_DBUS_SYSTEM_SOCKET, &s) == 0)
+			dbus_set_system_bus_env();
+
 		start_application(0, NULL);
 
 		// it will never get here!!!


### PR DESCRIPTION
update D-Bus environment variables during `join`, so that
a joining process is able to use D-Bus, too.