### PR TITLE
from my overrides

### DIFF
--- a/etc/inc/firefox-common-addons.inc
+++ b/etc/inc/firefox-common-addons.inc
@@ -2,6 +2,8 @@
 # Persistent customizations should go in a .local file.
 include firefox-common-addons.local
 
+ignore include whitelist-runuser-common.inc
+
 noblacklist ${HOME}/.config/kgetrc
 noblacklist ${HOME}/.config/okularpartrc
 noblacklist ${HOME}/.config/okularrc

--- a/etc/profile-a-l/0ad.profile
+++ b/etc/profile-a-l/0ad.profile
@@ -16,6 +16,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
+include disable-xdg.inc
 
 mkdir ${HOME}/.cache/0ad
 mkdir ${HOME}/.config/0ad
@@ -40,6 +41,7 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/baobab.profile
+++ b/etc/profile-a-l/baobab.profile
@@ -30,6 +30,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/bijiben.profile
+++ b/etc/profile-a-l/bijiben.profile
@@ -41,6 +41,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/celluloid.profile
+++ b/etc/profile-a-l/celluloid.profile
@@ -46,6 +46,7 @@ noroot
 nou2f
 protocol unix,inet,inet6
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/dconf-editor.profile
+++ b/etc/profile-a-l/dconf-editor.profile
@@ -35,6 +35,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/dia.profile
+++ b/etc/profile-a-l/dia.profile
@@ -9,16 +9,24 @@ include globals.local
 noblacklist ${HOME}/.dia
 noblacklist ${DOCUMENTS}
 
+include allow-python2.inc
+include allow-python3.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
-include allow-python2.inc
-include allow-python3.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-xdg.inc
 
+#mkdir ${HOME}/.dia
+#whitelist ${HOME}/.dia
+#whitelist ${DOCUMENTS}
+#include whitelist-common.inc
+whitelist /usr/share/dia
+include whitelist-runuser-common.inc
+include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
 apparmor
@@ -36,6 +44,7 @@ novideo
 protocol unix
 seccomp
 shell none
+tracelog
 
 disable-mnt
 #private-bin dia

--- a/etc/profile-a-l/eo-common.profile
+++ b/etc/profile-a-l/eo-common.profile
@@ -27,6 +27,7 @@ apparmor
 caps.drop all
 ipc-namespace
 machine-id
+net none
 no3d
 nodvd
 nogroups
@@ -38,6 +39,7 @@ nou2f
 novideo
 protocol unix,netlink
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/evince.profile
+++ b/etc/profile-a-l/evince.profile
@@ -41,6 +41,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/ffmpeg.profile
+++ b/etc/profile-a-l/ffmpeg.profile
@@ -41,6 +41,7 @@ novideo
 protocol inet,inet6
 # allow set_mempolicy, which is required to encode using libx265
 seccomp !set_mempolicy
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/file-roller.profile
+++ b/etc/profile-a-l/file-roller.profile
@@ -34,6 +34,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/firefox-common.profile
+++ b/etc/profile-a-l/firefox-common.profile
@@ -27,6 +27,7 @@ whitelist ${DOWNLOADS}
 whitelist ${HOME}/.pki
 whitelist ${HOME}/.local/share/pki
 include whitelist-common.inc
+include whitelist-runuser-common.inc
 include whitelist-var-common.inc
 
 apparmor

--- a/etc/profile-a-l/flameshot.profile
+++ b/etc/profile-a-l/flameshot.profile
@@ -45,6 +45,7 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/frogatto.profile
+++ b/etc/profile-a-l/frogatto.profile
@@ -36,6 +36,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/gapplication.profile
+++ b/etc/profile-a-l/gapplication.profile
@@ -38,6 +38,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 x11 none

--- a/etc/profile-a-l/gedit.profile
+++ b/etc/profile-a-l/gedit.profile
@@ -37,6 +37,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/gfeeds.profile
+++ b/etc/profile-a-l/gfeeds.profile
@@ -49,6 +49,7 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/ghostwriter.profile
+++ b/etc/profile-a-l/ghostwriter.profile
@@ -26,6 +26,7 @@ whitelist /usr/share/texlive
 whitelist /usr/share/pandoc*
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
 
 apparmor
 caps.drop all
@@ -41,6 +42,7 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp !chroot
+seccomp.block-secondary
 shell none
 #tracelog -- breaks
 

