### PR TITLE
Fix nomacs

### DIFF
--- a/etc/profile-m-z/nomacs.profile
+++ b/etc/profile-m-z/nomacs.profile
@@ -43,5 +43,3 @@ private-cache
 private-dev
 private-etc alternatives,ca-certificates,crypto-policies,dconf,drirc,fonts,gtk-3.0,hosts,login.defs,machine-id,pki,resolv.conf,ssl
 private-tmp
-
-memory-deny-write-execute


### PR DESCRIPTION
Probably very recently `ImageLounge 3.17.0`
```
Aug 11 16:32:32 korte audit[29004]: SECCOMP auid=1000 uid=1000 gid=1000
ses=2 subj==firejail-default (enforce) pid=29004 comm="nomacs"
exe="/usr/bin/nomacs" sig=31 arch=c000003e syscall=9 compat=0
ip=0x7fa2a1cc98c6 code=0x0

```