### PR TITLE
newsboat/newsbeuter corrections

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -334,6 +334,7 @@ blacklist ${HOME}/.config/nemo
 blacklist ${HOME}/.config/neomutt
 blacklist ${HOME}/.config/netsurf
 blacklist ${HOME}/.config/newsbeuter
+blacklist ${HOME}/.config/newsboat
 blacklist ${HOME}/.config/newsflash
 blacklist ${HOME}/.config/nheko
 blacklist ${HOME}/.config/NitroShare
@@ -702,6 +703,8 @@ blacklist ${HOME}/.local/share/nautilus-python
 blacklist ${HOME}/.local/share/nemo
 blacklist ${HOME}/.local/share/nemo-python
 blacklist ${HOME}/.local/share/news-flash
+blacklist ${HOME}/.local/share/newsbeuter
+blacklist ${HOME}/.local/share/newsboat
 blacklist ${HOME}/.local/share/nomacs
 blacklist ${HOME}/.local/share/notes
 blacklist ${HOME}/.local/share/ocenaudio

--- a/etc/profile-m-z/newsbeuter.profile
+++ b/etc/profile-m-z/newsbeuter.profile
@@ -7,13 +7,17 @@ include newsbeuter.local
 # added by included profile
 #include globals.local
 
-noblacklist ${HOME}/.config/newsbeuter
-noblacklist ${HOME}/.newsbeuter
+ignore include newsboat.local
+ignore mkdir ${HOME}/.local/share/newsboat
+ignore noblacklist ${HOME}/.config/newsboat
+ignore noblacklist ${HOME}/.local/share/newsboat
+ignore noblacklist ${HOME}/.newsboat
+ignore private-bin newsboat
+ignore whitelist ${HOME}/.config/newsboat
+ignore whitelist ${HOME}/.local/share/newsboat
+ignore whitelist ${HOME}/.newsboat
 
-mkdir ${HOME}/.config/newsbeuter
-mkdir ${HOME}/.newsbeuter
-whitelist ${HOME}/.config/newsbeuter
-whitelist ${HOME}/.newsbeuter
+mkdir ${HOME}/.local/share/newsbeuter
 
 private-bin newsbeuter
 

--- a/etc/profile-m-z/newsbeuter.profile
+++ b/etc/profile-m-z/newsbeuter.profile
@@ -19,6 +19,7 @@ nowhitelist ${HOME}/.config/newsboat
 nowhitelist ${HOME}/.local/share/newsboat
 nowhitelist ${HOME}/.newsboat
 
+mkdir ${HOME}/.config/newsbeuter
 mkdir ${HOME}/.local/share/newsbeuter
 
 private-bin newsbeuter

--- a/etc/profile-m-z/newsbeuter.profile
+++ b/etc/profile-m-z/newsbeuter.profile
@@ -10,6 +10,7 @@ include newsbeuter.local
 ignore include newsboat.local
 ignore mkdir ${HOME}/.config/newsboat
 ignore mkdir ${HOME}/.local/share/newsboat
+ignore mkdir ${HOME}/.newsboat
 ignore private-bin newsboat
 
 blacklist ${HOME}/.config/newsboat
@@ -22,6 +23,7 @@ nowhitelist ${HOME}/.newsboat
 
 mkdir ${HOME}/.config/newsbeuter
 mkdir ${HOME}/.local/share/newsbeuter
+mkdir ${HOME}/.newsbeuter
 
 private-bin newsbeuter
 

--- a/etc/profile-m-z/newsbeuter.profile
+++ b/etc/profile-m-z/newsbeuter.profile
@@ -11,7 +11,7 @@ ignore include newsboat.local
 ignore mkdir ${HOME}/.config/newsboat
 ignore mkdir ${HOME}/.local/share/newsboat
 ignore mkdir ${HOME}/.newsboat
-ignore private-bin newsboat
+blacklist ${PATH}/newsboat
 
 blacklist ${HOME}/.config/newsboat
 blacklist ${HOME}/.local/share/newsboat

--- a/etc/profile-m-z/newsbeuter.profile
+++ b/etc/profile-m-z/newsbeuter.profile
@@ -9,13 +9,15 @@ include newsbeuter.local
 
 ignore include newsboat.local
 ignore mkdir ${HOME}/.local/share/newsboat
