### PR TITLE
Whitelist Bohemia Interactive config dir for Steam

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -600,6 +600,7 @@ blacklist ${HOME}/.local/share/baloo
 blacklist ${HOME}/.local/share/barrier
 blacklist ${HOME}/.local/share/bibletime
 blacklist ${HOME}/.local/share/bijiben
+blacklist ${HOME}/.local/share/bohemiainteractive
 blacklist ${HOME}/.local/share/caja-python
 blacklist ${HOME}/.local/share/cantata
 blacklist ${HOME}/.local/share/cdprojektred

--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -9,6 +9,7 @@ include globals.local
 noblacklist ${HOME}/.killingfloor
 noblacklist ${HOME}/.local/share/3909/PapersPlease
 noblacklist ${HOME}/.local/share/aspyr-media
+noblacklist ${HOME}/.local/share/bohemiainteractive
 noblacklist ${HOME}/.local/share/cdprojektred
 noblacklist ${HOME}/.local/share/FasterThanLight
 noblacklist ${HOME}/.local/share/feral-interactive
@@ -45,6 +46,7 @@ mkdir ${HOME}/.config/unity3d
 mkdir ${HOME}/.killingfloor
 mkdir ${HOME}/.local/share/3909/PapersPlease
 mkdir ${HOME}/.local/share/aspyr-media
+mkdir ${HOME}/.local/share/bohemiainteractive
 mkdir ${HOME}/.local/share/cdprojektred
 mkdir ${HOME}/.local/share/FasterThanLight
 mkdir ${HOME}/.local/share/feral-interactive
@@ -64,6 +66,7 @@ whitelist ${HOME}/.config/unity3d
 whitelist ${HOME}/.killingfloor
 whitelist ${HOME}/.local/share/3909/PapersPlease
 whitelist ${HOME}/.local/share/aspyr-media
+whitelist ${HOME}/.local/share/bohemiainteractive
 whitelist ${HOME}/.local/share/cdprojektred
 whitelist ${HOME}/.local/share/FasterThanLight
 whitelist ${HOME}/.local/share/feral-interactive


### PR DESCRIPTION
At least Arma 3 stores its config directory under
~/.local/share/bohemiainteractive

Without this, Arma 3's configuration and game save do not persist across Steam firejail sessions.