### PR TITLE
Configure improvements

### DIFF
--- a/configure
+++ b/configure
@@ -5559,48 +5559,49 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
 $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
 
+cat <<EOF
 
-echo
-echo "Configuration options:"
-echo "   prefix: $prefix"
-echo "   sysconfdir: $sysconfdir"
-echo "   apparmor: $HAVE_APPARMOR"
-echo "   SELinux labeling support: $HAVE_SELINUX"
-echo "   global config: $HAVE_GLOBALCFG"
-echo "   chroot: $HAVE_CHROOT"
-echo "   network: $HAVE_NETWORK"
-echo "   user namespace: $HAVE_USERNS"
-echo "   X11 sandboxing support: $HAVE_X11"
-echo "   whitelisting: $HAVE_WHITELIST"
-echo "   private home support: $HAVE_PRIVATE_HOME"
-echo "   file transfer support: $HAVE_FILE_TRANSFER"
-echo "   overlayfs support: $HAVE_OVERLAYFS"
-echo "   DBUS proxy support: $HAVE_DBUSPROXY"
-echo "   allow tmpfs as regular user: $HAVE_USERTMPFS"
-echo "   enable --ouput logging: $HAVE_OUTPUT"
-echo "   Manpage support: $HAVE_MAN"
-echo "   firetunnel support: $HAVE_FIRETUNNEL"
-echo "   busybox workaround: $BUSYBOX_WORKAROUND"
-echo "   Spectre compiler patch: $HAVE_SPECTRE"
-echo "   EXTRA_LDFLAGS: $EXTRA_LDFLAGS"
-echo "   EXTRA_CFLAGS: $EXTRA_CFLAGS"
-echo "   fatal warnings: $HAVE_FATAL_WARNINGS"
-echo "   Gcov instrumentation: $HAVE_GCOV"
-echo "   Install contrib scripts: $HAVE_CONTRIB_INSTALL"
-echo "   Install as a SUID executable: $HAVE_SUID"
-echo "   LTS: $HAVE_LTS"
-echo "   Always enforce filters: $HAVE_FORCE_NONEWPRIVS"
-echo
+Configuration options:
+   prefix: $prefix
+   sysconfdir: $sysconfdir
+   apparmor: $HAVE_APPARMOR
+   SELinux labeling support: $HAVE_SELINUX
+   global config: $HAVE_GLOBALCFG
+   chroot: $HAVE_CHROOT
+   network: $HAVE_NETWORK
+   user namespace: $HAVE_USERNS
+   X11 sandboxing support: $HAVE_X11
+   whitelisting: $HAVE_WHITELIST
+   private home support: $HAVE_PRIVATE_HOME
+   file transfer support: $HAVE_FILE_TRANSFER
+   overlayfs support: $HAVE_OVERLAYFS
+   DBUS proxy support: $HAVE_DBUSPROXY
+   allow tmpfs as regular user: $HAVE_USERTMPFS
+   enable --ouput logging: $HAVE_OUTPUT
+   Manpage support: $HAVE_MAN
+   firetunnel support: $HAVE_FIRETUNNEL
+   busybox workaround: $BUSYBOX_WORKAROUND
+   Spectre compiler patch: $HAVE_SPECTRE
+   EXTRA_LDFLAGS: $EXTRA_LDFLAGS
+   EXTRA_CFLAGS: $EXTRA_CFLAGS
+   fatal warnings: $HAVE_FATAL_WARNINGS
+   Gcov instrumentation: $HAVE_GCOV
+   Install contrib scripts: $HAVE_CONTRIB_INSTALL
+   Install as a SUID executable: $HAVE_SUID
+   LTS: $HAVE_LTS
+   Always enforce filters: $HAVE_FORCE_NONEWPRIVS
 
+EOF
 
 if test "$HAVE_LTS" = -DHAVE_LTS; then
-	echo
-	echo
-	echo "*********************************************************"
-	echo "*    Warning: Long-term support (LTS) was enabled!      *"
-	echo "*    Most compile-time options have bean rewritten!     *"
-	echo "*********************************************************"
-	echo
-	echo
-fi
+	cat <<\EOF
 
