### PR TITLE
Refactor archivers

### DIFF
--- a/etc/inc/archiver-common.inc
+++ b/etc/inc/archiver-common.inc
@@ -4,7 +4,6 @@ include archiver-common.local
 
 # common profile for archiver/compression tools
 
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 include disable-common.inc

--- a/etc/inc/archiver-common.inc
+++ b/etc/inc/archiver-common.inc
@@ -2,7 +2,7 @@
 # Persistent customizations should go in a .local file.
 include archiver-common.local
 
-# common settings for all archiver/compression tool profiles
+# common profile for archiver/compression tools
 
 blacklist ${RUNUSER}/wayland-*
 

--- a/etc/inc/archiver-common.inc
+++ b/etc/inc/archiver-common.inc
@@ -5,6 +5,7 @@ include archiver-common.local
 # common profile for archiver/compression tools
 
 blacklist ${RUNUSER}/wayland-*
+blacklist ${RUNUSER}
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/inc/archiver-common.inc
+++ b/etc/inc/archiver-common.inc
@@ -1,0 +1,43 @@
+# This file is overwritten during software install.
+# Persistent customizations should go in a .local file.
+include archiver-common.local
+
+# common settings for all archiver/compression tool profiles
+
+blacklist ${RUNUSER}/wayland-*
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
+include disable-shell.inc
+
+caps.drop all
+hostname archiver
+ipc-namespace
+machine-id
+net none
+no3d
+nodvd
+nogroups
+nonewprivs
+#noroot
+nosound
+notv
+nou2f
+novideo
+protocol unix
+seccomp
+shell none
+tracelog
+x11 none
+
+private-cache
+private-dev
+
+dbus-user none
+dbus-system none
+
+memory-deny-write-execute

--- a/etc/inc/archiver-common.inc
+++ b/etc/inc/archiver-common.inc
@@ -14,6 +14,7 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-shell.inc
 
+apparmor
 caps.drop all
 hostname archiver
 ipc-namespace

--- a/etc/profile-a-l/7z.profile
+++ b/etc/profile-a-l/7z.profile
@@ -7,41 +7,8 @@ include 7z.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
-
-include disable-common.inc
-include disable-devel.inc
-include disable-exec.inc
-include disable-interpreters.inc
-include disable-passwdmgr.inc
-include disable-programs.inc
-
-apparmor
-caps.drop all
-hostname 7z
-ipc-namespace
-machine-id
-net none
-no3d
-nodvd
-#nogroups
-nonewprivs
-#noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix
-seccomp
-shell none
-tracelog
-x11 none
+ignore include disable-shell.inc
+ignore nogroups
+include archiver-common.inc
 
 #private-bin 7z,7z*,p7zip
-private-cache
-private-dev
-
-dbus-user none
-dbus-system none
-
-memory-deny-write-execute

--- a/etc/profile-a-l/ar.profile
+++ b/etc/profile-a-l/ar.profile
@@ -7,42 +7,6 @@ include ar.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
-
-include disable-common.inc
-include disable-devel.inc
-include disable-exec.inc
-include disable-interpreters.inc
-include disable-passwdmgr.inc
-include disable-programs.inc
-include disable-shell.inc
-
-apparmor
-caps.drop all
-hostname ar
-ipc-namespace
-machine-id
-net none
-no3d
-nodvd
-nogroups
-nonewprivs
-#noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix
-seccomp
-shell none
-tracelog
-x11 none
+include archiver-common.inc
 
 private-bin ar
-private-cache
-private-dev
-
-dbus-user none
-dbus-system none
-
-memory-deny-write-execute

--- a/etc/profile-a-l/atool.profile
+++ b/etc/profile-a-l/atool.profile
@@ -7,47 +7,15 @@ include atool.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
-
 # Allow perl (blacklisted by disable-interpreters.inc)
 include allow-perl.inc
+ignore include disable-devel.inc
+ignore include disable-shell.inc
+include archiver-common.inc
 
-include disable-common.inc
-# include disable-devel.inc
-include disable-exec.inc
-include disable-interpreters.inc
-include disable-passwdmgr.inc
-include disable-programs.inc
-
-apparmor
-caps.drop all
-hostname atool
-ipc-namespace
-machine-id
-net none
-no3d
-nodvd
-nogroups
-nonewprivs
 noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix
