### PR TITLE
Remove nou2f in ssh profile

### DIFF
--- a/etc/profile-m-z/ssh.profile
+++ b/etc/profile-m-z/ssh.profile
@@ -34,7 +34,7 @@ nonewprivs
 # noroot - see issue #1543
 nosound
 notv
-nou2f
+# nou2f - OpenSSH >= 8.2 supports U2F 
 novideo
 protocol unix,inet,inet6
 seccomp


### PR DESCRIPTION
[OpenSSH 8.2 added support for U2F](https://www.openssh.com/txt/release-8.2) but the current Firejail SSH profile has nou2f configured. 

My Yubikeys are working fine with the option commented out and I see no reason why U2F shouldn't be enabled in the profile now.