### PR TITLE
fixing engrampa profile

### DIFF
--- a/etc/profile-a-l/engrampa.profile
+++ b/etc/profile-a-l/engrampa.profile
@@ -17,7 +17,6 @@ include whitelist-var-common.inc
 
 apparmor
 caps.drop all
-net none
 no3d
 nodvd
 nogroups
@@ -36,7 +35,4 @@ tracelog
 private-dev
 # private-tmp
 
-dbus-user none
 dbus-system none
-
-memory-deny-write-execute


### PR DESCRIPTION
`memory-deny-write-execute` causes the app to be unusable (you just get, a messed up window)
at least on ubuntu 18.04 32bit

with these
```
net none
dbus-user none
```
it complains a lot in the terminal about dbus
Nothing obvious is broken, but not tested thoroughly either.