### PR TITLE
dbus.c: check_object_path: Allow /StatusNotifierWatcher

### DIFF
--- a/src/firejail/dbus.c
+++ b/src/firejail/dbus.c
@@ -111,7 +111,7 @@ static int check_object_path(const char *path) {
 		}
 		++p;
 	}
-	return in_segment && segments >= 2;
+	return in_segment && segments >= 1;
 }
 
 int dbus_check_name(const char *name) {


### PR DESCRIPTION
Without this I get 

```
Error: Invalid dbus-user.call rule: org.kde.StatusNotifierWatcher=org.kde.StatusNotifierWatcher.*@/StatusNotifierWatcher
```
for

```
dbus-user.call org.kde.StatusNotifierWatcher=org.kde.StatusNotifierWatcher.*@/StatusNotifierWatcher
```