### PR TITLE
Update Zoom profile for meeting recordings

### DIFF
--- a/etc/profile-m-z/zoom.profile
+++ b/etc/profile-m-z/zoom.profile
@@ -18,15 +18,18 @@ ignore dbus-system none
 
 noblacklist ${HOME}/.config/zoomus.conf
 noblacklist ${HOME}/.zoom
+noblacklist ${HOME}/Documents
 
 nowhitelist ${DOWNLOADS}
 
 mkdir ${HOME}/.cache/zoom
 mkfile ${HOME}/.config/zoomus.conf
 mkdir ${HOME}/.zoom
+mkdir ${HOME}/Documents/Zoom
 whitelist ${HOME}/.cache/zoom
 whitelist ${HOME}/.config/zoomus.conf
 whitelist ${HOME}/.zoom
+whitelist ${HOME}/Documents/Zoom
 
 # Disable for now, see https://github.com/netblue30/firejail/issues/3726
 #private-etc alternatives,ca-certificates,crypto-policies,fonts,group,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,machine-id,nsswitch.conf,pki,resolv.conf,ssl


### PR DESCRIPTION
By default, Zoom records meetings to ${HOME}/Documents/Zoom. Add that
folder to the whitelist so that future users don't lose their meeting
recordings upon shutting Zoom down.

That was a painful loss for me today =(.