### PR TITLE
Fix building C# projects in Godot

### DIFF
--- a/etc/profile-a-l/godot.profile
+++ b/etc/profile-a-l/godot.profile
@@ -38,7 +38,7 @@ tracelog
 # private-bin godot
 private-cache
 private-dev
-private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,drirc,fonts,machine-id,nsswitch.conf,openal,pki,pulse,resolv.conf,ssl
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,drirc,fonts,machine-id,mono,nsswitch.conf,openal,pki,pulse,resolv.conf,ssl
 private-tmp
 
 dbus-user none


### PR DESCRIPTION
Since version 3.0 Godot is supporting C# as a language for writing scripts. The C# solution can be built directly in Godot editor using MSBuild, which requires access to directory /etc/mono. This directory contains configuration of Mono enviroment. If MSBuild don't have access to this directory, it's not able to determine location of DLL files and it's throwing System.DllNotFoundException at beginning of the build process.