### PR TITLE
Add profile for authenticator-rs, improve falkon

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -584,6 +584,7 @@ blacklist ${HOME}/.local/share/agenda
 blacklist ${HOME}/.local/share/apps/korganizer
 blacklist ${HOME}/.local/share/aspyr-media
 blacklist ${HOME}/.local/share/autokey
+blacklist ${HOME}/.local/share/authenticator-rs 
 blacklist ${HOME}/.local/share/backintime
 blacklist ${HOME}/.local/share/baloo
 blacklist ${HOME}/.local/share/barrier

--- a/etc/profile-a-l/authenticator-rs.profile
+++ b/etc/profile-a-l/authenticator-rs.profile
@@ -1,0 +1,55 @@
+# Firejail profile for authenticator-rs
+# Description: Rust based 2FA authentication program
+# This file is overwritten after every install/update
+# Persistent local customizations
+include authenticator-rs.local
+# Persistent global definitions
+include globals.local
+
+noblacklist ${HOME}/.local/share/authenticator-rs 
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
+include disable-shell.inc
+include disable-xdg.inc
+
+mkdir ${HOME}/.local/share/authenticator-rs
+whitelist ${HOME}/.local/share/authenticator-rs 
+whitelist ${DOWNLOADS} 
+whitelist /usr/share/uk.co.grumlimited.authenticator-rs
+include whitelist-common.inc 
+include whitelist-runuser-common.inc 
+include whitelist-usr-share-common.inc 
+include whitelist-var-common.inc
+
+apparmor
+caps.drop all
+netfilter
+no3d
+nodvd
+nogroups
+nonewprivs
+noroot
+nosound
+notv
+nou2f
+novideo
+protocol unix,inet,inet6
+seccomp
+shell none
+tracelog
+
+disable-mnt
+private-bin authenticator-rs
+private-cache
+private-dev
+private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gtk-2.0,gtk-3.0,pki,resolv.conf,ssl,xdg
+private-tmp
+
+dbus-user filter
+dbus-user.own uk.co.grumlimited.authenticator-rs
+dbus-system none

--- a/etc/profile-a-l/authenticator-rs.profile
+++ b/etc/profile-a-l/authenticator-rs.profile
@@ -51,5 +51,5 @@ private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gtk-2.0,gtk
 private-tmp
 
 dbus-user filter
-dbus-user.own uk.co.grumlimited.authenticator-rs
+dbus-user.talk ca.desrt.dconf
 dbus-system none

--- a/etc/profile-a-l/balsa.profile
+++ b/etc/profile-a-l/balsa.profile
@@ -69,8 +69,8 @@ writable-run-user
 writable-var
 
 dbus-user filter
-dbus-user.talk ca.desrt.dconf
 dbus-user.own org.desktop.Balsa
+dbus-user.talk ca.desrt.dconf
 dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.freedesktop.secrets
 dbus-user.talk org.gnome.Keyring.SystemPrompter

--- a/etc/profile-a-l/balsa.profile
+++ b/etc/profile-a-l/balsa.profile
@@ -69,10 +69,11 @@ writable-run-user
 writable-var
 
 dbus-user filter
-dbus-user.own org.desktop.Balsa
 dbus-user.talk ca.desrt.dconf
-dbus-user.talk org.freedesktop.secrets
+dbus-user.own org.desktop.Balsa
 dbus-user.talk org.freedesktop.Notifications
+dbus-user.talk org.freedesktop.secrets
+dbus-user.talk org.gnome.Keyring.SystemPrompter
 dbus-system none
 
 read-only ${HOME}/.mozilla/firefox/profiles.ini

--- a/etc/profile-a-l/balsa.profile
+++ b/etc/profile-a-l/balsa.profile
@@ -71,9 +71,8 @@ writable-var
 dbus-user filter
 dbus-user.own org.desktop.Balsa
 dbus-user.talk ca.desrt.dconf
-dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.freedesktop.secrets
-dbus-user.talk org.gnome.Keyring.SystemPrompter
+dbus-user.talk org.freedesktop.Notifications
 dbus-system none
 
 read-only ${HOME}/.mozilla/firefox/profiles.ini

