### PR TITLE
profiles: add redirect from matrix-mirage to mirage

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -303,6 +303,7 @@ blacklist ${HOME}/.config/mana
 blacklist ${HOME}/.config/mate-calc
 blacklist ${HOME}/.config/mate/eom
 blacklist ${HOME}/.config/mate/mate-dictionary
+blacklist ${HOME}/.config/matrix-mirage
 blacklist ${HOME}/.config/meld
 blacklist ${HOME}/.config/meteo-qt
 blacklist ${HOME}/.config/menulibre.cfg
@@ -671,6 +672,7 @@ blacklist ${HOME}/.local/share/lugaru
 blacklist ${HOME}/.local/share/lutris
 blacklist ${HOME}/.local/share/mana
 blacklist ${HOME}/.local/share/maps-places.json
+blacklist ${HOME}/.local/share/matrix-mirage
 blacklist ${HOME}/.local/share/meld
 blacklist ${HOME}/.local/share/midori
 blacklist ${HOME}/.local/share/mirage
@@ -943,6 +945,7 @@ blacklist ${HOME}/.cache/libgweather
 blacklist ${HOME}/.cache/liferea
 blacklist ${HOME}/.cache/lutris
 blacklist ${HOME}/.cache/Mendeley Ltd.
+blacklist ${HOME}/.cache/matrix-mirage
 blacklist ${HOME}/.cache/midori
 blacklist ${HOME}/.cache/minetest
 blacklist ${HOME}/.cache/mirage

--- a/etc/profile-m-z/matrix-mirage.profile
+++ b/etc/profile-m-z/matrix-mirage.profile
@@ -1,0 +1,24 @@
+# Firejail profile for matrix-mirage
+# Description: Debian name for mirage binary/package
+# This file is overwritten after every install/update
+# Persistent local customizations
+include matrix-mirage.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+noblacklist ${HOME}/.cache/matrix-mirage
+noblacklist ${HOME}/.config/matrix-mirage
+noblacklist ${HOME}/.local/share/matrix-mirage
+
+mkdir ${HOME}/.cache/matrix-mirage
+mkdir ${HOME}/.config/matrix-mirage
+mkdir ${HOME}/.local/share/matrix-mirage
+whitelist ${HOME}/.cache/matrix-mirage
+whitelist ${HOME}/.config/matrix-mirage
+whitelist ${HOME}/.local/share/matrix-mirage
+
+private-bin matrix-mirage
+
+# Redirect
+include mirage.profile

--- a/etc/profile-m-z/mirage.profile
+++ b/etc/profile-m-z/mirage.profile
@@ -9,6 +9,7 @@ include globals.local
 noblacklist ${HOME}/.cache/mirage
 noblacklist ${HOME}/.config/mirage
 noblacklist ${HOME}/.local/share/mirage
+noblacklist /sbin
 
 include allow-python2.inc
 include allow-python3.inc
@@ -49,7 +50,7 @@ shell none
 tracelog
 
 disable-mnt
-private-bin mirage
+private-bin mirage,ldconfig
 private-cache
 private-dev
 private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,mime.types,nsswitch.conf,pki,pulse,resolv.conf,selinux,ssl,X11,xdg

--- a/etc/profile-m-z/mirage.profile
+++ b/etc/profile-m-z/mirage.profile
@@ -50,7 +50,7 @@ shell none
 tracelog
 
 disable-mnt
-private-bin mirage,ldconfig
+private-bin ldconfig,mirage
 private-cache
 private-dev
 private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,mime.types,nsswitch.conf,pki,pulse,resolv.conf,selinux,ssl,X11,xdg

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -462,6 +462,7 @@ mate-calculator
 mate-color-select
 mate-dictionary
 mathematica
+matrix-mirage
 mattermost-desktop
 mcabber
 mediainfo


### PR DESCRIPTION
In Debian mirage is packaged as matrix-mirage (as mirage was already taken by a different program).
This creates a redirect profile.

It also adds ldconfig to private-bin (and noblacklists /sbin), as otherwise some Python/Qt related modules were not loading:
```
! 18:17:41 | QSystemTrayIcon::setVisible: No Icon set
~ 18:17:42 | "PyOtherSide error: Traceback (most recent call last):\n\n  File \"qrc:/src/backend/qml_bridge.py\", line 27, in <module>\n    from .pyotherside_events import CoroutineDone, LoopException\n\n  File \"qrc:/src/backend/pyotherside_events.py\", line 8, in <module>\n    from .utils import serialize_value_for_qml\n\n  File \"qrc:/src/backend/utils.py\", line 26, in <module>\n    import magic\n\n  File \"/usr/lib/python3/dist-packages/magic/__init__.py\", line 361, in <module>\n    add_compat(globals())\n\n  File \"/usr/lib/python3/dist-packages/magic/__init__.py\", line 325, in add_compat\n    from magic import compat\n\n  File \"/usr/lib/python3/dist-packages/magic/compat.py\", line 61, in <module>\n    _open = _libraries['magic'].magic_open\n\n  File \"/usr/lib/python3.9/ctypes/__init__.py\", line 387, in __getattr__\n    func = self.__getitem__(name)\n\n  File \"/usr/lib/python3.9/ctypes/__init__.py\", line 392, in __getitem__\n    func = self._FuncPtr((name_or_ordinal, self))\n\nAttributeError: matrix-mirage: undefined symbol: magic_open\n"
! 18:17:42 | Unhandled PyOtherSide error: Cannot import module: backend.qml_bridge (Traceback (most recent call last):

  File "qrc:/src/backend/qml_bridge.py", line 27, in <module>
    from .pyotherside_events import CoroutineDone, LoopException

  File "qrc:/src/backend/pyotherside_events.py", line 8, in <module>
    from .utils import serialize_value_for_qml

  File "qrc:/src/backend/utils.py", line 26, in <module>
    import magic

  File "/usr/lib/python3/dist-packages/magic/__init__.py", line 361, in <module>
    add_compat(globals())

  File "/usr/lib/python3/dist-packages/magic/__init__.py", line 325, in add_compat
    from magic import compat

  File "/usr/lib/python3/dist-packages/magic/compat.py", line 61, in <module>
    _open = _libraries['magic'].magic_open

  File "/usr/lib/python3.9/ctypes/__init__.py", line 387, in __getattr__
    func = self.__getitem__(name)

  File "/usr/lib/python3.9/ctypes/__init__.py", line 392, in __getitem__
    func = self._FuncPtr((name_or_ordinal, self))

AttributeError: matrix-mirage: undefined symbol: magic_open
)
~ 18:17:42 | "PyOtherSide error: Traceback (most recent call last):\n\n  File \"<string>\", line 1, in <module>\n\nNameError: name 'BRIDGE' is not defined\n"
! 18:17:42 | Unhandled PyOtherSide error: Function not found: 'BRIDGE.call_backend_coro' (Traceback (most recent call last):

  File "<string>", line 1, in <module>

NameError: name 'BRIDGE' is not defined
```