### PR TITLE
steam.profile: fix rogue legacy paths and syntax

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -138,6 +138,7 @@ blacklist ${HOME}/.config/Rambox
 blacklist ${HOME}/.config/Riot
 blacklist ${HOME}/.config/Rocket.Chat
 blacklist ${HOME}/.config/RogueLegacy
+blacklist ${HOME}/.config/RogueLegacyStorageContainer
 blacklist ${HOME}/.config/Signal
 blacklist ${HOME}/.config/Sinew Software Systems
 blacklist ${HOME}/.config/Slack
@@ -612,7 +613,8 @@ blacklist ${HOME}/.local/share/QGIS
 blacklist ${HOME}/.local/share/QMediathekView
 blacklist ${HOME}/.local/share/QuiteRss
 blacklist ${HOME}/.local/share/Ricochet
-blacklist ${HOME}/.local/share/RogueLegacy*
+blacklist ${HOME}/.local/share/RogueLegacy
+blacklist ${HOME}/.local/share/RogueLegacyStorageContainer
 blacklist ${HOME}/.local/share/Shortwave
 blacklist ${HOME}/.local/share/Steam
 blacklist ${HOME}/.local/share/SteamWorldDig

--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -10,6 +10,7 @@ noblacklist ${HOME}/.config/Epic
 noblacklist ${HOME}/.config/Loop_Hero
 noblacklist ${HOME}/.config/ModTheSpire
 noblacklist ${HOME}/.config/RogueLegacy
+noblacklist ${HOME}/.config/RogueLegacyStorageContainer
 noblacklist ${HOME}/.killingfloor
 noblacklist ${HOME}/.klei
 noblacklist ${HOME}/.local/share/3909/PapersPlease
@@ -22,7 +23,8 @@ noblacklist ${HOME}/.local/share/feral-interactive
 noblacklist ${HOME}/.local/share/IntoTheBreach
 noblacklist ${HOME}/.local/share/Paradox Interactive
 noblacklist ${HOME}/.local/share/PillarsOfEternity
-noblacklist ${HOME}/.local/share/RogueLegacy*
+noblacklist ${HOME}/.local/share/RogueLegacy
+noblacklist ${HOME}/.local/share/RogueLegacyStorageContainer
 noblacklist ${HOME}/.local/share/Steam
 noblacklist ${HOME}/.local/share/SteamWorldDig
 noblacklist ${HOME}/.local/share/SteamWorld Dig 2
@@ -69,7 +71,7 @@ mkdir ${HOME}/.local/share/feral-interactive
 mkdir ${HOME}/.local/share/IntoTheBreach
 mkdir ${HOME}/.local/share/Paradox Interactive
 mkdir ${HOME}/.local/share/PillarsOfEternity
-mkdir ${HOME}/.local/share/RogueLegacy*
+mkdir ${HOME}/.local/share/RogueLegacy
 mkdir ${HOME}/.local/share/Steam
 mkdir ${HOME}/.local/share/SteamWorldDig
 mkdir ${HOME}/.local/share/SteamWorld Dig 2
@@ -86,6 +88,7 @@ whitelist ${HOME}/.config/Epic
 whitelist ${HOME}/.config/Loop_Hero
 whitelist ${HOME}/.config/ModTheSpire
 whitelist ${HOME}/.config/RogueLegacy
+whitelist ${HOME}/.config/RogueLegacyStorageContainer
 whitelist ${HOME}/.config/unity3d
 whitelist ${HOME}/.killingfloor
 whitelist ${HOME}/.klei
@@ -99,7 +102,8 @@ whitelist ${HOME}/.local/share/feral-interactive
 whitelist ${HOME}/.local/share/IntoTheBreach
 whitelist ${HOME}/.local/share/Paradox Interactive
 whitelist ${HOME}/.local/share/PillarsOfEternity
-whitelist ${HOME}/.local/share/RogueLegacy*
+whitelist ${HOME}/.local/share/RogueLegacy
+whitelist ${HOME}/.local/share/RogueLegacyStorageContainer
 whitelist ${HOME}/.local/share/Steam
 whitelist ${HOME}/.local/share/SteamWorldDig
 whitelist ${HOME}/.local/share/SteamWorld Dig 2
@@ -114,6 +118,14 @@ whitelist ${HOME}/.steampath
 whitelist ${HOME}/.steampid
 include whitelist-common.inc
 include whitelist-var-common.inc
