### PR TITLE
Allow --tmpfs and --bind inside $HOME for unprivileged users

### DIFF
--- a/RELNOTES
+++ b/RELNOTES
@@ -1,3 +1,6 @@
+firejail (0.9.65) baseline; urgency=low
+  * allow --tmpfs inside $HOME for unprivileged users
+
 firejail (0.9.64) baseline; urgency=low
   * replaced --nowrap option with --wrap in firemon
   * The blocking action of seccomp filters has been changed from

--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -366,6 +366,14 @@ void fs_blacklist(void) {
 		else if (strncmp(entry->data, "tmpfs ", 6) == 0) {
 			ptr = entry->data + 6;
 			op = MOUNT_TMPFS;
+			char *resolved_path = realpath(ptr, NULL);
+			if (!resolved_path || strncmp(cfg.homedir, resolved_path, strlen(cfg.homedir)) != 0) {
+				if (getuid() != 0) {
+					fprintf(stderr, "Error: tmpfs outside $HOME is only available for root\n");
+					exit(1);
+				}
+			}
+			free(resolved_path);
 		}
 		else if (strncmp(entry->data, "mkdir ", 6) == 0) {
 			EUID_USER();

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -1563,10 +1563,6 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 	else if (strncmp(ptr, "noexec ", 7) == 0)
 		ptr += 7;
 	else if (strncmp(ptr, "tmpfs ", 6) == 0) {
-		if (getuid() != 0) {
-			fprintf(stderr, "Error: tmpfs available only when running the sandbox as root\n");
-			exit(1);
-		}
 		ptr += 6;
 	}
 	else {

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -1412,11 +1412,6 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 	// filesystem bind
 	if (strncmp(ptr, "bind ", 5) == 0) {
 		if (checkcfg(CFG_BIND)) {
-			if (getuid() != 0) {
-				fprintf(stderr, "Error: --bind option is available only if running as root\n");
-				exit(1);
-			}
-
 			// extract two directories
 			char *dname1 = ptr + 5;
 			char *dname2 = split_comma(dname1); // this inserts a '0 to separate the two dierctories
@@ -1431,6 +1426,18 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 			if (strstr(dname1, "..") || strstr(dname2, "..")) {
 				fprintf(stderr, "Error: invalid file name.\n");
 				exit(1);
+			}
+			if (getuid() != 0) {
+				char *resolved_path1 = realpath(dname1, NULL);
+				char *resolved_path2 = realpath(dname2, NULL);
+				assert(resolved_path1 && resolved_path2);
+					if (strncmp(cfg.homedir, resolved_path1, strlen(cfg.homedir)) != 0
+					|| strncmp(cfg.homedir, resolved_path2, strlen(cfg.homedir)) != 0) {
+						fprintf(stderr, "Error: bind outside $HOME is only available for root\n");
+						exit(1);
+					}
+				free(resolved_path1);
+				free(resolved_path2);
 			}
 			if (is_link(dname1) || is_link(dname2)) {
 				fprintf(stderr, "Symbolic links are not allowed for bind command\n");


### PR DESCRIPTION
--tmpfs was added in 0.9.14 and restricted to root only in 0.9.38
due to priv-esc CVE-2016-10117 (e.g. --tmpfs=/etc and modify
/etc/sudoers). This commit reintroduce it for normal users, if the
realpath of it is inside users-home.

BTW: Could we not allow tmpfs complete if nnp is enforced?