### PR TITLE
Runuser fixes

### DIFF
--- a/etc/profile-a-l/curl.profile
+++ b/etc/profile-a-l/curl.profile
@@ -16,7 +16,6 @@ noblacklist ${HOME}/.curl-hsts
 noblacklist ${HOME}/.curlrc
 
 blacklist /tmp/.X11-unix
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 include disable-common.inc

--- a/etc/profile-a-l/dig.profile
+++ b/etc/profile-a-l/dig.profile
@@ -11,7 +11,6 @@ noblacklist ${HOME}/.digrc
 noblacklist ${PATH}/dig
 
 blacklist /tmp/.X11-unix
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 include disable-common.inc

--- a/etc/profile-a-l/drill.profile
+++ b/etc/profile-a-l/drill.profile
@@ -10,7 +10,6 @@ include globals.local
 noblacklist ${PATH}/drill
 
 blacklist /tmp/.X11-unix
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 include disable-common.inc

--- a/etc/profile-a-l/file.profile
+++ b/etc/profile-a-l/file.profile
@@ -7,7 +7,6 @@ include file.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 include disable-common.inc

--- a/etc/profile-a-l/gtk2-youtube-viewer.profile
+++ b/etc/profile-a-l/gtk2-youtube-viewer.profile
@@ -9,7 +9,6 @@ include gtk2-youtube-viewer.local
 ignore quiet
 
 noblacklist /tmp/.X11-unix
-noblacklist ${RUNUSER}/wayland-*
 noblacklist ${RUNUSER}
 
 include whitelist-runuser-common.inc

--- a/etc/profile-a-l/gtk3-youtube-viewer.profile
+++ b/etc/profile-a-l/gtk3-youtube-viewer.profile
@@ -9,7 +9,6 @@ include gtk3-youtube-viewer.local
 ignore quiet
 
 noblacklist /tmp/.X11-unix
-noblacklist ${RUNUSER}/wayland-*
 noblacklist ${RUNUSER}
 
 include whitelist-runuser-common.inc

--- a/etc/profile-a-l/highlight.profile
+++ b/etc/profile-a-l/highlight.profile
@@ -6,7 +6,6 @@ include highlight.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 include disable-common.inc

--- a/etc/profile-a-l/less.profile
+++ b/etc/profile-a-l/less.profile
@@ -7,7 +7,6 @@ include less.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 noblacklist ${HOME}/.lesshst

--- a/etc/profile-m-z/nslookup.profile
+++ b/etc/profile-m-z/nslookup.profile
@@ -8,7 +8,6 @@ include nslookup.local
 include globals.local
 
 blacklist /tmp/.X11-unix
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 noblacklist ${PATH}/nslookup

--- a/etc/profile-m-z/pandoc.profile
+++ b/etc/profile-m-z/pandoc.profile
@@ -7,7 +7,6 @@ include pandoc.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 noblacklist ${DOCUMENTS}

--- a/etc/profile-m-z/patch.profile
+++ b/etc/profile-m-z/patch.profile
@@ -7,7 +7,6 @@ include patch.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 noblacklist ${DOCUMENTS}

--- a/etc/profile-m-z/pdftotext.profile
+++ b/etc/profile-m-z/pdftotext.profile
@@ -6,7 +6,6 @@ include pdftotext.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 noblacklist ${DOCUMENTS}

--- a/etc/profile-m-z/ping.profile
+++ b/etc/profile-m-z/ping.profile
@@ -8,7 +8,6 @@ include ping.local
 include globals.local
 
 blacklist /tmp/.X11-unix
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 include disable-common.inc

--- a/etc/profile-m-z/qrencode.profile
+++ b/etc/profile-m-z/qrencode.profile
@@ -7,7 +7,6 @@ include qrencode.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 include disable-common.inc

--- a/etc/profile-m-z/rsync-download_only.profile
+++ b/etc/profile-m-z/rsync-download_only.profile
@@ -13,7 +13,6 @@ include globals.local
 # Usage: firejail --profile=rsync-download_only rsync
 
 blacklist /tmp/.X11-unix
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 include disable-common.inc

--- a/etc/profile-m-z/shellcheck.profile
+++ b/etc/profile-m-z/shellcheck.profile
@@ -7,7 +7,6 @@ include shellcheck.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 noblacklist ${DOCUMENTS}

--- a/etc/profile-m-z/strings.profile
+++ b/etc/profile-m-z/strings.profile
@@ -7,7 +7,6 @@ include strings.local
 # Persistent global definitions
 include globals.local
 
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 #include disable-common.inc

--- a/etc/profile-m-z/wget.profile
+++ b/etc/profile-m-z/wget.profile
@@ -12,7 +12,6 @@ noblacklist ${HOME}/.wget-hsts
 noblacklist ${HOME}/.wgetrc
 
 blacklist /tmp/.X11-unix
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 include disable-common.inc

--- a/etc/profile-m-z/whois.profile
+++ b/etc/profile-m-z/whois.profile
@@ -8,7 +8,6 @@ include whois.local
 include globals.local
 
 blacklist /tmp/.X11-unix
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 include disable-common.inc

--- a/etc/profile-m-z/youtube-dl.profile
+++ b/etc/profile-m-z/youtube-dl.profile
@@ -21,7 +21,6 @@ include allow-python2.inc
 include allow-python3.inc
 
 blacklist /tmp/.X11-unix
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 include disable-common.inc


### PR DESCRIPTION
Some profiles blacklisted both ${RUNUSER} and ${RUNUSER}/wayland-*, which doesn't make much sense. This PR removes the latter to avoid potential confusion. See discussion in https://github.com/netblue30/firejail/pull/3820.