+
+# Note: The following were intentionally left out as they are alternative
+# (i.e.: unnecessary and/or legacy) paths whose existence may potentially
+# clobber other paths (see #4225).  If you use any, either add the entry to
+# steam.local or move the contents to a path listed above (or open an issue if
+# it's missing above).
+#mkdir ${HOME}/.config/RogueLegacyStorageContainer
+#mkdir ${HOME}/.local/share/RogueLegacyStorageContainer
 
 caps.drop all
 #ipc-namespace


### PR DESCRIPTION
Due to using globbing on mkdir, the current version causes this:

@davidebeatrici commented on 2021-04-23[1]:

> ```
> Error: "${HOME}/.local/share/RogueLegacy*" is an invalid filename: rejected character: "*"
> ```

Added on commit a603d4d ("steam: some more games added") / PR #4170.

The wildcard was used because Rogue Legacy apparently looks up multiple
different paths for the config and also for the data[1][2][3]:

1. ~/.config/RogueLegacy
2. ~/.config/RogueLegacyStorageContainer
3. ~/.local/share/RogueLegacy
4. ~/.local/share/RogueLegacyStorageContainer

The ones containing "RogueLegacyStorageContainer" appear to be legacy
paths (i.e.: paths which are only created by older versions of Rogue
Legacy)[2].

So replace all globs with the full paths because:

* The paths are known a priori (unlike, say, `/var/lib/libpcre*`)
* There aren't too many of them

And use only the non-legacy paths on mkdir.  Besides mirroring what the
current version of Rogue Legacy does (and avoiding the creation of
unnecessary dirs), this is also done because _if_ the following applies
(i.e.: this was not tested):

* legacy paths take precedence over non-legacy paths
* the first path clobbers the other ones (i.e.: rather than "merge")
* save data exists in a non-legacy path (i.e.: path 3 in this case)
* firejail creates all 4 paths

Then it would make the newly-created and empty path 4 clobber the
non-legacy path 3 and thus make it seem like no save files exist.  This
would persist even if steam is run without firejail afterwards, as the
empty directory would still be there.  Losing (or appearing to lose)
game saves can be very unfortunate, so create just the non-legacy paths
to avoid confusion.

[1] #4170 (comment)
[2] https://steamcommunity.com/app/241600/discussions/1/846957366713233279/
[3] https://www.pcgamingwiki.com/wiki/Rogue_Legacy#Game_data

---

Original message below (for the thread to make sense):

---

steam.profile: remove rogue legacy to fix syntax

Remove the mkdir with globbing, which causes this:

@davidebeatrici commented on 2021-04-23[1]:

> ```
> Error: "${HOME}/.local/share/RogueLegacy*" is an invalid filename: rejected character: "*"
> ```

Added on commit bd7ad371e ("steam: also added paths to
disable-programs.inc") / PR #4170.

The wildcard was used because Rogue Legacy apparently looks up multiple
different paths for the config and also for the data[1][2][3]:

1. ~/.config/RogueLegacy
2. ~/.config/RogueLegacyStorageContainer
3. ~/.local/share/RogueLegacy
4. ~/.local/share/RogueLegacyStorageContainer

The ones containing "RogueLegacyStorageContainer" appear to be legacy
paths (i.e.: paths which are only created by older Rogue Legacy
versions)[2].  So _if_ the following applies (i.e.: it was not tested):

* legacy paths take precedence over non-legacy paths
* the first path clobbers the other ones (i.e.: rather than "merge")
* save data exists in a non-legacy path (i.e.: path 3 in this case)
* firejail creates all 4 paths (as whitelisting requires existing paths)

Then it would make the newly-created and empty path 4 clobber the
non-legacy path 3 and thus make it seem like no save files exist.  This
would persist even if steam is run without firejail afterwards, as the
empty directory would still be there.  Losing (or appearing to lose)
game saves can be very unfortunate, so just ignore all the Rogue Legacy
paths for now to avoid confusion.

Note: This is a problem whenever a program supports multiple clobbering
paths and mkdir/mkfile + whitelisting is involved.

[1] https://github.com/netblue30/firejail/pull/4170#issuecomment-825405930
[2] https://steamcommunity.com/app/241600/discussions/1/846957366713233279/
[3] https://www.pcgamingwiki.com/wiki/Rogue_Legacy#Game_data
