### PR TITLE
Miscellaneous whitelist-runuser-common fixes

### DIFF
--- a/etc/inc/whitelist-runuser-common.inc
+++ b/etc/inc/whitelist-runuser-common.inc
@@ -10,4 +10,5 @@ whitelist ${RUNUSER}/ICEauthority
 whitelist ${RUNUSER}/.mutter-Xwaylandauth.*
 whitelist ${RUNUSER}/pulse/native
 whitelist ${RUNUSER}/wayland-0
+whitelist ${RUNUSER}/wayland-1
 whitelist ${RUNUSER}/xauth_*

--- a/etc/profile-m-z/thunderbird.profile
+++ b/etc/profile-m-z/thunderbird.profile
@@ -6,7 +6,7 @@ include thunderbird.local
 # Persistent global definitions
 include globals.local
 
-ignore whitelist-runuser-common.inc
+ignore include whitelist-runuser-common.inc
 
 # writable-run-user and dbus are needed by enigmail
 ignore dbus-user none


### PR DESCRIPTION
1. We must ignore include `whitelist-runuser-common.profile` because it breaks Enigmail (TB 68) and GnuPG smartcard (TB 78) support. The current `thunderbird.profile` had a small typo, so the include wasn't ignored.

However, since the update to Thunderbird 78, Thunderbird does not call the gnupg agent for any GPG public key operations, and only calls it for private key operations if `mail.openpgp.allow_external_gnupg` is set (to allow the use of smart cards). So, this being a quite niche use-case, we might think about including `whitelist-runuser-common.profile` anyways, and leaving only a comment for gnupg agent users.

Alternatively, I had some success with just `whitelist ${RUNUSER}/gnupg` (in conjunction with `writable-run-user` already in `thunderbird.profile`), but that only works if `${RUNUSER}/gnupg` already exists, I think. Maybe `mkdir ${RUNUSER}/gnupg` could help here?

2. If the GDM display manager runs with Wayland support, and it starts a desktop environment other than (?) GNOME, the desktop environment will use the `wayland-1` socket instead of the `wayland-0` socket. Here, I just allow `wayland-1`, too. 

Situations where `wayland-2` or higher ends up being the default socket seem much rarer (but might be possible to trigger with nested compositors, see e.g. sway's wayland backend). So we might think about allowing higher numbers, too.

I'm not sure about the `pipewire-0` (and possibly higher) sockets. Screen sharing with browsers under Wayland (with `wlr-desktop-portal`) might rely on them, but I haven't had the chance to experiment.

Note that exposing multiple Wayland sockets might be a security hole if multiple sockets are created (e.g. with nested compositors, proxies à la dbus-proxy, or security features provided by compositors) for different application. Such setups are probably extremely niche currently. If they become popular, we might try to add direct support for them inside firejail (like `dbus-user` and `dbus-system`). In the meantime, those require manual configuration, but we should document which Wayland sockets are allowed by default (so they can be blocked when desired).