### PR TITLE
rework chromium

### DIFF
--- a/etc/inc/chromium-common-hardened.inc
+++ b/etc/inc/chromium-common-hardened.inc
@@ -1,0 +1,5 @@
+caps.drop all
+nonewprivs
+noroot
+protocol unix,inet,inet6,netlink
+seccomp !chroot

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -389,6 +389,7 @@ blacklist ${HOME}/.config/transmission
 blacklist ${HOME}/.config/truecraft
 blacklist ${HOME}/.config/tvbrowser
 blacklist ${HOME}/.config/uGet
+blacklist ${HOME}/.config/ungoogled-chromium
 blacklist ${HOME}/.config/uzbl
 blacklist ${HOME}/.config/viewnior
 blacklist ${HOME}/.config/vivaldi
@@ -974,6 +975,7 @@ blacklist ${HOME}/.cache/telepathy
 blacklist ${HOME}/.cache/thunderbird
 blacklist ${HOME}/.cache/torbrowser
 blacklist ${HOME}/.cache/transmission
+blacklist ${HOME}/.cache/ungoogled-chromium
 blacklist ${HOME}/.cache/vivaldi
 blacklist ${HOME}/.cache/vivaldi-snapshot
 blacklist ${HOME}/.cache/vlc

--- a/etc/profile-a-l/bnox.profile
+++ b/etc/profile-a-l/bnox.profile
@@ -5,6 +5,10 @@ include bnox.local
 # Persistent global definitions
 include globals.local
 
+# Disable for now, see ___
+ignore include whitelist-runuser-common.inc
+ignore include whitelist-usr-share-common.inc
+
 noblacklist ${HOME}/.cache/bnox
 noblacklist ${HOME}/.config/bnox
 

--- a/etc/profile-a-l/bnox.profile
+++ b/etc/profile-a-l/bnox.profile
@@ -5,7 +5,7 @@ include bnox.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see ___
+# Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
 ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/bnox.profile
+++ b/etc/profile-a-l/bnox.profile
@@ -6,6 +6,7 @@ include bnox.local
 include globals.local
 
 # Disable for now, see ___
+ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-a-l/brave.profile
+++ b/etc/profile-a-l/brave.profile
@@ -8,6 +8,8 @@ include globals.local
 
 # noexec /tmp is included in chromium-common.profile and breaks Brave
 ignore noexec /tmp
+# TOR is installed in ${HOME}
+ignore noexec ${HOME}
 # Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
 ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc

--- a/etc/profile-a-l/brave.profile
+++ b/etc/profile-a-l/brave.profile
@@ -8,6 +8,9 @@ include globals.local
 
 # noexec /tmp is included in chromium-common.profile and breaks Brave
 ignore noexec /tmp
+# Disable for now, see ___
+ignore include whitelist-runuser-common.inc
+ignore include whitelist-usr-share-common.inc
 
 noblacklist ${HOME}/.cache/BraveSoftware
 noblacklist ${HOME}/.config/BraveSoftware

--- a/etc/profile-a-l/brave.profile
+++ b/etc/profile-a-l/brave.profile
@@ -8,7 +8,7 @@ include globals.local
 
 # noexec /tmp is included in chromium-common.profile and breaks Brave
 ignore noexec /tmp
-# Disable for now, see ___
+# Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
 ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/brave.profile
+++ b/etc/profile-a-l/brave.profile
@@ -9,6 +9,7 @@ include globals.local
 # noexec /tmp is included in chromium-common.profile and breaks Brave
 ignore noexec /tmp
 # Disable for now, see ___
+ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-a-l/chromium-browser-privacy.profile
+++ b/etc/profile-a-l/chromium-browser-privacy.profile
@@ -1,0 +1,17 @@
+# Firejail profile for chromium-browser-privacy
+# This file is overwritten after every install/update
+# Persistent local customizations
+include chromium-browser-privacy.local
+
+noblacklist ${HOME}/.cache/ungoogled-chromium
+noblacklist ${HOME}/.config/ungoogled-chromium
+
+mkdir ${HOME}/.cache/ungoogled-chromium
+mkdir ${HOME}/.config/ungoogled-chromium
+whitelist ${HOME}/.cache/ungoogled-chromium
+whitelist ${HOME}/.config/ungoogled-chromium
+
+# private-bin basename,bash,chromium-browser-privacy,dirname,mkdir,readlink,sed,touch,which,xdg-settings
+
+# Redirect
+include chromium.profile

--- a/etc/profile-a-l/chromium-common.profile
+++ b/etc/profile-a-l/chromium-common.profile
@@ -16,15 +16,24 @@ include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
+# include disable-passwdmgr.inc
 include disable-programs.inc
+include disable-xdg.inc
 
 mkdir ${HOME}/.pki
 mkdir ${HOME}/.local/share/pki
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.pki
 whitelist ${HOME}/.local/share/pki
+whitelist /usr/share/chromium
 include whitelist-common.inc
+include whitelist-runuser-common.inc
+include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
+
+# Uncomment the next line (or add it to your chromium-common.local)
+# if your kernel allows unprivileged userns clone.
+#include chromium-common-hardened.inc
 
 apparmor
 caps.keep sys_admin,sys_chroot
@@ -36,8 +45,10 @@ notv
 shell none
 
 disable-mnt
+private-cache
 ?BROWSER_DISABLE_U2F: private-dev
-# private-tmp - problems with multiple browser sessions
+# problems with multiple browser sessions
+#private-tmp
 
 # prevents access to passwords saved in GNOME Keyring and KWallet, also breaks Gnome connector
 # dbus-user none

--- a/etc/profile-a-l/dnox.profile
+++ b/etc/profile-a-l/dnox.profile
@@ -5,6 +5,10 @@ include dnox.local
 # Persistent global definitions
 include globals.local
 
+# Disable for now, see ___
+ignore include whitelist-runuser-common.inc
+ignore include whitelist-usr-share-common.inc
+
 noblacklist ${HOME}/.cache/dnox
 noblacklist ${HOME}/.config/dnox
 

--- a/etc/profile-a-l/dnox.profile
+++ b/etc/profile-a-l/dnox.profile
@@ -5,7 +5,7 @@ include dnox.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see ___
+# Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
 ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/dnox.profile
+++ b/etc/profile-a-l/dnox.profile
@@ -6,6 +6,7 @@ include dnox.local
 include globals.local
 
 # Disable for now, see ___
+ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-a-l/enox.profile
+++ b/etc/profile-a-l/enox.profile
@@ -5,7 +5,7 @@ include enox.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see ___
+# Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
 ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/enox.profile
+++ b/etc/profile-a-l/enox.profile
@@ -6,6 +6,7 @@ include enox.local
 include globals.local
 
 # Disable for now, see ___
+ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-a-l/enox.profile
+++ b/etc/profile-a-l/enox.profile
@@ -5,6 +5,10 @@ include enox.local
 # Persistent global definitions
 include globals.local
 
+# Disable for now, see ___
+ignore include whitelist-runuser-common.inc
+ignore include whitelist-usr-share-common.inc
+
 noblacklist ${HOME}/.cache/Enox
 noblacklist ${HOME}/.config/Enox
 

--- a/etc/profile-a-l/flashpeak-slimjet.profile
+++ b/etc/profile-a-l/flashpeak-slimjet.profile
@@ -5,6 +5,10 @@ include flashpeak-slimjet.local
 # Persistent global definitions
 include globals.local
 
+# Disable for now, see ___
+ignore include whitelist-runuser-common.inc
+ignore include whitelist-usr-share-common.inc
+
 noblacklist ${HOME}/.cache/slimjet
 noblacklist ${HOME}/.config/slimjet
 

--- a/etc/profile-a-l/flashpeak-slimjet.profile
+++ b/etc/profile-a-l/flashpeak-slimjet.profile
@@ -5,7 +5,7 @@ include flashpeak-slimjet.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see ___
+# Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
 ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/flashpeak-slimjet.profile
