### PR TITLE
add apparmor to torbrowser-launcher

### DIFF
--- a/etc/profile-m-z/torbrowser-launcher.profile
+++ b/etc/profile-m-z/torbrowser-launcher.profile
@@ -31,6 +31,7 @@ whitelist ${HOME}/.local/share/torbrowser
 include whitelist-common.inc
 include whitelist-var-common.inc
 
+apparmor
 caps.drop all
 netfilter
 nodvd


### PR DESCRIPTION
At least on Arch Linux torbrowser-launcher comes with AppArmor support. Enabling apparmor in our profile sounds reasonable and shouldn't break on other distro's that do packaging differently.