### PR TITLE
add a /usr/share whitelist item for uim

### DIFF
--- a/etc/inc/whitelist-usr-share-common.inc
+++ b/etc/inc/whitelist-usr-share-common.inc
@@ -61,6 +61,7 @@ whitelist /usr/share/texlive
 whitelist /usr/share/texmf
 whitelist /usr/share/themes
 whitelist /usr/share/thumbnail.so
+whitelist /usr/share/uim
 whitelist /usr/share/vulkan
 whitelist /usr/share/X11
 whitelist /usr/share/xml


### PR DESCRIPTION
uim is a multilingual input method framework, so any program that takes user input potentially needs it to work.
