### PR TITLE
Fix SELinux crash

### DIFF
--- a/src/firejail/selinux.c
+++ b/src/firejail/selinux.c
@@ -49,6 +49,9 @@ void selinux_relabel_path(const char *path, const char *inside_path)
 	if (!label_hnd)
 		label_hnd = selabel_open(SELABEL_CTX_FILE, NULL, 0);
 
+	if (!label_hnd)
+		errExit("selabel_open");
+
 	/* Open the file as O_PATH, to pin it while we determine and adjust the label */
 	fd = open(path, O_NOFOLLOW|O_CLOEXEC|O_PATH);
 	if (fd < 0)

--- a/src/firejail/selinux.c
+++ b/src/firejail/selinux.c
@@ -43,7 +43,7 @@ void selinux_relabel_path(const char *path, const char *inside_path)
 	if (selinux_enabled == -1)
 		selinux_enabled = is_selinux_enabled();
 
-	if (!selinux_enabled && arg_debug)
+	if (!selinux_enabled)
 		return;
 
 	if (!label_hnd)


### PR DESCRIPTION
Fixes the crash on systems where SELinux is not enabled.

Also in case SELinux is enabled but the handle can't be opened, exit, as otherwise it would also crash.