### PR TITLE
Fix AppArmor 3.0 support (closes #3659)

### DIFF
--- a/etc/apparmor/firejail-default
+++ b/etc/apparmor/firejail-default
@@ -2,6 +2,10 @@
 # Generic Firejail AppArmor profile
 #########################################
 
+# AppArmor 3.0 uses the @{run} variable in <abstractions/dbus-strict>
+# and <abstractions/dbus-session-strict>.
+#include <tunables/global>
+
 ##########
 # A simple PID declaration based on Ubuntu's @{pid}
 # Ubuntu keeps it under tunables/kernelvars and include it via tunables/global.


### PR DESCRIPTION
AppArmor introduces the @{run} variable, which is used in
<abstractions/dbus-strict> and <abstractions/dbus-session-strict> among
other places. Thus, we must #include <tunables/run> to be able to call
these abstractions.

Standard profiles rely on <tunables/global> to include <tunables/run>, since it exists in previous AppArmor versions, too.

~As an attempt at backwards compatibility, we #include if exists instead
of #include, since there is no <tunables/run> in AppArmor 2.x.~

~However, if exists is a relatively new feature, see e.g.
https://phabricator.kde.org/D14526
(However, do note that if exists does not appear as a new feature in
https://gitlab.com/apparmor/apparmor/-/wikis/Release_Notes_2.13).
Therefore, this commit restricts our compatibility to relatively new
(<10 months) old AppArmor releases only.~

~As an alternative, we could detect the AppArmor version at configure
time, and emit a firejail-default profile based on that.~

~Here, I opted for the simpler approach, as distributions likely to ship >10 months old AppArmor (Debian) support Firejail on their own via backports (according to https://github.com/netblue30/firejail/security/policy), anyways.~