### PR TITLE
Fix minor typo in firecfg's manual page

### DIFF
--- a/src/man/firecfg.txt
+++ b/src/man/firecfg.txt
@@ -61,7 +61,7 @@ $ sudo firecfg --add-users dustin lucas mike eleven
 
 .TP
 \fB\-\-bindir=directory
-Create and search symbolic links in directory instead of the default location /user/local/bin.
+Create and search symbolic links in directory instead of the default location /usr/local/bin.
 Directory should precede /usr/bin and /bin in the PATH environment variable.
 
 .TP


### PR DESCRIPTION

I believe this to be a minor typo, given the precedence of `/usr` as a directory on many Linux distributions, and the lines following this which explicitly reference `/usr/local/bin `instead of `/user/local/bin` .