-seccomp
-shell none
-tracelog
-x11 none
 
 # private-bin atool,perl
-private-cache
-private-dev
 # without login.defs atool complains and uses UID/GID 1000 by default
 private-etc alternatives,group,login.defs,passwd
 private-tmp
-
-dbus-user none
-dbus-system none
-
-memory-deny-write-execute

--- a/etc/profile-a-l/bsdtar.profile
+++ b/etc/profile-a-l/bsdtar.profile
@@ -6,43 +6,10 @@ include bsdtar.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
-
-include disable-common.inc
-# include disable-devel.inc
-include disable-exec.inc
-include disable-interpreters.inc
-include disable-passwdmgr.inc
-include disable-programs.inc
-
-apparmor
-caps.drop all
-hostname bsdtar
-ipc-namespace
-machine-id
-net none
-no3d
-nodvd
-nogroups
-nonewprivs
-# noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix
-seccomp
-shell none
-tracelog
-x11 none
+ignore include disable-devel.inc
+ignore include disable-shell.inc
+include archiver-common.inc
 
 # support compressed archives
 private-bin bash,bsdcat,bsdcpio,bsdtar,bzip2,compress,gtar,gzip,lbzip2,libarchive,lz4,lzip,lzma,lzop,sh,xz
-private-cache
-private-dev
 private-etc alternatives,group,localtime,passwd
-
-dbus-user none
-dbus-system none
-
-memory-deny-write-execute

--- a/etc/profile-a-l/cpio.profile
+++ b/etc/profile-a-l/cpio.profile
@@ -7,40 +7,10 @@ include cpio.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
-
 noblacklist /sbin
 noblacklist /usr/sbin
 
-include disable-common.inc
-# include disable-devel.inc
-include disable-exec.inc
-include disable-passwdmgr.inc
-include disable-programs.inc
-
-apparmor
-caps.drop all
-hostname cpio
-ipc-namespace
-machine-id
-net none
-no3d
-nodvd
-nogroups
-nonewprivs
-nosound
-notv
-nou2f
-novideo
-seccomp
-shell none
-tracelog
-x11 none
-
-private-cache
-private-dev
-
-dbus-user none
-dbus-system none
-
-memory-deny-write-execute
+ignore include disable-devel.inc
+ignore include disable-interpreters.inc
+ignore include disable-shell.inc
+include archiver-common.inc

--- a/etc/profile-a-l/gzip.profile
+++ b/etc/profile-a-l/gzip.profile
@@ -7,43 +7,8 @@ include gzip.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
-
 # Arch Linux (based distributions) need access to /var/lib/pacman. As we drop all capabilities this is automatically read-only.
 noblacklist /var/lib/pacman
 
-include disable-common.inc
-include disable-devel.inc
-include disable-exec.inc
-include disable-interpreters.inc
-include disable-passwdmgr.inc
-include disable-programs.inc
-
-apparmor
-caps.drop all
-hostname gzip
-ipc-namespace
-machine-id
-net none
-no3d
-nodvd
-nogroups
-nonewprivs
-#noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix
-seccomp
-shell none
-tracelog
-x11 none
-
-private-cache
-private-dev
-
-dbus-user none
-dbus-system none
-
-memory-deny-write-execute
+ignore include disable-shell.inc
+include archiver-common.inc

--- a/etc/profile-m-z/tar.profile
+++ b/etc/profile-m-z/tar.profile
@@ -7,49 +7,15 @@ include tar.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
-
 # Arch Linux (based distributions) need access to /var/lib/pacman. As we drop all capabilities this is automatically read-only.
 noblacklist /var/lib/pacman
 
-include disable-common.inc
-include disable-devel.inc
-include disable-exec.inc
-include disable-interpreters.inc
-include disable-passwdmgr.inc
-include disable-programs.inc
-
-apparmor
-caps.drop all
-hostname tar
-ipc-namespace
-machine-id
-net none
-no3d
-nodvd
-nogroups
-nonewprivs
-#noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix
-seccomp
-shell none
-tracelog
-x11 none
+ignore include disable-shell.inc
+include archiver-common.inc
 
 # support compressed archives
 private-bin awk,bash,bzip2,compress,firejail,grep,gtar,gzip,lbzip2,lzip,lzma,lzop,sh,tar,xz
