### PR TITLE
unblock tor support in brave

### DIFF
--- a/etc/apparmor/firejail-local
+++ b/etc/apparmor/firejail-local
@@ -8,5 +8,8 @@
 #owner @HOME/bin/** ix
 #owner @HOME/.local/bin/** ix
 
+# Uncomment to opt-in to apparmor for brave + tor
+#owner @{HOME}/.config/BraveSoftware/Brave-Browser/biahpgbdmdkfgndcmfiipgcebobojjkp/*/** ix,
+
 # Uncomment to opt-in to apparmor for torbrowser-launcher
 #owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/** ix,

--- a/etc/profile-a-l/brave.profile
+++ b/etc/profile-a-l/brave.profile
@@ -8,7 +8,9 @@ include globals.local
 
 # noexec /tmp is included in chromium-common.profile and breaks Brave
 ignore noexec /tmp
-# TOR is installed in ${HOME}
+# TOR is installed in ${HOME}. Note that this breaks when enabling apparmor in the included
+# chromium-common.profile _without_ uncommenting the relevant rule in your
+# /etc/apparmor.d/local/firejail-default.
 ignore noexec ${HOME}
 
 noblacklist ${HOME}/.cache/BraveSoftware

--- a/etc/profile-a-l/brave.profile
+++ b/etc/profile-a-l/brave.profile
@@ -8,9 +8,10 @@ include globals.local
 
 # noexec /tmp is included in chromium-common.profile and breaks Brave
 ignore noexec /tmp
-# TOR is installed in ${HOME}. Note that this breaks when enabling apparmor in the included
-# chromium-common.profile _without_ uncommenting the relevant rule in your
-# /etc/apparmor.d/local/firejail-default.
+# TOR is installed in ${HOME}.
+# NOTE: chromium-common.profile enables apparmor. To keep that intact
+# you will need to uncomment the 'brave + tor' rule in /etc/apparmor.d/local/firejail-default.
+# Alternatively you can add 'ignore apparmor' to your brave.local.
 ignore noexec ${HOME}
 
 noblacklist ${HOME}/.cache/BraveSoftware

--- a/etc/profile-a-l/chromium-common.profile
+++ b/etc/profile-a-l/chromium-common.profile
@@ -36,11 +36,7 @@ include whitelist-var-common.inc
 # Add the next line to your chromium-common.local to allow screen sharing under wayland.
 #whitelist ${RUNUSER}/pipewire-0
 
-# AppArmor breaks brave's native Tor support, which is installed under ${HOME}.
-# Add 'apparmor' to your chromium-common.local to enable AppArmor support.
-# IMPORTANT: the relevant rule in /etc/apparmor.d/local/firejail-default will need
-# to be uncommented too for this to work as expected.
-#apparmor
+apparmor
 caps.keep sys_admin,sys_chroot
 netfilter
 nodvd

--- a/etc/profile-a-l/chromium-common.profile
+++ b/etc/profile-a-l/chromium-common.profile
@@ -36,7 +36,11 @@ include whitelist-var-common.inc
 # Add the next line to your chromium-common.local to allow screen sharing under wayland.
 #whitelist ${RUNUSER}/pipewire-0
 
-apparmor
+# AppArmor breaks brave's native Tor support, which is installed under ${HOME}.
+# Add 'apparmor' to your chromium-common.local to enable AppArmor support.
+# IMPORTANT: the relevant rule in /etc/apparmor.d/local/firejail-default will need
+# to be uncommented too for this to work as expected.
+#apparmor
 caps.keep sys_admin,sys_chroot
 netfilter
 nodvd


### PR DESCRIPTION
Fixes #4190. Instead of dropping apparmor here, it's better to add a comment directly into brave.profile. This keeps other apps including in chromium-common.profile. As the latter is included by profiles other than brave, this might not be the most elegant way to handle this. Open to suggestions!
UPDATE: changed the fix by adding instructions on how to opt-in to brave + tor into brave.profile. No need to affect all of the other apps that include chromium-common.profile.