### PR TITLE
Add localtime to signal-desktop's profile.

### DIFF
--- a/etc/profile-m-z/signal-desktop.profile
+++ b/etc/profile-m-z/signal-desktop.profile
@@ -23,7 +23,7 @@ read-only ${HOME}/.mozilla/firefox/profiles.ini
 mkdir ${HOME}/.config/Signal
 whitelist ${HOME}/.config/Signal
 
-private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,machine-id,nsswitch.conf,pki,resolv.conf,ssl
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,machine-id,nsswitch.conf,pki,resolv.conf,ssl
 
 # Redirect
 include electron.profile


### PR DESCRIPTION
Without it, all chat timestamps are in UTC.