### PR TITLE
allow notifications + comment fixes

### DIFF
--- a/etc/profile-m-z/signal-desktop.profile
+++ b/etc/profile-m-z/signal-desktop.profile
@@ -19,10 +19,9 @@ read-only ${HOME}/.mozilla/firefox/profiles.ini
 mkdir ${HOME}/.config/Signal
 whitelist ${HOME}/.config/Signal
 
-private-etc alternatives,ca-certificates,crypto-policies,fonts,group,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,machine-id,nsswitch.conf,passwd,pki,resolv.conf,ssl
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,machine-id,nsswitch.conf,pki,resolv.conf,ssl
 
 # allow D-Bus notifications
-ignore private-tmp
 dbus-user filter
 dbus-user.talk org.freedesktop.Notifications
 ignore dbus-user none

--- a/etc/profile-m-z/signal-desktop.profile
+++ b/etc/profile-m-z/signal-desktop.profile
@@ -5,10 +5,6 @@ include signal-desktop.local
 # Persistent global definitions
 include globals.local
 
-# Disabled until someone reported positive feedback
-ignore include whitelist-runuser-common.inc
-ignore include whitelist-usr-share-common.inc
-ignore private-cache
 ignore novideo
 
 ignore noexec /tmp
@@ -23,7 +19,13 @@ read-only ${HOME}/.mozilla/firefox/profiles.ini
 mkdir ${HOME}/.config/Signal
 whitelist ${HOME}/.config/Signal
 
-private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,machine-id,nsswitch.conf,pki,resolv.conf,ssl
+private-etc alternatives,ca-certificates,crypto-policies,fonts,group,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,machine-id,nsswitch.conf,passwd,pki,resolv.conf,ssl
+
+# allow D-Bus notifications
+ignore private-tmp
+dbus-user filter
+dbus-user.talk org.freedesktop.Notifications
+ignore dbus-user none
 
 # Redirect
 include electron.profile


### PR DESCRIPTION
Inspired by #4158.

Regarding the comment:
```
# Disabled until someone reported positive feedback
#include whitelist-runuser-common.inc
#include whitelist-usr-share-common.inc
#ignore private-cache --> signal-desktop doesn't use ~/.cache
```
IMO we can drop these. Both `whitelist-runuser-common.inc` and `whitelist-usr-share-common.inc` are already getting included via electron.profile and that seems to work as expected. On my Arch Linux box signal-desktop doesn't use ~/.cache so it should be safe to keep `private-cache` as well.