+
+*********************************************************
+*    Warning: Long-term support (LTS) was enabled!      *
+*    Most compile-time options have bean rewritten!     *
+*********************************************************
+
+
+EOF
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -311,47 +311,49 @@ src/profstats/Makefile src/man/Makefile src/zsh_completion/Makefile src/bash_com
 src/jailcheck/Makefile])
 AC_OUTPUT
 
-echo
-echo "Configuration options:"
-echo "   prefix: $prefix"
-echo "   sysconfdir: $sysconfdir"
-echo "   apparmor: $HAVE_APPARMOR"
-echo "   SELinux labeling support: $HAVE_SELINUX"
-echo "   global config: $HAVE_GLOBALCFG"
-echo "   chroot: $HAVE_CHROOT"
-echo "   network: $HAVE_NETWORK"
-echo "   user namespace: $HAVE_USERNS"
-echo "   X11 sandboxing support: $HAVE_X11"
-echo "   whitelisting: $HAVE_WHITELIST"
-echo "   private home support: $HAVE_PRIVATE_HOME"
-echo "   file transfer support: $HAVE_FILE_TRANSFER"
-echo "   overlayfs support: $HAVE_OVERLAYFS"
-echo "   DBUS proxy support: $HAVE_DBUSPROXY"
-echo "   allow tmpfs as regular user: $HAVE_USERTMPFS"
-echo "   enable --ouput logging: $HAVE_OUTPUT"
-echo "   Manpage support: $HAVE_MAN"
-echo "   firetunnel support: $HAVE_FIRETUNNEL"
-echo "   busybox workaround: $BUSYBOX_WORKAROUND"
-echo "   Spectre compiler patch: $HAVE_SPECTRE"
-echo "   EXTRA_LDFLAGS: $EXTRA_LDFLAGS"
-echo "   EXTRA_CFLAGS: $EXTRA_CFLAGS"
-echo "   fatal warnings: $HAVE_FATAL_WARNINGS"
-echo "   Gcov instrumentation: $HAVE_GCOV"
-echo "   Install contrib scripts: $HAVE_CONTRIB_INSTALL"
-echo "   Install as a SUID executable: $HAVE_SUID"
-echo "   LTS: $HAVE_LTS"
-echo "   Always enforce filters: $HAVE_FORCE_NONEWPRIVS"
-echo
+cat <<EOF
 
+Configuration options:
+   prefix: $prefix
+   sysconfdir: $sysconfdir
+   apparmor: $HAVE_APPARMOR
+   SELinux labeling support: $HAVE_SELINUX
+   global config: $HAVE_GLOBALCFG
+   chroot: $HAVE_CHROOT
+   network: $HAVE_NETWORK
+   user namespace: $HAVE_USERNS
+   X11 sandboxing support: $HAVE_X11
+   whitelisting: $HAVE_WHITELIST
+   private home support: $HAVE_PRIVATE_HOME
+   file transfer support: $HAVE_FILE_TRANSFER
+   overlayfs support: $HAVE_OVERLAYFS
+   DBUS proxy support: $HAVE_DBUSPROXY
+   allow tmpfs as regular user: $HAVE_USERTMPFS
+   enable --ouput logging: $HAVE_OUTPUT
+   Manpage support: $HAVE_MAN
+   firetunnel support: $HAVE_FIRETUNNEL
+   busybox workaround: $BUSYBOX_WORKAROUND
+   Spectre compiler patch: $HAVE_SPECTRE
+   EXTRA_LDFLAGS: $EXTRA_LDFLAGS
+   EXTRA_CFLAGS: $EXTRA_CFLAGS
+   fatal warnings: $HAVE_FATAL_WARNINGS
+   Gcov instrumentation: $HAVE_GCOV
+   Install contrib scripts: $HAVE_CONTRIB_INSTALL
+   Install as a SUID executable: $HAVE_SUID
+   LTS: $HAVE_LTS
+   Always enforce filters: $HAVE_FORCE_NONEWPRIVS
+
+EOF
 
 if test "$HAVE_LTS" = -DHAVE_LTS; then
