### PR TITLE
CI: build with GCC 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: sudo apt-get install gcc-10 libapparmor-dev libselinux1-dev expect xzdec
+      run: sudo apt-get install gcc-11 libapparmor-dev libselinux1-dev expect xzdec
     - name: configure
-      run: CC=gcc-10 ./configure --enable-fatal-warnings --enable-analyzer --enable-apparmor --enable-selinux --prefix=/usr
+      run: CC=gcc-11 ./configure --enable-fatal-warnings --enable-analyzer --enable-apparmor --enable-selinux --prefix=/usr
     - name: make
       run: make
     - name: make install

--- a/configure
+++ b/configure
@@ -1369,7 +1369,7 @@ Optional Features:
   --disable-option-checking  ignore unrecognized --enable/--with options
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
-  --enable-analyzer       enable GCC 10 static analyzer
+  --enable-analyzer       enable GCC static analyzer
   --enable-apparmor       enable apparmor
   --enable-selinux        SELinux labeling support
   --disable-dbusproxy     disable dbus proxy
@@ -3293,7 +3293,7 @@ fi
 
 if test "x$enable_analyzer" = "xyes"; then :
 
-	EXTRA_CFLAGS="$EXTRA_CFLAGS -fanalyzer"
+	EXTRA_CFLAGS="$EXTRA_CFLAGS -fanalyzer -Wno-analyzer-malloc-leak"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -40,9 +40,9 @@ AX_CHECK_COMPILE_FLAG(
 )
 
 AC_ARG_ENABLE([analyzer],
-    AS_HELP_STRING([--enable-analyzer], [enable GCC 10 static analyzer]))
+    AS_HELP_STRING([--enable-analyzer], [enable GCC static analyzer]))
 AS_IF([test "x$enable_analyzer" = "xyes"], [
-	EXTRA_CFLAGS="$EXTRA_CFLAGS -fanalyzer"
+	EXTRA_CFLAGS="$EXTRA_CFLAGS -fanalyzer -Wno-analyzer-malloc-leak"
 ])
 
 HAVE_APPARMOR=""


### PR DESCRIPTION
this fixes a new false positive memory leak (#4297), but unfortunately
opens a few new false positives (#4274).
therefore let it ignore memleak checks for now, until the detection
is a bit more stable in GCC.

Fixes: #4274, #4297

ping @smitsohu @rusty-snake @glitsj16 @kmk3 