### PR TITLE
Upstreaming a set of fixes from Sailfish's packaging

### DIFF
--- a/src/fcopy/main.c
+++ b/src/fcopy/main.c
@@ -172,6 +172,47 @@ static void mkdir_attr(const char *fname, mode_t mode, uid_t uid, gid_t gid) {
 	}
 }
 
+static char *proc_pid_to_self(const char *target)
+{
+	char *use_target = 0;
+	char *proc_pid = 0;
+
+	if (!(use_target = canonicalize_file_name(target)))
+		goto done;
+
+	// target is under /proc/<PID>?
+	static const char proc[] = "/proc/";
+	if (strncmp(use_target, proc, sizeof proc - 1))
+		goto done;
+
+	int digit = use_target[sizeof proc - 1];
+	if (digit < '1' || digit > '9')
+		goto done;
+
+	// check where /proc/self points to
+	static const char proc_self[] = "/proc/self";
+	if (!(proc_pid = canonicalize_file_name(proc_self)))
+		goto done;
+
+	// redirect /proc/PID/xxx -> /proc/self/XXX
+	size_t pfix = strlen(proc_pid);
+	if (strncmp(use_target, proc_pid, pfix))
+		goto done;
+
+	if (use_target[pfix] != 0 && use_target[pfix] != '/')
+		goto done;
+
+	char *tmp;
+	if (asprintf(&tmp, "%s%s", proc_self, use_target + pfix) != -1) {
+		if (arg_debug)
+			fprintf(stderr, "SYMLINK %s\n  -->   %s\n", use_target, tmp);
+		free(use_target), use_target = tmp;
+	}
+
+done:
+	free(proc_pid);
+	return use_target;
+}
 
 void copy_link(const char *target, const char *linkpath, mode_t mode, uid_t uid, gid_t gid) {
 	(void) mode;
@@ -183,7 +224,7 @@ void copy_link(const char *target, const char *linkpath, mode_t mode, uid_t uid,
 	if (lstat(linkpath, &s) == 0)
 	       return;
 
-	char *rp = realpath(target, NULL);
+	char *rp = proc_pid_to_self(target);
 	if (rp) {
 		if (symlink(rp, linkpath) == -1) {
 			free(rp);

--- a/src/fcopy/main.c
+++ b/src/fcopy/main.c
@@ -268,16 +268,14 @@ static int fs_copydir(const char *infname, const struct stat *st, int ftype, str
 			first = 0;
 		else if (!arg_quiet)
 			fprintf(stderr, "Warning fcopy: skipping %s, file already present\n", infname);
-		free(outfname);
-		return 0;
+		goto out;
 	}
 
 	// extract mode and ownership
 	if (stat(infname, &s) != 0) {
 		if (!arg_quiet)
 			fprintf(stderr, "Warning fcopy: skipping %s, cannot find inode\n", infname);
-		free(outfname);
-		return 0;
+		goto out;
 	}
 	uid_t uid = s.st_uid;
 	gid_t gid = s.st_gid;
@@ -287,8 +285,7 @@ static int fs_copydir(const char *infname, const struct stat *st, int ftype, str
 	if ((s.st_size + size_cnt) > copy_limit) {
 		fprintf(stderr, "Error fcopy: size limit of %lu MB reached\n", (copy_limit / 1024) / 1024);
 		size_limit_reached = 1;
-		free(outfname);
-		return 0;
+		goto out;
 	}
 
 	file_cnt++;
@@ -303,7 +300,8 @@ static int fs_copydir(const char *infname, const struct stat *st, int ftype, str
 	else if (ftype == FTW_SL) {
 		copy_link(infname, outfname, mode, uid, gid);
 	}
-
+out:
+	free(outfname);
 	return(0);
 }
 
@@ -336,6 +334,7 @@ static char *check(const char *src) {
 		return rsrc;			  // normal exit from the function
 
 errexit:
+	free(rsrc);
 	fprintf(stderr, "Error fcopy: invalid file %s\n", src);
 	exit(1);
 }

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -649,6 +649,8 @@ void network_set_run_file(pid_t pid);
 
 // fs_etc.c
 void fs_machineid(void);
+void fs_private_dir_copy(const char *private_dir, const char *private_run_dir, const char *private_list);
+void fs_private_dir_mount(const char *private_dir, const char *private_run_dir);
 void fs_private_dir_list(const char *private_dir, const char *private_run_dir, const char *private_list);
 
 // no_sandbox.c

--- a/src/firejail/fs_etc.c
+++ b/src/firejail/fs_etc.c
@@ -138,7 +138,7 @@ static void duplicate(const char *fname, const char *private_dir, const char *pr
 }
 
 
-void fs_private_dir_list(const char *private_dir, const char *private_run_dir, const char *private_list) {
+void fs_private_dir_copy(const char *private_dir, const char *private_run_dir, const char *private_list) {
 	assert(private_dir);
 	assert(private_run_dir);
 	assert(private_list);
@@ -185,7 +185,9 @@ void fs_private_dir_list(const char *private_dir, const char *private_run_dir, c
 		free(dlist);
 		fs_logger_print();
 	}
+}
 
+void fs_private_dir_mount(const char *private_dir, const char *private_run_dir) {
 	if (arg_debug)
 		printf("Mount-bind %s on top of %s\n", private_run_dir, private_dir);
 	if (mount(private_run_dir, private_dir, NULL, MS_BIND|MS_REC, NULL) < 0)
@@ -198,4 +200,9 @@ void fs_private_dir_list(const char *private_dir, const char *private_run_dir, c
 	fs_logger2("tmpfs", private_run_dir);
 
 	fmessage("Private %s installed in %0.2f ms\n", private_dir, timetrace_end());
+}
+
+void fs_private_dir_list(const char *private_dir, const char *private_run_dir, const char *private_list) {
+	fs_private_dir_copy(private_dir, private_run_dir, private_list);
+	fs_private_dir_mount(private_dir, private_run_dir);
 }

--- a/src/firejail/fs_etc.c
+++ b/src/firejail/fs_etc.c
@@ -188,6 +188,17 @@ void fs_private_dir_copy(const char *private_dir, const char *private_run_dir, c
 }
 
 void fs_private_dir_mount(const char *private_dir, const char *private_run_dir) {
+	assert(private_dir);
+	assert(private_run_dir);
+
+	// nothing to do if directory does not exist
+	struct stat s;
+	if (stat(private_dir, &s) == -1) {
+		if (arg_debug)
+			printf("Cannot find %s\n", private_dir);
+		return;
+	}
+
 	if (arg_debug)
 		printf("Mount-bind %s on top of %s\n", private_run_dir, private_dir);
 	if (mount(private_run_dir, private_dir, NULL, MS_BIND|MS_REC, NULL) < 0)

--- a/src/firejail/fs_mkdir.c
+++ b/src/firejail/fs_mkdir.c
@@ -46,7 +46,7 @@ static void mkdir_recursive(char *path) {
 	struct stat s;
 
 	if (chdir("/")) {
-		fprintf(stderr, "Error: can't chdir to /");
+		fprintf(stderr, "Error: can't chdir to /\n");
 		return;
 	}
 
@@ -63,7 +63,7 @@ static void mkdir_recursive(char *path) {
 			return;
 		}
 		if (chdir(subdir)) {
-			fprintf(stderr, "Error: can't chdir to %s", subdir);
+			fprintf(stderr, "Error: can't chdir to %s\n", subdir);
 			return;
 		}
 

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -297,7 +297,7 @@ static void check_network(Bridge *br) {
 	else if (br->ipsandbox) { // for macvlan check network range
 		char *rv = in_netrange(br->ipsandbox, br->ip, br->mask);
 		if (rv) {
-			fprintf(stderr, "%s", rv);
+			fprintf(stderr, "%s\n", rv);
 			exit(1);
 		}
 	}

--- a/src/firejail/network_main.c
+++ b/src/firejail/network_main.c
@@ -120,7 +120,7 @@ void net_configure_sandbox_ip(Bridge *br) {
 		// check network range
 		char *rv = in_netrange(br->ipsandbox, br->ip, br->mask);
 		if (rv) {
-			fprintf(stderr, "%s", rv);
+			fprintf(stderr, "%s\n", rv);
 			exit(1);
 		}
 		// send an ARP request and check if there is anybody on this IP address


### PR DESCRIPTION
This is upstreaming first set of fixes from [Sailfish's firejail packaging](https://github.com/sailfishos/firejail/). These were developed as part of implementing firejail sandboxing in Sailfish OS. See also #3960 for discussion.

These are general fixes to firejail touching logging, private-etc, memory handing and symbolic link construction around /proc filesystem. Please see the commit messages for explanations. These were written by my colleague and previously reviewed by me or one of my other colleagues.