### PR TITLE
Commons of opengl-game-wrapper.sh

### DIFF
--- a/etc/inc/allow-opengl-game.inc
+++ b/etc/inc/allow-opengl-game.inc
@@ -1,0 +1,3 @@
+noblacklist ${PATH}/bash
+whitelist /usr/share/opengl-games-utils/opengl-game-functions.sh
+private-bin basename,bash,cut,glxinfo,grep,head,sed,zenity

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -52,6 +52,7 @@ blacklist ${HOME}/.atom
 blacklist ${HOME}/.attic
 blacklist ${HOME}/.audacity-data
 blacklist ${HOME}/.avidemux6
+blacklist ${HOME}/.ballbuster.hs
 blacklist ${HOME}/.balsa
 blacklist ${HOME}/.bcast5
 blacklist ${HOME}/.bibletime
@@ -220,6 +221,7 @@ blacklist ${HOME}/.config/d-feet
 blacklist ${HOME}/.config/electron-mail
 blacklist ${HOME}/.config/emaildefaults
 blacklist ${HOME}/.config/emailidentities
+blacklist ${HOME}/.config/emilia
 blacklist ${HOME}/.config/enchant
 blacklist ${HOME}/.config/eog
 blacklist ${HOME}/.config/epiphany
@@ -490,6 +492,8 @@ blacklist ${HOME}/.frozen-bubble
 blacklist ${HOME}/.gimp*
 blacklist ${HOME}/.gist
 blacklist ${HOME}/.gitconfig
+blacklist ${HOME}/.gl-117
+blacklist ${HOME}/.glaxiumrc
 blacklist ${HOME}/.gnome/gnome-schedule
 blacklist ${HOME}/.googleearth
 blacklist ${HOME}/.gradle
@@ -637,6 +641,7 @@ blacklist ${HOME}/.local/share/cdprojektred
 blacklist ${HOME}/.local/share/clipit
 blacklist ${HOME}/.local/share/com.github.johnfactotum.Foliate
 blacklist ${HOME}/.local/share/contacts
+blacklist ${HOME}/.local/share/cor-games
 blacklist ${HOME}/.local/share/data/Mendeley Ltd.
 blacklist ${HOME}/.local/share/data/Mumble
 blacklist ${HOME}/.local/share/data/MusE
@@ -844,6 +849,7 @@ blacklist ${HOME}/.steampid
 blacklist ${HOME}/.stellarium
 blacklist ${HOME}/.subversion
 blacklist ${HOME}/.surf
+blacklist ${HOME}/.suve/colorful
 blacklist ${HOME}/.swb.ini
 blacklist ${HOME}/.sword
 blacklist ${HOME}/.sylpheed-2.0

--- a/etc/profile-a-l/alienarena-wrapper.profile
+++ b/etc/profile-a-l/alienarena-wrapper.profile
@@ -1,0 +1,14 @@
+# Firejail profile for alienarena-wrapper
+# This file is overwritten after every install/update
+# Persistent local customizations
+include alienarena-wrapper.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+include allow-opengl-game.inc
+
+private-bin alienarena-wrapper
+
+# Redirect
+include alienarena.profile

--- a/etc/profile-a-l/alienarena.profile
+++ b/etc/profile-a-l/alienarena.profile
@@ -1,0 +1,52 @@
+# Firejail profile for alienarena
+# Description: Multiplayer retro sci-fi deathmatch game
+# This file is overwritten after every install/update
+# Persistent local customizations
+include alienarena.local
+# Persistent global definitions
+include globals.local
+
+noblacklist ${HOME}/.local/share/cor-games
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
+include disable-shell.inc
+include disable-xdg.inc
+
+mkdir ${HOME}/.local/share/cor-games
+whitelist ${HOME}/.local/share/cor-games
+whitelist /usr/share/alienarena
+include whitelist-common.inc
+include whitelist-runuser-common.inc
+include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
+
+apparmor
+caps.drop all
+netfilter
+nodvd
+nogroups
+nonewprivs
+noroot
+notv
+nou2f
+novideo
+protocol unix,inet,inet6
+seccomp
+seccomp.block-secondary
+shell none
+tracelog
+
+disable-mnt
+private-bin alienarena
+private-cache
+private-dev
+private-etc alsa,alternatives,asound.conf,bumblebee,ca-certificates,crypto-policies,drirc,fonts,glvnd,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,nsswitch.conf,nvidia,pango,pki,protocols,pulse,resolv.conf,rpc,services,ssl,X11
+private-tmp
+
+dbus-user none
+dbus-system none

