### PR TITLE
Update celluloid.profile

### DIFF
--- a/etc/profile-a-l/celluloid.profile
+++ b/etc/profile-a-l/celluloid.profile
@@ -9,6 +9,7 @@ include globals.local
 noblacklist ${HOME}/.config/celluloid
 noblacklist ${HOME}/.config/gnome-mpv
 noblacklist ${HOME}/.config/youtube-dl
+noblacklist /usr/lib/liblua*
 
 # Allow python (blacklisted by disable-interpreters.inc)
 include allow-python2.inc

--- a/etc/profile-a-l/celluloid.profile
+++ b/etc/profile-a-l/celluloid.profile
@@ -9,11 +9,13 @@ include globals.local
 noblacklist ${HOME}/.config/celluloid
 noblacklist ${HOME}/.config/gnome-mpv
 noblacklist ${HOME}/.config/youtube-dl
-noblacklist /usr/lib/liblua*
 
 # Allow python (blacklisted by disable-interpreters.inc)
 include allow-python2.inc
 include allow-python3.inc
+
+# Allow lua (blacklisted by disable-interpreters.inc)
+include allow-lua.inc
 
 include disable-common.inc
 include disable-devel.inc


### PR DESCRIPTION
`liblua` is needed for celluloid & otherwise at least on arch it's showing this error - "celluloid: error while loading shared libraries: liblua5.2.so.5.2: cannot open shared object file: Permission denied."