### PR TITLE
fix command test in jail_prober.py

### DIFF
--- a/contrib/jail_prober.py
+++ b/contrib/jail_prober.py
@@ -114,7 +114,10 @@ def run_firejail(program, allArgs):
     print('Attempting to run %s in Firejail' % program)
     for arg in allArgs:
         print('Running with', arg)
-        subprocess.call(goodArgs)
+        #We are adding the argument in a copy of the actual list to avoid modify it now.
+        myargs=goodArgs.copy()
+        myargs.insert(-1,arg)
+        subprocess.call(myargs)
         ans = input('Did %s run correctly? [y]/n ' % program)
         if ans in ['n', 'N']:
             badArgs.append(arg)

--- a/contrib/jail_prober.py
+++ b/contrib/jail_prober.py
@@ -111,17 +111,22 @@ def run_firejail(program, allArgs):
     """
     goodArgs = ['firejail', '--noprofile', program]
     badArgs = []
+    allArgs.insert(0,"")
     print('Attempting to run %s in Firejail' % program)
     for arg in allArgs:
-        print('Running with', arg)
+        if arg:
+            print('Running with', arg)
+        else:
+            print('Running without profile')
         #We are adding the argument in a copy of the actual list to avoid modify it now.
         myargs=goodArgs.copy()
-        myargs.insert(-1,arg)
+        if arg:
+            myargs.insert(-1,arg)
         subprocess.call(myargs)
         ans = input('Did %s run correctly? [y]/n ' % program)
         if ans in ['n', 'N']:
             badArgs.append(arg)
-        else:
+        elif arg:
             goodArgs.insert(-1, arg)
         print('\n')
     # Don't include 'firejail', '--noprofile', or program name in arguments


### PR DESCRIPTION
In jail_prober.py, a bug prevent a correct testing :
Argument of the firejail command  aren't tested when they are presented to the user, but one loop after (once they're added to "goodargs" array).
This also imply that they're not removed if they doesn't work 

This little modification correct these two problems.
