### PR TITLE
Add profile for checksum tools

### DIFF
--- a/etc/profile-a-l/b2sum.profile
+++ b/etc/profile-a-l/b2sum.profile
@@ -1,0 +1,13 @@
+# Firejail profile for b2sum
+# Description: compute and check BLAKE2 message digest
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include b2sum.local
+# Persistent global definitions
+include globals.local
+
+private-bin b2sum
+
+# Redirect
+include hasher-common.profile

--- a/etc/profile-a-l/cksum.profile
+++ b/etc/profile-a-l/cksum.profile
@@ -1,0 +1,13 @@
+# Firejail profile for cksum
+# Description: checksum and count the bytes in a file
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include cksum.local
+# Persistent global definitions
+include globals.local
+
+private-bin cksum
+
+# Redirect
+include hasher-common.profile

--- a/etc/profile-a-l/hasher-common.profile
+++ b/etc/profile-a-l/hasher-common.profile
@@ -1,0 +1,60 @@
+# This file is overwritten during software install.
+# Persistent customizations should go in a .local file.
+include hasher-common.local
+
+# common profile for hasher/checksum tools
+
+blacklist ${RUNUSER}
+
+# WARNING:
+# Users can (un)restrict file access for **all** hashers by commenting/uncommenting the needed
+# include file(s) here or by putting those into hasher-common.local.
+# Another option is to do this **per hasher** in the relevant <hasher>.local.
+# Just beware that things tend to break when overtightening profiles. For example, because you only
+# need to hash/check files in ${DOWNLOADS}, other applications may need access to ${HOME}/.local/share.
+
+# Uncomment the next line (or put it into your hasher-common.local) if you don't need to hash files in disable-common.inc.
+#include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-passwdmgr.inc
+# Uncomment the next line (or put it into your hasher-common.local) if you don't need to hash files in disable-programs.inc.
+#include disable-programs.inc
+include disable-shell.inc
+include disable-write-mnt.inc
+# Uncomment the next line (or put it into your hasher-common.local) if you don't need to hash files in disable-xdg.inc.
+#include disable-xdg.inc
+
+apparmor
+caps.drop all
+ipc-namespace
+machine-id
+net none
+no3d
+nodvd
+nogroups
+nonewprivs
+noroot
+nosound
+notv
+nou2f
+novideo
+protocol unix
+seccomp
+seccomp.block-secondary
+shell none
+tracelog
+x11 none
+
+# Uncomment the next line (or put it into your hasher-common.local) if you don't need to hash files in /tmp.
+#private-cache
+private-dev
+# Uncomment the next line (or put it into your hasher-common.local) if you don't need to hash files in /tmp.
+#private-tmp
+
+dbus-user none
+dbus-system none
+
+memory-deny-write-execute
+read-only ${HOME}

--- a/etc/profile-m-z/md5sum.profile
+++ b/etc/profile-m-z/md5sum.profile
@@ -1,0 +1,13 @@
+# Firejail profile for md5sum
+# Description: compute and check MD5 message digest
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include md5sum.local
+# Persistent global definitions
+include globals.local
+
+private-bin md5sum
+
+# Redirect
+include hasher-common.profile

--- a/etc/profile-m-z/sha1sum.profile
+++ b/etc/profile-m-z/sha1sum.profile
@@ -1,0 +1,13 @@
+# Firejail profile for sha1sum
+# Description: compute and check SHA1 message digest
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include sha1sum.local
+# Persistent global definitions
+include globals.local
+
+private-bin sha1sum
+
+# Redirect
+include hasher-common.profile

--- a/etc/profile-m-z/sha224sum.profile
+++ b/etc/profile-m-z/sha224sum.profile
@@ -1,0 +1,13 @@
+# Firejail profile for sha224sum
+# Description: compute and check SHA224 message digest
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include sha224sum.local
+# Persistent global definitions
+include globals.local
+
+private-bin sha224sum
+
+# Redirect
+include hasher-common.profile

--- a/etc/profile-m-z/sha256sum.profile
+++ b/etc/profile-m-z/sha256sum.profile
@@ -1,0 +1,13 @@
+# Firejail profile for sha256sum
+# Description: compute and check SHA256 message digest
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include sha256sum.local
+# Persistent global definitions
+include globals.local
+
+private-bin sha256sum
+
+# Redirect
+include hasher-common.profile

--- a/etc/profile-m-z/sha384sum.profile
+++ b/etc/profile-m-z/sha384sum.profile
@@ -1,0 +1,13 @@
+# Firejail profile for sha384sum
+# Description: compute and check SHA384 message digest
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include sha384sum.local
+# Persistent global definitions
+include globals.local
+
+private-bin sha384sum
+
+# Redirect
+include hasher-common.profile

--- a/etc/profile-m-z/sha512sum.profile
+++ b/etc/profile-m-z/sha512sum.profile
@@ -1,0 +1,13 @@
+# Firejail profile for sha512sum
+# Description: compute and check SHA512 message digest
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include sha512sum.local
+# Persistent global definitions
+include globals.local
+
+private-bin sha512sum
+
+# Redirect
+include hasher-common.profile

--- a/etc/profile-m-z/sum.profile
+++ b/etc/profile-m-z/sum.profile
@@ -1,0 +1,13 @@
+# Firejail profile for sum
+# Description: checksum and count the blocks in a file
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include sum.local
+# Persistent global definitions
+include globals.local
+
+private-bin sum
+
+# Redirect
+include hasher-common.profile


### PR DESCRIPTION
Someone told me that md5 is insecure, so I decided it is better to sandbox it so that is can be used securely. :upside_down_face:

---
hasher-common.profile is based on archiver-common.profile.