### PR TITLE
man firejail: fix --dbus-{system,user}.log requirement

### DIFF
--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -433,7 +433,7 @@ org.freedesktop.Notifications.*@/org/freedesktop/Notifications
 
 .TP
 \fB\-\-dbus-system.log
-Turn on DBus logging for the system DBus. This option requires --dbus-system=log.
+Turn on DBus logging for the system DBus. This option requires --dbus-system=filter.
 
 .br
 Example:
@@ -560,7 +560,7 @@ org.freedesktop.Notifications.*@/org/freedesktop/Notifications
 
 .TP
 \fB\-\-dbus-user.log
-Turn on DBus logging for the session DBus. This option requires --dbus-user=log.
+Turn on DBus logging for the session DBus. This option requires --dbus-user=filter.
 
 .br
 Example:


### PR DESCRIPTION
Both --dbus-system.log and --dbus-user.log refer to a non-existing requirement --dbus-foo=log. The examples use the correct policy (filter).
```
$ firejail --dbus-system=log --dbus-system.log
Unknown dbus-system policy: log

$ firejail --dbus-user=log --dbus-user.log
Unknown dbus-user policy: log
```