### PR TITLE
Disable the webkit2gtk-4.0 sandbox in bijiben

### DIFF
--- a/etc/profile-a-l/bijiben.profile
+++ b/etc/profile-a-l/bijiben.profile
@@ -57,3 +57,5 @@ dbus-user.own org.gnome.Notes
 dbus-user.talk ca.desrt.dconf
 dbus-user.talk org.freedesktop.Tracker1
 dbus-system none
+
+env WEBKIT_FORCE_SANDBOX=0


### PR DESCRIPTION
webkit2gtk uses a bwrap based sandbox by default since 4.0, see #3647.
This is good as it means more security by default on for linux system.
Unfortunately is it not possible to run bwrap inside firejail if bwrap
is started with --unshare-pid --proc /proc at all. In general we should
exclude a program from firecfg until a final solution is found. But
bijiben is special, while epiphany or evolution display random stuff
from the internet is webkit2gtk in bijiben used to display local files
create by the user. Bijiben has a thight profile (net none, whitelist,
private-bin, ...) therefore my decision here was to disable the
webkit2gtk sandbox rather then firejail.
