### PR TITLE
Updated fix_private-bin.py shebang to use env python3 like other contrib/*.py scripts

### DIFF
--- a/contrib/fix_private-bin.py
+++ b/contrib/fix_private-bin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 __author__ = "KOLANICH"
 __copyright__ = """This is free and unencumbered software released into the public domain.
 


### PR DESCRIPTION
This will simplify some distro packagings of firejail.

Signed-off-by: Hank Leininger <hlein@korelogic.com>