### PR TITLE
let tests fail build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,16 +7,20 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  build_and_test:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: sudo apt-get install gcc-10 libapparmor-dev libselinux1-dev
+      run: sudo apt-get install gcc-10 libapparmor-dev libselinux1-dev expect xzdec
     - name: configure
-      run: CC=gcc-10 ./configure --enable-fatal-warnings --enable-analyzer --enable-apparmor --enable-selinux
+      run: CC=gcc-10 ./configure --enable-fatal-warnings --enable-analyzer --enable-apparmor --enable-selinux --prefix=/usr
     - name: make
       run: make
+    - name: make install
+      run: sudo make install
+    - name: run tests
+      run: SHELL=/bin/bash make test-github
   build-clang:
     runs-on: ubuntu-20.04
     steps:

--- a/Makefile.in
+++ b/Makefile.in
@@ -74,6 +74,7 @@ clean:
 	for dir in $$(dirname $(ALL_ITEMS)) $(MYDIRS); do \
 		$(MAKE) -C $$dir clean; \
 	done
+	$(MAKE) -C test clean
 	rm -f $(MANPAGES) $(MANPAGES:%=%.gz) firejail*.rpm
 	rm -f $(SECCOMP_FILTERS)
 	rm -f test/utils/index.html*
@@ -227,45 +228,11 @@ scan-build: clean
 # make test
 #
 
+TESTS=profiles private-lib apps apps-x11 apps-x11-xorg sysutils utils environment filters arguments fs fcopy fnetfilter
+TEST_TARGETS=$(patsubst %,test-%,$(TESTS))
 
-test-profiles:
-	cd test/profiles; ./profiles.sh | grep TESTING
-
-test-private-lib:
-	cd test/private-lib; ./private-lib.sh | grep TESTING
-
-test-apps:
-	cd test/apps; ./apps.sh | grep TESTING
-
-test-apps-x11:
-	cd test/apps-x11; ./apps-x11.sh | grep TESTING
-
-test-apps-x11-xorg:
-	cd test/apps-x11-xorg; ./apps-x11-xorg.sh | grep TESTING
-
-test-sysutils:
-	cd test/sysutils; ./sysutils.sh | grep TESTING
-
-test-utils:
-	cd test/utils; ./utils.sh | grep TESTING
-
-test-environment:
-	cd test/environment; ./environment.sh | grep TESTING
-
-test-filters:
-	cd test/filters; ./filters.sh | grep TESTING
-
-test-arguments:
-	cd test/arguments; ./arguments.sh | grep TESTING
-
-test-fs:
-	cd test/fs; ./fs.sh | grep TESTING
-
-test-fcopy:
-	cd test/fcopy; ./fcopy.sh | grep TESTING
-
-test-fnetfilter:
-	cd test/fnetfilter; ./fnetfilter.sh | grep TESTING
+$(TEST_TARGETS):
+	$(MAKE) -C test $(subst test-,,$@)
 
 test: test-profiles test-private-lib test-fcopy test-fnetfilter test-fs test-utils test-sysutils test-environment test-apps test-apps-x11 test-apps-x11-xorg test-filters test-arguments
 	echo "TEST COMPLETE"
@@ -284,32 +251,32 @@ test-travis: test-profiles test-fcopy test-fnetfilter test-fs test-utils test-sy
 
 # a firejail-test account is required, public/private key setup
 test-ssh:
-	cd test/ssh; ./ssh.sh | grep TESTING
+	$(MAKE) -C test $(subst test-,,$@)
 
 # requires root access
 test-chroot:
-	cd test/chroot; ./chroot.sh | grep testing
+	$(MAKE) -C test $(subst test-,,$@)
 
 # Huge appimage files, not included in "make dist" archive
 test-appimage:
-	cd test/appimage; ./appimage.sh | grep TESTING
+	$(MAKE) -C test $(subst test-,,$@)
 
 # Root access, network devices are created before the test
 # restart your computer to get rid of these devices
 test-network:
-	cd test/network; ./network.sh | grep TESTING
+	$(MAKE) -C test $(subst test-,,$@)
 
 # requires the same setup as test-network
 test-stress:
-	cd test/stress; ./stress.sh | grep TESTING
+	$(MAKE) -C test $(subst test-,,$@)
 
 # Tests running a root user
 test-root:
