### PR TITLE
Rename chromium-common-hardened and feh-network …

### DIFF
--- a/etc/profile-a-l/chromium-common-hardened.inc.profile
+++ b/etc/profile-a-l/chromium-common-hardened.inc.profile
@@ -1,6 +1,6 @@
 # This file is overwritten during software install.
 # Persistent customizations should go in a .local file.
-include chromium-common-hardened.local
+include chromium-common-hardened.inc.local
 
 caps.drop all
 nonewprivs

--- a/etc/profile-a-l/feh-network.inc.profile
+++ b/etc/profile-a-l/feh-network.inc.profile
@@ -1,6 +1,6 @@
 # This file is overwritten during software install.
 # Persistent customizations should go in a .local file.
-include feh-network.local
+include feh-network.inc.local
 
 ignore net none
 netfilter


### PR DESCRIPTION
…again

I am still not really happy about the rename from #4028, #4029, #4030
and #4031. I've no problem with moving away .inc but I don't like the
result. So here's a proposal to make this better:

| NAME                      | DESCRIPTION                                                  |
| ------------------------- | ------------------------------------------------------------ |
| `*-addons.profile`        | (include) Allow external addons                              |
| `*-common.profile`        | (include) Common parts across multiple profiles              |
| `*-hardened.inc.profile`  | Further hardening which can not be made default              |
| `*-network.inc.profile`   | Allow optional network access                                |
| `*-whitelist.inc.profile` | Enabled whitelisting (which can not be made default) ¹       |
| `*.inc.profile`           | Other profile specific includes                              |
| `*.profile`               | A profile for a program                                      |
| `allow-*.inc`             | Multiple `noblacklist`s  that should always be used together |
| `disable-*.inc`           | `blacklist`ing                                               |
| `whitelist-*-common.inc`  | common `whitelist`s                                          |
| `*.inc`                   | Other generic includes                                       |
| `globals.local`           | User overrides for all profiles                              |
| `*.local`                 | Per profile user overrides                                   |

¹ can be used for programs like KeePassXC or editors.