### PR TITLE
streamline comments in inc files

### DIFF
--- a/etc/inc/whitelist-common.inc
+++ b/etc/inc/whitelist-common.inc
@@ -1,4 +1,5 @@
-# Local customizations come here
+# This file is overwritten during software install.
+# Persistent customizations should go in a .local file.
 include whitelist-common.local
 
 # common whitelist for all profiles

--- a/etc/inc/whitelist-players.inc
+++ b/etc/inc/whitelist-players.inc
@@ -1,4 +1,5 @@
-# Local customizations come here
+# This file is overwritten during software install.
+# Persistent customizations should go in a .local file.
 include whitelist-players.local
 
 # common whitelist for all media players

--- a/etc/inc/whitelist-runuser-common.inc
+++ b/etc/inc/whitelist-runuser-common.inc
@@ -1,4 +1,5 @@
-# Local customizations come here
+# This file is overwritten during software install.
+# Persistent customizations should go in a .local file.
 include whitelist-runuser-common.local
 
 # common ${RUNUSER} (=/run/user/$UID) whitelist for all profiles

--- a/etc/inc/whitelist-usr-share-common.inc
+++ b/etc/inc/whitelist-usr-share-common.inc
@@ -1,4 +1,5 @@
-# Local customizations come here
+# This file is overwritten during software install.
+# Persistent customizations should go in a .local file.
 include whitelist-usr-share-common.local
 
 # common /usr/share whitelist for all profiles

--- a/etc/inc/whitelist-var-common.inc
+++ b/etc/inc/whitelist-var-common.inc
@@ -1,4 +1,5 @@
-# Local customizations come here
+# This file is overwritten during software install.
+# Persistent customizations should go in a .local file.
 include whitelist-var-common.local
 
 # common /var whitelist for all profiles


### PR DESCRIPTION
Use the same wording in our includes as we do in all other files that get overwritten after every install/update.