-	cd test/root; su -c ./root.sh | grep TESTING
+	$(MAKE) -C test $(subst test-,,$@)
 
 # OverlayFS is not available on all platforms
 test-overlay:
-	cd test/overlay; ./overlay.sh | grep TESTING
+	$(MAKE) -C test $(subst test-,,$@)
 
 # For testing hidepid system, the command to set it up is "mount -o remount,rw,hidepid=2 /proc"
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -243,6 +243,9 @@ test-noprofiles: test-private-lib test-fcopy test-fnetfilter test-fs test-utils 
 test-travis: test-profiles test-fcopy test-fnetfilter test-fs test-utils test-sysutils test-environment test-filters test-arguments
 	echo "TEST COMPLETE"
 
+test-github: test-fcopy test-fnetfilter test-utils test-sysutils test-environment test-arguments
+	echo "TEST COMPLETE"
+
 ##########################################
 # Individual tests, some of them require root access
 # The tests are very intrusive, by the time you are done

--- a/Makefile.in
+++ b/Makefile.in
@@ -182,7 +182,7 @@ uninstall:
 	@echo "If you want to install a different version of firejail, you might also need to run 'rm -fr $(DESTDIR)$(sysconfdir)/firejail', see #2038."
 
 DISTFILES = "src etc m4 platform contrib configure configure.ac Makefile.in install.sh mkman.sh mketc.sh mkdeb.sh.in COPYING README RELNOTES"
-DISTFILES_TEST = "test/apps test/apps-x11 test/apps-x11-xorg test/root test/fcopy test/environment test/profiles test/utils test/compile test/filters test/network test/arguments test/fs test/sysutils test/chroot"
+DISTFILES_TEST = "test/Makefile.in test/apps test/apps-x11 test/apps-x11-xorg test/root test/fcopy test/environment test/profiles test/utils test/compile test/filters test/network test/arguments test/fs test/sysutils test/chroot"
 
 dist:
 	mv config.status config.status.old

--- a/configure
+++ b/configure
@@ -4257,7 +4257,7 @@ fi
 
 ac_config_files="$ac_config_files mkdeb.sh"
 
-ac_config_files="$ac_config_files Makefile src/common.mk src/lib/Makefile src/fcopy/Makefile src/fnet/Makefile src/firejail/Makefile src/fnetfilter/Makefile src/firemon/Makefile src/libtrace/Makefile src/libtracelog/Makefile src/firecfg/Makefile src/fbuilder/Makefile src/fsec-print/Makefile src/ftee/Makefile src/faudit/Makefile src/fseccomp/Makefile src/fldd/Makefile src/libpostexecseccomp/Makefile src/fsec-optimize/Makefile src/profstats/Makefile src/man/Makefile"
+ac_config_files="$ac_config_files Makefile src/common.mk src/lib/Makefile src/fcopy/Makefile src/fnet/Makefile src/firejail/Makefile src/fnetfilter/Makefile src/firemon/Makefile src/libtrace/Makefile src/libtracelog/Makefile src/firecfg/Makefile src/fbuilder/Makefile src/fsec-print/Makefile src/ftee/Makefile src/faudit/Makefile src/fseccomp/Makefile src/fldd/Makefile src/libpostexecseccomp/Makefile src/fsec-optimize/Makefile src/profstats/Makefile src/man/Makefile test/Makefile"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -4988,6 +4988,7 @@ do
     "src/fsec-optimize/Makefile") CONFIG_FILES="$CONFIG_FILES src/fsec-optimize/Makefile" ;;
     "src/profstats/Makefile") CONFIG_FILES="$CONFIG_FILES src/profstats/Makefile" ;;
     "src/man/Makefile") CONFIG_FILES="$CONFIG_FILES src/man/Makefile" ;;
+    "test/Makefile") CONFIG_FILES="$CONFIG_FILES test/Makefile" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac

