### PR TITLE
add PATH_FCOPY to private-lib automatically

### DIFF
--- a/src/firejail/sbox.c
+++ b/src/firejail/sbox.c
@@ -203,15 +203,16 @@ static int __attribute__((noreturn)) sbox_do_exec_v(unsigned filtermask, char * 
 		}
 	}
 
-	if (filtermask & SBOX_ROOT) {
+	if (filtermask & SBOX_USER)
+		drop_privs(1);
+	else if (filtermask & SBOX_ROOT) {
 		// elevate privileges in order to get grsecurity working
 		if (setreuid(0, 0))
 			errExit("setreuid");
 		if (setregid(0, 0))
 			errExit("setregid");
 	}
-	else if (filtermask & SBOX_USER)
-		drop_privs(1);
+	else assert(0);
 
 	if (arg[0]) { // get rid of scan-build warning
 		int fd = open(arg[0], O_PATH | O_CLOEXEC);


### PR DESCRIPTION
Essentially restores 45304621a6c600d8e30e98bfbef05149caaf56c5. Removing read permission on helper executables (fcopy) broke this original fix.

Now run fldd as root in order to fix #3741 without having to compromise or give up on the new permission system. It runs as root only on binaries that are not controlled by the user, and that Firejail needs to trust anyway. Also infrastructure is put in place to add more helper binaries to private-lib, should the need arise.

This pull request might be useful also for other reasons. For example, if one day we want to run the test suite with ASan/UBsan instrumentation, private-lib should now pick up all necessary libraries automatically (again).
