### PR TITLE
Minetest profile fix

### DIFF
--- a/etc/minetest.profile
+++ b/etc/minetest.profile
@@ -9,6 +9,8 @@ include globals.local
 noblacklist ${HOME}/.cache/minetest
 noblacklist ${HOME}/.minetest
 
+include allow-lua.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/minetest.profile
+++ b/etc/minetest.profile
@@ -43,7 +43,7 @@ shell none
 tracelog
 
 disable-mnt
-private-bin minetest
+private-bin minetest,rm
 private-cache
 private-dev
 # private-etc needs to be updated, see #1702


### PR DESCRIPTION
Minetest uses `luajit.so`
https://github.com/minetest/minetest/blob/07500479191ed927ab661b3758ffcd2fd43158c5/README.md#dependencies

Minetest uses `rm` to delete files (saved games and mods)
https://github.com/minetest/minetest/blob/07500479191ed927ab661b3758ffcd2fd43158c5/src/filesys.cpp#L309