### PR TITLE
Update okular.profile to support cbr files

### DIFF
--- a/etc/profile-m-z/okular.profile
+++ b/etc/profile-m-z/okular.profile
@@ -53,7 +53,7 @@ seccomp
 shell none
 tracelog
 
-private-bin kbuildsycoca4,kdeinit4,lpr,okular,unrar,unar
+private-bin kbuildsycoca4,kdeinit4,lpr,okular,unar,unrar
 private-dev
 private-etc alternatives,cups,fonts,kde4rc,kde5rc,ld.so.cache,machine-id,passwd,xdg
 # private-tmp - on KDE we need access to the real /tmp for data exchange with email clients

--- a/etc/profile-m-z/okular.profile
+++ b/etc/profile-m-z/okular.profile
@@ -53,7 +53,7 @@ seccomp
 shell none
 tracelog
 
-private-bin kbuildsycoca4,kdeinit4,lpr,okular
+private-bin kbuildsycoca4,kdeinit4,lpr,okular,unrar,unar
 private-dev
 private-etc alternatives,cups,fonts,kde4rc,kde5rc,ld.so.cache,machine-id,passwd,xdg
 # private-tmp - on KDE we need access to the real /tmp for data exchange with email clients


### PR DESCRIPTION
okular has support for reading cbr (rar-compressed comic book). without unrar or unar  in private-bin, okular fails to decompress the files for viewing.


If your PR isn't about profiles or you have no idea how to do one of these, skip the following and go ahead with this PR.

If you make a PR for new profiles or changeing profiles please do the following:
 - The ordering of options follow the rules descripted in [/usr/share/doc/firejail/profile.template](https://github.com/netblue30/firejail/blob/master/etc/templates/profile.template).  
   > Hint: The profile-template is very new, if you install firejail with your package-manager, it maybe missing, therefore, and to follow the latest rules, it is recommended to use the template from the repository.
 - Order the arguments of options alphabetical, you can easy do this with the [sort.py](https://github.com/netblue30/firejail/tree/master/contrib/sort.py).  
 The path to it depends on your distro:

   | Distro | Path |
   | ------ | ---- |
   | Arch/Fedora | `/usr/lib64/firejail/sort.py` |
   | Debian/Ubuntu/Mint | `/usr/lib/x86_64-linux-gnu/firejail/sort.py` |
   | local git clone | `contrib/sort.py` |

   Note also that the sort.py script exists only since firejail `0.9.61`.

See also [CONTRIBUTING.md](/CONTRIBUTING.md).