--- a/etc/profile-a-l/ballbuster-wrapper.profile
+++ b/etc/profile-a-l/ballbuster-wrapper.profile
@@ -1,0 +1,14 @@
+# Firejail profile for ballbuster-wrapper
+# This file is overwritten after every install/update
+# Persistent local customizations
+include ballbuster-wrapper.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+include allow-opengl-game.inc
+
+private-bin ballbuster-wrapper
+
+# Redirect
+include ballbuster.profile

--- a/etc/profile-a-l/ballbuster.profile
+++ b/etc/profile-a-l/ballbuster.profile
@@ -1,0 +1,52 @@
+# Firejail profile for ballbuster
+# Description: Move the paddle to bounce the ball and break all the bricks
+# This file is overwritten after every install/update
+# Persistent local customizations
+include ballbuster.local
+# Persistent global definitions
+include globals.local
+
+noblacklist ${HOME}/.ballbuster.hs
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
+include disable-shell.inc
+include disable-xdg.inc
+
+mkfile ${HOME}/.ballbuster.hs
+whitelist ${HOME}/.ballbuster.hs
+whitelist /usr/share/ballbuster
+include whitelist-common.inc
+include whitelist-runuser-common.inc
+include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
+
+apparmor
+caps.drop all
+net none
+nodvd
+nogroups
+nonewprivs
+noroot
+notv
+nou2f
+novideo
+protocol unix
+seccomp
+seccomp.block-secondary
+shell none
+tracelog
+
+disable-mnt
+private-bin ballbuster
+private-cache
+private-dev
+private-etc alsa,alternatives,asound.conf,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,machine-id,pulse
+private-tmp
+
+dbus-user none
+dbus-system none

--- a/etc/profile-a-l/colorful-wrapper.profile
+++ b/etc/profile-a-l/colorful-wrapper.profile
@@ -1,0 +1,14 @@
+# Firejail profile for colorful-wrapper
+# This file is overwritten after every install/update
+# Persistent local customizations
+include colorful-wrapper.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+include allow-opengl-game.inc
+
+private-bin colorful-wrapper
+
+# Redirect
+include colorful.profile

--- a/etc/profile-a-l/colorful.profile
+++ b/etc/profile-a-l/colorful.profile
@@ -1,0 +1,52 @@
+# Firejail profile for colorful
+# Description: simple 2D sideview shooter
+# This file is overwritten after every install/update
+# Persistent local customizations
+include colorful.local
+# Persistent global definitions
+include globals.local
+
+noblacklist ${HOME}/.suve/colorful
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
+include disable-shell.inc
+include disable-xdg.inc
+
+mkdir ${HOME}/.suve/colorful
+whitelist ${HOME}/.suve/colorful
+whitelist /usr/share/suve
+include whitelist-common.inc
+include whitelist-runuser-common.inc
+include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
+
+apparmor
+caps.drop all
+net none
+nodvd
+nogroups
+nonewprivs
+noroot
+notv
+nou2f
+novideo
+protocol unix
+seccomp
+seccomp.block-secondary
+shell none
+tracelog
+
+disable-mnt
+private-bin colorful
+private-cache
+private-dev
+private-etc alsa,alternatives,asound.conf,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,machine-id,pulse
+private-tmp
+
+dbus-user none
+dbus-system none

--- a/etc/profile-a-l/etr-wrapper.profile
+++ b/etc/profile-a-l/etr-wrapper.profile
@@ -1,0 +1,14 @@
+# Firejail profile for etr-wrapper
+# This file is overwritten after every install/update
+# Persistent local customizations
+include etr-wrapper.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+include allow-opengl-game.inc
+
+private-bin etr-wrapper
+
+# Redirect
+include etr.profile

