### PR TITLE
disable-interpreters.inc: blacklist the other libmozjs

### DIFF
--- a/etc/inc/allow-gjs.inc
+++ b/etc/inc/allow-gjs.inc
@@ -5,7 +5,8 @@ include allow-gjs.local
 noblacklist ${PATH}/gjs
 noblacklist ${PATH}/gjs-console
 noblacklist /usr/lib/gjs
-noblacklist /usr/lib64/gjs
 noblacklist /usr/lib/libgjs*
+noblacklist /usr/lib/libmozjs-*
+noblacklist /usr/lib64/gjs
 noblacklist /usr/lib64/libgjs*
 noblacklist /usr/lib64/libmozjs-*

--- a/etc/inc/disable-interpreters.inc
+++ b/etc/inc/disable-interpreters.inc
@@ -20,6 +20,7 @@ blacklist /usr/lib64/lua
 blacklist /usr/share/lua*
 
 # mozjs
+blacklist /usr/lib/libmozjs-*
 blacklist /usr/lib64/libmozjs-*
 
 # Node.js

--- a/etc/inc/disable-interpreters.inc
+++ b/etc/inc/disable-interpreters.inc
@@ -6,8 +6,8 @@ include disable-interpreters.local
 blacklist ${PATH}/gjs
 blacklist ${PATH}/gjs-console
 blacklist /usr/lib/gjs
-blacklist /usr/lib64/gjs
 blacklist /usr/lib/libgjs*
+blacklist /usr/lib64/gjs
 blacklist /usr/lib64/libgjs*
 
 # Lua
@@ -30,8 +30,8 @@ blacklist /usr/include/node
 blacklist ${HOME}/.nvm
 
 # Perl
-blacklist ${PATH}/cpan*
 blacklist ${PATH}/core_perl
+blacklist ${PATH}/cpan*
 blacklist ${PATH}/perl
 blacklist ${PATH}/site_perl
 blacklist ${PATH}/vendor_perl


### PR DESCRIPTION
And sort the paths on allow-gjs.inc.

    $ pacman -Q js78
    js78 78.6.0-1
    $ pacman -Qlq js78 | grep -v /usr/include/
    /usr/
    /usr/bin/
    /usr/bin/js78
    /usr/bin/js78-config
    /usr/lib/
    /usr/lib/libmozjs-78.so
    /usr/lib/pkgconfig/
    /usr/lib/pkgconfig/mozjs-78.pc

This appears to be the only counterpart path missing when looking at the
current lib64 entries with:

    $ grep -Fnr lib64 etc

---

Note: As mentioned on #3845, please don't squash any commits; use normal merge
or rebase instead.