### PR TITLE
Add --mkdir and --mkfile command line options for firejail

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1589,7 +1589,26 @@ int main(int argc, char **argv, char **envp) {
 			profile_add(line);
 		}
 #endif
-
+		else if (strncmp(argv[i], "--mkdir=", 8) == 0) {
+			char *line;
+			if (asprintf(&line, "mkdir %s", argv[i] + 8) == -1)
+				errExit("asprintf");
+			/* Note: Applied both immediately in profile_check_line()
+			 *       and later on via fs_blacklist().
+			 */
+			profile_check_line(line, 0, NULL);
+			profile_add(line);
+		}
+		else if (strncmp(argv[i], "--mkfile=", 9) == 0) {
+			char *line;
+			if (asprintf(&line, "mkfile %s", argv[i] + 9) == -1)
+				errExit("asprintf");
+			/* Note: Applied both immediately in profile_check_line()
+			 *       and later on via fs_blacklist().
+			 */
+			profile_check_line(line, 0, NULL);
+			profile_add(line);
+		}
 		else if (strncmp(argv[i], "--read-only=", 12) == 0) {
 			char *line;
 			if (asprintf(&line, "read-only %s", argv[i] + 12) == -1)

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -246,6 +246,8 @@ static char *usage_str =
 #ifdef HAVE_WHITELIST
 	"    --whitelist=filename - whitelist directory or file.\n"
 #endif
+	"    --mkdir=dirname - create a directory.\n"
+	"    --mkfile=filename - create a file.\n"
 	"    --writable-etc - /etc directory is mounted read-write.\n"
 	"    --writable-run-user - allow access to /run/user/$UID/systemd and\n"
 	"\t/run/user/$UID/gnupg.\n"


### PR DESCRIPTION
Profile files are defined as a means to "pass several command line arguments to firejail" but apparently for example mkdir and mkfile options are available in context of profile files, but can't be specified directly from command line.

Add support for -mkdir and --mkfile options so that executing:
  firejail --mkdir=${HOME}/directory/path\
           --whitelist=${HOME}/directory/path

behaves similarly as having profile file content:
  mkdir ${HOME}/directory/path
  whitelist ${HOME}/directory/path

This patches was part of [Sailfish's firejail packaging](https://github.com/sailfishos/firejail/). It was developed as part of implementing firejail sandboxing in Sailfish OS and just like the previous patches written by my colleague and previously reviewed by me or one of my other colleagues. See also #3960 for discussion.