### PR TITLE
signal-desktop.profile: fix typo of disable-xdg.profile

### DIFF
--- a/etc/profile-m-z/signal-desktop.profile
+++ b/etc/profile-m-z/signal-desktop.profile
@@ -6,7 +6,6 @@ include signal-desktop.local
 include globals.local
 
 # Disabled until someone reported positive feedback
-ignore include-xdg.inc
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 ignore private-cache


### PR DESCRIPTION
Added on commit f4f676745 ("Refactor electron.profile and electron based
programs (#3807)").

This appears to be the only instance of that:

    $ grep -Fnr 'include-xdg' etc
    etc/profile-m-z/signal-desktop.profile:9:ignore include-xdg.inc

Credits go to syntax highlighting on vim.

---

Also, note that the file says this:

```firejail
# Disabled until someone reported positive feedback
ignore include-xdg.inc
```

So if there was no negative feedback, should xdg dirs (other than
`${DOWNLOADS}`, that is) be allowed or should we just remove that line instead?
As all this PR would do is allow xdg dirs for the first time since at least
commit f4f676745.
