### PR TITLE
New disable include: disable-write-mnt.inc

### DIFF
--- a/etc/inc/disable-write-mnt.inc
+++ b/etc/inc/disable-write-mnt.inc
@@ -1,0 +1,8 @@
+# This file is overwritten during software install.
+# Persistent customizations should go in a .local file.
+include disable-write-mnt.local
+
+read-only /mnt
+read-only /media
+read-only /run/mount
+read-only /run/media

--- a/etc/profile-a-l/default.profile
+++ b/etc/profile-a-l/default.profile
@@ -14,7 +14,7 @@ include disable-common.inc
 # include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
-include disable-write-mnt.inc
+# include disable-write-mnt.inc
 # include disable-xdg.inc
 
 # include whitelist-common.inc

--- a/etc/profile-a-l/default.profile
+++ b/etc/profile-a-l/default.profile
@@ -14,6 +14,7 @@ include disable-common.inc
 # include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
+include disable-write-mnt.inc
 # include disable-xdg.inc
 
 # include whitelist-common.inc

--- a/etc/profile-a-l/eo-common.profile
+++ b/etc/profile-a-l/eo-common.profile
@@ -17,6 +17,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
+include disable-write-mnt.inc
 
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc

--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -110,6 +110,7 @@ include globals.local
 #include disable-passwdmgr.inc
 #include disable-programs.inc
 #include disable-shell.inc
+#include disable-write-mnt.inc
 #include disable-xdg.inc
 
 # This section often mirrors noblacklist section above. The idea is


### PR DESCRIPTION
It is for profiles which have a reasonable mnt access (we can not add
disable-mnt), but no edit function (e.g. any kind of viewer).

Added to
 - profile.template
 - default.profile
 - eo-common.profile