### PR TITLE
configure*: fix typo of HAVE_USERTMPFS

### DIFF
--- a/configure
+++ b/configure
@@ -3539,7 +3539,7 @@ HAVE_OVERLAYFS=""
 #	AC_SUBST(HAVE_OVERLAYFS)
 #])
 
-HAVE_USERTMPS=""
+HAVE_USERTMPFS=""
 # Check whether --enable-usertmpfs was given.
 if test "${enable_usertmpfs+set}" = set; then :
   enableval=$enable_usertmpfs;

--- a/configure.ac
+++ b/configure.ac
@@ -77,7 +77,7 @@ AC_SUBST(HAVE_OVERLAYFS)
 #	AC_SUBST(HAVE_OVERLAYFS)
 #])
 
-HAVE_USERTMPS=""
+HAVE_USERTMPFS=""
 AC_ARG_ENABLE([usertmpfs],
     AS_HELP_STRING([--disable-usertmpfs], [disable tmpfs as regular user]))
 AS_IF([test "x$enable_usertmpfs" != "xno"], [


### PR DESCRIPTION
Added on commit 64a8d6a7f ("compile time option to disable
--private-cache and --tmpfs for regular user").

These are the only occurrences:

    $ git ls-files -z | xargs -0 grep -Fin USERTMPS
    configure:3542:HAVE_USERTMPS=""
    configure.ac:80:HAVE_USERTMPS=""
