### PR TITLE
Add examples how to allow browser access to Gnome extensions connector

### DIFF
--- a/etc/profile-a-l/chromium-common.profile
+++ b/etc/profile-a-l/chromium-common.profile
@@ -12,6 +12,10 @@ include chromium-common.local
 noblacklist ${HOME}/.pki
 noblacklist ${HOME}/.local/share/pki
 
+# Add the next line to your chromium-common.local if you want Google Chrome/Chromium browser
+# to have access to Gnome extensions (extensions.gnome.org) via browser connector
+#include allow-python3.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/profile-a-l/firefox-common-addons.profile
+++ b/etc/profile-a-l/firefox-common-addons.profile
@@ -73,8 +73,9 @@ whitelist /usr/share/vulkan
 # GNOME Shell integration (chrome-gnome-shell) needs dbus and python
 noblacklist ${HOME}/.local/share/gnome-shell
 whitelist ${HOME}/.local/share/gnome-shell
-ignore dbus-user none
-ignore dbus-system none
+dbus-user.talk ca.desrt.dconf
+dbus-user.talk org.gnome.ChromeGnomeShell
+dbus-user.talk org.gnome.Shell
 # Allow python (blacklisted by disable-interpreters.inc)
 include allow-python3.inc
 


### PR DESCRIPTION
Fixes #4177.