### PR TITLE
Remove redundant read-only item

### DIFF
--- a/etc/profile-a-l/email-common.profile
+++ b/etc/profile-a-l/email-common.profile
@@ -59,7 +59,6 @@ private-dev
 private-tmp
 
 # encrypting and signing email
-read-only ${HOME}/.config/mimeapps.list
 writable-run-user
 
 # If you want to read local mail stored in /var/mail, add the following to email-common.local:

--- a/etc/profile-a-l/geary.profile
+++ b/etc/profile-a-l/geary.profile
@@ -26,8 +26,6 @@ whitelist ${HOME}/.config/geary
 whitelist ${HOME}/.local/share/geary
 whitelist /usr/share/geary
 
-read-only ${HOME}/.config/mimeapps.list
-
 # allow Mozilla browsers
 # Redirect
 include firefox.profile

--- a/etc/profile-m-z/thunderbird.profile
+++ b/etc/profile-m-z/thunderbird.profile
@@ -58,7 +58,5 @@ novideo
 # We need the real /tmp for data exchange when xdg-open handles email attachments on KDE
 ignore private-tmp
 
-read-only ${HOME}/.config/mimeapps.list
-
 # Redirect
 include firefox-common.profile


### PR DESCRIPTION
'read-only ${HOME}/.config/mimeapps.list' is already part of disable-common.inc, no need to add it twice.