--- a/etc/profile-a-l/gl-117-wrapper.profie
+++ b/etc/profile-a-l/gl-117-wrapper.profie
@@ -1,0 +1,14 @@
+# Firejail profile for gl-117-wrapper
+# This file is overwritten after every install/update
+# Persistent local customizations
+include gl-117-wrapper.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+include allow-opengl-game.inc
+
+private-bin gl-117-wrapper
+
+# Redirect
+include gl-117.profile

--- a/etc/profile-a-l/gl-117-wrapper.profile
+++ b/etc/profile-a-l/gl-117-wrapper.profile
@@ -1,0 +1,14 @@
+# Firejail profile for gl-117-wrapper
+# This file is overwritten after every install/update
+# Persistent local customizations
+include gl-117-wrapper.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+include allow-opengl-game.inc
+
+private-bin gl-117-wrapper
+
+# Redirect
+include gl-117.profile

--- a/etc/profile-a-l/gl-117.profile
+++ b/etc/profile-a-l/gl-117.profile
@@ -1,0 +1,52 @@
+# Firejail profile for gl-117
+# Description: Action flight simulator
+# This file is overwritten after every install/update
+# Persistent local customizations
+include gl-117.local
+# Persistent global definitions
+include globals.local
+
+noblacklist ${HOME}/.gl-117
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
+include disable-shell.inc
+include disable-xdg.inc
+
+mkdir ${HOME}/.gl-117
+whitelist ${HOME}/.gl-117
+whitelist /usr/share/gl-117
+include whitelist-common.inc
+include whitelist-runuser-common.inc
+include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
+
+apparmor
+caps.drop all
+net none
+nodvd
+nogroups
+nonewprivs
+noroot
+notv
+nou2f
+novideo
+protocol unix
+seccomp
+seccomp.block-secondary
+shell none
+tracelog
+
+disable-mnt
+private-bin gl-117
+private-cache
+private-dev
+private-etc alsa,alternatives,asound.conf,bumblebee,drirc,glvnd,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,machine-id,nvidia,pulse
+private-tmp
+
+dbus-user none
+dbus-system none

--- a/etc/profile-a-l/glaxium-wrapper.profie
+++ b/etc/profile-a-l/glaxium-wrapper.profie
@@ -1,0 +1,14 @@
+# Firejail profile for glaxium-wrapper
+# This file is overwritten after every install/update
+# Persistent local customizations
+include glaxium-wrapper.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+include allow-opengl-game.inc
+
+private-bin glaxium-wrapper
+
+# Redirect
+include glaxium.profile

--- a/etc/profile-a-l/glaxium-wrapper.profile
+++ b/etc/profile-a-l/glaxium-wrapper.profile
@@ -1,0 +1,14 @@
+# Firejail profile for glaxium-wrapper
+# This file is overwritten after every install/update
+# Persistent local customizations
+include glaxium-wrapper.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+include allow-opengl-game.inc
+
+private-bin glaxium-wrapper
+
+# Redirect
+include glaxium.profile

--- a/etc/profile-a-l/glaxium.profile
+++ b/etc/profile-a-l/glaxium.profile
@@ -1,0 +1,52 @@
+# Firejail profile for glaxium
+# Description: 3d spaceship shoot-em-up
+# This file is overwritten after every install/update
+# Persistent local customizations
+include glaxium.local
+# Persistent global definitions
+include globals.local
+
+noblacklist ${HOME}/.glaxiumrc
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
+include disable-shell.inc
+include disable-xdg.inc
+
+mkfile ${HOME}/.glaxiumrc
+whitelist ${HOME}/.glaxiumrc
+whitelist /usr/share/glaxium
+include whitelist-common.inc
+include whitelist-runuser-common.inc
+include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
+
+apparmor
+caps.drop all
+net none
+nodvd
+nogroups
+nonewprivs
+noroot
+notv
+nou2f
+novideo
+protocol unix
+seccomp
+seccomp.block-secondary
+shell none
+tracelog
+
+disable-mnt
+private-bin glaxium
+private-cache
+private-dev
+private-etc alsa,alternatives,asound.conf,bumblebee,drirc,glvnd,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,machine-id,nvidia,pulse
+private-tmp
+
+dbus-user none
+dbus-system none

