### PR TITLE
contrib/firejail-welcome.sh: fix copyright year

### DIFF
--- a/contrib/firejail-welcome.sh
+++ b/contrib/firejail-welcome.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This file is part of Firejail project
-# Copyright (C) 2021 Firejail Authors
+# Copyright (C) 2020-2021 Firejail Authors
 # License GPL v2
 
 if ! command -v zenity >/dev/null; then


### PR DESCRIPTION
Append the current year rather than replace the previous one.

This amends commit 2609e5cf0 ("copyright update").

Commands that helped catch this:

    $ git show --pretty='' 2609e5cf0 | sed -n 's/^-.*Copyright //p' |
      LC_ALL=C sort | uniq
    (C) 2014-2020 Firejail Authors
    (C) 2014-2020 Firejail Authors (see README file for more details)
    (C) 2020 Firejail Authors
    (C) 2020 Firejail and systemd authors
    (c) 2019,2020 rusty-snake
    $ git show --pretty='' 2609e5cf0 | sed -n 's/^+.*Copyright //p' |
      LC_ALL=C sort | uniq
    (C) 2014-2021 Firejail Authors
    (C) 2014-2021 Firejail Authors (see README file for more details)
    (C) 2020-2021 Firejail Authors
    (C) 2020-2021 Firejail and systemd authors
    (C) 2021 Firejail Authors
    (c) 2019-2021 rusty-snake

---

@startx2017 When doing the mass replace, checking for the presence of "-" in
each notice could help avoid accidentally overwriting the year.  Also, would
you mind committing the script/program used for this?  That would enable us to
make improvements and bugfixes to it.

Cc: @rusty-snake (as the author of firejail-welcome.sh)
