### PR TITLE
join: add fexecve fallback for shells

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -372,7 +372,7 @@ char *guess_shell(void);
 // sandbox.c
 #define SANDBOX_DONE '1'
 int sandbox(void* sandbox_arg);
-void start_application(int no_sandbox, char *set_sandbox_status) __attribute__((noreturn));
+void start_application(int no_sandbox, int fd, char *set_sandbox_status) __attribute__((noreturn));
 void set_apparmor(void);
 
 // network_main.c

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -2786,7 +2786,7 @@ int main(int argc, char **argv, char **envp) {
 
 	// build the sandbox command
 	if (prog_index == -1 && cfg.shell) {
-		cfg.command_line = cfg.shell;
+		assert(cfg.command_line == NULL); // runs cfg.shell
 		cfg.window_title = cfg.shell;
 		cfg.command_name = cfg.shell;
 	}

--- a/src/firejail/no_sandbox.c
+++ b/src/firejail/no_sandbox.c
@@ -211,7 +211,7 @@ void run_no_sandbox(int argc, char **argv) {
 	}
 
 	if (prog_index == 0) {
-		cfg.command_line = cfg.shell;
+		assert(cfg.command_line == NULL); // runs cfg.shell
 		cfg.window_title = cfg.shell;
 	} else {
 		build_cmdline(&cfg.command_line, &cfg.window_title, argc, argv, prog_index);
@@ -230,5 +230,5 @@ void run_no_sandbox(int argc, char **argv) {
 
 	arg_quiet = 1;
 
-	start_application(1, NULL);
+	start_application(1, -1, NULL);
 }


### PR DESCRIPTION
Allows users to join a sandbox and get a shell even if there is none in the sandbox mount namespace.

Limitations are described in https://github.com/netblue30/firejail/issues/2934#issuecomment-747819719