### PR TITLE
Update bibletime.profile, add new whitelist

### DIFF
--- a/etc/profile-a-l/bibletime.profile
+++ b/etc/profile-a-l/bibletime.profile
@@ -26,6 +26,7 @@ whitelist ${HOME}/.bibletime
 whitelist ${HOME}/.sword
 whitelist ${HOME}/.local/share/bibletime
 whitelist /usr/share/bibletime
+whitelist /usr/share/doc/bibletime
 whitelist /usr/share/sword
 include whitelist-common.inc
 include whitelist-usr-share-common.inc


### PR DESCRIPTION
To fix issue #3907, doc directory of the bibletime has to be whitelisted. Otherwise, it always fails to start.