### PR TITLE
Follow-up fixes for torbrowser-launcher

### DIFF
--- a/etc/apparmor/firejail-default
+++ b/etc/apparmor/firejail-default
@@ -82,9 +82,6 @@ owner /proc/@{PID}/{uid_map,gid_map,setgroups} w,
 owner /proc/@{PID}/oom_score_adj w,
 owner /proc/@{PID}/clear_refs w,
 
-# Needed for torbrowser-launcher
-owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/** ix,
-
 ##########
 # Allow running programs only from well-known system directories. If you need
 # to run programs from your home directory, uncomment /home line.

--- a/etc/apparmor/firejail-default
+++ b/etc/apparmor/firejail-default
@@ -82,6 +82,9 @@ owner /proc/@{PID}/{uid_map,gid_map,setgroups} w,
 owner /proc/@{PID}/oom_score_adj w,
 owner /proc/@{PID}/clear_refs w,
 
+# Needed for torbrowser-launcher
+owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/** ix,
+
 ##########
 # Allow running programs only from well-known system directories. If you need
 # to run programs from your home directory, uncomment /home line.

--- a/etc/apparmor/firejail-local
+++ b/etc/apparmor/firejail-local
@@ -1,2 +1,5 @@
 # Site-specific additions and overrides for 'firejail-default'.
 # For more details, please see /etc/apparmor.d/local/README.
+
+# Uncomment to opt-in to apparmor for torbrowser-launcher
+#owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/** ix,

--- a/etc/profile-m-z/start-tor-browser.desktop.profile
+++ b/etc/profile-m-z/start-tor-browser.desktop.profile
@@ -72,8 +72,5 @@ whitelist ${HOME}/.tor-browser_vi
 whitelist ${HOME}/.tor-browser_zh-CN
 whitelist ${HOME}/.tor-browser_zh-TW
 
-# Ignoring apparmor, tor browser is installed in user home directory using the binary archive distributed by Tor Foundation
-ignore apparmor
-
 # Redirect
 include torbrowser-launcher.profile

--- a/etc/profile-m-z/start-tor-browser.desktop.profile
+++ b/etc/profile-m-z/start-tor-browser.desktop.profile
@@ -4,7 +4,7 @@
 include start-tor-browser.desktop.local
 # Persistent global definitions
 # added by included profile
-include globals.local
+#include globals.local
 
 noblacklist ${HOME}/.tor-browser*
 

--- a/etc/profile-m-z/start-tor-browser.profile
+++ b/etc/profile-m-z/start-tor-browser.profile
@@ -3,7 +3,8 @@
 # Persistent local customizations
 include start-tor-browser.local
 # Persistent global definitions
-include globals.local
+# added by included profile
+#include globals.local
 
 # Redirect
 include start-tor-browser.desktop.profile

--- a/etc/profile-m-z/torbrowser-launcher.profile
+++ b/etc/profile-m-z/torbrowser-launcher.profile
@@ -31,7 +31,10 @@ whitelist ${HOME}/.local/share/torbrowser
 include whitelist-common.inc
 include whitelist-var-common.inc
 
-apparmor
+# Uncomment the line below or put 'apparmor' in your torbrowser-launcher.local.
+# IMPORTANT: the relevant rule in /etc/apparmor.d/local/firejail-default will need
+# to be uncommented too for this to work as expected.
+#apparmor
 caps.drop all
 netfilter
 nodvd


### PR DESCRIPTION
I retested enabling the apparmor option after legitimate questions posed by @rusty-snake and @Vincent43 in #3988 - thanks!. Apologies for the confusion, I forgot to add the AppArmor rule to allow access to the torbrowser-launcher executables installed under ${HOME}. 