### PR TITLE
profile.template: add missing noautopulse option

### DIFF
--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -145,6 +145,7 @@ include globals.local
 #net none
 #netfilter
 #no3d
+#noautopulse
 ##nodbus (deprecated, use 'dbus-user none' and 'dbus-system none', see below)
 #nodvd
 #nogroups


### PR DESCRIPTION
Added on commit 617ff40c9 ("add --noautopulse arg for complex pulse
setups") / PR #1854.

Note: The template was added after that, on commit cb98aea61 ("Add
profile templates").

Misc: I noticed that it was missing when comparing it to
contrib/vim/syntax/firejail.vim on commit 22a91aedf ("contrib/vim: add
missing noinput command to syn match") / PR #4259.

Cc: @vermeeren (as the author of #1854)
