### PR TITLE
Update nodejs-common: enable npx, clarify

### DIFF
--- a/etc/profile-m-z/nodejs-common.profile
+++ b/etc/profile-m-z/nodejs-common.profile
@@ -50,7 +50,6 @@ disable-mnt
 private-dev
 # Pass-through passwd because it's required to run `npx`
 private-etc alternatives,ca-certificates,crypto-policies,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,login.defs,mime.types,nsswitch.conf,passwd,pki,protocols,resolv.conf,rpc,services,ssl,xdg
-private-tmp
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/nodejs-common.profile
+++ b/etc/profile-m-z/nodejs-common.profile
@@ -7,12 +7,15 @@ include nodejs-common.local
 # added by caller profile
 #include globals.local
 
-blacklist /tmp/.X11-unix
-blacklist ${RUNUSER}
-
 ignore noexec ${HOME}
 
+# Required to run `npx`
+noblacklist ${HOME}/.npm
+
 include allow-bin-sh.inc
+
+blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}
 
 include disable-common.inc
 include disable-exec.inc
@@ -45,9 +48,8 @@ shell none
 
 disable-mnt
 private-dev
-# May need to add `passwd` to `private-etc` below to enable debugging with some IDEs
-private-etc alternatives,ca-certificates,crypto-policies,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,login.defs,mime.types,nsswitch.conf,pki,protocols,resolv.conf,rpc,services,ssl,xdg
-# May need to be commented out in order to enable debugging with some IDEs
+# Pass-through passwd because it's required to run `npx`
+private-etc alternatives,ca-certificates,crypto-policies,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,login.defs,mime.types,nsswitch.conf,passwd,pki,protocols,resolv.conf,rpc,services,ssl,xdg
 private-tmp
 
 dbus-user none


### PR DESCRIPTION
Settings to enable npx ([bundled with node](https://nodejs.org/ca/blog/release/v8.2.0/)).

Changed the order a bit to match the [profile.template sections](https://github.com/netblue30/firejail/blob/master/etc/templates/profile.template).

Removed the private-tmp comment because if an IDE debugs Node, then Node inherits the sandbox from the IDE. I wrote [that mistaken PR](https://github.com/netblue30/firejail/pull/4085/files#diff-6d6766db31289911872e5c664b0e77be7ef045360c7341d53ff7567784866077R48) early on when I didn't understand this aspect of firejail well.