### PR TITLE
Dc add ldns

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -518,10 +518,13 @@ blacklist ${PATH}/dig
 blacklist ${PATH}/dlint
 blacklist ${PATH}/dns2tcp
 blacklist ${PATH}/dnswalk
+blacklist ${PATH}/drill
 blacklist ${PATH}/host
 blacklist ${PATH}/iodine
 blacklist ${PATH}/kdig
 blacklist ${PATH}/knsupdate
+blacklist ${PATH}/ldns-*
+blacklist ${PATH}/ldnsd
 blacklist ${PATH}/nslookup
 blacklist ${PATH}/resolvectl
 

--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -515,18 +515,18 @@ blacklist /proc/config.gz
 # prevent DNS malware attempting to communicate with the server
 # using regular DNS tools
 blacklist ${PATH}/dig
-blacklist ${PATH}/kdig
-blacklist ${PATH}/nslookup
-blacklist ${PATH}/host
 blacklist ${PATH}/dlint
-blacklist ${PATH}/dnswalk
 blacklist ${PATH}/dns2tcp
+blacklist ${PATH}/dnswalk
+blacklist ${PATH}/host
 blacklist ${PATH}/iodine
+blacklist ${PATH}/kdig
 blacklist ${PATH}/knsupdate
+blacklist ${PATH}/nslookup
 blacklist ${PATH}/resolvectl
 
 # rest of ${RUNUSER}
 blacklist ${RUNUSER}/*.lock
 blacklist ${RUNUSER}/inaccessible
-blacklist ${RUNUSER}/update-notifier.pid
 blacklist ${RUNUSER}/pk-debconf-socket
+blacklist ${RUNUSER}/update-notifier.pid


### PR DESCRIPTION
 disable-common.inc: blacklist ldns tools

drill(1) from ldns is the first tool suggested on the Arch Wiki for DNS
lookup:
https://wiki.archlinux.org/index.php/Domain_name_resolution#Lookup_utilities

Home page: https://www.nlnetlabs.nl/projects/ldns/about/

    $ pacman -Q ldns
    ldns 1.7.1-2
    $ pacman -Qlq ldns | grep bin
    /usr/bin/
    /usr/bin/drill
    /usr/bin/ldns-chaos
    /usr/bin/ldns-compare-zones
    /usr/bin/ldns-config
    /usr/bin/ldns-dane
    /usr/bin/ldns-dpa
    /usr/bin/ldns-gen-zone
    /usr/bin/ldns-key2ds
    /usr/bin/ldns-keyfetcher
    /usr/bin/ldns-keygen
    /usr/bin/ldns-mx
    /usr/bin/ldns-notify
    /usr/bin/ldns-nsec3-hash
    /usr/bin/ldns-read-zone
    /usr/bin/ldns-resolver
    /usr/bin/ldns-revoke
    /usr/bin/ldns-rrsig
    /usr/bin/ldns-signzone
    /usr/bin/ldns-test-edns
    /usr/bin/ldns-testns
    /usr/bin/ldns-update
    /usr/bin/ldns-verify-zone
    /usr/bin/ldns-version
    /usr/bin/ldns-walk
    /usr/bin/ldns-zcat
    /usr/bin/ldns-zsplit
    /usr/bin/ldnsd