+++ b/etc/profile-a-l/flashpeak-slimjet.profile
@@ -6,6 +6,7 @@ include flashpeak-slimjet.local
 include globals.local
 
 # Disable for now, see ___
+ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-a-l/google-chrome-beta.profile
+++ b/etc/profile-a-l/google-chrome-beta.profile
@@ -5,6 +5,10 @@ include google-chrome-beta.local
 # Persistent global definitions
 include globals.local
 
+# Disable for now, see ___
+ignore include whitelist-runuser-common.inc
+ignore include whitelist-usr-share-common.inc
+
 noblacklist ${HOME}/.cache/google-chrome-beta
 noblacklist ${HOME}/.config/google-chrome-beta
 

--- a/etc/profile-a-l/google-chrome-beta.profile
+++ b/etc/profile-a-l/google-chrome-beta.profile
@@ -5,7 +5,7 @@ include google-chrome-beta.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see ___
+# Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
 ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/google-chrome-beta.profile
+++ b/etc/profile-a-l/google-chrome-beta.profile
@@ -6,6 +6,7 @@ include google-chrome-beta.local
 include globals.local
 
 # Disable for now, see ___
+ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-a-l/google-chrome-unstable.profile
+++ b/etc/profile-a-l/google-chrome-unstable.profile
@@ -5,7 +5,7 @@ include google-chrome-unstable.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see ___
+# Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
 ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/google-chrome-unstable.profile
+++ b/etc/profile-a-l/google-chrome-unstable.profile
@@ -5,6 +5,10 @@ include google-chrome-unstable.local
 # Persistent global definitions
 include globals.local
 
+# Disable for now, see ___
+ignore include whitelist-runuser-common.inc
+ignore include whitelist-usr-share-common.inc
+
 noblacklist ${HOME}/.cache/google-chrome-unstable
 noblacklist ${HOME}/.config/google-chrome-unstable
 

--- a/etc/profile-a-l/google-chrome-unstable.profile
+++ b/etc/profile-a-l/google-chrome-unstable.profile
@@ -6,6 +6,7 @@ include google-chrome-unstable.local
 include globals.local
 
 # Disable for now, see ___
+ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-a-l/google-chrome.profile
+++ b/etc/profile-a-l/google-chrome.profile
@@ -5,6 +5,10 @@ include google-chrome.local
 # Persistent global definitions
 include globals.local
 
+# Disable for now, see ___
+ignore include whitelist-runuser-common.inc
+ignore include whitelist-usr-share-common.inc
+
 noblacklist ${HOME}/.cache/google-chrome
 noblacklist ${HOME}/.config/google-chrome
 

--- a/etc/profile-a-l/google-chrome.profile
+++ b/etc/profile-a-l/google-chrome.profile
@@ -5,7 +5,7 @@ include google-chrome.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see ___
+# Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
 ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/google-chrome.profile
+++ b/etc/profile-a-l/google-chrome.profile
@@ -6,6 +6,7 @@ include google-chrome.local
 include globals.local
 
 # Disable for now, see ___
+ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-a-l/inox.profile
+++ b/etc/profile-a-l/inox.profile
@@ -5,6 +5,10 @@ include inox.local
 # Persistent global definitions
 include globals.local
 
+# Disable for now, see ___
+ignore include whitelist-runuser-common.inc
+ignore include whitelist-usr-share-common.inc
+
 noblacklist ${HOME}/.cache/inox
 noblacklist ${HOME}/.config/inox
 

--- a/etc/profile-a-l/inox.profile
+++ b/etc/profile-a-l/inox.profile
@@ -5,7 +5,7 @@ include inox.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see ___
+# Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
 ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/inox.profile
+++ b/etc/profile-a-l/inox.profile
@@ -6,6 +6,7 @@ include inox.local
 include globals.local
 
 # Disable for now, see ___
+ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-a-l/iridium.profile
+++ b/etc/profile-a-l/iridium.profile
@@ -5,7 +5,7 @@ include iridium.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see ___
+# Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
 ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/iridium.profile
+++ b/etc/profile-a-l/iridium.profile
@@ -6,6 +6,7 @@ include iridium.local
 include globals.local
 
 # Disable for now, see ___
+ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-a-l/iridium.profile
+++ b/etc/profile-a-l/iridium.profile
@@ -5,6 +5,10 @@ include iridium.local
 # Persistent global definitions
 include globals.local
 
+# Disable for now, see ___
+ignore include whitelist-runuser-common.inc
+ignore include whitelist-usr-share-common.inc
+
 noblacklist ${HOME}/.cache/iridium
 noblacklist ${HOME}/.config/iridium
 

--- a/etc/profile-m-z/min.profile
+++ b/etc/profile-m-z/min.profile
@@ -6,7 +6,7 @@ include min.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see ___
+# Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
 ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-m-z/min.profile
+++ b/etc/profile-m-z/min.profile
@@ -7,6 +7,7 @@ include min.local
 include globals.local
 
 # Disable for now, see ___
+ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-m-z/min.profile
+++ b/etc/profile-m-z/min.profile
@@ -6,6 +6,10 @@ include min.local
 # Persistent global definitions
 include globals.local
 
+# Disable for now, see ___
+ignore include whitelist-runuser-common.inc
+ignore include whitelist-usr-share-common.inc
+
 noblacklist ${HOME}/.config/Min
 
 mkdir ${HOME}/.config/Min

--- a/etc/profile-m-z/opera-beta.profile
+++ b/etc/profile-m-z/opera-beta.profile
@@ -5,7 +5,7 @@ include opera-beta.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see ___
+# Disable for now, see https://www.tutorialspoint.com/difference-between-void-main-and-int-main-in-c-cplusplus
 ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-m-z/opera-beta.profile
+++ b/etc/profile-m-z/opera-beta.profile
@@ -5,6 +5,10 @@ include opera-beta.local
 # Persistent global definitions
 include globals.local
 
+# Disable for now, see ___
+ignore include whitelist-runuser-common.inc
+ignore include whitelist-usr-share-common.inc
+
 noblacklist ${HOME}/.cache/opera
 noblacklist ${HOME}/.config/opera-beta
 

--- a/etc/profile-m-z/opera-beta.profile
+++ b/etc/profile-m-z/opera-beta.profile
@@ -6,6 +6,7 @@ include opera-beta.local
 include globals.local
 
 # Disable for now, see ___
+ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-m-z/opera.profile
+++ b/etc/profile-m-z/opera.profile
@@ -6,6 +6,10 @@ include opera.local
 # Persistent global definitions
 include globals.local
 
+# Disable for now, see ___
+ignore include whitelist-runuser-common.inc
+ignore include whitelist-usr-share-common.inc
+
 noblacklist ${HOME}/.cache/opera
 noblacklist ${HOME}/.config/opera
 noblacklist ${HOME}/.opera

--- a/etc/profile-m-z/opera.profile
+++ b/etc/profile-m-z/opera.profile
@@ -7,6 +7,7 @@ include opera.local
 include globals.local
 
 # Disable for now, see ___
+ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-m-z/opera.profile
+++ b/etc/profile-m-z/opera.profile
@@ -6,7 +6,7 @@ include opera.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see ___
+# Disable for now, see https://www.tutorialspoint.com/difference-between-void-main-and-int-main-in-c-cplusplus
 ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-m-z/snox.profile
+++ b/etc/profile-m-z/snox.profile
@@ -5,7 +5,7 @@ include snox.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see ___
+# Disable for now, see https://www.tutorialspoint.com/difference-between-void-main-and-int-main-in-c-cplusplus
 ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-m-z/snox.profile
+++ b/etc/profile-m-z/snox.profile
@@ -5,6 +5,10 @@ include snox.local
 # Persistent global definitions
 include globals.local
 
