### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -22,6 +22,7 @@ MAN_SRC = src/man
 endif
 
 COMPLETIONDIRS = src/zsh_completion src/bash_completion
+
 all: all_items mydirs $(MAN_TARGET) filters
 APPS = src/firecfg/firecfg src/firejail/firejail src/firemon/firemon src/profstats/profstats src/jailtest/jailtest
 SBOX_APPS = src/fbuilder/fbuilder src/ftee/ftee

--- a/Makefile.in
+++ b/Makefile.in
@@ -44,7 +44,6 @@ mydirs: $(MYDIRS)
 $(MYDIRS):
 	$(MAKE) -C $@
 
-
 $(MANPAGES): src/man
 	./mkman.sh $(VERSION) src/man/$(basename $@).man $@
 
@@ -231,7 +230,6 @@ cppcheck: clean
 
 scan-build: clean
 	NO_EXTRA_CFLAGS="yes" scan-build make
-
 
 #
 # make test

--- a/Makefile.in
+++ b/Makefile.in
@@ -23,6 +23,7 @@ endif
 
 COMPLETIONDIRS = src/zsh_completion src/bash_completion
 
+.PHONY: all
 all: all_items mydirs $(MAN_TARGET) filters
 APPS = src/firecfg/firecfg src/firejail/firejail src/firemon/firemon src/profstats/profstats src/jailtest/jailtest
 SBOX_APPS = src/fbuilder/fbuilder src/ftee/ftee
@@ -72,6 +73,7 @@ seccomp.mdwx: src/fseccomp/fseccomp
 seccomp.mdwx.32: src/fseccomp/fseccomp
 	src/fseccomp/fseccomp memory-deny-write-execute.32 seccomp.mdwx.32
 
+.PHONY: clean
 clean:
 	for dir in $$(dirname $(ALL_ITEMS)) $(MYDIRS); do \
 		$(MAKE) -C $$dir clean; \
@@ -91,6 +93,7 @@ clean:
 	rm -f test/sysutils/firejail_t*
 	cd test/compile; ./compile.sh --clean; cd ../..
 
+.PHONY: distclean
 distclean: clean
 	for dir in $$(dirname $(ALL_ITEMS)) $(MYDIRS); do \
 		$(MAKE) -C $$dir distclean; \

--- a/src/bash_completion/Makefile.in
+++ b/src/bash_completion/Makefile.in
@@ -1,3 +1,4 @@
+.PHONY: all
 all: firejail.bash_completion
 
 include ../common.mk
@@ -7,8 +8,10 @@ firejail.bash_completion: firejail.bash_completion.in
 	sed "s|_SYSCONFDIR_|$(sysconfdir)|" < $@.tmp > $@
 	rm $@.tmp
 
+.PHONY: clean
 clean:
 	rm -fr firejail.bash_completion
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/fbuilder/Makefile.in
+++ b/src/fbuilder/Makefile.in
@@ -1,3 +1,4 @@
+.PHONY: all
 all: fbuilder
 
 include ../common.mk
@@ -8,7 +9,9 @@ include ../common.mk
 fbuilder: $(OBJS)
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) $(LIBS) $(EXTRA_LDFLAGS)
 
+.PHONY: clean
 clean:; rm -fr *.o fbuilder *.gcov *.gcda *.gcno *.plist
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/fcopy/Makefile.in
+++ b/src/fcopy/Makefile.in
@@ -1,3 +1,4 @@
+.PHONY: all
 all: fcopy
 
 include ../common.mk
@@ -8,7 +9,9 @@ include ../common.mk
 fcopy: $(OBJS) ../lib/common.o
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) ../lib/common.o $(LIBS) $(EXTRA_LDFLAGS)
 
+.PHONY: clean
 clean:; rm -fr *.o fcopy *.gcov *.gcda *.gcno *.plist
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/firecfg/Makefile.in
+++ b/src/firecfg/Makefile.in
@@ -1,3 +1,4 @@
+.PHONY: all
 all: firecfg
 
 include ../common.mk
@@ -8,7 +9,9 @@ include ../common.mk
 firecfg: $(OBJS) ../lib/common.o ../lib/firejail_user.o
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) ../lib/common.o ../lib/firejail_user.o $(LIBS) $(EXTRA_LDFLAGS)
 
+.PHONY: clean
 clean:; rm -fr *.o firecfg *.gcov *.gcda *.gcno *.plist
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/firejail/Makefile.in
+++ b/src/firejail/Makefile.in
@@ -1,3 +1,4 @@
+.PHONY: all
 all: firejail
 
 include ../common.mk
