### PR TITLE
refactor playonlinux as wine redirect

### DIFF
--- a/etc/profile-m-z/playonlinux.profile
+++ b/etc/profile-m-z/playonlinux.profile
@@ -4,34 +4,17 @@
 # Persistent local customizations
 include playonlinux.local
 # Persistent global definitions
-include globals.local
+# added by included profile
+#include globals.local
 
-noblacklist ${HOME}/.Steam
-noblacklist ${HOME}/.local/share/Steam
-noblacklist ${HOME}/.local/share/steam
-noblacklist ${HOME}/.steam
 noblacklist ${HOME}/.PlayOnLinux
 
 # nc is needed to run playonlinux
 noblacklist ${PATH}/nc
 
-# Allow python (blacklisted by disable-interpreters.inc)
 include allow-python2.inc
 include allow-python3.inc
-
-# Allow perl (blacklisted by disable-interpreters.inc)
 include allow-perl.inc
 
-include disable-common.inc
-include disable-devel.inc
-include disable-interpreters.inc
-include disable-programs.inc
-
-caps.drop all
-netfilter
-nodvd
-nogroups
-nonewprivs
-noroot
-notv
-seccomp
+# Redirect
+include wine.profile


### PR DESCRIPTION
Playonlinux is only a (graphical) wrapper around wine. Everything required for wine is therefore required for PoL.
https://github.com/netblue30/firejail/issues/3800#issuecomment-742603654

This adds `private-dev` and `whitelist-var-common` as additional restriction to PoL, I don't think that it breaks but testing would be greate. (@Rosika2 would you be so kind `firejail --include=/etc/firejail/whitelist-var-common.inc --private-dev '--noblacklist=/tmp/.wine-*' --private=media/rosika/f14a27c2-0b49-4607-94ea-2e56bbf76fe1/DATEN-PARTITION/PLAYONLINUX playonlinux`).