### PR TITLE
whitelist /var/lib/aspell in whitelist-var-common.inc

### DIFF
--- a/etc/inc/whitelist-var-common.inc
+++ b/etc/inc/whitelist-var-common.inc
@@ -4,6 +4,7 @@ include whitelist-var-common.local
 
 # common /var whitelist for all profiles
 
+whitelist /var/lib/aspell
 whitelist /var/lib/ca-certificates
 whitelist /var/lib/dbus
 whitelist /var/lib/menu-xdg


### PR DESCRIPTION
In claws-mail you can't switch the language in the spellchecker without this line. I'm assuming this should be generic.