### PR TITLE
drop doubled disable-exec in signal-desktop

### DIFF
--- a/etc/profile-m-z/signal-desktop.profile
+++ b/etc/profile-m-z/signal-desktop.profile
@@ -21,8 +21,6 @@ noblacklist ${HOME}/.mozilla
 whitelist ${HOME}/.mozilla/firefox/profiles.ini
 read-only ${HOME}/.mozilla/firefox/profiles.ini
 
-include disable-exec.inc
-
 mkdir ${HOME}/.config/Signal
 whitelist ${HOME}/.config/Signal
 


### PR DESCRIPTION
disable-exec.inc is already included in electron redirect