-ignore noblacklist ${HOME}/.config/newsboat
-ignore noblacklist ${HOME}/.local/share/newsboat
-ignore noblacklist ${HOME}/.newsboat
 ignore private-bin newsboat
-ignore whitelist ${HOME}/.config/newsboat
-ignore whitelist ${HOME}/.local/share/newsboat
-ignore whitelist ${HOME}/.newsboat
+
+blacklist ${HOME}/.config/newsboat
+blacklist ${HOME}/.local/share/newsboat
+blacklist ${HOME}/.newsboat
+
+nowhitelist ${HOME}/.config/newsboat
+nowhitelist ${HOME}/.local/share/newsboat
+nowhitelist ${HOME}/.newsboat
 
 mkdir ${HOME}/.local/share/newsbeuter
 

--- a/etc/profile-m-z/newsbeuter.profile
+++ b/etc/profile-m-z/newsbeuter.profile
@@ -8,6 +8,7 @@ include newsbeuter.local
 #include globals.local
 
 ignore include newsboat.local
+ignore mkdir ${HOME}/.config/newsboat
 ignore mkdir ${HOME}/.local/share/newsboat
 ignore private-bin newsboat
 

--- a/etc/profile-m-z/newsboat.profile
+++ b/etc/profile-m-z/newsboat.profile
@@ -21,6 +21,7 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-xdg.inc
 
+mkdir ${HOME}/.config/newsboat
 mkdir ${HOME}/.local/share/newsboat
 whitelist ${HOME}/.config/newsbeuter
 whitelist ${HOME}/.config/newsboat

--- a/etc/profile-m-z/newsboat.profile
+++ b/etc/profile-m-z/newsboat.profile
@@ -23,6 +23,7 @@ include disable-xdg.inc
 
 mkdir ${HOME}/.config/newsboat
 mkdir ${HOME}/.local/share/newsboat
+mkdir ${HOME}/.newsboat
 whitelist ${HOME}/.config/newsbeuter
 whitelist ${HOME}/.config/newsboat
 whitelist ${HOME}/.local/share/newsbeuter

--- a/etc/profile-m-z/newsboat.profile
+++ b/etc/profile-m-z/newsboat.profile
@@ -6,6 +6,11 @@ include newsboat.local
 # Persistent global definitions
 include globals.local
 
+noblacklist ${HOME}/.config/newsbeuter
+noblacklist ${HOME}/.config/newsboat
+noblacklist ${HOME}/.local/share/newsbeuter
+noblacklist ${HOME}/.local/share/newsboat
+noblacklist ${HOME}/.newsbeuter
 noblacklist ${HOME}/.newsboat
 
 include disable-common.inc
@@ -16,7 +21,12 @@ include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-xdg.inc
 
-mkdir ${HOME}/.newsboat
+mkdir ${HOME}/.local/share/newsboat
+whitelist ${HOME}/.config/newsbeuter
+whitelist ${HOME}/.config/newsboat
+whitelist ${HOME}/.local/share/newsbeuter
+whitelist ${HOME}/.local/share/newsboat
+whitelist ${HOME}/.newsbeuter
 whitelist ${HOME}/.newsboat
 include whitelist-common.inc
 include whitelist-runuser-common.inc
@@ -38,7 +48,7 @@ seccomp
 shell none
 
 disable-mnt
-private-bin gzip,lynx,newsboat,sh
+private-bin gzip,lynx,newsboat,sh,w3m
 private-cache
 private-dev
 private-etc alternatives,ca-certificates,crypto-policies,lynx.cfg,lynx.lss,pki,resolv.conf,ssl,terminfo


### PR DESCRIPTION
https://github.com/netblue30/firejail/issues/1139#issuecomment-790180711_
added newsbeuter folders for migration
added xdg folders

rm mkdir .newsboat, because it doesn't even start, unless you already already have a urls file. It's a cli application.

.local is needed,if you are using .config folder, it doesn't start otherwise. So it needs a mkdir. If you are using .newsboat, it's not needed. That was a bug in the current profile.

newsbeuter is abandoned, this is why is was forked into newsboat. This is why it's a mess like this with all  the ignores and a redirect to newsboat. In the future when finally dead, it just needs to be deleted.

EDIT: And added w3m in private-bin