### PR TITLE
profiles: whitelist mozilla (webext) extensions in chromium profile

### DIFF
--- a/etc/profile-a-l/chromium.profile
+++ b/etc/profile-a-l/chromium.profile
@@ -16,6 +16,7 @@ whitelist ${HOME}/.cache/chromium
 whitelist ${HOME}/.config/chromium
 whitelist ${HOME}/.config/chromium-flags.conf
 whitelist /usr/share/chromium
+whitelist /usr/share/mozilla/extensions
 
 # private-bin chromium,chromium-browser,chromedriver
 


### PR DESCRIPTION
Webext browser extensions installed through packages are installed into `/usr/share/mozilla/extensions/` in Debian.
To make them usable in Chromium, symlinks are created from `/usr/share/chromium/extensions/` to the mozilla dir.

Reporty by Ralf Jung on [#986049](https://bugs.debian.org/986049).