--- a/etc/profile-a-l/falkon.profile
+++ b/etc/profile-a-l/falkon.profile
@@ -36,7 +36,7 @@ nogroups
 nonewprivs
 noroot
 notv
-?BROWSER_DISABLE_U2F: nou2f
+nou2f
 protocol unix,inet,inet6,netlink
 # blacklisting of chroot system calls breaks falkon
 seccomp !chroot
@@ -44,10 +44,10 @@ seccomp !chroot
 
 disable-mnt
 private-cache
-?BROWSER_DISABLE_U2F: private-dev
+private-dev
 private-etc adobe,alternatives,asound.conf,ati,ca-certificates,crypto-policies,dconf,drirc,fonts,group,gtk-2.0,gtk-3.0,hostname,hosts,localtime,machine-id,mailcap,mime.types,nsswitch.conf,pango,passwd,pki,pulse,resolv.conf,selinux,ssl,xdg
 # private-tmp - interferes with the opening of downloaded files
 
-dbus-user filter
-dbus-user.own org.kde.Falkon
+# dbus-user filter
+# dbus-user.own org.kde.Falkon
 dbus-system none

--- a/etc/profile-a-l/falkon.profile
+++ b/etc/profile-a-l/falkon.profile
@@ -43,10 +43,11 @@ seccomp !chroot
 # tracelog
 
 disable-mnt
+# private-bin falkon
 private-cache
 private-dev
 private-etc adobe,alternatives,asound.conf,ati,ca-certificates,crypto-policies,dconf,drirc,fonts,group,gtk-2.0,gtk-3.0,hostname,hosts,localtime,machine-id,mailcap,mime.types,nsswitch.conf,pango,passwd,pki,pulse,resolv.conf,selinux,ssl,xdg
-# private-tmp - interferes with the opening of downloaded files
+private-tmp
 
 # dbus-user filter
 # dbus-user.own org.kde.Falkon

--- a/etc/profile-a-l/falkon.profile
+++ b/etc/profile-a-l/falkon.profile
@@ -15,15 +15,20 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
+include disable-xdg.inc
 
 mkdir ${HOME}/.cache/falkon
 mkdir ${HOME}/.config/falkon
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.cache/falkon
 whitelist ${HOME}/.config/falkon
+whitelist /usr/share/falkon
 include whitelist-common.inc
+include whitelist-runuser-common.inc
+include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+apparmor
 caps.drop all
 netfilter
 nodvd
@@ -31,13 +36,18 @@ nogroups
 nonewprivs
 noroot
 notv
-nou2f
+?BROWSER_DISABLE_U2F: nou2f
 protocol unix,inet,inet6,netlink
 # blacklisting of chroot system calls breaks falkon
 seccomp !chroot
 # tracelog
 
-private-dev
-# private-etc alternatives,passwd,group,hostname,hosts,localtime,nsswitch.conf,resolv.conf,gtk-2.0,pango,fonts,adobe,mime.types,mailcap,asound.conf,pulse,machine-id,ca-certificates,ssl,pki,crypto-policies
+disable-mnt
+private-cache
+?BROWSER_DISABLE_U2F: private-dev
+private-etc adobe,alternatives,asound.conf,ati,ca-certificates,crypto-policies,dconf,drirc,fonts,group,gtk-2.0,gtk-3.0,hostname,hosts,localtime,machine-id,mailcap,mime.types,nsswitch.conf,pango,passwd,pki,pulse,resolv.conf,selinux,ssl,xdg
 # private-tmp - interferes with the opening of downloaded files
 
+dbus-user filter
+dbus-user.own org.kde.Falkon
+dbus-system none

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -63,6 +63,7 @@ audacious
 audacity
 audio-recorder
 authenticator
+authenticator-rs
 autokey-gtk
 autokey-qt
 autokey-run


### PR DESCRIPTION
> `# private-tmp - interferes with the opening of downloaded files` 

Is that currently supported in browsers? If not we can harden it more by adding private-bin, disable-shell.inc etc.

The dbus permissions is taken from flatpak. It'd be best if `email-common.profile` or at least sylpheed/claws had some dbus restrictions of their own. 