### PR TITLE
Update wire-desktop.profile (again)

### DIFF
--- a/etc/profile-m-z/wire-desktop.profile
+++ b/etc/profile-m-z/wire-desktop.profile
@@ -27,7 +27,7 @@ seccomp !chroot
 shell none
 
 disable-mnt
-private-bin bash,electron,electron4,electron6,electron9,env,sh,wire-desktop
+private-bin bash,electron,electron[0-9],electron[0-9][0-9],env,sh,wire-desktop
 private-dev
 private-etc alternatives,ca-certificates,crypto-policies,fonts,machine-id,pki,resolv.conf,ssl
 private-tmp

--- a/etc/profile-m-z/wire-desktop.profile
+++ b/etc/profile-m-z/wire-desktop.profile
@@ -27,7 +27,7 @@ seccomp !chroot
 shell none
 
 disable-mnt
-private-bin bash,electron,electron4,electron6,env,sh,wire-desktop
+private-bin bash,electron,electron4,electron6,electron9,env,sh,wire-desktop
 private-dev
 private-etc alternatives,ca-certificates,crypto-policies,fonts,machine-id,pki,resolv.conf,ssl
 private-tmp


### PR DESCRIPTION
On arch,wire-desktop is now depending on electron9. Using wildcard for this sorta packages would be better.
