### PR TITLE
Fix for KeePassXC plugin

### DIFF
--- a/etc/profile-a-l/firefox.profile
+++ b/etc/profile-a-l/firefox.profile
@@ -49,7 +49,7 @@ dbus-user.own org.mpris.MediaPlayer2.firefox.*
 # implementation)
 #ignore noroot
 # Uncomment or put in your firefox.local one of the following whitelist to enable KeePassXC Plugin
-# note: run KeePassXC before Firefox to allow coomunication between them
+# NOTE: start KeePassXC before Firefox and keep it open to allow communication between them
 #whitelist ${RUNUSER}/kpxc_server
 #whitelist ${RUNUSER}/org.keepassxc.KeePassXC.BrowserServer
 ignore dbus-user none

--- a/etc/profile-a-l/firefox.profile
+++ b/etc/profile-a-l/firefox.profile
@@ -14,6 +14,11 @@ mkdir ${HOME}/.mozilla
 whitelist ${HOME}/.cache/mozilla/firefox
 whitelist ${HOME}/.mozilla
 
+# Uncomment or put in your firefox.local one of the following whitelist to enable KeePassXC Plugin
+# NOTE: start KeePassXC before Firefox and keep it open to allow communication between them
+#whitelist ${RUNUSER}/kpxc_server
+#whitelist ${RUNUSER}/org.keepassxc.KeePassXC.BrowserServer
+
 whitelist /usr/share/doc
 whitelist /usr/share/firefox
 whitelist /usr/share/gnome-shell/search-providers/firefox-search-provider.ini
@@ -48,10 +53,6 @@ dbus-user.own org.mpris.MediaPlayer2.firefox.*
 # does not work with the above lines (might depend on the portal
 # implementation)
 #ignore noroot
-# Uncomment or put in your firefox.local one of the following whitelist to enable KeePassXC Plugin
-# NOTE: start KeePassXC before Firefox and keep it open to allow communication between them
-#whitelist ${RUNUSER}/kpxc_server
-#whitelist ${RUNUSER}/org.keepassxc.KeePassXC.BrowserServer
 ignore dbus-user none
 
 # Redirect

--- a/etc/profile-a-l/firefox.profile
+++ b/etc/profile-a-l/firefox.profile
@@ -48,6 +48,10 @@ dbus-user.own org.mpris.MediaPlayer2.firefox.*
 # does not work with the above lines (might depend on the portal
 # implementation)
 #ignore noroot
+# Uncomment or put in your firefox.local one of the following whitelist to enable KeePassXC Plugin
+# note: run KeePassXC before Firefox to allow coomunication between them
+#whitelist ${RUNUSER}/kpxc_server
+#whitelist ${RUNUSER}/org.keepassxc.KeePassXC.BrowserServer
 ignore dbus-user none
 
 # Redirect


### PR DESCRIPTION
KeePassXC changed the socket name.
https://github.com/keepassxreboot/keepassxc/commit/a145bf91191f0a4630a7e31654aff8a8dfd09bf0
Keep also old socket name in whitelist for back compatibility