--- a/etc/profile-a-l/gitg.profile
+++ b/etc/profile-a-l/gitg.profile
@@ -45,6 +45,7 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/gnome-calculator.profile
+++ b/etc/profile-a-l/gnome-calculator.profile
@@ -38,6 +38,7 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/gnome-calendar.profile
+++ b/etc/profile-a-l/gnome-calendar.profile
@@ -36,6 +36,7 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/gnome-characters.profile
+++ b/etc/profile-a-l/gnome-characters.profile
@@ -39,6 +39,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/gnome-contacts.profile
+++ b/etc/profile-a-l/gnome-contacts.profile
@@ -32,6 +32,7 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
+seccomp.block-secondary
 
 disable-mnt
 private-dev

--- a/etc/profile-a-l/gnome-hexgl.profile
+++ b/etc/profile-a-l/gnome-hexgl.profile
@@ -33,6 +33,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/gnome-keyring.profile
+++ b/etc/profile-a-l/gnome-keyring.profile
@@ -9,8 +9,6 @@ include globals.local
 
 noblacklist ${HOME}/.gnupg
 
-whitelist ${HOME}/.gnupg
-whitelist ${DOWNLOADS}
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
@@ -19,9 +17,15 @@ include disable-interpreters.inc
 include disable-programs.inc
 include disable-xdg.inc
 
+mkdir ${HOME}/.gnupg
+whitelist ${HOME}/.gnupg
+whitelist ${DOWNLOADS}
+whitelist ${RUNUSER}/gnupg
+whitelist ${RUNUSER}/keyring
 whitelist /usr/share/gnupg
 whitelist /usr/share/gnupg2
 include whitelist-common.inc
+include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
@@ -41,6 +45,7 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 
@@ -52,6 +57,6 @@ private-dev
 private-tmp
 
 # dbus-user none
-# dbus-system none
+dbus-system none
 
 memory-deny-write-execute

--- a/etc/profile-a-l/gnome-latex.profile
+++ b/etc/profile-a-l/gnome-latex.profile
@@ -41,6 +41,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/gnome-maps.profile
+++ b/etc/profile-a-l/gnome-maps.profile
@@ -54,6 +54,7 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/gnome-passwordsafe.profile
+++ b/etc/profile-a-l/gnome-passwordsafe.profile
@@ -43,6 +43,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/gnome-photos.profile
+++ b/etc/profile-a-l/gnome-photos.profile
@@ -33,6 +33,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/gnome-screenshot.profile
+++ b/etc/profile-a-l/gnome-screenshot.profile
@@ -35,6 +35,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/gnome-sound-recorder.profile
+++ b/etc/profile-a-l/gnome-sound-recorder.profile
@@ -33,6 +33,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/gnome-weather.profile
+++ b/etc/profile-a-l/gnome-weather.profile
@@ -37,6 +37,7 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/gnome_games-common.profile
+++ b/etc/profile-a-l/gnome_games-common.profile
@@ -34,6 +34,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/gucharmap.profile
+++ b/etc/profile-a-l/gucharmap.profile
@@ -35,6 +35,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/keepassxc.profile
+++ b/etc/profile-a-l/keepassxc.profile
@@ -55,6 +55,7 @@ nou2f
 novideo
 protocol unix,netlink
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/libreoffice.profile
+++ b/etc/profile-a-l/libreoffice.profile
@@ -43,6 +43,8 @@ shell none
 # comment tracelog when using the ubuntu 18.04/debian 10 apparmor profile
 tracelog
 
+#private-bin libreoffice,sh,uname,dirname,grep,sed,basename,ls
+private-cache
 private-dev
 private-tmp
 

--- a/etc/profile-m-z/megaglest.profile
+++ b/etc/profile-m-z/megaglest.profile
@@ -14,6 +14,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
+include disable-shell.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.megaglest
@@ -37,6 +38,7 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-m-z/meld.profile
+++ b/etc/profile-m-z/meld.profile
@@ -62,6 +62,7 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-m-z/menulibre.profile
+++ b/etc/profile-m-z/menulibre.profile
@@ -44,6 +44,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-m-z/minetest.profile
+++ b/etc/profile-m-z/minetest.profile
@@ -47,6 +47,7 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -67,6 +67,7 @@ noroot
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-m-z/patch.profile
+++ b/etc/profile-m-z/patch.profile
@@ -37,6 +37,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 x11 none