@@ -8,7 +9,9 @@ include ../common.mk
 firejail: $(OBJS) ../lib/libnetlink.o ../lib/common.o ../lib/ldd_utils.o ../lib/firejail_user.o ../lib/errno.o ../lib/syscall.o
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) ../lib/common.o ../lib/ldd_utils.o ../lib/firejail_user.o ../lib/errno.o ../lib/syscall.o $(LIBS) $(EXTRA_LDFLAGS)
 
+.PHONY: clean
 clean:; rm -fr *.o firejail *.gcov *.gcda *.gcno *.plist
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/firemon/Makefile.in
+++ b/src/firemon/Makefile.in
@@ -1,3 +1,4 @@
+.PHONY: all
 all: firemon
 
 include ../common.mk
@@ -8,7 +9,9 @@ include ../common.mk
 firemon: $(OBJS) ../lib/common.o ../lib/pid.o
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) ../lib/common.o ../lib/pid.o $(LIBS) $(EXTRA_LDFLAGS)
 
+.PHONY: clean
 clean:; rm -fr *.o firemon *.gcov *.gcda *.gcno *.plist
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/fldd/Makefile.in
+++ b/src/fldd/Makefile.in
@@ -1,3 +1,4 @@
+.PHONY: all
 all: fldd
 
 include ../common.mk
@@ -8,7 +9,9 @@ include ../common.mk
 fldd: $(OBJS) ../lib/common.o ../lib/ldd_utils.o
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) ../lib/common.o ../lib/ldd_utils.o $(LIBS) $(EXTRA_LDFLAGS)
 
+.PHONY: clean
 clean:; rm -fr *.o fldd *.gcov *.gcda *.gcno *.plist
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/fnet/Makefile.in
+++ b/src/fnet/Makefile.in
@@ -1,3 +1,4 @@
+.PHONY: all
 all: fnet
 
 include ../common.mk
@@ -8,7 +9,9 @@ include ../common.mk
 fnet: $(OBJS) ../lib/common.o ../lib/libnetlink.o
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) ../lib/common.o ../lib/libnetlink.o $(LIBS) $(EXTRA_LDFLAGS)
 
+.PHONY: clean
 clean:; rm -fr *.o fnet *.gcov *.gcda *.gcno *.plist
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/fnetfilter/Makefile.in
+++ b/src/fnetfilter/Makefile.in
@@ -1,3 +1,4 @@
+.PHONY: all
 all: fnetfilter
 
 include ../common.mk
@@ -8,7 +9,9 @@ include ../common.mk
 fnetfilter: $(OBJS) ../lib/common.o
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) ../lib/common.o $(LIBS) $(EXTRA_LDFLAGS)
 
+.PHONY: clean
 clean:; rm -fr *.o fnetfilter *.gcov *.gcda *.gcno *.plist
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/fsec-optimize/Makefile.in
+++ b/src/fsec-optimize/Makefile.in
@@ -1,3 +1,4 @@
+.PHONY: all
 all: fsec-optimize
 
 include ../common.mk
@@ -8,7 +9,9 @@ include ../common.mk
 fsec-optimize: $(OBJS) ../lib/common.o ../lib/libnetlink.o
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) ../lib/common.o ../lib/errno.o $(LIBS) $(EXTRA_LDFLAGS)
 
+.PHONY: clean
 clean:; rm -fr *.o fsec-optimize *.gcov *.gcda *.gcno *.plist
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/fsec-print/Makefile.in
+++ b/src/fsec-print/Makefile.in
@@ -1,3 +1,4 @@
+.PHONY: all
 all: fsec-print
 
 include ../common.mk
@@ -8,7 +9,9 @@ include ../common.mk
 fsec-print: $(OBJS) ../lib/common.o ../lib/libnetlink.o ../lib/errno.o ../lib/syscall.o
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) ../lib/common.o ../lib/errno.o ../lib/syscall.o $(LIBS) $(EXTRA_LDFLAGS)
 
+.PHONY: clean
 clean:; rm -fr *.o fsec-print *.gcov *.gcda *.gcno *.plist
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/fseccomp/Makefile.in
+++ b/src/fseccomp/Makefile.in
@@ -1,3 +1,4 @@
+.PHONY: all
 all: fseccomp
 
 include ../common.mk
@@ -8,7 +9,9 @@ include ../common.mk
 fseccomp: $(OBJS) ../lib/common.o ../lib/errno.o ../lib/syscall.o
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) ../lib/common.o ../lib/errno.o ../lib/syscall.o $(LIBS) $(EXTRA_LDFLAGS)
 
