### PR TITLE
Fix blu-ray playback with libaacs

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -68,6 +68,7 @@ blacklist ${HOME}/.cliqz
 blacklist ${HOME}/.clonk
 blacklist ${HOME}/.config/0ad
 blacklist ${HOME}/.config/2048-qt
+blacklist ${HOME}/.config/aacs
 blacklist ${HOME}/.config/Atom
 blacklist ${HOME}/.config/Audaciousrc
 blacklist ${HOME}/.config/Authenticator

--- a/etc/profile-m-z/vlc.profile
+++ b/etc/profile-m-z/vlc.profile
@@ -8,6 +8,7 @@ include globals.local
 
 noblacklist ${HOME}/.cache/vlc
 noblacklist ${HOME}/.config/vlc
+noblacklist ${HOME}/.config/aacs
 noblacklist ${HOME}/.local/share/vlc
 
 include disable-common.inc
@@ -23,6 +24,7 @@ mkdir ${HOME}/.config/vlc
 mkdir ${HOME}/.local/share/vlc
 whitelist ${HOME}/.cache/vlc
 whitelist ${HOME}/.config/vlc
+whitelist ${HOME}/.config/aacs
 whitelist ${HOME}/.local/share/vlc
 include whitelist-common.inc
 include whitelist-players.inc


### PR DESCRIPTION
This fixes #3682 by allowing access to ~/.config/aacs, where the key database for libaacs resides.