-	echo
-	echo
-	echo "*********************************************************"
-	echo "*    Warning: Long-term support (LTS) was enabled!      *"
-	echo "*    Most compile-time options have bean rewritten!     *"
-	echo "*********************************************************"
-	echo
-	echo
-fi
+	cat <<\EOF
 
+
+*********************************************************
+*    Warning: Long-term support (LTS) was enabled!      *
+*    Most compile-time options have bean rewritten!     *
+*********************************************************
+
+
+EOF
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@
 #
 
 AC_PREREQ([2.68])
-AC_INIT(firejail, 0.9.65, netblue30@protonmail.com, , https://firejail.wordpress.com)
+AC_INIT([firejail],[0.9.65],[netblue30@protonmail.com],[],[https://firejail.wordpress.com])
 AC_CONFIG_SRCDIR([src/firejail/main.c])
 
 AC_CONFIG_MACRO_DIR([m4])
@@ -304,11 +304,12 @@ if test "$prefix" = /usr; then
 fi
 
 AC_CONFIG_FILES([mkdeb.sh], [chmod +x mkdeb.sh])
-AC_OUTPUT(Makefile src/common.mk src/lib/Makefile src/fcopy/Makefile src/fnet/Makefile src/firejail/Makefile src/fnetfilter/Makefile \
+AC_CONFIG_FILES([Makefile src/common.mk src/lib/Makefile src/fcopy/Makefile src/fnet/Makefile src/firejail/Makefile src/fnetfilter/Makefile \
 src/firemon/Makefile src/libtrace/Makefile src/libtracelog/Makefile src/firecfg/Makefile src/fbuilder/Makefile src/fsec-print/Makefile \
 src/ftee/Makefile src/fseccomp/Makefile src/fldd/Makefile src/libpostexecseccomp/Makefile src/fsec-optimize/Makefile \
 src/profstats/Makefile src/man/Makefile src/zsh_completion/Makefile src/bash_completion/Makefile test/Makefile \
-src/jailcheck/Makefile)
+src/jailcheck/Makefile])
+AC_OUTPUT
 
 echo
 echo "Configuration options:"


### PR DESCRIPTION
```sh
$ git log --reverse --pretty='%s%n%n%b%n-----%n' master..HEAD
```

configure.ac: run autoupdate to fix autoconf warning

This fixes the following warning:

    $ autoconf
    configure.ac:306: warning: AC_OUTPUT should be used without arguments.
    configure.ac:306: You should run autoupdate.

Environment:

    $ grep '^NAME' /etc/os-release
    NAME="Artix Linux"
    $ pacman -Q autoconf
    autoconf 2.71-1

Though keep `AC_PREREQ` at 2.68 (released on 2010-09-23[1]), as version
2.71 (which autoupdate automatically bumps to) is rather recent
(released on 2021-01-28[2]) and the changes do not appear to require a
version bump, as on `AC_INIT` it only adds some quotes, and the rest of
the changes are consistent with the autoconf 2.68 manual.  From Section
18.4, Obsolete Macros[3]:

> — Macro: AC_OUTPUT ([file]..., [extra-cmds], [init-cmds])
>
>     The use of AC_OUTPUT with arguments is deprecated.  This obsoleted
>     interface is equivalent to:
>
>               AC_CONFIG_FILES(file...)
>               AC_CONFIG_COMMANDS([default],
>                                  extra-cmds, init-cmds)
>               AC_OUTPUT
>
>     See AC_CONFIG_FILES, AC_CONFIG_COMMANDS, and AC_OUTPUT.

Note: The usage of the above format has been present since the inception
of configure.ac, on commit 137985136 ("Baseline firejail 0.9.28").

Misc: This is a continuation of #4293.

[1] https://lists.gnu.org/archive/html/info-gnu/2010-09/msg00013.html
[2] https://lists.gnu.org/archive/html/autoconf/2021-01/msg00126.html
[3] https://www.gnu.org/software/autoconf/manual/autoconf-2.68/html_node/Obsolete-Macros.html#index-AC_005fOUTPUT-2058

-----

configure*: use cat instead of many echoes

For simplicity and increased portability.

-----
