### PR TITLE
Improve error messages

### DIFF
--- a/src/firejail/fs_etc.c
+++ b/src/firejail/fs_etc.c
@@ -18,6 +18,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 #include "firejail.h"
+#include <errno.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -147,7 +148,7 @@ void fs_private_dir_copy(const char *private_dir, const char *private_run_dir, c
 	struct stat s;
 	if (stat(private_dir, &s) == -1) {
 		if (arg_debug)
-			printf("Cannot find %s\n", private_dir);
+			printf("Cannot find %s: %s\n", private_dir, strerror(errno));
 		return;
 	}
 
@@ -191,16 +192,17 @@ void fs_private_dir_mount(const char *private_dir, const char *private_run_dir) 
 	assert(private_dir);
 	assert(private_run_dir);
 
+	if (arg_debug)
+		printf("Mount-bind %s on top of %s\n", private_run_dir, private_dir);
+
 	// nothing to do if directory does not exist
 	struct stat s;
 	if (stat(private_dir, &s) == -1) {
 		if (arg_debug)
-			printf("Cannot find %s\n", private_dir);
+			printf("Cannot find %s: %s\n", private_dir, strerror(errno));
 		return;
 	}
 
-	if (arg_debug)
-		printf("Mount-bind %s on top of %s\n", private_run_dir, private_dir);
 	if (mount(private_run_dir, private_dir, NULL, MS_BIND|MS_REC, NULL) < 0)
 		errExit("mount bind");
 	fs_logger2("mount", private_dir);

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -975,10 +975,10 @@ int sandbox(void* sandbox_arg) {
 			fs_private_dir_copy("/usr/etc", RUN_USR_ETC_DIR, cfg.etc_private_keep); // openSUSE
 
 			if (umount2("/etc/group", MNT_DETACH) == -1)
-				fprintf(stderr, "/etc/group: unmount: %m\n");
+				fprintf(stderr, "/etc/group: unmount: %s\n", strerror(errno));
 
 			if (umount2("/etc/passwd", MNT_DETACH) == -1)
-				fprintf(stderr, "/etc/passwd: unmount: %m\n");
+				fprintf(stderr, "/etc/passwd: unmount: %s\n", strerror(errno));
 
 			fs_private_dir_mount("/etc", RUN_ETC_DIR);
 			fs_private_dir_mount("/usr/etc", RUN_USR_ETC_DIR);


### PR DESCRIPTION
I sent some changes recently (#3998) and now I noticed that there were some minor things that could have been better.

The first commit moves error message of missing directory while mounting after debug logging so that it's easy to see when the error happens and adds a cause message. The second commit changes %m usages introduced by the changes I made. While %m is reentrant and allows very nice and clean code, it's not consistent with the rest of firejail and also not portable across libc implementations.