### PR TITLE
Clarify what the Description comment is for

### DIFF
--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -1,5 +1,5 @@
 # Firejail profile for PROGRAM_NAME
-# Description: DESCRIPTION
+# Description: DESCRIPTION OF THE PROGRAM
 # This file is overwritten after every install/update
 # --- CUT HERE ---
 # This is a generic template to help you create profiles.


### PR DESCRIPTION
In most profiles I've seen, this comment describes the program.

In some, it's missing, e.g. [Mathematica](https://github.com/netblue30/firejail/blob/master/etc/profile-m-z/Mathematica.profile)

In others, it's wrong (copy/pasted?), e.g. [Node.js](https://github.com/netblue30/firejail/blob/master/etc/profile-m-z/nodejs-common.profile#L2) says "Common profile for npm/yarn".