### PR TITLE
Minor Fixes

### DIFF
--- a/etc/profile-a-l/amarok.profile
+++ b/etc/profile-a-l/amarok.profile
@@ -39,8 +39,6 @@ dbus-user filter
 dbus-user.own org.kde.amarok
 #dbus-user.own org.kde.kded
 #dbus-user.own org.kde.klauncher
-# The following one is needed for keyboard shortcuts even on kde. 
-#dbus-user.own org.kde.kglobalaccel
 dbus-user.own org.mpris.amarok
 dbus-user.own org.mpris.MediaPlayer2.amarok
 dbus-user.talk org.freedesktop.Notifications

--- a/etc/profile-m-z/spectacle.profile
+++ b/etc/profile-m-z/spectacle.profile
@@ -59,6 +59,7 @@ private-tmp
 
 dbus-user filter
 dbus-user.own org.kde.spectacle
+dbus-user.own org.kde.Spectacle
 dbus-user.talk org.freedesktop.FileManager1
 #dbus-user.talk org.kde.JobViewServer
 #dbus-user.talk org.kde.kglobalaccel


### PR DESCRIPTION
`dbus-user.own org.kde.Spectacle` -is needed for keybindings to work.

`dbus-user.own org.kde.kglobalaccel` -is not necessary for keybindings to work as amarok already has ownership of `org.kde.amarok`.