### PR TITLE
rename whitelist-players.inc to whitelist-player-common.inc

### DIFF
--- a/etc/inc/whitelist-player-common.inc
+++ b/etc/inc/whitelist-player-common.inc
@@ -1,6 +1,6 @@
 # This file is overwritten during software install.
 # Persistent customizations should go in a .local file.
-include whitelist-players.local
+include whitelist-player-common.local
 
 # common whitelist for all media players
 

--- a/etc/profile-a-l/celluloid.profile
+++ b/etc/profile-a-l/celluloid.profile
@@ -32,7 +32,7 @@ whitelist ${HOME}/.config/celluloid
 whitelist ${HOME}/.config/gnome-mpv
 whitelist ${HOME}/.config/youtube-dl
 include whitelist-common.inc
-include whitelist-players.inc
+include whitelist-player-common.inc
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc

--- a/etc/profile-m-z/mplayer.profile
+++ b/etc/profile-m-z/mplayer.profile
@@ -19,7 +19,7 @@ read-only ${DESKTOP}
 mkdir ${HOME}/.mplayer
 whitelist ${HOME}/.mplayer
 include whitelist-common.inc
-include whitelist-players.inc
+include whitelist-player-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 

--- a/etc/profile-m-z/mpsyt.profile
+++ b/etc/profile-m-z/mpsyt.profile
@@ -44,7 +44,7 @@ whitelist ${HOME}/.mplayer
 whitelist ${HOME}/.netrc
 whitelist ${HOME}/mps
 include whitelist-common.inc
-include whitelist-players.inc
+include whitelist-player-common.inc
 include whitelist-var-common.inc
 
 apparmor

--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -50,7 +50,7 @@ whitelist ${HOME}/.config/mpv
 whitelist ${HOME}/.config/youtube-dl
 whitelist ${HOME}/.netrc
 include whitelist-common.inc
-include whitelist-players.inc
+include whitelist-player-common.inc
 whitelist /usr/share/lua
 whitelist /usr/share/lua*
 whitelist /usr/share/vulkan

--- a/etc/profile-m-z/totem.profile
+++ b/etc/profile-m-z/totem.profile
@@ -30,7 +30,7 @@ whitelist ${HOME}/.config/totem
 whitelist ${HOME}/.local/share/totem
 whitelist /usr/share/totem
 include whitelist-common.inc
-include whitelist-players.inc
+include whitelist-player-common.inc
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc

--- a/etc/profile-m-z/vlc.profile
+++ b/etc/profile-m-z/vlc.profile
@@ -27,7 +27,7 @@ whitelist ${HOME}/.config/vlc
 whitelist ${HOME}/.config/aacs
 whitelist ${HOME}/.local/share/vlc
 include whitelist-common.inc
-include whitelist-players.inc
+include whitelist-player-common.inc
 include whitelist-var-common.inc
 
 #apparmor - on Ubuntu 18.04 it refuses to start without dbus access

--- a/etc/profile-m-z/xplayer.profile
+++ b/etc/profile-m-z/xplayer.profile
@@ -25,7 +25,7 @@ mkdir ${HOME}/.local/share/xplayer
 whitelist ${HOME}/.config/xplayer
 whitelist ${HOME}/.local/share/xplayer
 include whitelist-common.inc
-include whitelist-players.inc
+include whitelist-player-common.inc
 include whitelist-var-common.inc
 
 # apparmor - makes settings immutable


### PR DESCRIPTION
whitelist-player-common.inc fits in with the naming-scheme used throughout our codebase

IMPORTANT NOTE:
users will have to rename their whitelist-players.local to whitelist-player-common.local to ensure stuff stays working as expected