### PR TITLE
configure*: fix build with non-bash /bin/sh

### DIFF
--- a/configure
+++ b/configure
@@ -3171,7 +3171,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___mindirect_branch_thunk" >&5
 $as_echo "$ax_cv_check_cflags___mindirect_branch_thunk" >&6; }
 if test "x$ax_cv_check_cflags___mindirect_branch_thunk" = xyes; then :
-  HAVE_SPECTRE="yes" && EXTRA_CFLAGS+=" -mindirect-branch=thunk"
+  HAVE_SPECTRE="yes" && EXTRA_CFLAGS="$EXTRA_CFLAGS -mindirect-branch=thunk"
 
 else
   :
@@ -3207,7 +3207,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___mretpoline" >&5
 $as_echo "$ax_cv_check_cflags___mretpoline" >&6; }
 if test "x$ax_cv_check_cflags___mretpoline" = xyes; then :
-  HAVE_SPECTRE="yes" && EXTRA_CFLAGS+=" -mretpoline"
+  HAVE_SPECTRE="yes" && EXTRA_CFLAGS="$EXTRA_CFLAGS -mretpoline"
 
 else
   :
@@ -3243,7 +3243,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___fstack_clash_protection" >&5
 $as_echo "$ax_cv_check_cflags___fstack_clash_protection" >&6; }
 if test "x$ax_cv_check_cflags___fstack_clash_protection" = xyes; then :
-  HAVE_SPECTRE="yes" && EXTRA_CFLAGS+=" -fstack-clash-protection"
+  HAVE_SPECTRE="yes" && EXTRA_CFLAGS="$EXTRA_CFLAGS -fstack-clash-protection"
 
 else
   :
@@ -3279,7 +3279,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___fstack_protector_strong" >&5
 $as_echo "$ax_cv_check_cflags___fstack_protector_strong" >&6; }
 if test "x$ax_cv_check_cflags___fstack_protector_strong" = xyes; then :
-  HAVE_SPECTRE="yes" && EXTRA_CFLAGS+=" -fstack-protector-strong"
+  HAVE_SPECTRE="yes" && EXTRA_CFLAGS="$EXTRA_CFLAGS -fstack-protector-strong"
 
 else
   :
@@ -3293,7 +3293,7 @@ fi
 
 if test "x$enable_analyzer" = "xyes"; then :
 
-	EXTRA_CFLAGS+=" -fanalyzer"
+	EXTRA_CFLAGS="$EXTRA_CFLAGS -fanalyzer"
 
 fi
 
@@ -3515,7 +3515,7 @@ else
 	AA_LIBS=$pkg_cv_AA_LIBS
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-	EXTRA_CFLAGS+=" $AA_CFLAGS" && EXTRA_LDFLAGS+=" $AA_LIBS"
+	EXTRA_CFLAGS="$EXTRA_CFLAGS $AA_CFLAGS" && EXTRA_LDFLAGS="$EXTRA_LDFLAGS $AA_LIBS"
 fi
 
 
@@ -3530,7 +3530,7 @@ fi
 if test "x$enable_selinux" = "xyes"; then :
 
 	HAVE_SELINUX="-DHAVE_SELINUX"
-	EXTRA_LDFLAGS+=" -lselinux "
+	EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lselinux "
 
 
 fi
@@ -3810,7 +3810,7 @@ fi
 if test "x$enable_gcov" = "xyes"; then :
 
 	HAVE_GCOV="--coverage -DHAVE_GCOV "
-	EXTRA_LDFLAGS+=" -lgcov --coverage "
+	EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lgcov --coverage "
 
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -24,25 +24,25 @@ AC_PROG_RANLIB
 HAVE_SPECTRE="no"
 AX_CHECK_COMPILE_FLAG(
     [-mindirect-branch=thunk],
-    [HAVE_SPECTRE="yes" && EXTRA_CFLAGS+=" -mindirect-branch=thunk"]
+    [HAVE_SPECTRE="yes" && EXTRA_CFLAGS="$EXTRA_CFLAGS -mindirect-branch=thunk"]
 )
 AX_CHECK_COMPILE_FLAG(
     [-mretpoline],
-    [HAVE_SPECTRE="yes" && EXTRA_CFLAGS+=" -mretpoline"]
+    [HAVE_SPECTRE="yes" && EXTRA_CFLAGS="$EXTRA_CFLAGS -mretpoline"]
 )
 AX_CHECK_COMPILE_FLAG(
     [-fstack-clash-protection],
-    [HAVE_SPECTRE="yes" && EXTRA_CFLAGS+=" -fstack-clash-protection"]
+    [HAVE_SPECTRE="yes" && EXTRA_CFLAGS="$EXTRA_CFLAGS -fstack-clash-protection"]
 )
 AX_CHECK_COMPILE_FLAG(
     [-fstack-protector-strong],
-    [HAVE_SPECTRE="yes" && EXTRA_CFLAGS+=" -fstack-protector-strong"]
+    [HAVE_SPECTRE="yes" && EXTRA_CFLAGS="$EXTRA_CFLAGS -fstack-protector-strong"]
 )
 
 AC_ARG_ENABLE([analyzer],
     AS_HELP_STRING([--enable-analyzer], [enable GCC 10 static analyzer]))
 AS_IF([test "x$enable_analyzer" = "xyes"], [
-	EXTRA_CFLAGS+=" -fanalyzer"
+	EXTRA_CFLAGS="$EXTRA_CFLAGS -fanalyzer"
 ])
 
 HAVE_APPARMOR=""