+# Disable for now, see ___
+ignore include whitelist-runuser-common.inc
+ignore include whitelist-usr-share-common.inc
+
 noblacklist ${HOME}/.cache/snox
 noblacklist ${HOME}/.config/snox
 

--- a/etc/profile-m-z/snox.profile
+++ b/etc/profile-m-z/snox.profile
@@ -6,6 +6,7 @@ include snox.local
 include globals.local
 
 # Disable for now, see ___
+ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-m-z/vivaldi-beta.profile
+++ b/etc/profile-m-z/vivaldi-beta.profile
@@ -1,5 +1,7 @@
-# Firejail profile alias for vivaldi
+# Firejail profile for vivaldi-beta
 # This file is overwritten after every install/update
+# Persistent local customizations
+include vivaldi-beta.local
 
 # Redirect
 include vivaldi.profile

--- a/etc/profile-m-z/vivaldi-snapshot.profile
+++ b/etc/profile-m-z/vivaldi-snapshot.profile
@@ -2,16 +2,6 @@
 # This file is overwritten after every install/update
 # Persistent local customizations
 include vivaldi-snapshot.local
-# Persistent global definitions
-include globals.local
-
-noblacklist ${HOME}/.cache/vivaldi-snapshot
-noblacklist ${HOME}/.config/vivaldi-snapshot
-
-mkdir ${HOME}/.cache/vivaldi-snapshot
-mkdir ${HOME}/.config/vivaldi-snapshot
-whitelist ${HOME}/.cache/vivaldi-snapshot
-whitelist ${HOME}/.config/vivaldi-snapshot
 
 # Redirect
-include chromium-common.profile
+include vivaldi.profile

--- a/etc/profile-m-z/vivaldi-stable.profile
+++ b/etc/profile-m-z/vivaldi-stable.profile
@@ -1,5 +1,7 @@
-# Firejail profile alias for vivaldi
+# Firejail profile for vivaldi-stable
 # This file is overwritten after every install/update
+# Persistent local customizations
+include vivaldi-stable.local
 
 # Redirect
 include vivaldi.profile

--- a/etc/profile-m-z/vivaldi.profile
+++ b/etc/profile-m-z/vivaldi.profile
@@ -6,21 +6,27 @@ include vivaldi.local
 include globals.local
 
 # Allow HTML5 Proprietary Media & DRM/EME (Widevine)
-ignore apparmor
-ignore noexec /var
-noblacklist /var/opt
-whitelist /var/opt/vivaldi
-writable-var
+?BROWSER_ALLOW_DRM: ignore apparmor
+?BROWSER_ALLOW_DRM: ignore noexec /var
+?BROWSER_ALLOW_DRM: noblacklist /var/opt
+?BROWSER_ALLOW_DRM: whitelist /var/opt/vivaldi
+?BROWSER_ALLOW_DRM: writable-var
 
 noblacklist ${HOME}/.cache/vivaldi
+noblacklist ${HOME}/.cache/vivaldi-snapshot
 noblacklist ${HOME}/.config/vivaldi
+noblacklist ${HOME}/.config/vivaldi-snapshot
 noblacklist ${HOME}/.local/lib/vivaldi
 
 mkdir ${HOME}/.cache/vivaldi
+mkdir ${HOME}/.cache/vivaldi-snapshot
 mkdir ${HOME}/.config/vivaldi
+mkdir ${HOME}/.config/vivaldi-snapshot
 mkdir ${HOME}/.local/lib/vivaldi
 whitelist ${HOME}/.cache/vivaldi
+whitelist ${HOME}/.cache/vivaldi-snapshot
 whitelist ${HOME}/.config/vivaldi
+whitelist ${HOME}/.config/vivaldi-snapshot
 whitelist ${HOME}/.local/lib/vivaldi
 
 # breaks vivaldi sync

