### PR TITLE
New profile for neochat

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -106,6 +106,7 @@ blacklist ${HOME}/.config/Gpredict
 blacklist ${HOME}/.config/INRIA
 blacklist ${HOME}/.config/InSilmaril
 blacklist ${HOME}/.config/Jitsi Meet
+blacklist ${HOME}/.config/KDE/neochat
 blacklist ${HOME}/.config/Kid3
 blacklist ${HOME}/.config/Kingsoft
 blacklist ${HOME}/.config/Loop_Hero
@@ -341,6 +342,8 @@ blacklist ${HOME}/.config/mypaint
 blacklist ${HOME}/.config/nano
 blacklist ${HOME}/.config/nautilus
 blacklist ${HOME}/.config/nemo
+blacklist ${HOME}/.config/neochatrc
+blacklist ${HOME}/.config/neochat.notifyrc
 blacklist ${HOME}/.config/neomutt
 blacklist ${HOME}/.config/netsurf
 blacklist ${HOME}/.config/newsbeuter
@@ -600,6 +603,7 @@ blacklist ${HOME}/.local/share/Empathy
 blacklist ${HOME}/.local/share/Enpass
 blacklist ${HOME}/.local/share/Flavio Tordini
 blacklist ${HOME}/.local/share/JetBrains
+blacklist ${HOME}/.local/share/KDE/neochat
 blacklist ${HOME}/.local/share/Kingsoft
 blacklist ${HOME}/.local/share/Mendeley Ltd.
 blacklist ${HOME}/.local/share/Mumble

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -995,6 +995,7 @@ blacklist ${HOME}/.cache/inkscape
 blacklist ${HOME}/.cache/inox
 blacklist ${HOME}/.cache/iridium
 blacklist ${HOME}/.cache/kcmshell5
+blacklist ${HOME}/.cache/KDE/neochat
 blacklist ${HOME}/.cache/kdenlive
 blacklist ${HOME}/.cache/keepassxc
 blacklist ${HOME}/.cache/kfind

