### PR TITLE
Github-desktop: Add chroot to seccomp

### DIFF
--- a/etc/profile-a-l/github-desktop.profile
+++ b/etc/profile-a-l/github-desktop.profile
@@ -30,7 +30,7 @@ notv
 nou2f
 novideo
 protocol unix,inet,inet6,netlink
-seccomp
+seccomp !chroot
 
 # Note: On debian-based distributions the binary might be located in
 # /opt/GitHub Desktop/github-desktop, and therefore not be in PATH.


### PR DESCRIPTION
Can't start on Ubuntu or Debian

```
:~$ journalctl --grep=syscall --follow

-- Logs begin at Thu 2020-07-24 07:12:31 GMT. --
Jul 24 09:10:45 korte audit[14351]: SECCOMP auid=4294967295 uid=1000 gid=1000 ses=4294967295 pid=14351 comm="github-desktop" exe="/usr/lib/github-desktop/github-desktop" sig=31 arch=c000003e syscall=161 compat=0 ip=0x7f024fe5d70d code=0x0
Jul 24 09:10:46 korte kernel: audit: type=1326 audit(1595581845.049:36): auid=4294967295 uid=1000 gid=1000 ses=4294967295 pid=14351 comm="github-desktop" exe="/usr/lib/github-desktop/github-desktop" sig=31 arch=c000003e syscall=161 compat=0 ip=0x7f024fe5d70d code=0x0
Jul 24 09:10:46 korte audit[14476]: SECCOMP auid=4294967295 uid=1000 gid=1000 ses=4294967295 pid=14476 comm="github-desktop" exe="/usr/lib/github-desktop/github-desktop" sig=31 arch=c000003e syscall=161 compat=0 ip=0x7f6b2a76270d code=0x0
Jul 24 09:10:47 korte kernel: audit: type=1326 audit(1595581881.208:37): auid=4294967295 uid=1000 gid=1000 ses=4294967295 pid=14476 comm="github-desktop" exe="/usr/lib/github-desktop/github-desktop" sig=31 arch=c000003e syscall=161 compat=0 ip=0x7f6b2a76270d code=0x0

:~$ firejail --debug-syscalls | grep 161
161	- chroot
```
