### PR TITLE
pluma broken with memory-deny-write-execute

### DIFF
--- a/etc/profile-m-z/pluma.profile
+++ b/etc/profile-m-z/pluma.profile
@@ -50,6 +50,4 @@ private-tmp
 # dbus-user none
 # dbus-system none
 
-memory-deny-write-execute
-
 join-or-start pluma


### PR DESCRIPTION
with memory-deny-write-execute you just get a messed up window.

The same error was in engrampa, so most likely, they are other gtk3 application profiles with the same error.