+.PHONY: clean
 clean:; rm -fr *.o fseccomp *.gcov *.gcda *.gcno *.plist
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/ftee/Makefile.in
+++ b/src/ftee/Makefile.in
@@ -1,3 +1,4 @@
+.PHONY: all
 all: ftee
 
 include ../common.mk
@@ -8,7 +9,9 @@ include ../common.mk
 ftee: $(OBJS)
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) $(LIBS) $(EXTRA_LDFLAGS)
 
+.PHONY: clean
 clean:; rm -fr *.o ftee *.gcov *.gcda *.gcno *.plist
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/jailtest/Makefile.in
+++ b/src/jailtest/Makefile.in
@@ -1,3 +1,4 @@
+.PHONY: all
 all: jailtest
 
 include ../common.mk
@@ -8,7 +9,9 @@ include ../common.mk
 jailtest: $(OBJS)
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS)  ../lib/common.o ../lib/pid.o $(LIBS) $(EXTRA_LDFLAGS)
 
+.PHONY: clean
 clean:; rm -fr *.o jailtest *.gcov *.gcda *.gcno *.plist
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -1,11 +1,14 @@
 include ../common.mk
 
+.PHONY: all
 all: $(OBJS)
 
 %.o : %.c $(H_FILE_LIST)
 	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(INCLUDE) -c $< -o $@
 
+.PHONY: clean
 clean:; rm -fr $(OBJS) *.gcov *.gcda *.gcno *.plist
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/libpostexecseccomp/Makefile.in
+++ b/src/libpostexecseccomp/Makefile.in
@@ -11,6 +11,7 @@ BINOBJS =  $(foreach file, $(OBJS), $file)
 CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIC -Wformat -Wformat-security
 LDFLAGS += -pie -fPIE -Wl,-z,relro -Wl,-z,now
 
+.PHONY: all
 all: libpostexecseccomp.so
 
 %.o : %.c $(H_FILE_LIST) ../include/seccomp.h ../include/rundefs.h
@@ -19,7 +20,9 @@ all: libpostexecseccomp.so
 libpostexecseccomp.so: $(OBJS)
 	$(CC) $(LDFLAGS) -shared -fPIC -z relro -o $@ $(OBJS) -ldl
 
+.PHONY: clean
 clean:; rm -fr $(OBJS) libpostexecseccomp.so *.plist
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/libtrace/Makefile.in
+++ b/src/libtrace/Makefile.in
@@ -19,7 +19,6 @@ all: libtrace.so
 libtrace.so: $(OBJS)
 	$(CC) $(LDFLAGS) -shared -fPIC -z relro -o $@ $(OBJS) -ldl
 
-
 clean:; rm -fr $(OBJS) libtrace.so *.plist
 
 distclean: clean

--- a/src/libtrace/Makefile.in
+++ b/src/libtrace/Makefile.in
@@ -11,6 +11,7 @@ BINOBJS =  $(foreach file, $(OBJS), $file)
 CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIC -Wformat -Wformat-security
 LDFLAGS += -pie -fPIE -Wl,-z,relro -Wl,-z,now
 
+.PHONY: all
 all: libtrace.so
 
 %.o : %.c $(H_FILE_LIST)
@@ -19,7 +20,9 @@ all: libtrace.so
 libtrace.so: $(OBJS)
 	$(CC) $(LDFLAGS) -shared -fPIC -z relro -o $@ $(OBJS) -ldl
 
+.PHONY: clean
 clean:; rm -fr $(OBJS) libtrace.so *.plist
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/libtracelog/Makefile.in
+++ b/src/libtracelog/Makefile.in
@@ -11,6 +11,7 @@ BINOBJS =  $(foreach file, $(OBJS), $file)
 CFLAGS += -ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIC -Wformat -Wformat-security
 LDFLAGS += -pie -fPIE -Wl,-z,relro -Wl,-z,now
 
+.PHONY: all
 all: libtracelog.so
 
 %.o : %.c $(H_FILE_LIST) ../include/rundefs.h
@@ -19,7 +20,9 @@ all: libtracelog.so
 libtracelog.so: $(OBJS)
 	$(CC) $(LDFLAGS) -shared -fPIC -z relro -o $@ $(OBJS) -ldl
 
+.PHONY: clean
 clean:; rm -fr $(OBJS) libtracelog.so *.plist
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/libtracelog/Makefile.in
+++ b/src/libtracelog/Makefile.in
@@ -19,7 +19,6 @@ all: libtracelog.so
 libtracelog.so: $(OBJS)
 	$(CC) $(LDFLAGS) -shared -fPIC -z relro -o $@ $(OBJS) -ldl
 
