### PR TITLE
dropbox: allow python3, fix for issue #4150

### DIFF
--- a/etc/profile-a-l/dropbox.profile
+++ b/etc/profile-a-l/dropbox.profile
@@ -9,6 +9,9 @@ noblacklist ${HOME}/.config/autostart
 noblacklist ${HOME}/.dropbox
 noblacklist ${HOME}/.dropbox-dist
 
+# Allow python3 (blacklisted by disable-interpreters.inc)
+include allow-python3.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc


### PR DESCRIPTION
/usr/bin/dropbox needs access to python3, at least for dropbox
command-line interface version 2020.03.04 as packaged by the RPM Fusion
project.  Fixes issue #4150
