### PR TITLE
Apply --rmenv immediately to help to avoid the env var length check

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1004,17 +1004,21 @@ int main(int argc, char **argv, char **envp) {
 			fprintf(stderr, "Error: too long arguments\n");
 			exit(1);
 		}
+		// Also remove requested environment variables
+		// entirely to avoid tripping the length check below
+		if (strncmp(argv[i], "--rmenv=", 8) == 0)
+			unsetenv(argv[i] + 8);
 	}
 
 	// sanity check for environment variables
 	for (i = 0, ptr = envp; ptr && *ptr && i < MAX_ENVS; i++, ptr++) {
 		if (strlen(*ptr) >= MAX_ENV_LEN) {
-			fprintf(stderr, "Error: too long environment variables\n");
+			fprintf(stderr, "Error: too long environment variables, please use --rmenv\n");
 			exit(1);
 		}
 	}
 	if (i >= MAX_ENVS) {
-		fprintf(stderr, "Error: too many environment variables\n");
+		fprintf(stderr, "Error: too many environment variables, please use --rmenv\n");
 		exit(1);
 	}
 

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -912,6 +912,7 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		return 0;
 	}
 	if (strncmp(ptr, "rmenv ", 6) == 0) {
+		unsetenv(ptr + 6); // Remove also immediately from Firejail itself
 		env_store(ptr + 6, RMENV);
 		return 0;
 	}


### PR DESCRIPTION
Remove environment variables with --rmenv (and profile rmenv)
immediately. This fixes removing long environment variables (LS_COLORS
generated by vivid), previously the length filter would trip before
the command was processed.

This changes user visible behavior slightly, for example --rmenv=LANG
now applies also to Firejail, while earlier it would only apply to
sandboxed program.

Closes #3673.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>