### PR TITLE
add gnome-shell search-provider file to firefox.profile

### DIFF
--- a/etc/profile-a-l/firefox.profile
+++ b/etc/profile-a-l/firefox.profile
@@ -16,6 +16,8 @@ whitelist ${HOME}/.mozilla
 
 whitelist /usr/share/doc
 whitelist /usr/share/firefox
+# Uncomment or put in your firefox.local to enable gnome-shell search provider support
+#whitelist /usr/share/gnome-shell/search-providers
 whitelist /usr/share/gtk-doc/html
 whitelist /usr/share/mozilla
 whitelist /usr/share/webext

--- a/etc/profile-a-l/firefox.profile
+++ b/etc/profile-a-l/firefox.profile
@@ -30,6 +30,7 @@ include whitelist-usr-share-common.inc
 #private-etc firefox
 
 dbus-user filter
+dbus-user.own org.mozilla.Firefox.*
 dbus-user.own org.mozilla.firefox.*
 dbus-user.own org.mpris.MediaPlayer2.firefox.*
 # Uncomment or put in your firefox.local to enable native notifications.

--- a/etc/profile-a-l/firefox.profile
+++ b/etc/profile-a-l/firefox.profile
@@ -16,8 +16,7 @@ whitelist ${HOME}/.mozilla
 
 whitelist /usr/share/doc
 whitelist /usr/share/firefox
-# Uncomment or put in your firefox.local to enable gnome-shell search provider support
-#whitelist /usr/share/gnome-shell/search-providers
+whitelist /usr/share/gnome-shell/search-providers/firefox-search-provider.ini
 whitelist /usr/share/gtk-doc/html
 whitelist /usr/share/mozilla
 whitelist /usr/share/webext


### PR DESCRIPTION
Firefox has gnome-shell search-provider support since version 78:
- https://bugzilla.mozilla.org/show_bug.cgi?id=1239694
- https://mastransky.wordpress.com/2020/09/25/firefox-gnome-shell-search-provider/

Let's add a comment on how to enable this in firejail.