### PR TITLE
seccomp: logging

### DIFF
--- a/etc/firejail.config
+++ b/etc/firejail.config
@@ -107,7 +107,7 @@
 # Enable or disable seccomp support, default enabled.
 # seccomp yes
 
-# Seccomp error action, kill or errno (EPERM, ENOSYS etc)
+# Seccomp error action, kill, log or errno (EPERM, ENOSYS etc)
 # seccomp-error-action EPERM
 
 # Enable or disable user namespace support, default enabled.

--- a/src/firejail/checkcfg.c
+++ b/src/firejail/checkcfg.c
@@ -229,6 +229,8 @@ int checkcfg(int val) {
 #ifdef HAVE_SECCOMP
 				if (strcmp(ptr + 21, "kill") == 0)
 					cfg_val[CFG_SECCOMP_ERROR_ACTION] = SECCOMP_RET_KILL;
+				else if (strcmp(ptr + 21, "log") == 0)
+					cfg_val[CFG_SECCOMP_ERROR_ACTION] = SECCOMP_RET_LOG;
 				else {
 					cfg_val[CFG_SECCOMP_ERROR_ACTION] = errno_find_name(ptr + 21);
 					if (cfg_val[CFG_SECCOMP_ERROR_ACTION] == -1)

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -186,7 +186,7 @@ typedef struct config_t {
 	char *seccomp_list_drop, *seccomp_list_drop32;	// seccomp drop list
 	char *seccomp_list_keep, *seccomp_list_keep32;	// seccomp keep list
 	char *protocol;			// protocol list
-	char *seccomp_error_action;			// error action: kill or errno
+	char *seccomp_error_action;			// error action: kill, log or errno
 
 	// rlimits
 	long long unsigned rlimit_cpu;

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1442,6 +1442,8 @@ int main(int argc, char **argv, char **envp) {
 				if (config_seccomp_error_action == -1) {
 					if (strcmp(argv[i] + 23, "kill") == 0)
 						arg_seccomp_error_action = SECCOMP_RET_KILL;
+					else if (strcmp(argv[i] + 23, "log") == 0)
+						arg_seccomp_error_action = SECCOMP_RET_LOG;
 					else {
 						arg_seccomp_error_action = errno_find_name(argv[i] + 23);
 						if (arg_seccomp_error_action == -1)

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -991,6 +991,8 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 			if (config_seccomp_error_action == -1) {
 				if (strcmp(ptr + 21, "kill") == 0)
 					arg_seccomp_error_action = SECCOMP_RET_KILL;
+				else if (strcmp(ptr + 21, "log") == 0)
+					arg_seccomp_error_action = SECCOMP_RET_LOG;
 				else {
 					arg_seccomp_error_action = errno_find_name(ptr + 21);
 					if (arg_seccomp_error_action == -1)

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -224,7 +224,8 @@ static char *usage_str =
 	"    --seccomp.print=name|pid - print the seccomp filter for the sandbox\n"
 	"\tidentified by name or PID.\n"
 	"    --seccomp.32[.drop,.keep][=syscall] - like above but for 32 bit architecture.\n"
-	"    --seccomp-error-action=errno|kill - change error code or kill process.\n"
+	"    --seccomp-error-action=errno|kill|log - change error code, kill process\n"
+	"\tor log the attempt.\n"
 #endif
 	"    --shell=none - run the program directly without a user shell.\n"
 	"    --shell=program - set default user shell.\n"

--- a/src/fseccomp/main.c
+++ b/src/fseccomp/main.c
@@ -20,7 +20,7 @@
 #include "fseccomp.h"
 #include "../include/seccomp.h"
 int arg_quiet = 0;
-int arg_seccomp_error_action = EPERM; // error action: errno or kill
+int arg_seccomp_error_action = EPERM; // error action: errno, log or kill
 
 static void usage(void) {
 	printf("Usage:\n");
@@ -73,6 +73,8 @@ printf("\n");
 	if (error_action) {
 		if (strcmp(error_action, "kill") == 0)
 			arg_seccomp_error_action = SECCOMP_RET_KILL;
+		else if (strcmp(error_action, "log") == 0)
+			arg_seccomp_error_action = SECCOMP_RET_LOG;
 		else {
 			arg_seccomp_error_action = errno_find_name(error_action);
 			if (arg_seccomp_error_action == -1)

--- a/src/include/seccomp.h
+++ b/src/include/seccomp.h
@@ -274,7 +274,7 @@ struct seccomp_data {
 #define RETURN_ERRNO(nr) \
 	BPF_STMT(BPF_RET+BPF_K, SECCOMP_RET_ERRNO | nr)
 
-extern int arg_seccomp_error_action;	// error action: errno or kill
+extern int arg_seccomp_error_action;	// error action: errno, log or kill
 #define KILL_OR_RETURN_ERRNO \
 	BPF_STMT(BPF_RET+BPF_K, arg_seccomp_error_action)
 

--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -433,8 +433,10 @@ Enable seccomp filter and whitelist the system calls in the list.
 \fBseccomp.32.keep syscall,syscall,syscall
 Enable seccomp filter and whitelist the system calls in the list for 32 bit system calls on a 64 bit architecture system.
 .TP
-\fBseccomp-error-action kill | ERRNO
-Return a different error instead of EPERM to the process or kill it when an attempt is made to call a blocked system call.
+\fBseccomp-error-action kill | log | ERRNO
+Return a different error instead of EPERM to the process, kill it when
+an attempt is made to call a blocked system call, or allow but log the
+attempt.
 .TP
 \fBx11
 Enable X11 sandboxing.

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -1059,7 +1059,7 @@ that are both writable and executable, to change mappings to be
 executable, or to create executable shared memory. The filter examines
 the arguments of mmap, mmap2, mprotect, pkey_mprotect, memfd_create
 and shmat system calls and returns error EPERM to the process (or
-kills it, see \-\-seccomp-error-action below) if necessary.
+kills it or log the attempt, see \-\-seccomp-error-action below) if necessary.
 .br
 
 .br
@@ -2122,8 +2122,8 @@ Instead of dropping the syscall by returning EPERM, another error
 number can be returned using \fBsyscall:errno\fR syntax. This can be
 also changed globally with \-\-seccomp-error-action or
 in /etc/firejail/firejail.config file.  The process can also be killed
-by using \fBsyscall:kill\fR syntax.
-
+by using \fBsyscall:kill\fR syntax, or the attempt may be logged with
+\fBsyscall:log\fR.
 .br
 
 .br
@@ -2193,7 +2193,8 @@ Instead of dropping the syscall by returning EPERM, another error
 number can be returned using \fBsyscall:errno\fR syntax. This can be
 also changed globally with \-\-seccomp-error-action or
 in /etc/firejail/firejail.config file.  The process can also be killed
-by using \fBsyscall:kill\fR syntax.
+by using \fBsyscall:kill\fR syntax, or the attempt may be logged with
+\fBsyscall:log\fR.
 .br
 
 .br
@@ -2402,7 +2403,8 @@ By default, if a seccomp filter blocks a system call, the process gets
 EPERM as the error. With \-\-seccomp-error-action=error, another error
 number can be returned, for example ENOSYS or EACCES. The process can
 also be killed (like in versions <0.9.63 of Firejail) by using
-\-\-seccomp-error-action=kill syntax. Not killing the process weakens
+\-\-seccomp-error-action=kill syntax, or the attempt may be logged
+with \-\-seccomp-error-action=log. Not killing the process weakens
 Firejail slightly when trying to contain intrusion, but it may also
 allow tighter filters if the only alternative is to allow a system
 call.


### PR DESCRIPTION
Allow `log` as an alternative seccomp error action instead of killing
or returning an errno code.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>
