### PR TITLE
Fix patch-util not having access to libdl.so

### DIFF
--- a/etc/profile-m-z/patch.profile
+++ b/etc/profile-m-z/patch.profile
@@ -43,7 +43,7 @@ x11 none
 
 private-bin patch,red
 private-dev
-private-lib libfakeroot libdl.so.*
+private-lib libdl.so.*,libfakeroot
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/patch.profile
+++ b/etc/profile-m-z/patch.profile
@@ -43,7 +43,7 @@ x11 none
 
 private-bin patch,red
 private-dev
-private-lib libfakeroot
+private-lib libfakeroot libdl.so.*
 
 dbus-user none
 dbus-system none


### PR DESCRIPTION
As mentioned here https://github.com/netblue30/firetools/issues/55 I ran into this issue today and including libdl.so as per rusty-snake's advice fixes this error for me.