### PR TITLE
Fix Lutris profile

### DIFF
--- a/etc/profile-a-l/lutris.profile
+++ b/etc/profile-a-l/lutris.profile
@@ -14,6 +14,10 @@ noblacklist ${HOME}/.config/lutris
 noblacklist ${HOME}/.local/share/lutris
 # noblacklist ${HOME}/.wine
 noblacklist /tmp/.wine-*
+# Don't block access to /sbin and /usr/sbin to allow using ldconfig. Otherwise
+# Lutris won't even start.
+noblacklist /sbin
+noblacklist /usr/sbin
 
 ignore noexec ${HOME}
 

--- a/etc/profile-a-l/lutris.profile
+++ b/etc/profile-a-l/lutris.profile
@@ -74,5 +74,7 @@ shell none
 #private-dev
 private-tmp
 
-dbus-user none
+dbus-user filter
+dbus-user.own net.lutris.Lutris
+dbus-user.talk com.feralinteractive.GameMode
 dbus-system none


### PR DESCRIPTION
Recently I updated my OS to Ubuntu 21.04 and I discovered that profile for Lutris has been added. Unfortunately Lutris v0.5.8.3 didn't start when I tried to use it. After spending some time on debugging I found two problems (both are fixed in this pull request):
1. Lutris is using ldconfig, so it requires access to /sbin and /usr/sbin. I've added noblacklist option for both paths.
2. Games with enabled Feral GameMode won't run if D-Bus is disabled. I've disabled options dbus-user and dbus-system.