-
 clean:; rm -fr $(OBJS) libtracelog.so *.plist
 
 distclean: clean

--- a/src/man/Makefile.in
+++ b/src/man/Makefile.in
@@ -1,4 +1,5 @@
 all: firecfg.man firejail.man firejail-login.man firejail-users.man firejail-profile.man firemon.man jailtest.man
+
 include ../common.mk
 
 %.man: %.txt

--- a/src/man/Makefile.in
+++ b/src/man/Makefile.in
@@ -1,3 +1,4 @@
+.PHONY: all
 all: firecfg.man firejail.man firejail-login.man firejail-users.man firejail-profile.man firemon.man jailtest.man
 
 include ../common.mk
@@ -5,7 +6,9 @@ include ../common.mk
 %.man: %.txt
 	gawk -f ./preproc.awk -- $(MANFLAGS) < $< > $@
 
+.PHONY: clean
 clean:; rm -fr *.man
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/profstats/Makefile.in
+++ b/src/profstats/Makefile.in
@@ -1,3 +1,4 @@
+.PHONY: all
 all: profstats
 
 include ../common.mk
@@ -8,7 +9,9 @@ include ../common.mk
 profstats: $(OBJS)
 	$(CC)  $(LDFLAGS) -o $@ $(OBJS) $(LIBS) $(EXTRA_LDFLAGS)
 
+.PHONY: clean
 clean:; rm -fr *.o profstats *.gcov *.gcda *.gcno *.plist
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/src/zsh_completion/Makefile.in
+++ b/src/zsh_completion/Makefile.in
@@ -1,3 +1,4 @@
+.PHONY: all
 all: _firejail
 
 include ../common.mk
@@ -7,8 +8,10 @@ _firejail: _firejail.in
 	sed "s|_SYSCONFDIR_|$(sysconfdir)|" < $@.tmp > $@
 	rm $@.tmp
 
+.PHONY: clean
 clean:
 	rm -fr _firejail
 
+.PHONY: distclean
 distclean: clean
 	rm -fr Makefile

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -1,7 +1,6 @@
 TESTS=$(patsubst %/,%,$(wildcard */))
 
 .PHONY: $(TESTS)
-
 $(TESTS):
 	cd $@ && ./$@.sh 2>&1 | tee $@.log
 	cd $@ && grep -a TESTING $@.log && grep -a -L "TESTING ERROR" $@.log

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -5,8 +5,10 @@ $(TESTS):
 	cd $@ && ./$@.sh 2>&1 | tee $@.log
 	cd $@ && grep -a TESTING $@.log && grep -a -L "TESTING ERROR" $@.log
 
+.PHONY: clean
 clean:
 	for test in $(TESTS); do rm -f "$$test/$$test.log"; done
 
+.PHONY: distclean
 distclean: clean
 	rm -f Makefile


### PR DESCRIPTION
```console
$ git log --reverse --pretty='* %s' master..
* makefiles: fix whitespace
* makefiles: fix misc blank line consistency
* makefiles: make all, clean and distclean PHONY
```

Some minor cleanup and improvements before adding new stuff.

-----

@Fred-Barclay From the amount of whitespace-fixing commits, I think you'll like
the commands from commit 00437760d ("makefiles: fix whitespace"):

    $ git ls-files -z -- '*Makefile*' |
      xargs -0 -I '{}' sh -c \
      "test -s '{}' && printf '%s\n' \"\`git stripspace <'{}'\`\" >'{}'"

I don't know if you've used something like that before, but to me it has been
very handy on many occasions.  From git-stripspace(1):

> Read text, such as commit messages, notes, tags and branch descriptions, from
> the standard input and clean it in the manner used by Git.
> 
> With no arguments, this will:
> 
> * remove trailing whitespace from all lines
> 
> * collapse multiple consecutive empty lines into one empty line
> 
> * remove empty lines from the beginning and end of the input
> 
> * add a missing \n to the last line if necessary.
> 
> In the case where the input consists entirely of whitespace characters, no
> output will be produced.
> 
> **NOTE**: This is intended for cleaning metadata, prefer the --whitespace=fix
> mode of git-apply(1) for correcting whitespace of patches or files in the
> repository.

Though if there any plans to do a mass cleaning, it would be nice to have
something like that on a pre-commit hook/ci check beforehand, to catch errors
before they go to master and thus avoid the need for periodic clean-ups.
