### PR TITLE
minetest: Enable rm

### DIFF
--- a/etc/profile-m-z/minetest.profile
+++ b/etc/profile-m-z/minetest.profile
@@ -52,7 +52,7 @@ shell none
 tracelog
 
 disable-mnt
-private-bin minetest
+private-bin minetest,rm
 private-cache
 private-dev
 # private-etc needs to be updated, see #1702


### PR DESCRIPTION
Minetest uses `rm` to delete files (saved data and mods).

https://github.com/minetest/minetest/blob/07500479191ed927ab661b3758ffcd2fd43158c5/src/filesys.cpp#L309