### PR TITLE
fix typo in multicast CIDR

### DIFF
--- a/etc/net/nolocal.net
+++ b/etc/net/nolocal.net
@@ -32,5 +32,5 @@
 -A OUTPUT -d 172.16.0.0/12 -j DROP
 
 # drop multicast traffic
--A OUTPUT -d 244.0.0.0/4 -j DROP
+-A OUTPUT -d 224.0.0.0/4 -j DROP
 COMMIT


### PR DESCRIPTION
The current rule for dropping outgoing traffic to multicast addresses in nolocal.net does not properly prohibit multicasting due to a typo. The multicast CIDR should be 224.0.0.0/4 and not 244.0.0.0/4.