### PR TITLE
added configure option to disable man pages

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -14,12 +14,18 @@ HAVE_APPARMOR=@HAVE_APPARMOR@
 HAVE_CONTRIB_INSTALL=@HAVE_CONTRIB_INSTALL@
 BUSYBOX_WORKAROUND=@BUSYBOX_WORKAROUND@
 HAVE_SUID=@HAVE_SUID@
+NEED_MAN=@NEED_MAN@
 
-all: all_items mydirs man filters
+ifneq ($(NEED_MAN),no)
+MAN_TARGET = man
+MAN_SRC = src/man
+endif
+
+all: all_items mydirs $(MAN_TARGET) filters
 APPS = src/firecfg/firecfg src/firejail/firejail src/firemon/firemon src/profstats/profstats
 SBOX_APPS = src/faudit/faudit src/fbuilder/fbuilder src/ftee/ftee
 SBOX_APPS_NON_DUMPABLE = src/fcopy/fcopy src/fldd/fldd src/fnet/fnet src/fnetfilter/fnetfilter
-MYDIRS = src/lib src/man
+MYDIRS = src/lib $(MAN_SRC)
 MYLIBS = src/libpostexecseccomp/libpostexecseccomp.so src/libtrace/libtrace.so src/libtracelog/libtracelog.so
 MANPAGES = firejail.1 firemon.1 firecfg.1 firejail-profile.5 firejail-login.5 firejail-users.5
 SBOX_APPS_NON_DUMPABLE += src/fsec-optimize/fsec-optimize src/fsec-print/fsec-print src/fseccomp/fseccomp
@@ -133,6 +139,7 @@ ifeq ($(HAVE_APPARMOR),-DHAVE_APPARMOR)
 	# install apparmor profile customization file
 	sh -c "if [ ! -f $(DESTDIR)/$(sysconfdir)/apparmor.d/local/firejail-default ]; then install -c -m 0644 etc/apparmor/firejail-local $(DESTDIR)/$(sysconfdir)/apparmor.d/local/firejail-default; fi;"
 endif
+ifneq ($(NEED_MAN),no)
 	# man pages
 	install -m 0755 -d $(DESTDIR)$(mandir)/man1 $(DESTDIR)$(mandir)/man5
 	for man in $(MANPAGES); do \
@@ -144,6 +151,7 @@ endif
 		esac; \
 	done
 	rm -f $(MANPAGES) $(MANPAGES:%=%.gz)
+endif
 	# bash completion
 	install -m 0755 -d $(DESTDIR)$(datarootdir)/bash-completion/completions
 	install -m 0644 src/bash_completion/firejail.bash_completion $(DESTDIR)$(datarootdir)/bash-completion/completions/firejail

--- a/configure
+++ b/configure
@@ -630,6 +630,7 @@ CPP
 HAVE_SELINUX
 HAVE_CONTRIB_INSTALL
 HAVE_GCOV
+NEED_MAN
 BUSYBOX_WORKAROUND
 HAVE_FATAL_WARNINGS
 HAVE_SUID
@@ -721,6 +722,7 @@ enable_whitelist
 enable_suid
 enable_fatal_warnings
 enable_busybox_workaround
+enable_man
 enable_gcov
 enable_contrib_install
 enable_selinux
@@ -1377,6 +1379,7 @@ Optional Features:
   --enable-fatal-warnings -W -Wall -Werror
   --enable-busybox-workaround
                           enable busybox workaround
+  --enable-man            generate and install man pages
   --enable-gcov           Gcov instrumentation
   --enable-contrib-install
                           install contrib scripts
@@ -3693,6 +3696,18 @@ if test "x$enable_busybox_workaround" = "xyes"; then :
 
 fi
 
+NEED_MAN="yes"
+# Check whether --enable-man was given.
+if test "${enable_man+set}" = set; then :
+  enableval=$enable_man;
+fi
+
+if test "x$enable_man" = "xno"; then :
+
+	NEED_MAN="no"
+
+
+fi
 
 HAVE_GCOV=""
 # Check whether --enable-gcov was given.
@@ -5412,6 +5427,7 @@ echo "   EXTRA_LDFLAGS: $EXTRA_LDFLAGS"
 echo "   EXTRA_CFLAGS: $EXTRA_CFLAGS"
 echo "   fatal warnings: $HAVE_FATAL_WARNINGS"
 echo "   Gcov instrumentation: $HAVE_GCOV"
+echo "   Generate and install man pages: $NEED_MAN"
 echo "   Install contrib scripts: $HAVE_CONTRIB_INSTALL"
 echo "   SELinux labeling support: $HAVE_SELINUX"
 echo "   Install as a SUID executable: $HAVE_SUID"


### PR DESCRIPTION
Those are unnecessary in embedded environment. Besides, in our particular build environment, man page generation simply fails.