### PR TITLE
Add new allow include allow-bin-sh.inc

### DIFF
--- a/etc/inc/allow-bin-sh.inc
+++ b/etc/inc/allow-bin-sh.inc
@@ -1,0 +1,7 @@
+# This file is overwritten during software install.
+# Persistent customizations should go in a .local file.
+include allow-bin-sh.local
+
+noblacklist ${PATH}/bash
+noblacklist ${PATH}/dash
+noblacklist ${PATH}/sh

--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -21,7 +21,7 @@ include globals.local
 #  - ...
 #
 # Often these scripts require a shell:
-#noblacklist ${PATH}/sh
+#include allow-bin-sh.inc
 #private-bin sh
 
 noblacklist ${HOME}/.config/mpv

--- a/etc/profile-m-z/nodejs-common.profile
+++ b/etc/profile-m-z/nodejs-common.profile
@@ -12,9 +12,7 @@ blacklist ${RUNUSER}
 
 ignore noexec ${HOME}
 
-noblacklist ${PATH}/bash
-noblacklist ${PATH}/dash
-noblacklist ${PATH}/sh
+include allow-bin-sh.inc
 
 include disable-common.inc
 include disable-exec.inc


### PR DESCRIPTION
/bin/sh is usually just a symlink to bash. However this is not the case
for every distro, debian for example uses dash. bash,dash and sh have a
blacklist command in disable-shell.inc. An own allow-*.inc for it
enusres usage of all necessary nolacklists.

For private-bin sh is enough because it follows symlinks.