### PR TITLE
Archiver fixes - drop private-bin

### DIFF
--- a/etc/profile-a-l/7z.profile
+++ b/etc/profile-a-l/7z.profile
@@ -10,5 +10,3 @@ include globals.local
 noblacklist ${PATH}/bash
 noblacklist ${PATH}/sh
 include archiver-common.inc
-
-private-bin 7z,7z*,bash,p7zip,sh

--- a/etc/profile-a-l/ar.profile
+++ b/etc/profile-a-l/ar.profile
@@ -8,5 +8,3 @@ include ar.local
 include globals.local
 
 include archiver-common.inc
-
-private-bin ar

--- a/etc/profile-a-l/bsdtar.profile
+++ b/etc/profile-a-l/bsdtar.profile
@@ -8,6 +8,4 @@ include globals.local
 
 include archiver-common.inc
 
-# support compressed archives
-private-bin bash,bsdcat,bsdcpio,bsdtar,bzip2,compress,gtar,gzip,lbzip2,libarchive,lz4,lzip,lzma,lzop,sh,xz
 private-etc alternatives,group,localtime,passwd

--- a/etc/profile-m-z/tar.profile
+++ b/etc/profile-m-z/tar.profile
@@ -13,8 +13,6 @@ noblacklist /var/lib/pacman
 ignore include disable-shell.inc
 include archiver-common.inc
 
-# support compressed archives
-private-bin awk,bash,bzip2,compress,firejail,grep,gtar,gzip,lbzip2,lzip,lzma,lzop,sh,tar,xz
 private-etc alternatives,group,localtime,login.defs,passwd
 private-lib libfakeroot,liblzma.so.*,libreadline.so.*
 # Debian based distributions need this for 'dpkg --unpack' (incl. synaptic)

--- a/etc/profile-m-z/tar.profile
+++ b/etc/profile-m-z/tar.profile
@@ -14,6 +14,6 @@ ignore include disable-shell.inc
 include archiver-common.inc
 
 private-etc alternatives,group,localtime,login.defs,passwd
-private-lib libfakeroot,liblzma.so.*,libreadline.so.*
+#private-lib libfakeroot,liblzma.so.*,libreadline.so.*
 # Debian based distributions need this for 'dpkg --unpack' (incl. synaptic)
 writable-var

--- a/etc/profile-m-z/unzip.profile
+++ b/etc/profile-m-z/unzip.profile
@@ -10,8 +10,6 @@ include globals.local
 # GNOME Shell integration (chrome-gnome-shell)
 noblacklist ${HOME}/.local/share/gnome-shell
 
-noroot
 include archiver-common.inc
 
-private-bin unzip
 private-etc alternatives,group,localtime,passwd


### PR DESCRIPTION
Archivers should be able to compress binaries (see discussion in https://github.com/netblue30/firejail/commit/95ad89d24e8e75f2f52defbb80d0d4ee0f27d31e). Let's drop private-bin in relevant profiles.