### PR TITLE
Allowing links in netns

### DIFF
--- a/src/firejail/netns.c
+++ b/src/firejail/netns.c
@@ -60,7 +60,7 @@ void check_netns(const char *nsname) {
 			nsname, control_file, strerror(errno));
 		exit(1);
 	}
-	if (!S_ISREG(st.st_mode)) {
+	if (!S_ISREG(st.st_mode) && !S_ISLNK(st.st_mode)) {
 		fprintf(stderr, "Error: invalid netns '%s' (%s: not a regular file)\n",
 			nsname, control_file);
 		exit(1);


### PR DESCRIPTION
Hello,

In Linux it is possible to expose the network of a Docker container as a network namespace of the host with the following commands:
```
NAME="my_container"
pid="$(docker inspect -f '{{.State.Pid}}' "$NAME")"
mkdir -p /var/run/netns
ln -nsf "/proc/$pid/ns/net" "/var/run/netns/$NAME"
```
However, since that is created as a symlink (and it is not a regular file), Firejail fails to recognize it:
```
$ /usr/bin/firejail --noprofile --netns=my_container /usr/bin/firefox
Error: invalid netns 'my_container' (/var/run/netns/my_container: not a regular file)
```
This tiny PR allows using symlinks as arguments of the `netns` option. 