### PR TITLE
mkdeb.sh should not use files outside $CODE_DIR

### DIFF
--- a/mkdeb.sh.in
+++ b/mkdeb.sh.in
@@ -52,12 +52,12 @@ echo "*****************************************"
 mv $INSTALL_DIR/usr/share/doc/firejail/RELNOTES $INSTALL_DIR/usr/share/doc/firejail/changelog.Debian
 gzip -9 -n $INSTALL_DIR/usr/share/doc/firejail/changelog.Debian
 rm $INSTALL_DIR/usr/share/doc/firejail/COPYING
-install -m644 platform/debian/copyright $INSTALL_DIR/usr/share/doc/firejail/.
+install -m644 $CODE_DIR/platform/debian/copyright $INSTALL_DIR/usr/share/doc/firejail/.
 mkdir -p $DEBIAN_CTRL_DIR
-sed "s/FIREJAILVER/$VERSION/g"  platform/debian/control.$(dpkg-architecture -qDEB_HOST_ARCH) > $DEBIAN_CTRL_DIR/control
+sed "s/FIREJAILVER/$VERSION/g"  $CODE_DIR/platform/debian/control.$(dpkg-architecture -qDEB_HOST_ARCH) > $DEBIAN_CTRL_DIR/control
 
 mkdir -p $INSTALL_DIR/usr/share/lintian/overrides/
-install -m644 platform/debian/firejail.lintian-overrides $INSTALL_DIR/usr/share/lintian/overrides/firejail
+install -m644 $CODE_DIR/platform/debian/firejail.lintian-overrides $INSTALL_DIR/usr/share/lintian/overrides/firejail
 
 find $INSTALL_DIR/etc -type f | sed "s,^$INSTALL_DIR,," | LC_ALL=C sort > $DEBIAN_CTRL_DIR/conffiles
 chmod 644 $DEBIAN_CTRL_DIR/conffiles


### PR DESCRIPTION
With this change you can build firejail deb with only `firejail-*.tar.xz` and `mkdeb.sh` in current dir.

Currently (as well as in 9.62) such build fails:
```
install: cannot stat ‘platform/debian/copyright’: No such file or directory
```