### PR TITLE
Improve firejail exec failure logging

### DIFF
--- a/snowflake/build_and_publish_rpm.sh
+++ b/snowflake/build_and_publish_rpm.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -ex
+#
+# Copyright (c) 2020 Snowflake Computing Inc. All right reserved.
+#
+#
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $THIS_DIR/version.sh
+TARGET_YUM_REPO=$1
+
+if [[ -z $TARGET_YUM_REPO ]]; then
+  echo "ERROR: {TARGET_YUM_REPO} not specified"
+  exit 1
+fi
+
+
+$THIS_DIR/../platform/rpm/mkrpm.sh firejail $FIREJAIL_SF_VERSION \
+    "--disable-userns --disable-contrib-install --disable-file-transfer --disable-x11 --disable-firetunnel"
+
+PACKAGE_NAME=$(ls -1 -- firejail-${FIREJAIL_SF_VERSION}-1.x86_64.rpm)
+
+if [[ -z $PACKAGE_NAME ]]; then
+  echo "ERROR: RPM package not found"
+  exit 1
+fi
+
+$THIS_DIR/publish_rpm.sh $TARGET_YUM_REPO $PACKAGE_NAME

--- a/snowflake/build_and_publish_rpm.sh
+++ b/snowflake/build_and_publish_rpm.sh
@@ -1,17 +1,34 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 #
 # Copyright (c) 2020 Snowflake Computing Inc. All right reserved.
 #
 #
+
+function usage()
+{
+    echo "usage: ./build_and_publish_rpm.sh [TARGET_YUM_REPO] [TARGET_HOST_URL]"
+    exit 1
+}
+
+if [ "$#" -ne 2 ]; then
+  usage
+fi
+
+
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $THIS_DIR/version.sh
 TARGET_YUM_REPO=$1
+TARGET_HOST_URL=$2
 
 if [[ -z $TARGET_YUM_REPO ]]; then
   echo "ERROR: {TARGET_YUM_REPO} not specified"
   exit 1
 fi
 
+if [[ -z $TARGET_HOST_URL ]]; then
+  echo "ERROR: {TARGET_HOST_URL} not specified"
+  exit 1
+fi
 
 $THIS_DIR/../platform/rpm/mkrpm.sh firejail $FIREJAIL_SF_VERSION \
     "--disable-userns --disable-contrib-install --disable-file-transfer --disable-x11 --disable-firetunnel"
@@ -23,4 +40,4 @@ if [[ -z $PACKAGE_NAME ]]; then
   exit 1
 fi
 
-$THIS_DIR/publish_rpm.sh $TARGET_YUM_REPO $PACKAGE_NAME
+$THIS_DIR/publish_rpm.sh $TARGET_YUM_REPO $TARGET_HOST_URL $PACKAGE_NAME

--- a/snowflake/publish_rpm.sh
+++ b/snowflake/publish_rpm.sh
@@ -4,11 +4,11 @@
 #
 #
 TARGET_REPO=$1
+REPO_HOST=$2
 SSH_OPT="-o UserKnownHostsFile=/dev/null -o PasswordAuthentication=no -o StrictHostKeyChecking=no"
-REPO_HOST=repo-ha-write.int.snowflakecomputing.com
 
-if [ ! -z "$2" ]; then
-  RPMS=($2)
+if [ ! -z "$3" ]; then
+  RPMS=($3)
 else
   # list current directory to get rpm
   RPMS=$(ls -1 -- *.rpm)

--- a/snowflake/publish_rpm.sh
+++ b/snowflake/publish_rpm.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -ex
+#
+# Copyright (c) 2020 Snowflake Computing Inc. All right reserved.
+#
+#
+TARGET_REPO=$1
+SSH_OPT="-o UserKnownHostsFile=/dev/null -o PasswordAuthentication=no -o StrictHostKeyChecking=no"
+REPO_HOST=repo-ha-write.int.snowflakecomputing.com
+
+if [ ! -z "$2" ]; then
+  RPMS=($2)
+else
+  # list current directory to get rpm
+  RPMS=$(ls -1 -- *.rpm)
+fi
+
+scp $OPT $RPMS jenkins@$REPO_HOST:/tmp
+for each in $RPMS; do
+  ssh -l jenkins $SSH_OPT $REPO_HOST \
+    "sudo -u yumrepo /opt/sfc/operations/scripts/yum_repos/add_rpm_to_repository.pl $TARGET_REPO /tmp/$each"
+  ssh $SSH_OPT jenkins@$REPO_HOST rm -f /tmp/$each
+done

--- a/snowflake/version.sh
+++ b/snowflake/version.sh
@@ -1,2 +1,2 @@
 #0.9.62 is the firejail version, last suffix is snowflake identifier
-FIREJAIL_SF_VERSION=0.9.62.2
+FIREJAIL_SF_VERSION=0.9.62.3

--- a/snowflake/version.sh
+++ b/snowflake/version.sh
@@ -1,0 +1,2 @@
+#0.9.62 is the firejail version, last suffix is snowflake identifier
+FIREJAIL_SF_VERSION=0.9.62.1

--- a/snowflake/version.sh
+++ b/snowflake/version.sh
@@ -1,2 +1,2 @@
 #0.9.62 is the firejail version, last suffix is snowflake identifier
-FIREJAIL_SF_VERSION=0.9.62.1
+FIREJAIL_SF_VERSION=0.9.62.2


### PR DESCRIPTION
Firejail already does some basic checks to ensure that the child process looks launch-able, but there is a race between that check and the actual exec.  This change writes strerror(errno) to stderr in the case that exec does fail.

This was tested by (temporarily) commenting out the existing checks that verify that the provide child is indeed a valid executable and then trying to launch something that wasn't runable.  