### PR TITLE
Map /dev/input with "--private-dev", add "--no-input" option to disable it

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -339,7 +339,8 @@ extern int arg_noprofile;	// use default.profile if none other found/specified
 extern int arg_memory_deny_write_execute;	// block writable and executable memory
 extern int arg_notv;	// --notv
 extern int arg_nodvd;	// --nodvd
-extern int arg_nou2f;   // --nou2f
+extern int arg_nou2f;	// --nou2f
+extern int arg_noinput;	// --noinput
 extern int arg_deterministic_exit_code;	// always exit with first child's exit status
 
 typedef enum {
@@ -569,6 +570,7 @@ void fs_dev_disable_video(void);
 void fs_dev_disable_tv(void);
 void fs_dev_disable_dvd(void);
 void fs_dev_disable_u2f(void);
+void fs_dev_disable_input(void);
 
 // fs_home.c
 // private mode (--private)

--- a/src/firejail/fs_dev.c
+++ b/src/firejail/fs_dev.c
@@ -41,6 +41,7 @@ typedef enum {
 	DEV_TV,
 	DEV_DVD,
 	DEV_U2F,
+	DEV_INPUT
 } DEV_TYPE;
 
 
@@ -89,6 +90,7 @@ static DevEntry dev[] = {
 	{"/dev/hidraw8", RUN_DEV_DIR "/hidraw8", DEV_U2F},
 	{"/dev/hidraw9", RUN_DEV_DIR "/hidraw9", DEV_U2F},
 	{"/dev/usb", RUN_DEV_DIR "/usb", DEV_U2F},	// USB devices such as Yubikey, U2F
+	{"/dev/input", RUN_DEV_DIR "/input", DEV_INPUT},
 	{NULL, NULL, DEV_NONE}
 };
 
@@ -103,7 +105,8 @@ static void deventry_mount(void) {
 			    (dev[i].type == DEV_VIDEO && arg_novideo == 0) ||
 			    (dev[i].type == DEV_TV && arg_notv == 0) ||
 			    (dev[i].type == DEV_DVD && arg_nodvd == 0) ||
-			    (dev[i].type == DEV_U2F && arg_nou2f == 0)) {
+			    (dev[i].type == DEV_U2F && arg_nou2f == 0) ||
+			    (dev[i].type == DEV_INPUT && arg_noinput == 0)) {
 
 				int dir = is_dir(dev[i].run_fname);
 				if (arg_debug)
@@ -382,6 +385,15 @@ void fs_dev_disable_u2f(void) {
 	int i = 0;
 	while (dev[i].dev_fname != NULL) {
 		if (dev[i].type == DEV_U2F)
+			disable_file_or_dir(dev[i].dev_fname);
+		i++;
+	}
+}
+
+void fs_dev_disable_input(void) {
+	int i = 0;
+	while (dev[i].dev_fname != NULL) {
+		if (dev[i].type == DEV_INPUT)
 			disable_file_or_dir(dev[i].dev_fname);
 		i++;
 	}

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -143,6 +143,7 @@ int arg_memory_deny_write_execute = 0;		// block writable and executable memory
 int arg_notv = 0;	// --notv
 int arg_nodvd = 0; // --nodvd
 int arg_nou2f = 0; // --nou2f
+int arg_noinput = 0; // --noinput
 int arg_deterministic_exit_code = 0;	// always exit with first child's exit status
 DbusPolicy arg_dbus_user = DBUS_POLICY_ALLOW;	// --dbus-user
 DbusPolicy arg_dbus_system = DBUS_POLICY_ALLOW;	// --dbus-system
@@ -2086,6 +2087,8 @@ int main(int argc, char **argv, char **envp) {
 			arg_nodvd = 1;
 		else if (strcmp(argv[i], "--nou2f") == 0)
 			arg_nou2f = 1;
+		else if (strcmp(argv[i], "--noinput") == 0)
+			arg_noinput = 1;
 		else if (strcmp(argv[i], "--nodbus") == 0) {
 			arg_dbus_user = DBUS_POLICY_BLOCK;
 			arg_dbus_system = DBUS_POLICY_BLOCK;

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -442,6 +442,10 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		arg_no3d = 1;
 		return 0;
 	}
+	else if (strcmp(ptr, "noinput") == 0) {
+		arg_noinput = 1;
+		return 0;
+	}
 	else if (strcmp(ptr, "nodbus") == 0) {
 #ifdef HAVE_DBUSPROXY
 		arg_dbus_user = DBUS_POLICY_BLOCK;

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -1033,6 +1033,9 @@ int sandbox(void* sandbox_arg) {
 	if (arg_novideo)
 		fs_dev_disable_video();
 
+	if (arg_noinput)
+		fs_dev_disable_input();
+
 	//****************************
 	// set dns
 	//****************************

--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -668,6 +668,9 @@ Disable U2F devices.
 \fBnovideo
 Disable video capture devices.
 .TP
+\fBnoinput
+Disable input devices.
+.TP
 \fBshell none
 Run the program directly, without a shell.
 

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -1515,6 +1515,15 @@ Example:
 .br
 $ firejail \-\-nodvd
 .TP
+\fB\-\-noinput
+Disable input devices.
+.br
+
+.br
+Example:
+.br
+$ firejail \-\-noinput
+.TP
 \fB\-\-noexec=dirname_or_filename
 Remount directory or file noexec, nodev and nosuid. File globbing is supported, see \fBFILE GLOBBING\fR section for more details.
 .br


### PR DESCRIPTION
Fixes #2203.

---

By default only joystick devices (`/dev/input/js*`) can be accessed.
At least, that's the case on Debian: the other entries have more restrictive permissions.
The original owner and group are `root` and `input`, respectively.
However, until we have granular input control options, allowing access to joysticks only is better than nothing.

```bash
$ ls -l /dev
total 0
lrwxrwxrwx  1 nobody nogroup      8 23 apr 07.22 cdrom -> /dev/sr0
lrwxrwxrwx  1 nobody nogroup      8 23 apr 07.22 cdrw -> /dev/sr0
drwxr-xr-x  3 nobody nogroup    100 22 apr 19.18 dri
lrwxrwxrwx  1 nobody nogroup      8 23 apr 07.22 dvd -> /dev/sr0
lrwxrwxrwx  1 nobody nogroup      8 23 apr 07.22 dvdrw -> /dev/sr0
lrwxrwxrwx  1 nobody nogroup     13 23 apr 07.22 fd -> /proc/self/fd
crw-rw-rw-  1 nobody nogroup   1, 7 23 apr 07.22 full
crw-rw----+ 1 nobody nogroup 244, 0 22 apr 19.18 hidraw0
crw-rw----+ 1 nobody nogroup 244, 1 22 apr 19.18 hidraw1
crw-rw----+ 1 nobody nogroup 244, 2 22 apr 19.18 hidraw2
crw-rw----+ 1 nobody nogroup 244, 3 22 apr 19.18 hidraw3
crw-rw----+ 1 nobody nogroup 244, 4 22 apr 19.18 hidraw4
crw-rw----+ 1 nobody nogroup 244, 5 22 apr 19.18 hidraw5
drwxr-xr-x  4 nobody nogroup    760 23 apr 07.22 input
srw-rw-rw-  1 nobody nogroup      0 22 apr 19.18 log
crw-rw-rw-  1 nobody nogroup   1, 3 23 apr 07.22 null
lrwxrwxrwx  1 nobody nogroup     13 23 apr 07.22 ptmx -> /dev/pts/ptmx
drwxr-xr-x  2 nobody nogroup      0 23 apr 07.22 pts
crw-rw-rw-  1 nobody nogroup   1, 8 23 apr 07.22 random
drwxrwxrwt  2 nobody nogroup     40 23 apr 07.22 shm
drwxr-xr-x  4 nobody nogroup    500 22 apr 19.18 snd
brw-rw----+ 1 nobody nogroup  11, 0 23 apr 00.24 sr0
lrwxrwxrwx  1 nobody nogroup     15 23 apr 07.22 stderr -> /proc/self/fd/2
lrwxrwxrwx  1 nobody nogroup     15 23 apr 07.22 stdin -> /proc/self/fd/0
lrwxrwxrwx  1 nobody nogroup     15 23 apr 07.22 stdout -> /proc/self/fd/1
crw-rw-rw-  1 nobody nogroup   5, 0 23 apr 07.22 tty
crw-rw-rw-  1 nobody nogroup   1, 9 23 apr 07.22 urandom
drwxr-xr-x  2 nobody nogroup    120 22 apr 19.18 usb
crw-rw----+ 1 nobody video    81, 0 22 apr 19.18 video0
crw-rw----+ 1 nobody video    81, 1 22 apr 19.18 video1
crw-rw----+ 1 nobody video    81, 2 22 apr 19.18 video2
crw-rw----+ 1 nobody video    81, 3 22 apr 19.18 video3
crw-rw-rw-  1 nobody nogroup   1, 5 23 apr 07.22 zero
```
```bash
$ ls -l /dev/input
total 0
drwxr-xr-x  2 nobody nogroup    280 23 apr 07.22 by-id
drwxr-xr-x  2 nobody nogroup    300 23 apr 07.22 by-path
crw-rw----  1 nobody nogroup 13, 64 22 apr 19.18 event0
crw-rw----  1 nobody nogroup 13, 65 22 apr 19.18 event1
crw-rw----  1 nobody nogroup 13, 74 22 apr 19.18 event10
crw-rw----  1 nobody nogroup 13, 75 22 apr 19.18 event11
crw-rw----  1 nobody nogroup 13, 76 22 apr 19.18 event12
crw-rw----  1 nobody nogroup 13, 77 22 apr 19.18 event13
crw-rw----  1 nobody nogroup 13, 78 22 apr 19.18 event14
crw-rw----  1 nobody nogroup 13, 79 22 apr 19.18 event15
crw-rw----  1 nobody nogroup 13, 80 22 apr 19.18 event16
crw-rw----  1 nobody nogroup 13, 81 22 apr 19.18 event17
crw-rw----  1 nobody nogroup 13, 82 22 apr 19.18 event18
crw-rw----  1 nobody nogroup 13, 83 22 apr 19.18 event19
crw-rw----  1 nobody nogroup 13, 66 22 apr 19.18 event2
crw-rw----  1 nobody nogroup 13, 84 22 apr 19.18 event20
crw-rw----  1 nobody nogroup 13, 85 22 apr 19.18 event21
crw-rw----  1 nobody nogroup 13, 86 22 apr 19.18 event22
crw-rw----  1 nobody nogroup 13, 87 22 apr 19.18 event23
crw-rw----  1 nobody nogroup 13, 88 22 apr 19.18 event24
crw-rw----  1 nobody nogroup 13, 89 22 apr 19.18 event25
crw-rw----  1 nobody nogroup 13, 90 22 apr 19.18 event26
crw-rw----  1 nobody nogroup 13, 91 22 apr 19.18 event27
crw-rw----+ 1 nobody nogroup 13, 92 23 apr 07.22 event28
crw-rw----  1 nobody nogroup 13, 67 22 apr 19.18 event3
crw-rw----  1 nobody nogroup 13, 68 22 apr 19.18 event4
crw-rw----  1 nobody nogroup 13, 69 22 apr 19.18 event5
crw-rw----  1 nobody nogroup 13, 70 22 apr 19.18 event6
crw-rw----  1 nobody nogroup 13, 71 22 apr 19.18 event7
crw-rw----  1 nobody nogroup 13, 72 22 apr 19.18 event8
crw-rw----  1 nobody nogroup 13, 73 22 apr 19.18 event9
crw-rw-r--  1 nobody nogroup 13,  0 22 apr 19.18 js0
crw-rw-r--+ 1 nobody nogroup 13,  1 23 apr 07.22 js1
crw-rw----  1 nobody nogroup 13, 63 22 apr 19.18 mice
crw-rw----  1 nobody nogroup 13, 32 22 apr 19.18 mouse0
crw-rw----  1 nobody nogroup 13, 33 22 apr 19.18 mouse1
```
```bash
$ ls -l /dev/input/by-id
total 0
lrwxrwxrwx 1 nobody nogroup  9 22 apr 19.18 usb-BY_Tech_Usb-event-if01 -> ../event9
lrwxrwxrwx 1 nobody nogroup  9 22 apr 19.18 usb-BY_Tech_Usb-event-kbd -> ../event8
lrwxrwxrwx 1 nobody nogroup 10 22 apr 19.18 usb-BY_Tech_Usb-if01-event-kbd -> ../event11
lrwxrwxrwx 1 nobody nogroup 10 22 apr 19.18 usb-BY_Tech_Usb-if01-event-mouse -> ../event12
lrwxrwxrwx 1 nobody nogroup  9 22 apr 19.18 usb-BY_Tech_Usb-if01-mouse -> ../mouse1
lrwxrwxrwx 1 nobody nogroup  9 22 apr 19.18 usb-SOAI_USB_Gaming_Mouse-event-if01 -> ../event5
lrwxrwxrwx 1 nobody nogroup  9 22 apr 19.18 usb-SOAI_USB_Gaming_Mouse-event-mouse -> ../event2
lrwxrwxrwx 1 nobody nogroup  9 22 apr 19.18 usb-SOAI_USB_Gaming_Mouse-if01-event-kbd -> ../event3
lrwxrwxrwx 1 nobody nogroup  9 22 apr 19.18 usb-SOAI_USB_Gaming_Mouse-mouse -> ../mouse0
lrwxrwxrwx 1 nobody nogroup 10 22 apr 19.18 usb-Sonix_Technology_Co.__Ltd._H264_USB_Camera_SN0001-event-if00 -> ../event27
lrwxrwxrwx 1 nobody nogroup 10 23 apr 07.22 usb-ZEROPLUS_Controller_3136303033313032354246323543-event-joystick -> ../event28
lrwxrwxrwx 1 nobody nogroup  6 23 apr 07.22 usb-ZEROPLUS_Controller_3136303033313032354246323543-joystick -> ../js1
```
```bash
$ ls -l /dev/input/by-path
total 0
lrwxrwxrwx 1 nobody nogroup 10 23 apr 07.22 pci-0000:05:00.1-usb-0:6.1:1.0-event-joystick -> ../event28
lrwxrwxrwx 1 nobody nogroup  6 23 apr 07.22 pci-0000:05:00.1-usb-0:6.1:1.0-joystick -> ../js1
lrwxrwxrwx 1 nobody nogroup  9 22 apr 19.18 pci-0000:05:00.3-usb-0:6.3:1.0-event-mouse -> ../event2
lrwxrwxrwx 1 nobody nogroup  9 22 apr 19.18 pci-0000:05:00.3-usb-0:6.3:1.0-mouse -> ../mouse0
lrwxrwxrwx 1 nobody nogroup  9 22 apr 19.18 pci-0000:05:00.3-usb-0:6.3:1.1-event -> ../event5
lrwxrwxrwx 1 nobody nogroup  9 22 apr 19.18 pci-0000:05:00.3-usb-0:6.3:1.1-event-kbd -> ../event3
lrwxrwxrwx 1 nobody nogroup  9 22 apr 19.18 pci-0000:05:00.3-usb-0:6.4:1.0-event-kbd -> ../event8
lrwxrwxrwx 1 nobody nogroup  9 22 apr 19.18 pci-0000:05:00.3-usb-0:6.4:1.1-event -> ../event9
lrwxrwxrwx 1 nobody nogroup 10 22 apr 19.18 pci-0000:05:00.3-usb-0:6.4:1.1-event-kbd -> ../event11
lrwxrwxrwx 1 nobody nogroup 10 22 apr 19.18 pci-0000:05:00.3-usb-0:6.4:1.1-event-mouse -> ../event12
lrwxrwxrwx 1 nobody nogroup  9 22 apr 19.18 pci-0000:05:00.3-usb-0:6.4:1.1-mouse -> ../mouse1
lrwxrwxrwx 1 nobody nogroup 10 22 apr 19.18 pci-0000:0c:00.3-usb-0:4:1.0-event -> ../event27
lrwxrwxrwx 1 nobody nogroup 10 22 apr 19.18 platform-pcspkr-event-spkr -> ../event13
```