### PR TITLE
reimplement --private-cache using --tmpfs

### DIFF
--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -162,11 +162,12 @@ static void disable_file(OPERATION op, const char *filename) {
 	}
 	else if (op == MOUNT_TMPFS) {
 		if (S_ISDIR(s.st_mode)) {
-			if (getuid() &&
-			   (strncmp(cfg.homedir, fname, strlen(cfg.homedir)) != 0 ||
-			    fname[strlen(cfg.homedir)] != '/')) {
-				fprintf(stderr, "Error: tmpfs outside $HOME is only available for root\n");
-				exit(1);
+			if (getuid()) {
+				if (strncmp(cfg.homedir, fname, strlen(cfg.homedir)) != 0 ||
+				    fname[strlen(cfg.homedir)] != '/') {
+					fprintf(stderr, "Error: tmpfs outside $HOME is only available for root\n");
+					exit(1);
+				}
 			}
 			fs_tmpfs(fname, getuid());
 			last_disable = SUCCESSFUL;
@@ -1259,29 +1260,4 @@ void fs_private_tmp(void) {
 		}
 	}
 	closedir(dir);
-}
-
-// this function is called from sandbox.c before blacklist/whitelist functions
-void fs_private_cache(void) {
-	char *cache;
-	if (asprintf(&cache, "%s/.cache", cfg.homedir) == -1)
-		errExit("asprintf");
-	// check if ~/.cache is a valid destination
-	struct stat s;
-	if (lstat(cache, &s) == -1) {
-		fwarning("skipping private-cache: cannot find %s\n", cache);
-		free(cache);
-		return;
-	}
-	if (!S_ISDIR(s.st_mode)) {
-		if (S_ISLNK(s.st_mode))
-			fwarning("skipping private-cache: %s is a symbolic link\n", cache);
-		else
-			fwarning("skipping private-cache: %s is not a directory\n", cache);
-		free(cache);
-		return;
-	}
-	// do the mount
-	fs_tmpfs(cache, getuid()); // check ownership of ~/.cache
-	free(cache);
 }

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -923,12 +923,9 @@ int sandbox(void* sandbox_arg) {
 
 #ifdef HAVE_USERTMPFS
 	if (arg_private_cache) {
-		if (cfg.chrootdir)
-			fwarning("private-cache feature is disabled in chroot\n");
-		else if (arg_overlay)
-			fwarning("private-cache feature is disabled in overlay\n");
-		else
-			fs_private_cache();
+		EUID_USER();
+		profile_add("tmpfs ${HOME}/.cache");
+		EUID_ROOT();
 	}
 #endif
 

--- a/test/fs/private-cache.exp
+++ b/test/fs/private-cache.exp
@@ -7,15 +7,16 @@ set timeout 10
 spawn $env(SHELL)
 match_max 100000
 
-if {[file exists ~/.cache]} {
-	puts "found .cache directory\n"
-} else {
-	send -- "mkdir --mode=755 ~/.cache\r"
-}
+send -- "mkdir --mode=700 ~/.cache\r"
 after 100
 
 send -- "touch ~/.cache/abcdefg\r"
 after 100
+
+if { ! [file exists ~/.cache/abcdefg] } {
+	puts "TESTING ERROR 0\n"
+	exit
+}
 
 send -- "firejail --noprofile --private-cache\r"
 expect {
@@ -34,23 +35,8 @@ after 100
 send -- "exit\r"
 sleep 1
 
-send -- "rm -v ~/.cache/abcdefg\r"
-expect {
-	timeout {puts "TESTING ERROR 3\n";exit}
-	"removed"
-}
+# cleanup
+send -- "rm ~/.cache/abcdefg\r"
 after 100
-
-# redo the test with --private
-
-send -- "firejail --noprofile --private --private-cache\r"
-expect {
-	timeout {puts "TESTING ERROR 4\n";exit}
-	"Warning"
-}
-sleep 1
-
-send -- "exit\r"
-sleep 1
 
 puts "\nall done\n"


### PR DESCRIPTION
Use new `--tmpfs` functionality to implement `--private-cache`. This has the added advantage that Firejail can now deal with symlinked ~/.cache directories, at least as long as the symlink's target lives in user home.

The new `--private-cache` is less verbose and now behaves like `--blacklist`, `--read-only` and so on, which is why the test had to be adapted.