### PR TITLE
Fix sound in games using FMOD

### DIFF
--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -112,7 +112,7 @@ shell none
 # comment the following line if you need controller support
 private-dev
 # private-etc breaks a small selection of games on some systems, comment to support those
-private-etc alternatives,asound.conf,bumblebee,ca-certificates,crypto-policies,dbus-1,drirc,fonts,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,lsb-release,machine-id,mime.types,nvidia,os-release,passwd,pki,pulse,resolv.conf,services,ssl
+private-etc alsa,alternatives,asound.conf,bumblebee,ca-certificates,crypto-policies,dbus-1,drirc,fonts,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,lsb-release,machine-id,mime.types,nvidia,os-release,passwd,pki,pulse,resolv.conf,services,ssl
 private-tmp
 
 # breaks appindicator support


### PR DESCRIPTION
I've noticed that profile template has `alsa` in `private-etc`, and `steam.profile` does not, which breaks sound in games using FMOD (Pillars of Eternity in my case, but it should also fix problems mentioned in #3508).