-private-cache
-private-dev
 private-etc alternatives,group,localtime,login.defs,passwd
 private-lib libfakeroot
 # Debian based distributions need this for 'dpkg --unpack' (incl. synaptic)
 writable-var
-
-dbus-user none
-dbus-system none
-
-memory-deny-write-execute

--- a/etc/profile-m-z/unrar.profile
+++ b/etc/profile-m-z/unrar.profile
@@ -7,40 +7,10 @@ include unrar.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
-
-include disable-common.inc
-include disable-devel.inc
-include disable-exec.inc
-include disable-interpreters.inc
-include disable-passwdmgr.inc
-include disable-programs.inc
-include disable-shell.inc
-
-caps.drop all
-hostname unrar
-ipc-namespace
-machine-id
-net none
-no3d
-nodvd
-#nogroups
-nonewprivs
-#noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix
-seccomp
-shell none
-tracelog
-x11 none
+ignore nogroups
+ignore private-cache
+include archiver-common.inc
 
 private-bin unrar
-private-dev
 private-etc alternatives,group,localtime,passwd
 private-tmp
-
-dbus-user none
-dbus-system none

--- a/etc/profile-m-z/unzip.profile
+++ b/etc/profile-m-z/unzip.profile
@@ -7,42 +7,12 @@ include unzip.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
-
 # GNOME Shell integration (chrome-gnome-shell)
 noblacklist ${HOME}/.local/share/gnome-shell
 
-include disable-common.inc
-include disable-devel.inc
-include disable-exec.inc
-include disable-interpreters.inc
-include disable-passwdmgr.inc
-include disable-programs.inc
-include disable-shell.inc
-
-caps.drop all
-hostname unzip
-ipc-namespace
-machine-id
-net none
-no3d
-nodvd
-#nogroups
-nonewprivs
+ignore nogroups
 noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix
-seccomp
-shell none
-tracelog
-x11 none
+include archiver-common.inc
 
 private-bin unzip
-private-dev
 private-etc alternatives,group,localtime,passwd
-
-dbus-user none
-dbus-system none

--- a/etc/profile-m-z/xzdec.profile
+++ b/etc/profile-m-z/xzdec.profile
@@ -7,35 +7,6 @@ include xzdec.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
-
-include disable-common.inc
-include disable-devel.inc
-include disable-exec.inc
-include disable-interpreters.inc
-include disable-passwdmgr.inc
-include disable-programs.inc
-
-caps.drop all
-ipc-namespace
-machine-id
-net none
-no3d
-nodvd
-#nogroups
-nonewprivs
-#noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix
-seccomp
-shell none
-tracelog
-x11 none
-
-private-dev
-
-dbus-user none
-dbus-system none
+ignore include disable-shell.inc
+ignore nogroups
+include archiver-common.inc

--- a/etc/profile-m-z/zstd.profile
+++ b/etc/profile-m-z/zstd.profile
@@ -7,37 +7,5 @@ include zstd.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
-
-include disable-common.inc
-include disable-devel.inc
-include disable-exec.inc
-include disable-interpreters.inc
-include disable-passwdmgr.inc
-include disable-programs.inc
-
-apparmor
-caps.drop all
-hostname zstd
-ipc-namespace
-machine-id
-net none
-no3d
-nodvd
-nogroups
-nonewprivs
-#noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix
-seccomp
-shell none
-tracelog
-x11 none
-
-private-cache
-private-dev
-
-memory-deny-write-execute
+ignore include disable-shell.inc
+include archiver-common.inc


### PR DESCRIPTION
Introduce `archive-common.inc`: common file for all archivers.
For now this WIP simply recreates existing archiver profiles.
It's intention is to:
- simplify adding new archiver profile(s);
- review potential inconsistencies in existing archiver profile(s).
E.g. most have nogroups and have noroot commented, but a few divert from this pattern. I intend to do a follow-up review after extended testing, so for now this is a WIP.