### PR TITLE
minetest.profile: whitelist /usr/share/games/minetest

### DIFF
--- a/etc/profile-m-z/minetest.profile
+++ b/etc/profile-m-z/minetest.profile
@@ -28,6 +28,7 @@ mkdir ${HOME}/.cache/minetest
 mkdir ${HOME}/.minetest
 whitelist ${HOME}/.cache/minetest
 whitelist ${HOME}/.minetest
+whitelist /usr/share/games/minetest
 whitelist /usr/share/minetest
 include whitelist-common.inc
 include whitelist-runuser-common.inc


### PR DESCRIPTION
It's the path to the game's data in the official Debian package.