### PR TITLE
Revert "etc: use ${DOCUMENTS} macro where appropriate"

### DIFF
--- a/etc/profile-a-l/keepassxc.profile
+++ b/etc/profile-a-l/keepassxc.profile
@@ -31,9 +31,9 @@ include disable-shell.inc
 include disable-xdg.inc
 
 # You can enable whitelisting for keepassxc by uncommenting (or adding to you keepassxc.local) the following lines.
-# If you do so, you MUST store your database under ${DOCUMENTS}/KeePassXC/foo.kdbx
-#mkdir ${DOCUMENTS}/KeePassXC
-#whitelist ${DOCUMENTS}/KeePassXC
+# If you do so, you MUST store your database under ${HOME}/Documents/KeePassXC/foo.kdbx
+#mkdir ${HOME}/Documents/KeePassXC
+#whitelist ${HOME}/Documents/KeePassXC
 # Needed for KeePassXC-Browser
 #mkfile ${HOME}/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts/org.keepassxc.keepassxc_browser.json
 #whitelist ${HOME}/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts/org.keepassxc.keepassxc_browser.json

--- a/etc/profile-m-z/Mathematica.profile
+++ b/etc/profile-m-z/Mathematica.profile
@@ -16,10 +16,10 @@ include disable-programs.inc
 
 mkdir ${HOME}/.Mathematica
 mkdir ${HOME}/.Wolfram Research
-mkdir ${DOCUMENTS}/Wolfram Mathematica
+mkdir ${HOME}/Documents/Wolfram Mathematica
 whitelist ${HOME}/.Mathematica
 whitelist ${HOME}/.Wolfram Research
-whitelist ${DOCUMENTS}/Wolfram Mathematica
+whitelist ${HOME}/Documents/Wolfram Mathematica
 include whitelist-common.inc
 
 caps.drop all


### PR DESCRIPTION
This reverts commit 5df1f27c638c487dfd664ea3a0f756565e1e57bd.

That commit breaks things, as pointed out by @rusty-snake[1]:

> @kmk3 @glitsj16 The xdg macros are treated literally if they have sub
> components (#2359):
>
> ```
> Error: "${DOCUMENTS}/KeePassXC" is an invalid filename: rejected character: "{"
> ```

[1]: https://github.com/netblue30/firejail/commit/3fa2927c3c1c5cf583864746538ea791c1ba2dc4#commitcomment-46913219