--- a/etc/inc/whitelist-1793-workaround.inc
+++ b/etc/inc/whitelist-1793-workaround.inc
@@ -1,0 +1,26 @@
+# This file is overwritten during software install.
+# Persistent customizations should go in a .local file.
+include allow-nodejs.local
+# This works around bug 1793, and allows whitelisting to be used for some KDE applications.
+
+whitelist ${HOME}/.config/ibus
+whitelist ${HOME}/.config/mimeapps.list
+whitelist ${HOME}/.config/pkcs11
+read-only ${HOME}/.config/pkcs11
+whitelist ${HOME}/.config/user-dirs.dirs
+read-only ${HOME}/.config/user-dirs.dirs
+whitelist ${HOME}/.config/user-dirs.locale
+read-only ${HOME}/.config/user-dirs.locale
+whitelist ${HOME}/.config/fontconfig
+whitelist ${HOME}/.config/Kvantum
+whitelist ${HOME}/.config/Trolltech.conf
+whitelist ${HOME}/.config/QtProject.conf
+whitelist ${HOME}/.config/kdeglobals
+whitelist ${HOME}/.config/kio_httprc
+whitelist ${HOME}/.config/kioslaverc
+whitelist ${HOME}/.config/ksslcablacklist
+whitelist ${HOME}/.config/qt5ct
+whitelist ${HOME}/.config/qtcurve
+
+blacklist ${HOME}/.config/*
+whitelist ${HOME}/.config

--- a/etc/inc/whitelist-1793-workaround.inc
+++ b/etc/inc/whitelist-1793-workaround.inc
@@ -3,24 +3,27 @@
 include allow-nodejs.local
 # This works around bug 1793, and allows whitelisting to be used for some KDE applications.
 
-whitelist ${HOME}/.config/ibus
-whitelist ${HOME}/.config/mimeapps.list
-whitelist ${HOME}/.config/pkcs11
-read-only ${HOME}/.config/pkcs11
-whitelist ${HOME}/.config/user-dirs.dirs
-read-only ${HOME}/.config/user-dirs.dirs
-whitelist ${HOME}/.config/user-dirs.locale
-read-only ${HOME}/.config/user-dirs.locale
-whitelist ${HOME}/.config/fontconfig
-whitelist ${HOME}/.config/Kvantum
-whitelist ${HOME}/.config/Trolltech.conf
-whitelist ${HOME}/.config/QtProject.conf
-whitelist ${HOME}/.config/kdeglobals
-whitelist ${HOME}/.config/kio_httprc
-whitelist ${HOME}/.config/kioslaverc
-whitelist ${HOME}/.config/ksslcablacklist
-whitelist ${HOME}/.config/qt5ct
-whitelist ${HOME}/.config/qtcurve
+noblacklist ${HOME}/.config/ibus
+noblacklist ${HOME}/.config/mimeapps.list
+noblacklist ${HOME}/.config/pkcs11
+noblacklist ${HOME}/.config/user-dirs.dirs
+noblacklist ${HOME}/.config/user-dirs.locale
+noblacklist ${HOME}/.config/dconf
+noblacklist ${HOME}/.config/fontconfig
+noblacklist ${HOME}/.config/gtk-2.0
+noblacklist ${HOME}/.config/gtk-3.0
+noblacklist ${HOME}/.config/gtk-4.0
+noblacklist ${HOME}/.config/gtkrc
+noblacklist ${HOME}/.config/gtkrc-2.0
+noblacklist ${HOME}/.config/Kvantum
+noblacklist ${HOME}/.config/Trolltech.conf
+noblacklist ${HOME}/.config/QtProject.conf
+noblacklist ${HOME}/.config/kdeglobals
+noblacklist ${HOME}/.config/kio_httprc
+noblacklist ${HOME}/.config/kioslaverc
+noblacklist ${HOME}/.config/ksslcablacklist
+noblacklist ${HOME}/.config/qt5ct
+noblacklist ${HOME}/.config/qtcurve
 
 blacklist ${HOME}/.config/*
 whitelist ${HOME}/.config

--- a/etc/inc/whitelist-1793-workaround.inc
+++ b/etc/inc/whitelist-1793-workaround.inc
@@ -1,6 +1,6 @@
 # This file is overwritten during software install.
 # Persistent customizations should go in a .local file.
-include allow-nodejs.local
+include whitelist-1793-workaround.local
 # This works around bug 1793, and allows whitelisting to be used for some KDE applications.
 
 noblacklist ${HOME}/.config/ibus

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -63,7 +63,6 @@ dbus-user filter
 dbus-user.own org.kde.neochat
 dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.kde.StatusNotifierWatcher
-dbus-user.talk org.kde.kwalletd5
 dbus-system none
 
 join-or-start neochat

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -61,7 +61,7 @@ disable-mnt
 private-bin neochat
 private-dev
 ##private-etc Common,Networking,GUI,Qt,KDE,D-Bus
-private-etc alternatives,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,mime.types,xdg,ca-certificates,ssl,pki,crypto-policies,nsswitch.conf,resolv.conf,hosts,host.conf,hostname,protocols,services,rpc,fonts,pango,X11,Trolltech.conf,kde4rc,kde5rc,dbus-1,machine-id
+private-etc alternatives,ca-certificates,crypto-policies,dbus-1,fonts,host.conf,hostname,hosts,kde4rc,kde5rc,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,pango,pki,protocols,resolv.conf,rpc,services,ssl,Trolltech.conf,X11,xdg
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -62,11 +62,8 @@ private-bin neochat
 private-dev
 ##private-etc Common,Networking,GUI,Qt,KDE,D-Bus
 private-etc alternatives,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,mime.types,xdg,ca-certificates,ssl,pki,crypto-policies,nsswitch.conf,resolv.conf,hosts,host.conf,hostname,protocols,services,rpc,fonts,pango,X11,Trolltech.conf,kde4rc,kde5rc,dbus-1,machine-id
-##private-lib LIBS
-##private-opt NAME
 private-tmp
 
-## dbus-user permissions copied from the flatpak package
 dbus-user filter
 dbus-user.own org.kde.neochat
 dbus-user.talk org.freedesktop.Notifications

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -62,7 +62,6 @@ private-tmp
 dbus-user filter
 dbus-user.own org.kde.neochat
 dbus-user.talk org.freedesktop.Notifications
-dbus-user.talk com.canonical.AppMenu.Registrar
 dbus-user.talk org.kde.StatusNotifierWatcher
 dbus-user.talk org.kde.kwalletd5
 dbus-system none

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -11,7 +11,6 @@ noblacklist ${HOME}/.config/KDE/neochat
 noblacklist ${HOME}/.config/neochatrc
 noblacklist ${HOME}/.config/neochat.notifyrc
 noblacklist ${HOME}/.local/share/KDE/neochat
-noblacklist ${DOWNLOADS}
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -66,5 +66,3 @@ dbus-user.own org.kde.neochat
 dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.kde.StatusNotifierWatcher
 dbus-system none
-
-join-or-start neochat

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -39,6 +39,7 @@ include whitelist-var-common.inc
 
 apparmor
 caps.drop all
+machine-id
 netfilter
 nodvd
 nogroups

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -7,6 +7,7 @@ include neochat.local
 include globals.local
 
 noblacklist ${HOME}/.cache/KDE/neochat
+noblacklist ${HOME}/.config/KDE
 noblacklist ${HOME}/.config/KDE/neochat
 noblacklist ${HOME}/.config/neochatrc
 noblacklist ${HOME}/.config/neochat.notifyrc
@@ -22,16 +23,11 @@ include disable-shell.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.cache/KDE/neochat
-mkdir ${HOME}/.config/KDE/neochat.conf
 mkdir ${HOME}/.local/share/KDE/neochat
-mkfile ${HOME}/.config/neochatrc
-mkfile ${HOME}/.config/neochat.notifyrc
 whitelist ${HOME}/.cache/KDE/neochat
-whitelist ${HOME}/.config/KDE/neochat.conf
-whitelist ${HOME}/.config/neochatrc
 whitelist ${HOME}/.local/share/KDE/neochat
-whitelist ${HOME}/.config/neochat.notifyrc
 whitelist ${DOWNLOADS}
+include whitelist-1793-workaround.inc
 include whitelist-common.inc
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -1,0 +1,79 @@
+# Firejail profile for neochat
+# Description: Matrix Client
+# This file is overwritten after every install/update
+# Persistent local customizations
+include neochat.local
+# Persistent global definitions
+include globals.local
+
+#TODO: Add these to disable-programs
+noblacklist ${HOME}/.cache/KDE/neochat
+noblacklist ${HOME}/.config/KDE/neochat
+noblacklist ${HOME}/.config/neochatrc
+noblacklist ${HOME}/.config/neochat.notifyrc
+noblacklist ${HOME}/.local/share/KDE/neochat
+noblacklist ${DOWNLOADS}
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
+include disable-shell.inc
+include disable-write-mnt.inc
+include disable-xdg.inc
+
+mkdir ${HOME}/.cache/KDE/neochat
+mkdir ${HOME}/.config/KDE/neochat.conf
+mkdir ${HOME}/.local/share/KDE/neochat
+mkfile ${HOME}/.config/neochatrc
+mkfile ${HOME}/.config/neochat.notifyrc
+
+whitelist ${HOME}/.cache/KDE/neochat
+whitelist ${HOME}/.config/KDE/neochat.conf
+whitelist ${HOME}/.config/neochatrc
+whitelist ${HOME}/.local/share/KDE/neochat
+whitelist ${HOME}/.config/neochat.notifyrc
+whitelist ${DOWNLOADS}
+include whitelist-common.inc
+
+include whitelist-runuser-common.inc
+include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
+
+apparmor
+caps.drop all
+netfilter
+nodvd
+nogroups
+nonewprivs
+noroot
+nosound
+notv
+nou2f
+novideo
+protocol unix,inet,inet6
+seccomp
+shell none
+tracelog
+
+disable-mnt
+private-bin neochat
+private-dev
+##private-etc Common,Networking,GUI,Qt,KDE,D-Bus
+private-etc alternatives,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,mime.types,xdg,ca-certificates,ssl,pki,crypto-policies,nsswitch.conf,resolv.conf,hosts,host.conf,hostname,protocols,services,rpc,fonts,pango,X11,Trolltech.conf,kde4rc,kde5rc,dbus-1,machine-id
+##private-lib LIBS
+##private-opt NAME
+private-tmp
+
+## dbus-user permissions copied from the flatpak package
+dbus-user filter
+dbus-user.own org.kde.neochat
+dbus-user.talk org.freedesktop.Notifications
+dbus-user.talk com.canonical.AppMenu.Registrar
+dbus-user.talk org.kde.StatusNotifierWatcher
+dbus-user.talk org.kde.kwalletd5
+dbus-system none
+
+join-or-start neochat

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -28,7 +28,6 @@ mkdir ${HOME}/.config/KDE/neochat.conf
 mkdir ${HOME}/.local/share/KDE/neochat
 mkfile ${HOME}/.config/neochatrc
 mkfile ${HOME}/.config/neochat.notifyrc
-
 whitelist ${HOME}/.cache/KDE/neochat
 whitelist ${HOME}/.config/KDE/neochat.conf
 whitelist ${HOME}/.config/neochatrc
@@ -36,7 +35,6 @@ whitelist ${HOME}/.local/share/KDE/neochat
 whitelist ${HOME}/.config/neochat.notifyrc
 whitelist ${DOWNLOADS}
 include whitelist-common.inc
-
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
@@ -60,7 +58,6 @@ tracelog
 disable-mnt
 private-bin neochat
 private-dev
-##private-etc Common,Networking,GUI,Qt,KDE,D-Bus
 private-etc alternatives,ca-certificates,crypto-policies,dbus-1,fonts,host.conf,hostname,hosts,kde4rc,kde5rc,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,pango,pki,protocols,resolv.conf,rpc,services,ssl,Trolltech.conf,X11,xdg
 private-tmp
 

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -6,7 +6,6 @@ include neochat.local
 # Persistent global definitions
 include globals.local
 
-#TODO: Add these to disable-programs
 noblacklist ${HOME}/.cache/KDE/neochat
 noblacklist ${HOME}/.config/KDE/neochat
 noblacklist ${HOME}/.config/neochatrc

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -19,7 +19,6 @@ include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-write-mnt.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.cache/KDE/neochat

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -50,6 +50,7 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -65,7 +65,6 @@ dbus-user filter
 dbus-user.own org.kde.neochat
 dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.kde.StatusNotifierWatcher
-# dbus-user.talk org.kde.kwalletd5
 dbus-system none
 
 join-or-start neochat

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -61,4 +61,5 @@ dbus-user filter
 dbus-user.own org.kde.neochat
 dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.kde.StatusNotifierWatcher
+dbus-user.talk org.kde.kwalletd5
 dbus-system none

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -63,6 +63,7 @@ dbus-user filter
 dbus-user.own org.kde.neochat
 dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.kde.StatusNotifierWatcher
+# dbus-user.talk org.kde.kwalletd5
 dbus-system none
 
 join-or-start neochat

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -555,6 +555,7 @@ mypaint
 mypaint-ora-thumbnailer
 natron
 ncdu
+neochat
 neomutt
 netactview
 nethack


### PR DESCRIPTION
This is a firejail profile for Neochat, the KDE Matrix Client ( https://apps.kde.org/id/neochat/ ).
I have tested this only on Arch Linux (and everything seems to work).
I've also added the neochat config files to `disable-programs.inc`.