### PR TITLE
remove noblacklist without blacklist

### DIFF
--- a/etc/profile-a-l/aosp.profile
+++ b/etc/profile-a-l/aosp.profile
@@ -6,7 +6,6 @@ include aosp.local
 include globals.local
 
 noblacklist ${HOME}/.android
-noblacklist ${HOME}/.bash_history
 noblacklist ${HOME}/.jack-server
 noblacklist ${HOME}/.jack-settings
 noblacklist ${HOME}/.repo_.gitconfig.json

--- a/etc/profile-a-l/gnome-builder.profile
+++ b/etc/profile-a-l/gnome-builder.profile
@@ -6,8 +6,6 @@ include gnome-builder.local
 # Persistent global definitions
 include globals.local
 
-noblacklist ${HOME}/.bash_history
-
 noblacklist ${HOME}/.cache/gnome-builder
 noblacklist ${HOME}/.config/gnome-builder
 noblacklist ${HOME}/.local/share/gnome-builder


### PR DESCRIPTION
${HOME}/.bash_history is not blacklisted anywhere. Hence a noblacklist doesn't make sense. Affected profiles: aosp & gnome-builder.