### PR TITLE
make appimage mounts private to sandbox

### DIFF
--- a/src/firejail/appimage.c
+++ b/src/firejail/appimage.c
@@ -61,7 +61,7 @@ void appimage_set(const char *appimage) {
 
 	// get appimage type and ELF size
 	// a value of 0 means we are dealing with a type1 appimage
-	size = appimage2_size(appimage);
+	size = appimage2_size(ffd);
 	if (arg_debug)
 		printf("AppImage ELF size %lu\n", size);
 

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -802,7 +802,7 @@ void appimage_mount(void);
 void appimage_clear(void);
 
 // appimage_size.c
-long unsigned int appimage2_size(const char *fname);
+long unsigned int appimage2_size(int fd);
 
 // cmdline.c
 void build_cmdline(char **command_line, char **window_title, int argc, char **argv, int index);

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -798,15 +798,15 @@ void print_compiletime_support(void);
 
 // appimage.c
 void appimage_set(const char *appimage_path);
+void appimage_mount(void);
 void appimage_clear(void);
-const char *appimage_getdir(void);
 
 // appimage_size.c
 long unsigned int appimage2_size(const char *fname);
 
 // cmdline.c
 void build_cmdline(char **command_line, char **window_title, int argc, char **argv, int index);
-void build_appimage_cmdline(char **command_line, char **window_title, int argc, char **argv, int index, char *apprun_path);
+void build_appimage_cmdline(char **command_line, char **window_title, int argc, char **argv, int index);
 
 // sbox.c
 // programs

--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -800,8 +800,6 @@ void disable_config(void) {
 		disable_file(BLACKLIST_FILE, RUN_FIREJAIL_PROFILE_DIR);
 	if (stat(RUN_FIREJAIL_X11_DIR, &s) == 0)
 		disable_file(BLACKLIST_FILE, RUN_FIREJAIL_X11_DIR);
-	if (!arg_appimage && stat(RUN_FIREJAIL_APPIMAGE_DIR, &s) == 0)
-		disable_file(BLACKLIST_FILE, RUN_FIREJAIL_APPIMAGE_DIR);
 }
 
 

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -2790,7 +2790,7 @@ int main(int argc, char **argv, char **envp) {
 		if (arg_debug)
 			printf("Configuring appimage environment\n");
 		appimage_set(cfg.command_name);
-		build_appimage_cmdline(&cfg.command_line, &cfg.window_title, argc, argv, prog_index, cfg.command_line);
+		build_appimage_cmdline(&cfg.command_line, &cfg.window_title, argc, argv, prog_index);
 	}
 	else {
 		build_cmdline(&cfg.command_line, &cfg.window_title, argc, argv, prog_index);

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -630,6 +630,8 @@ int sandbox(void* sandbox_arg) {
 		errExit("mounting " RUN_FIREJAIL_LIB_DIR);
 	// keep a copy of dhclient executable before the filesystem is modified
 	dhcp_store_exec();
+	// mount appimage before the filesystem is modified
+	appimage_mount();
 
 	//****************************
 	// log sandbox data

--- a/test/appimage/appimage-args.exp
+++ b/test/appimage/appimage-args.exp
@@ -96,7 +96,7 @@ send -- "firejail --shutdown=appimage-test\r"
 set spawn_id $appimage_id
 expect {
 	timeout {puts "shutdown\n";exit}
-	"AppImage unmounted"
+	"AppImage detached"
 }
 
 after 100

--- a/test/appimage/appimage-trace.exp
+++ b/test/appimage/appimage-trace.exp
@@ -31,7 +31,7 @@ expect {
 }
 expect {
 	timeout {puts "shutdown\n"}
-	"AppImage unmounted"
+	"AppImage detached"
 }
 sleep 1
 
@@ -58,7 +58,7 @@ expect {
 }
 expect {
 	timeout {puts "shutdown\n"}
-	"AppImage unmounted"
+	"AppImage detached"
 }
 sleep 1
 

--- a/test/appimage/appimage-v1.exp
+++ b/test/appimage/appimage-v1.exp
@@ -84,7 +84,7 @@ send -- "firejail --shutdown=appimage-test\r"
 set spawn_id $appimage_id
 expect {
 	timeout {puts "shutdown\n"}
-	"AppImage unmounted"
+	"AppImage detached"
 }
 
 after 100

--- a/test/appimage/appimage-v2.exp
+++ b/test/appimage/appimage-v2.exp
@@ -83,7 +83,7 @@ send -- "firejail --shutdown=appimage-test\r"
 set spawn_id $appimage_id
 expect {
 	timeout {puts "shutdown\n"}
-	"AppImage unmounted"
+	"AppImage detached"
 }
 
 after 100

--- a/test/appimage/appimage.sh
+++ b/test/appimage/appimage.sh
@@ -20,4 +20,4 @@ echo "TESTING: AppImage argsv1 (test/appimage/appimage-args.exp)"
 ./appimage-args.exp
 
 echo "TESTING: AppImage trace (test/appimage/appimage-trace.exp)"
-./appimage-args.exp
+./appimage-trace.exp

--- a/test/appimage/filename.exp
+++ b/test/appimage/filename.exp
@@ -17,7 +17,7 @@ after 100
 send -- "firejail --appimage /etc/shadow\r"
 expect {
 	timeout {puts "TESTING ERROR 2\n";exit}
-	"cannot access"
+	"cannot read"
 }
 after 100
 


### PR DESCRIPTION
Mount AppImage on `/run/firejail/appimage` in the sandbox process, rather than on a subdirectory in the main process. This way the mount is destroyed automatically when the sandbox terminates, and it is private to the sandbox and not a global resource (except for root, who can always peek into the loop device).