--- a/configure.ac
+++ b/configure.ac
@@ -223,7 +223,7 @@ AC_CONFIG_FILES([mkdeb.sh], [chmod +x mkdeb.sh])
 AC_OUTPUT(Makefile src/common.mk src/lib/Makefile src/fcopy/Makefile src/fnet/Makefile src/firejail/Makefile src/fnetfilter/Makefile \
 src/firemon/Makefile src/libtrace/Makefile src/libtracelog/Makefile src/firecfg/Makefile src/fbuilder/Makefile src/fsec-print/Makefile \
 src/ftee/Makefile src/faudit/Makefile src/fseccomp/Makefile src/fldd/Makefile src/libpostexecseccomp/Makefile src/fsec-optimize/Makefile \
-src/profstats/Makefile src/man/Makefile)
+src/profstats/Makefile src/man/Makefile test/Makefile)
 
 echo
 echo "Configuration options:"

--- a/platform/rpm/mkrpm.sh
+++ b/platform/rpm/mkrpm.sh
@@ -44,7 +44,7 @@ sed -e "s/__NAME__/${name}/g" \
 # FIXME: We could parse RELNOTES and create a %changelog section here
 
 # Copy the source to build into a tarball
-tar --exclude='./.git*' --exclude='./test' --transform "s/^./${name}-${version}/" -czf ${tmpdir}/SOURCES/${name}-${version}.tar.gz .
+tar --exclude='./.git*' --transform "s/^./${name}-${version}/" -czf ${tmpdir}/SOURCES/${name}-${version}.tar.gz .
 
 # Build the files (rpm, debug rpm and source rpm)
 rpmbuild --quiet --define "_topdir ${tmpdir}" -ba ${tmp_spec_file}

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -3,7 +3,6 @@ TESTS=$(patsubst %/,%,$(wildcard */))
 .PHONY: $(TESTS)
 
 $(TESTS):
-	echo $(TESTS)
 	cd $@ && ./$@.sh 2>&1 | tee $@.log
 	cd $@ && grep -a TESTING $@.log && grep -a -L "TESTING ERROR" $@.log
 

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -1,0 +1,11 @@
+TESTS=$(patsubst %/,%,$(wildcard */))
+
+.PHONY: $(TESTS)
+
+$(TESTS):
+	echo $(TESTS)
+	cd $@ && ./$@.sh 2>&1 | tee $@.log
+	cd $@ && grep -a TESTING $@.log && grep -a -L "TESTING ERROR" $@.log
+
+clean:
+	for test in $(TESTS); do rm -f "$$test/$$test.log"; done

--- a/test/sysutils/less.exp
+++ b/test/sysutils/less.exp
@@ -10,6 +10,7 @@ match_max 100000
 send -- "firejail less sysutils.sh\r"
 expect {
 	timeout {puts "TESTING ERROR 1\n";exit}
+	"(press RETURN)" {puts "TESTING SKIP 1.1\n";exit}
 	"MALLOC_CHECK"
 }
 expect {

--- a/test/sysutils/xz.exp
+++ b/test/sysutils/xz.exp
@@ -3,7 +3,7 @@
 # Copyright (C) 2014-2020 Firejail Authors
 # License GPL v2
 
-set timeout 10
+set timeout 15
 spawn $env(SHELL)
 match_max 100000
 

--- a/test/sysutils/xz.exp
+++ b/test/sysutils/xz.exp
@@ -3,7 +3,7 @@
 # Copyright (C) 2014-2020 Firejail Authors
 # License GPL v2
 
-set timeout 15
+set timeout 60
 spawn $env(SHELL)
 match_max 100000
 
@@ -11,6 +11,9 @@ send -- "/usr/bin/xz -c /usr/bin/firejail > firejail_t1\r"
 sleep 1
 
 send -- "firejail /usr/bin/xz -c /usr/bin/firejail > firejail_t2\r"
+sleep 1
+
+send -- "md5sum firejail_t1 firejail_t2; ls -l firejail_t1 firejail_t2\r"
 sleep 1
 
 send -- "diff -s firejail_t1 firejail_t2\r"

--- a/test/utils/man.exp
+++ b/test/utils/man.exp
@@ -10,6 +10,7 @@ match_max 100000
 send -- "man firejail\r"
 expect {
 	timeout {puts "TESTING ERROR 0\n";exit}
+	"(press RETURN)" {puts "TESTING SKIP 1.1\n";exit}
 	"Linux namespaces sandbox program"
 }
 after 100


### PR DESCRIPTION
This change simplifies the test targets, as the test names need to be specified only once, instead of repeating the targets for each test.
It will now also check the tests for errors and cause a build failure, as they currently seem to not get noticed.