--- a/etc/profile-m-z/pdftotext.profile
+++ b/etc/profile-m-z/pdftotext.profile
@@ -13,6 +13,7 @@ noblacklist ${DOCUMENTS}
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
@@ -40,6 +41,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 x11 none

--- a/etc/profile-m-z/peek.profile
+++ b/etc/profile-m-z/peek.profile
@@ -41,6 +41,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-m-z/pngquant.profile
+++ b/etc/profile-m-z/pngquant.profile
@@ -7,6 +7,8 @@ include pngquant.local
 # Persistent global definitions
 include globals.local
 
+noblacklist ${PICTURES}
+
 blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
@@ -16,6 +18,7 @@ include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-shell.inc
+include disable-xdg.inc
 
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc

--- a/etc/profile-m-z/rhythmbox.profile
+++ b/etc/profile-m-z/rhythmbox.profile
@@ -45,10 +45,12 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 
 private-bin rhythmbox,rhythmbox-client
+private-cache
 private-dev
 private-tmp
 

--- a/etc/profile-m-z/shellcheck.profile
+++ b/etc/profile-m-z/shellcheck.profile
@@ -40,6 +40,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 x11 none

--- a/etc/profile-m-z/sqlitebrowser.profile
+++ b/etc/profile-m-z/sqlitebrowser.profile
@@ -18,6 +18,7 @@ include disable-programs.inc
 include disable-shell.inc
 include disable-xdg.inc
 
+include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
@@ -35,6 +36,7 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
+seccomp.block-secondary
 shell none
 
 private-bin sqlitebrowser

--- a/etc/profile-m-z/strings.profile
+++ b/etc/profile-m-z/strings.profile
@@ -38,6 +38,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 x11 none

--- a/etc/profile-m-z/supertux2.profile
+++ b/etc/profile-m-z/supertux2.profile
@@ -36,6 +36,7 @@ nou2f
 novideo
 protocol unix,netlink
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-m-z/supertuxkart.profile
+++ b/etc/profile-m-z/supertuxkart.profile
@@ -43,6 +43,7 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-m-z/thunderbird.profile
+++ b/etc/profile-m-z/thunderbird.profile
@@ -6,6 +6,8 @@ include thunderbird.local
 # Persistent global definitions
 include globals.local
 
+ignore whitelist-runuser-common.inc
+
 # writable-run-user and dbus are needed by enigmail
 ignore dbus-user none
 ignore dbus-system none

--- a/etc/profile-m-z/transmission-common.profile
+++ b/etc/profile-m-z/transmission-common.profile
@@ -39,6 +39,7 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-m-z/vivaldi.profile
+++ b/etc/profile-m-z/vivaldi.profile
@@ -29,6 +29,8 @@ whitelist ${HOME}/.config/vivaldi
 whitelist ${HOME}/.config/vivaldi-snapshot
 whitelist ${HOME}/.local/lib/vivaldi
 
+#private-bin bash,cat,dirname,readlink,rm,vivaldi,vivaldi-stable,vivaldi-snapshot
+
 # breaks vivaldi sync
 ignore dbus-user none
 ignore dbus-system none

--- a/etc/profile-m-z/wget.profile
+++ b/etc/profile-m-z/wget.profile
@@ -44,6 +44,7 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-m-z/whois.profile
+++ b/etc/profile-m-z/whois.profile
@@ -39,6 +39,7 @@ nou2f
 novideo
 protocol inet,inet6
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-m-z/xournal.profile
+++ b/etc/profile-m-z/xournal.profile
@@ -36,6 +36,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-m-z/yelp.profile
+++ b/etc/profile-m-z/yelp.profile
@@ -41,6 +41,7 @@ nou2f
 novideo
 protocol unix
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-m-z/youtube-dl.profile
+++ b/etc/profile-m-z/youtube-dl.profile
@@ -52,6 +52,7 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -157,6 +157,7 @@ include globals.local
 #seccomp
 ##seccomp !chroot
 ##seccomp.drop SYSCALLS (see syscalls.txt)
+#seccomp.block-secondary
 #shell none
 #tracelog
 # Prefer 'x11 none' instead of 'blacklist /tmp/.X11-unix' if 'net none' is set


### PR DESCRIPTION
 - add seccomp.block-secondary to a lot profiles
 - add wruc to firefox-common and ignore it in TB and
   firefox-common-addons
 - harden dia, gnome-keyring, libreoffice, megaglest, pngquant,
   ghostwriter, rhythmbox, sqlitebrowser
