### PR TITLE
man: corrections regarding --private-FOO options

### DIFF
--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -295,7 +295,9 @@ Use the options no3d, nodvd, nosound, notv, nou2f and novideo for additional res
 Build a new /etc in a temporary
 filesystem, and copy the files and directories in the list.
 The files and directories in the list must be expressed as relative to
-the /etc directory.
+the /etc directory, and must not contain the / character
+(e.g., /etc/foo must be expressed as foo, but /etc/foo/bar --
+expressed as foo/bar -- is disallowed).
 All modifications are discarded when the sandbox is closed.
 #ifdef HAVE_PRIVATE_HOME
 .TP
@@ -319,14 +321,18 @@ This feature is still under development, see \fBman 1 firejail\fR for some examp
 Build a new /opt in a temporary
 filesystem, and copy the files and directories in the list.
 The files and directories in the list must be expressed as relative to
-the /opt directory.
+the /opt directory, and must not contain the / character
+(e.g., /opt/foo must be expressed as foo, but /opt/foo/bar --
+expressed as foo/bar -- is disallowed).
 All modifications are discarded when the sandbox is closed.
 .TP
 \fBprivate-srv file,directory
 Build a new /srv in a temporary
 filesystem, and copy the files and directories in the list.
 The files and directories in the list must be expressed as relative to
-the /srv directory.
+the /srv directory, and must not contain the / character
+(e.g., /srv/foo must be expressed as foo, but /srv/foo/bar --
+expressed as foo/bar -- is disallowed).
 All modifications are discarded when the sandbox is closed.
 .TP
 \fBprivate-tmp

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -1883,7 +1883,9 @@ $
 Build a new /etc in a temporary
 filesystem, and copy the files and directories in the list.
 The files and directories in the list must be expressed as relative to
-the /etc directory.
+the /etc directory, and must not contain the / character
+(e.g., /etc/foo must be expressed as foo, but /etc/foo/bar --
+expressed as foo/bar -- is disallowed).
 If no listed file is found, /etc directory will be empty.
 All modifications are discarded when the sandbox is closed.
 .br
@@ -1893,7 +1895,7 @@ Example:
 .br
 $ firejail --private-etc=group,hostname,localtime, \\
 .br
-nsswitch.conf,passwd,resolv.conf,default/motd-news
+nsswitch.conf,passwd,resolv.conf
 #ifdef HAVE_PRIVATE_HOME
 .TP
 \fB\-\-private-home=file,directory
@@ -1968,7 +1970,9 @@ $
 Build a new /opt in a temporary
 filesystem, and copy the files and directories in the list.
 The files and directories in the list must be expressed as relative to
-the /opt directory.
+the /opt directory, and must not contain the / character
+(e.g., /opt/foo must be expressed as foo, but /opt/foo/bar --
+expressed as foo/bar -- is disallowed).
 If no listed file is found, /opt directory will be empty.
 All modifications are discarded when the sandbox is closed.
 .br
@@ -1983,7 +1987,9 @@ $ firejail --private-opt=firefox /opt/firefox/firefox
 Build a new /srv in a temporary
 filesystem, and copy the files and directories in the list.
 The files and directories in the list must be expressed as relative to
-the /srv directory.
+the /srv directory, and must not contain the / character
+(e.g., /opt/srv must be expressed as foo, but /srv/foo/bar --
+expressed as srv/bar -- is disallowed).
 If no listed file is found, /srv directory will be empty.
 All modifications are discarded when the sandbox is closed.
 .br


### PR DESCRIPTION
Commit 0.9.60-1070-g40d3604f (40d3604f) updated the man pages with respect to
--private-opt, --private-etc, and --private-srv.  It was made after
testing firejail 0.9.52 (from Ubuntu 18.04).  However, it
unfortunately did not accurately reflect the the behavior of the
current HEAD at the time, because commit 0.9.56-rc1-14-ga9242301 (a9242301) had
previously slightly changed the behavior of these three options (after
0.9.52), and was released in 0.9.56.  The man pages changes made in
commit 40d3604f were therefore not entirely correct.

This commit updates the man pages to describe the behavior as
implemented in a9242301 (and is still the behavior as of the current
HEAD: 0.9.64-737-g937815ba (937815ba)).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>