--- a/etc/profile-m-z/vivaldi.profile
+++ b/etc/profile-m-z/vivaldi.profile
@@ -6,11 +6,11 @@ include vivaldi.local
 include globals.local
 
 # Allow HTML5 Proprietary Media & DRM/EME (Widevine)
-?BROWSER_ALLOW_DRM: ignore apparmor
-?BROWSER_ALLOW_DRM: ignore noexec /var
-?BROWSER_ALLOW_DRM: noblacklist /var/opt
-?BROWSER_ALLOW_DRM: whitelist /var/opt/vivaldi
-?BROWSER_ALLOW_DRM: writable-var
+ignore apparmor
+ignore noexec /var
+noblacklist /var/opt
+whitelist /var/opt/vivaldi
+writable-var
 
 noblacklist ${HOME}/.cache/vivaldi
 noblacklist ${HOME}/.cache/vivaldi-snapshot

--- a/etc/profile-m-z/yandex-browser.profile
+++ b/etc/profile-m-z/yandex-browser.profile
@@ -5,7 +5,7 @@ include yandex-browser.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see ___
+# Disable for now, see https://www.tutorialspoint.com/difference-between-void-main-and-int-main-in-c-cplusplus
 ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-m-z/yandex-browser.profile
+++ b/etc/profile-m-z/yandex-browser.profile
@@ -5,6 +5,10 @@ include yandex-browser.local
 # Persistent global definitions
 include globals.local
 
+# Disable for now, see ___
+ignore include whitelist-runuser-common.inc
+ignore include whitelist-usr-share-common.inc
+
 noblacklist ${HOME}/.cache/yandex-browser
 noblacklist ${HOME}/.cache/yandex-browser-beta
 noblacklist ${HOME}/.config/yandex-browser

--- a/etc/profile-m-z/yandex-browser.profile
+++ b/etc/profile-m-z/yandex-browser.profile
@@ -6,6 +6,7 @@ include yandex-browser.local
 include globals.local
 
 # Disable for now, see ___
+ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -119,6 +119,7 @@ cheese
 cherrytree
 chromium
 chromium-browser
+chromium-browser-privacy
 chromium-freeworld
 cin
 cinelerra


### PR DESCRIPTION
 + 516d0811 has removed fundamental security features.
   (remove caps.drop=all, nonewprivs, noroot, seccomp, protocol; add
caps.keep)  Though this is only necessary if running under a kernel which
disallow   unprivileged userns clones. Arch's linux-hardened and debian kernel
are   patched accordingly. Arch's linux and linux-lts kernels support this
   restriction via sysctk (kernel.unprivileged_userns_clone=0) as users
opt-in.   Other kernels such as mainline or fedora/redhat always support
unprivileged   userns clone and have no sysctl parameter to disable it. Debian and
Arch   users can enable it with 'sysctl kernel.unprivileged_userns_clone=1'.
   This commit adds a chromium-common-hardened.inc which can be included
in   chromium-common to enhance security of chromium-based programs.

 + chromium-common.profile: add private-cache

 + chromium-common.profile: add wruc and wusc, but disable it for the   following   profiles until tested. tests welcome.

    - [ ] bnox, dnox, enox, inox, snox
    - [ ] brave
    - [ ] flashpeak-slimjet
    - [ ] google-chrome, google-chrome-beta, google-chrome-unstable
    - [ ] iridium
    - [ ] min
    - [ ] opera, opera-beta

 + move vivaldi-snapshot paths from vivaldi-snapshot.profile to vivaldi.
   /usr/bin/vivaldi is a symlink to /etc/alternatives/vivaldi which can be  vivaldi-stable, vivaldi-beta or vivaldi-snapshot. vivaldi-snapshot.profile  missed also some features from vivaldi.profile, solve this by making it  redirect to vivaldi.profile. TODO: exist new paths such as .local/lib/vivaldi  also for vivaldi-snapshot?

 + ~Move drm-relaktions in vivaldi.profile behind BROWSER_ALLOW_DRM.~

 + create chromium-browser-privacy.profile (closes #3633)