### PR TITLE
really fix running kernel config check

### DIFF
--- a/etc/profile-m-z/zcat.profile
+++ b/etc/profile-m-z/zcat.profile
@@ -8,6 +8,8 @@ include zcat.local
 #include globals.local
 
 # Allow running kernel config check
+noblacklist ${PATH}/bash
+noblacklist ${PATH}/sh
 noblacklist /proc/config.gz
 
 # Redirect

--- a/etc/profile-m-z/zgrep.profile
+++ b/etc/profile-m-z/zgrep.profile
@@ -8,6 +8,8 @@ include zgrep.local
 #include globals.local
 
 # Allow running kernel config check
+noblacklist ${PATH}/bash
+noblacklist ${PATH}/sh
 noblacklist /proc/config.gz
 
 # Redirect


### PR DESCRIPTION
Our archiver-common.inc includes `disable-shell.inc`, breaking running kernel config check with zcat or zgrep.