### PR TITLE
[WIP] refactor vivaldi profiles

### DIFF
--- a/etc/profile-m-z/vivaldi-snapshot.profile
+++ b/etc/profile-m-z/vivaldi-snapshot.profile
@@ -3,5 +3,17 @@
 # Persistent local customizations
 include vivaldi-snapshot.local
 
+noblacklist ${HOME}/.cache/vivaldi-snapshot
+noblacklist ${HOME}/.config/vivaldi-snapshot
+
+mkdir ${HOME}/.cache/vivaldi-snapshot
+mkdir ${HOME}/.config/vivaldi-snapshot
+whitelist ${HOME}/.cache/vivaldi-snapshot
+whitelist ${HOME}/.config/vivaldi-snapshot
+
+# Add the next line to your vivaldi-snapshot.local to enable private-bin.
+# Note: this first needs to be enabled in vivaldi.local too.
+#private-bin vivaldi-snapshot
+
 # Redirect
 include vivaldi.profile

--- a/etc/profile-m-z/vivaldi-stable.profile
+++ b/etc/profile-m-z/vivaldi-stable.profile
@@ -3,5 +3,9 @@
 # Persistent local customizations
 include vivaldi-stable.local
 
+# Add the next line to your vivaldi-stable.local to enable private-bin.
+# Note: this first needs to be enabled in your vivaldi.local too.
+#private-bin vivaldi-stable
+
 # Redirect
 include vivaldi.profile

--- a/etc/profile-m-z/vivaldi.profile
+++ b/etc/profile-m-z/vivaldi.profile
@@ -13,25 +13,20 @@ whitelist /var/opt/vivaldi
 writable-var
 
 noblacklist ${HOME}/.cache/vivaldi
-noblacklist ${HOME}/.cache/vivaldi-snapshot
 noblacklist ${HOME}/.config/vivaldi
-noblacklist ${HOME}/.config/vivaldi-snapshot
 noblacklist ${HOME}/.local/lib/vivaldi
 
 mkdir ${HOME}/.cache/vivaldi
-mkdir ${HOME}/.cache/vivaldi-snapshot
 mkdir ${HOME}/.config/vivaldi
-mkdir ${HOME}/.config/vivaldi-snapshot
 mkdir ${HOME}/.local/lib/vivaldi
 whitelist ${HOME}/.cache/vivaldi
-whitelist ${HOME}/.cache/vivaldi-snapshot
 whitelist ${HOME}/.config/vivaldi
-whitelist ${HOME}/.config/vivaldi-snapshot
 whitelist ${HOME}/.local/lib/vivaldi
 
-#private-bin bash,cat,dirname,readlink,rm,vivaldi,vivaldi-stable,vivaldi-snapshot
+# Add the next line to your vivaldi.local to activate private-bin
+#private-bin bash,cat,dirname,readlink,rm,vivaldi
 
-# breaks vivaldi sync
+# vivaldi sync needs full D-Bus access
 ignore dbus-user none
 ignore dbus-system none
 

--- a/etc/profile-m-z/vivaldi.profile
+++ b/etc/profile-m-z/vivaldi.profile
@@ -23,7 +23,7 @@ whitelist ${HOME}/.cache/vivaldi
 whitelist ${HOME}/.config/vivaldi
 whitelist ${HOME}/.local/lib/vivaldi
 
-# Add the next line to your vivaldi.local to activate private-bin
+# Add the next line to your vivaldi.local to enable private-bin.
 #private-bin bash,cat,dirname,readlink,rm,vivaldi
 
 # vivaldi sync needs full D-Bus access


### PR DESCRIPTION
Minor changes to avoid creating unneeded directories and files depending on the specific vivaldi setup.

IMO we can harden the vivaldi profiles a bit more:
- keep apparmor intact and add an opt-in rule to /etc/apparmor.d/local/firejail-default (cfr. brave and torbrowser-launcher);
- put some of the DRM-related options (see snippet below) behind a `?BROWSER_ALLOW_DRM:` conditional (like we do in other web browser profiles).

I've only recently started to experiment with Vivaldi, so I might overlook something. Any opinions/suggestions on this are very welcome.

```
# Allow HTML5 Proprietary Media & DRM/EME (Widevine)
ignore apparmor
ignore noexec /var
noblacklist /var/opt
whitelist /var/opt/vivaldi
writable-var
```