### PR TITLE
etc: use ${DOCUMENTS} macro where appropriate

### DIFF
--- a/etc/profile-a-l/keepassxc.profile
+++ b/etc/profile-a-l/keepassxc.profile
@@ -31,9 +31,9 @@ include disable-shell.inc
 include disable-xdg.inc
 
 # You can enable whitelisting for keepassxc by uncommenting (or adding to you keepassxc.local) the following lines.
-# If you do so, you MUST store your database under ${HOME}/Documents/KeePassXC/foo.kdbx
-#mkdir ${HOME}/Documents/KeePassXC
-#whitelist ${HOME}/Documents/KeePassXC
+# If you do so, you MUST store your database under ${DOCUMENTS}/KeePassXC/foo.kdbx
+#mkdir ${DOCUMENTS}/KeePassXC
+#whitelist ${DOCUMENTS}/KeePassXC
 # Needed for KeePassXC-Browser
 #mkfile ${HOME}/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts/org.keepassxc.keepassxc_browser.json
 #whitelist ${HOME}/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts/org.keepassxc.keepassxc_browser.json

--- a/etc/profile-m-z/Mathematica.profile
+++ b/etc/profile-m-z/Mathematica.profile
@@ -16,10 +16,10 @@ include disable-programs.inc
 
 mkdir ${HOME}/.Mathematica
 mkdir ${HOME}/.Wolfram Research
-mkdir ${HOME}/Documents/Wolfram Mathematica
+mkdir ${DOCUMENTS}/Wolfram Mathematica
 whitelist ${HOME}/.Mathematica
 whitelist ${HOME}/.Wolfram Research
-whitelist ${HOME}/Documents/Wolfram Mathematica
+whitelist ${DOCUMENTS}/Wolfram Mathematica
 include whitelist-common.inc
 
 caps.drop all


### PR DESCRIPTION
Currently, some paths are hard-coded:

    $ grep -Fnr '${HOME}/Documents' etc etc-fixes
    etc/profile-m-z/Mathematica.profile:19:mkdir ${HOME}/Documents/Wolfram Mathematica
    etc/profile-m-z/Mathematica.profile:22:whitelist ${HOME}/Documents/Wolfram Mathematica
    etc/profile-a-l/keepassxc.profile:34:# If you do so, you MUST store your database under ${HOME}/Documents/KeePassXC/foo.kdbx
    etc/profile-a-l/keepassxc.profile:35:#mkdir ${HOME}/Documents/KeePassXC
    etc/profile-a-l/keepassxc.profile:36:#whitelist ${HOME}/Documents/KeePassXC

Commands used to search and replace:

    $ find etc etc-fixes/ -type f -exec \
      sed -i.bak -e 's|\${HOME}/Documents|${DOCUMENTS}|' '{}' +

Related to that, the (lack of) usage of ${DOWNLOADS} has been recently
fixed on commit deae31301 ("use ${DOWNLOADS} in lutris.profile
(#3955)").

With the above change, all macros other than ${DOCUMENTS} seem to be
already used appropriately:

    $ grep -Fnr '${HOME}/Desktop' etc etc-fixes
    $ grep -Fnr '${HOME}/Downloads' etc etc-fixes
    $ grep -Fnr '${HOME}/Music' etc etc-fixes
    $ grep -Fnr '${HOME}/Pictures' etc etc-fixes
    $ grep -Fnr '${HOME}/Videos' etc etc-fixes

See src/firejail/macros.c for details.
