### PR TITLE
add passwd to private-etc

### DIFF
--- a/etc/profile-m-z/quodlibet.profile
+++ b/etc/profile-m-z/quodlibet.profile
@@ -60,7 +60,7 @@ tracelog
 private-bin exfalso,operon,python*,quodlibet,sh
 private-cache
 private-dev
-private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,pki,pulse,resolv.conf,ssl
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,passwd,pki,pulse,resolv.conf,ssl
 private-tmp
 
 dbus-system none


### PR DESCRIPTION
Now we have the new quodlibet.profile I've tested its functionality on a setup where users only have exfalso, but not quodlibet. Both profiles are looking good, but I noticed the below error when firejailing exfalso:

```
...
/usr/lib/python3.9/site-packages/quodlibet/qltk/filesel.py:130: Warning: getpwuid_r(): failed due to unknown user id (1001)
...
```

Adding `passwd` to private-etc fixes this for uid's > 1000.