### PR TITLE
add support for cargo toml/non-toml files

### DIFF
--- a/etc/inc/allow-common-devel.inc
+++ b/etc/inc/allow-common-devel.inc
@@ -30,8 +30,10 @@ noblacklist ${HOME}/.pythonhist
 # Rust
 noblacklist ${HOME}/.cargo/advisory-db
 noblacklist ${HOME}/.cargo/config
+noblacklist ${HOME}/.cargo/config.toml
 noblacklist ${HOME}/.cargo/git
 noblacklist ${HOME}/.cargo/registry
+noblacklist ${HOME}/.cargo/.crates
 noblacklist ${HOME}/.cargo/.crates.toml
 noblacklist ${HOME}/.cargo/.crates2.json
 noblacklist ${HOME}/.cargo/.package-cache

--- a/etc/inc/allow-common-devel.inc
+++ b/etc/inc/allow-common-devel.inc
@@ -28,12 +28,4 @@ noblacklist ${HOME}/.python_history
 noblacklist ${HOME}/.pythonhist
 
 # Rust
-noblacklist ${HOME}/.cargo/advisory-db
-noblacklist ${HOME}/.cargo/config
-noblacklist ${HOME}/.cargo/config.toml
-noblacklist ${HOME}/.cargo/git
-noblacklist ${HOME}/.cargo/registry
-noblacklist ${HOME}/.cargo/.crates
-noblacklist ${HOME}/.cargo/.crates.toml
-noblacklist ${HOME}/.cargo/.crates2.json
-noblacklist ${HOME}/.cargo/.package-cache
+noblacklist ${HOME}/.cargo/*

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -61,8 +61,10 @@ blacklist ${HOME}/.bogofilter
 blacklist ${HOME}/.bzf
 blacklist ${HOME}/.cargo/advisory-db
 blacklist ${HOME}/.cargo/config
+blacklist ${HOME}/.cargo/config.toml
 blacklist ${HOME}/.cargo/git
 blacklist ${HOME}/.cargo/registry
+blacklist ${HOME}/.cargo/.crates
 blacklist ${HOME}/.cargo/.crates.toml
 blacklist ${HOME}/.cargo/.crates2.json
 blacklist ${HOME}/.cargo/.package-cache

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -59,15 +59,7 @@ blacklist ${HOME}/.bibletime
 blacklist ${HOME}/.bitcoin
 blacklist ${HOME}/.bogofilter
 blacklist ${HOME}/.bzf
-blacklist ${HOME}/.cargo/advisory-db
-blacklist ${HOME}/.cargo/config
-blacklist ${HOME}/.cargo/config.toml
-blacklist ${HOME}/.cargo/git
-blacklist ${HOME}/.cargo/registry
-blacklist ${HOME}/.cargo/.crates
-blacklist ${HOME}/.cargo/.crates.toml
-blacklist ${HOME}/.cargo/.crates2.json
-blacklist ${HOME}/.cargo/.package-cache
+blacklist ${HOME}/.cargo/*
 blacklist ${HOME}/.claws-mail
 blacklist ${HOME}/.cliqz
 blacklist ${HOME}/.clonk


### PR DESCRIPTION
This is a follow-up for https://github.com/netblue30/firejail/pull/4284. See [cargo book](https://doc.rust-lang.org/cargo/reference/config.html) and [discussion](https://github.com/netblue30/firejail/pull/4284#discussion_r633132914) for details.