### PR TITLE
[minor] qcomicbook and pipe-viewer in disable-programs

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -121,6 +121,7 @@ blacklist ${HOME}/.config/Nathan Osman
 blacklist ${HOME}/.config/Nextcloud
 blacklist ${HOME}/.config/Nylas Mail
 blacklist ${HOME}/.config/PacmanLogViewer
+blacklist ${HOME}/.config/PawelStolowski
 blacklist ${HOME}/.config/PBE
 blacklist ${HOME}/.config/Philipp Schmieder
 blacklist ${HOME}/.config/QGIS
@@ -358,6 +359,7 @@ blacklist ${HOME}/.config/pavucontrol.ini
 blacklist ${HOME}/.config/pcmanfm
 blacklist ${HOME}/.config/pdfmod
 blacklist ${HOME}/.config/Pinta
+blacklist ${HOME}/.config/pipe-viewer
 blacklist ${HOME}/.config/pitivi
 blacklist ${HOME}/.config/pix
 blacklist ${HOME}/.config/pluma
@@ -587,6 +589,7 @@ blacklist ${HOME}/.local/share/Mendeley Ltd.
 blacklist ${HOME}/.local/share/Mumble
 blacklist ${HOME}/.local/share/Nextcloud
 blacklist ${HOME}/.local/share/PBE
+blacklist ${HOME}/.local/share/PawelStolowski
 blacklist ${HOME}/.local/share/Psi
 blacklist ${HOME}/.local/share/QGIS
 blacklist ${HOME}/.local/share/QMediathekView
@@ -896,6 +899,7 @@ blacklist ${HOME}/.cache/INRIA
 blacklist ${HOME}/.cache/MusicBrainz
 blacklist ${HOME}/.cache/NewsFlashGTK
 blacklist ${HOME}/.cache/Otter
+blacklist ${HOME}/.cache/PawelStolowski
 blacklist ${HOME}/.cache/Psi
 blacklist ${HOME}/.cache/QuiteRss
 blacklist ${HOME}/.cache/Quotient/quaternion
@@ -1004,6 +1008,7 @@ blacklist ${HOME}/.cache/org.gnome.Maps
 blacklist ${HOME}/.cache/pdfmod
 blacklist ${HOME}/.cache/peek
 blacklist ${HOME}/.cache/pip
+blacklist ${HOME}/.cache/pipe-viewer
 blacklist ${HOME}/.cache/plasmashell
 blacklist ${HOME}/.cache/plasmashellbookmarkrunnerfirefoxdbfile.sqlite*
 blacklist ${HOME}/.cache/psi

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -312,6 +312,7 @@ blacklist ${HOME}/.config/mate-calc
 blacklist ${HOME}/.config/mate/eom
 blacklist ${HOME}/.config/mate/mate-dictionary
 blacklist ${HOME}/.config/matrix-mirage
+blacklist ${HOME}/.config/mcomix
 blacklist ${HOME}/.config/meld
 blacklist ${HOME}/.config/meteo-qt
 blacklist ${HOME}/.config/menulibre.cfg
@@ -694,6 +695,7 @@ blacklist ${HOME}/.local/share/man
 blacklist ${HOME}/.local/share/mana
 blacklist ${HOME}/.local/share/maps-places.json
 blacklist ${HOME}/.local/share/matrix-mirage
+blacklist ${HOME}/.local/share/mcomix
 blacklist ${HOME}/.local/share/meld
 blacklist ${HOME}/.local/share/midori
 blacklist ${HOME}/.local/share/minder


### PR DESCRIPTION
qcomicbook is the "PawelStolowski" folders

pipe-viewer doesn't has a .local folder.

EDIT: adding mcomix, it has no cache