### PR TITLE
Refine appimage example in docs

### DIFF
--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -147,12 +147,12 @@ private-bin and private-lib are disabled by default when running appimages.
 .br
 Example:
 .br
-$ firejail --appimage krita-3.0-x86_64.appimage
+$ firejail --appimage --profile=krita krita-3.0-x86_64.appimage
 .br
-$ firejail --appimage --private krita-3.0-x86_64.appimage
+$ firejail --appimage --private --profile=krita krita-3.0-x86_64.appimage
 .br
 #ifdef HAVE_X11
-$ firejail --appimage --net=none --x11 krita-3.0-x86_64.appimage
+$ firejail --appimage --net=none --x11 --profile=krita krita-3.0-x86_64.appimage
 #endif
 .TP
 #ifdef HAVE_NETWORK


### PR DESCRIPTION
The example should explicitly pick krita profile. Otherwise it looks like firejail does automatically guess "krita" profile for "krita-3.0-x86_64.appimage" which is not true.

### Please pay attention to the following

It may be not important in the case of `--private` (since non existing `.config/kritarc` is not blacklisted and krita can create and write to it), but if a user copy-paste the sample cmd and replace `--private` with `--private=some-dir`, krita would complain about `.config/kritarc` being not writable if only it exists (which means it would not complain on first run with empty `some-dir`, but the next run the file gets blacklisted since it exists).