@@ -50,7 +50,8 @@ AC_ARG_ENABLE([apparmor],
     AS_HELP_STRING([--enable-apparmor], [enable apparmor]))
 AS_IF([test "x$enable_apparmor" = "xyes"], [
 	HAVE_APPARMOR="-DHAVE_APPARMOR"
-	PKG_CHECK_MODULES([AA], libapparmor, [EXTRA_CFLAGS+=" $AA_CFLAGS" && EXTRA_LDFLAGS+=" $AA_LIBS"])
+	PKG_CHECK_MODULES([AA], libapparmor,
+	    [EXTRA_CFLAGS="$EXTRA_CFLAGS $AA_CFLAGS" && EXTRA_LDFLAGS="$EXTRA_LDFLAGS $AA_LIBS"])
 	AC_SUBST(HAVE_APPARMOR)
 ])
 
@@ -59,7 +60,7 @@ AC_ARG_ENABLE([selinux],
     AS_HELP_STRING([--enable-selinux], [SELinux labeling support]))
 AS_IF([test "x$enable_selinux" = "xyes"], [
 	HAVE_SELINUX="-DHAVE_SELINUX"
-	EXTRA_LDFLAGS+=" -lselinux "
+	EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lselinux "
 	AC_SUBST(HAVE_SELINUX)
 ])
 
@@ -215,7 +216,7 @@ AC_ARG_ENABLE([gcov],
     AS_HELP_STRING([--enable-gcov], [Gcov instrumentation]))
 AS_IF([test "x$enable_gcov" = "xyes"], [
 	HAVE_GCOV="--coverage -DHAVE_GCOV "
-	EXTRA_LDFLAGS+=" -lgcov --coverage "
+	EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lgcov --coverage "
 	AC_SUBST(HAVE_GCOV)
 ])
 


### PR DESCRIPTION
The configure script happens to work if /bin/sh supports the non-POSIX
"+=" operator (e.g.: bash) and fails otherwise (e.g.: dash).

This usage first appeared on configure.ac on commit 66a476419 ("gcov
support"), which is from 2016.

If the --enable-apparmor flag is passed to ./configure (which is the
default on Arch Linux), running `make` fails due to the missing
-lapparmor LDFLAG.  Thus, building firejail-git from the AUR does not
work if /bin/sh is e.g.: dash.

Errors when running the build commands below from makepkg:

    $ ./configure --prefix=/usr --enable-apparmor >/dev/null
    ./configure: 3174: EXTRA_CFLAGS+= -mindirect-branch=thunk: not found
    ./configure: 3246: EXTRA_CFLAGS+= -fstack-clash-protection: not found
    ./configure: 3282: EXTRA_CFLAGS+= -fstack-protector-strong: not found
    ./configure: 3518: EXTRA_CFLAGS+= : not found
    $ make >/dev/null
    /usr/bin/ld: apparmor.o: in function `apparmor_test':
    /tmp/firejail-git/src/firejail-git/src/jailcheck/apparmor.c:28: undefined reference to `aa_gettaskcon'
    collect2: error: ld returned 1 exit status
    make[1]: *** [Makefile:10: jailcheck] Error 1
    make: *** [Makefile:42: src/jailcheck/jailcheck] Error 2
    make: *** Waiting for unfinished jobs....
    /usr/bin/ld: apparmor.o: in function `print_apparmor':
    /tmp/firejail-git/src/firejail-git/src/firemon/apparmor.c:28: undefined reference to `aa_gettaskcon'
    collect2: error: ld returned 1 exit status
    make[1]: *** [Makefile:10: firemon] Error 1
    make: *** [Makefile:42: src/firemon/firemon] Error 2
    /usr/bin/ld: join.o: in function `extract_apparmor':
    /tmp/firejail-git/src/firejail-git/src/firejail/join.c:65: undefined reference to `aa_is_enabled'
    /usr/bin/ld: sandbox.o: in function `set_apparmor':
    /tmp/firejail-git/src/firejail-git/src/firejail/sandbox.c:133: undefined reference to `aa_change_onexec'
    collect2: error: ld returned 1 exit status
    make[1]: *** [Makefile:10: firejail] Error 1
    make: *** [Makefile:42: src/firejail/firejail] Error 2

Without the apparmor flag, the CFLAGS related to HAVE_SPECTRE do not get
applied either, but `make` does not error out, so the problem is harder
to detect in this case.

Diff comparing the output of `./configure 2>&1` when running without and
then with this patch:

    $ git --no-pager diff --no-index configure_current.log configure_patch.log
    diff --git a/configure_current.log b/configure_patch.log
    index f5e814f..099d836 100644
    --- a/configure_current.log
    +++ b/configure_patch.log
    @@ -10,12 +10,9 @@ checking for gcc option to accept ISO C89... none needed
     checking for a BSD-compatible install... /usr/bin/install -c
     checking for ranlib... ranlib
     checking whether C compiler accepts -mindirect-branch=thunk... yes
    -./configure: 3174: EXTRA_CFLAGS+= -mindirect-branch=thunk: not found
     checking whether C compiler accepts -mretpoline... no
     checking whether C compiler accepts -fstack-clash-protection... yes
    -./configure: 3246: EXTRA_CFLAGS+= -fstack-clash-protection: not found
     checking whether C compiler accepts -fstack-protector-strong... yes
    -./configure: 3282: EXTRA_CFLAGS+= -fstack-protector-strong: not found
     checking for pkg-config... /usr/bin/pkg-config
     checking pkg-config is at least version 0.9.0... yes
     checking for gawk... yes
    @@ -88,7 +85,7 @@ Configuration options:
        busybox workaround: no
        Spectre compiler patch: yes
        EXTRA_LDFLAGS:
    -   EXTRA_CFLAGS:
    +   EXTRA_CFLAGS:  -mindirect-branch=thunk -fstack-clash-protection -fstack-protector-strong
        fatal warnings:
        Gcov instrumentation:
        Install contrib scripts: yes
