### PR TITLE
fix #3699 -- Firefox can't inhibit screensavers/screen blanking

### DIFF
--- a/etc/profile-a-l/firefox.profile
+++ b/etc/profile-a-l/firefox.profile
@@ -33,6 +33,8 @@ dbus-user.own org.mozilla.firefox.*
 dbus-user.own org.mpris.MediaPlayer2.firefox.*
 # Uncomment or put in your firefox.local to enable native notifications.
 #dbus-user.talk org.freedesktop.Notifications
+# Uncomment or put in your firefox.local to allow to inhibit screensavers
+#dbus-user.talk org.freedesktop.ScreenSaver
 ignore dbus-user none
 
 # Redirect


### PR DESCRIPTION
`org.freedesktop.ScreenSaver` allows to unlock the screen, that not something we want browsers can do. So add it commented for now.