--- a/etc/profile-m-z/neverball-wrapper.profie
+++ b/etc/profile-m-z/neverball-wrapper.profie
@@ -1,0 +1,14 @@
+# Firejail profile for neverball-wrapper
+# This file is overwritten after every install/update
+# Persistent local customizations
+include neverball-wrapper.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+include allow-opengl-game.inc
+
+private-bin neverball-wrapper
+
+# Redirect
+include neverball.profile

--- a/etc/profile-m-z/neverball-wrapper.profile
+++ b/etc/profile-m-z/neverball-wrapper.profile
@@ -1,0 +1,14 @@
+# Firejail profile for neverball-wrapper
+# This file is overwritten after every install/update
+# Persistent local customizations
+include neverball-wrapper.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+include allow-opengl-game.inc
+
+private-bin neverball-wrapper
+
+# Redirect
+include neverball.profile

--- a/etc/profile-m-z/neverputt-wrapper.profie
+++ b/etc/profile-m-z/neverputt-wrapper.profie
@@ -1,0 +1,14 @@
+# Firejail profile for neverputt-wrapper
+# This file is overwritten after every install/update
+# Persistent local customizations
+include neverputt-wrapper.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+include allow-opengl-game.inc
+
+private-bin neverputt-wrapper
+
+# Redirect
+include neverputt.profile

--- a/etc/profile-m-z/neverputt-wrapper.profile
+++ b/etc/profile-m-z/neverputt-wrapper.profile
@@ -1,0 +1,14 @@
+# Firejail profile for neverputt-wrapper
+# This file is overwritten after every install/update
+# Persistent local customizations
+include neverputt-wrapper.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+include allow-opengl-game.inc
+
+private-bin neverputt-wrapper
+
+# Redirect
+include neverputt.profile

--- a/etc/profile-m-z/pinball-wrapper.profie
+++ b/etc/profile-m-z/pinball-wrapper.profie
@@ -1,0 +1,14 @@
+# Firejail profile for pinball-wrapper
+# This file is overwritten after every install/update
+# Persistent local customizations
+include pinball-wrapper.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+include allow-opengl-game.inc
+
+private-bin pinball-wrapper
+
+# Redirect
+include pinball.profile

--- a/etc/profile-m-z/pinball-wrapper.profile
+++ b/etc/profile-m-z/pinball-wrapper.profile
@@ -1,0 +1,14 @@
+# Firejail profile for pinball-wrapper
+# This file is overwritten after every install/update
+# Persistent local customizations
+include pinball-wrapper.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+include allow-opengl-game.inc
+
+private-bin pinball-wrapper
+
+# Redirect
+include pinball.profile

--- a/etc/profile-m-z/pinball.profile
+++ b/etc/profile-m-z/pinball.profile
@@ -1,0 +1,52 @@
+# Firejail profile for pinball
+# Description: Emilia 3D Pinball Game
+# This file is overwritten after every install/update
+# Persistent local customizations
+include pinball.local
+# Persistent global definitions
+include globals.local
+
+noblacklist ${HOME}/.config/emilia
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
+include disable-shell.inc
+include disable-xdg.inc
+
+mkdir ${HOME}/.config/emilia
+whitelist ${HOME}/.config/emilia
+whitelist /usr/share/pinball
+include whitelist-common.inc
+include whitelist-runuser-common.inc
+include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
+
+apparmor
+caps.drop all
+net none
+nodvd
+nogroups
+nonewprivs
+noroot
+notv
+nou2f
+novideo
+protocol unix
+seccomp
+seccomp.block-secondary
+shell none
+tracelog
+
+disable-mnt
+private-bin pinball
+private-cache
+private-dev
+private-etc alsa,alternatives,asound.conf,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,machine-id,pulse
+private-tmp
+
+dbus-user none
+dbus-system none

--- a/etc/profile-m-z/scorched3d-wrapper.profile
+++ b/etc/profile-m-z/scorched3d-wrapper.profile
@@ -1,10 +1,11 @@
-# Firejail profile for scorched3d
+# Firejail profile for scorched3d-wrapper
 # This file is overwritten after every install/update
 # Persistent local customizations
 include scorched3d-wrapper.local
 
