### PR TITLE
Always allow empty environment variables

### DIFF
--- a/src/firejail/env.c
+++ b/src/firejail/env.c
@@ -166,12 +166,10 @@ void env_store(const char *str, ENV_OP op) {
 	if (*str == '\0')
 		goto errexit;
 	char *ptr = strchr(str, '=');
-	if (op == SETENV || op == SETENV_ALLOW_EMPTY) {
+	if (op == SETENV) {
 		if (!ptr)
 			goto errexit;
 		ptr++;
-		if (*ptr == '\0' && op != SETENV_ALLOW_EMPTY)
-			goto errexit;
 		op = SETENV;
 	}
 
@@ -206,11 +204,6 @@ void env_store_name_val(const char *name, const char *val, ENV_OP op) {
 	// some basic checking
 	if (*name == '\0')
 		goto errexit;
-	if (*val == '\0' && op != SETENV_ALLOW_EMPTY)
-		goto errexit;
-
-	if (op == SETENV_ALLOW_EMPTY)
-		op = SETENV;
 
 	// build list entry
 	Env *env = calloc(1, sizeof(Env));

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -661,7 +661,6 @@ void run_no_sandbox(int argc, char **argv) __attribute__((noreturn));
 // env.c
 typedef enum {
 	SETENV = 0,
-	SETENV_ALLOW_EMPTY,
 	RMENV
 } ENV_OP;
 

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1004,7 +1004,7 @@ int main(int argc, char **argv, char **envp) {
 
 	// Stash environment variables
 	for (i = 0, ptr = envp; ptr && *ptr && i < MAX_ENVS; i++, ptr++)
-		env_store(*ptr, SETENV_ALLOW_EMPTY);
+		env_store(*ptr, SETENV);
 
 	// sanity check for environment variables
 	if (i >= MAX_ENVS) {


### PR DESCRIPTION
With the recent changes to environment variable handling, it should be
safe to always allow empty variables.

Closes: #3965
