### PR TITLE
keepassxc.profile: Fix hang due to seccomp

### DIFF
--- a/etc/profile-a-l/keepassxc.profile
+++ b/etc/profile-a-l/keepassxc.profile
@@ -54,7 +54,7 @@ notv
 nou2f
 novideo
 protocol unix,netlink
-seccomp
+seccomp !name_to_handle_at
 seccomp.block-secondary
 shell none
 tracelog


### PR DESCRIPTION
With the current profile, keepassxc hangs on startup, before showing the
main window:

    $ uname -r -m
    5.9.1-artix1-1 x86_64
    $ firejail --version | head -n 1
    firejail version 0.9.64
    $ firejail --quiet keepassxc --version
    KeePassXC 2.6.2
    $ firejail --quiet keepassxc
    # (nothing happens)
    ^C

Seccomp debugging as explained on etc/templates/syscalls.txt:

    $ sudo grep -Eo 'keepassxc.* syscall=[0-9]+' /var/log/messages.log | tail -n 1
    keepassxc" exe="/usr/bin/keepassxc" sig=31 arch=c000003e syscall=303
    $ firejail --debug-syscalls | grep 303
    303     - name_to_handle_at

So allow the name_to_handle_at syscall.

Relates to #3549.