-whitelist /usr/share/opengl-games-utils
-private-bin basename,bash,cut,glxinfo,grep,head,sed,zenity
+include allow-opengl-game.inc
+
+private-bin scorched3d-wrapper
 
 # Redirect
 include scorched3d.profile

--- a/etc/profile-m-z/scorched3d.profile
+++ b/etc/profile-m-z/scorched3d.profile
@@ -40,7 +40,7 @@ shell none
 tracelog
 
 disable-mnt
-private-bin scorched3d,scorched3d-wrapper,scorched3dc,scorched3ds
+private-bin scorched3d,scorched3dc,scorched3ds
 private-cache
 private-dev
 private-tmp

--- a/etc/profile-m-z/supertuxkart-wrapper.profile
+++ b/etc/profile-m-z/supertuxkart-wrapper.profile
@@ -1,0 +1,14 @@
+# Firejail profile for supertuxkart-wrapper
+# This file is overwritten after every install/update
+# Persistent local customizations
+include supertuxkart-wrapper.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+include allow-opengl-game.inc
+
+private-bin supertuxkart-wrapper
+
+# Redirect
+include supertuxkart.profile

--- a/etc/profile-m-z/xonotic.profile
+++ b/etc/profile-m-z/xonotic.profile
@@ -8,12 +8,16 @@ include globals.local
 
 noblacklist ${HOME}/.xonotic
 
+include allow-bin-sh.inc
+include allow-opengl-game.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
+include disable-shell.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.xonotic
@@ -41,7 +45,7 @@ tracelog
 
 disable-mnt
 private-cache
-private-bin basename,bash,blind-id,cut,darkplaces-glx,darkplaces-sdl,dirname,glxinfo,grep,head,ldd,netstat,ps,readlink,sed,sh,uname,xonotic,xonotic-glx,xonotic-linux32-dedicated,xonotic-linux32-glx,xonotic-linux32-sdl,xonotic-linux64-dedicated,xonotic-linux64-glx,xonotic-linux64-sdl,xonotic-sdl,xonotic-sdl-wrapper,zenity
+private-bin blind-id,darkplaces-glx,darkplaces-sdl,dirname,ldd,netstat,ps,readlink,sh,uname,xonotic*
 private-dev
 private-etc alternatives,asound.conf,ca-certificates,crypto-policies,drirc,fonts,group,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,machine-id,nsswitch.conf,passwd,pki,pulse,resolv.conf,ssl
 private-tmp

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -74,6 +74,7 @@ autokey-run
 autokey-shell
 avidemux3_qt5
 aweather
+ballbuster
 baloo_file
 baloo_filemetadata_temp_extractor
 balsa
@@ -147,6 +148,7 @@ cmus
 code
 code-oss
 cola
+colorful
 com.github.bleakgrey.tootle
 com.github.dahenson.agenda
 com.github.johnfactotum.Foliate
@@ -293,6 +295,8 @@ git-cola
 github-desktop
 gitter
 # gjs -- https://github.com/netblue30/firejail/issues/3333#issuecomment-612601102
+gl-117
+glaxium
 globaltime
 gmpc
 gnome-2048
@@ -615,6 +619,7 @@ penguin-command
 photoflare
 picard
 pidgin
+pinball
 #ping - disabled until we fix  #1912
 pingus
 pinta

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -678,7 +678,6 @@ runenpass.sh
 sayonara
 scallion
 scorched3d
-scorched3d-wrapper
 scorchwentbonkers
 scribus
 sdat2img
@@ -872,7 +871,6 @@ xmr-stak
 xonotic
 xonotic-glx
 xonotic-sdl
-xonotic-sdl-wrapper
 xournal
 xournalpp
 xpdf


### PR DESCRIPTION
Add profiles for alienarena, ballbuster, colorful, gl-117, glaxium, pinball

Commons of opengl-game-wrapper.sh 

 - Add allow-opengl-game.inc
 - Add profiles for alienarena-wrapper, ballbuster-wrapper,
   colorful-wrapper, etr-wrapper, gl-117-wrapper, glaxium-wrapper,
   neverball-wrapper, neverputt-wrapper, pinball-wrapper,
   supertuxkart-wrapper
 - Use allow-opengl-game.inc in xonotic.profile and the profiles above
 - xonotic.profile: simplify private-bin by using xonotic*