### PR TITLE
cmdline.c: optionally quote the resulting command line

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -803,8 +803,8 @@ void appimage_clear(void);
 long unsigned int appimage2_size(int fd);
 
 // cmdline.c
-void build_cmdline(char **command_line, char **window_title, int argc, char **argv, int index);
-void build_appimage_cmdline(char **command_line, char **window_title, int argc, char **argv, int index);
+void build_cmdline(char **command_line, char **window_title, int argc, char **argv, int index, bool want_extra_quotes);
+void build_appimage_cmdline(char **command_line, char **window_title, int argc, char **argv, int index, bool want_extra_quotes);
 
 // sbox.c
 // programs

--- a/src/firejail/join.c
+++ b/src/firejail/join.c
@@ -147,7 +147,7 @@ static void extract_command(int argc, char **argv, int index) {
 	}
 
 	// build command
-	build_cmdline(&cfg.command_line, &cfg.window_title, argc, argv, index);
+	build_cmdline(&cfg.command_line, &cfg.window_title, argc, argv, index, true);
 }
 
 static void extract_nogroups(pid_t pid) {

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -2810,10 +2810,11 @@ int main(int argc, char **argv, char **envp) {
 		if (arg_debug)
 			printf("Configuring appimage environment\n");
 		appimage_set(cfg.command_name);
-		build_appimage_cmdline(&cfg.command_line, &cfg.window_title, argc, argv, prog_index);
+		build_appimage_cmdline(&cfg.command_line, &cfg.window_title, argc, argv, prog_index, true);
 	}
 	else {
-		build_cmdline(&cfg.command_line, &cfg.window_title, argc, argv, prog_index);
+		// Only add extra quotes if we were not launched by sshd.
+		build_cmdline(&cfg.command_line, &cfg.window_title, argc, argv, prog_index, !parent_sshd);
 	}
 /*	else {
 		fprintf(stderr, "Error: command must be specified when --shell=none used.\n");

--- a/src/firejail/no_sandbox.c
+++ b/src/firejail/no_sandbox.c
@@ -204,7 +204,7 @@ void run_no_sandbox(int argc, char **argv) {
 		// force --shell=none in order to not break firecfg symbolic links
 		arg_shell_none = 1;
 
-		build_cmdline(&cfg.command_line, &cfg.window_title, argc, argv, prog_index);
+		build_cmdline(&cfg.command_line, &cfg.window_title, argc, argv, prog_index, true);
 	}
 
 	fwarning("an existing sandbox was detected. "


### PR DESCRIPTION
The commit message contains an abbreviated version of this explanation.  This PR is a possible solution for #1644, #887, and #1817.

-----

# Short version

`sshd` invokes firejail slightly differently than how firejail is normally invoked on the command line.  One possible fix is to recognize that firejail was launched by sshd and slightly modify its quoting behavior.

# More details

There's a difference between invoking firejail with a multi-token command:

```sh
# Using --quiet for brevity
$ firejail --quiet echo hello world
hello world
```

and ssh'ing in a non-interactive multi-token command with firejail as the login shell (assume a trivial `username: --shell=/bin/bash` line in `/etc/firejail/login.users`):

```
$ ssh username@othernode echo hello world
/bin/bash: echo hello world: command not found
```

The difference is that in the `ssh` case, the local `sshd` on `somenode` will invoke the following:

* `argv[0]`: `/usr/bin/firejail`
* `argv[1]`: `-c`
* `argv[2]`: `echo hello world`

Notice how `echo hello world` is a single token (`argv[2]`). 

For simplicity of explanation, let's take `ssh`/`sshd` out of the situation and just explain two different command line cases.

## Case 1: a single token

Consider:

```sh
# Using --quiet for brevity
$ firejail --quiet -c "echo hello world"
/bin/bash: echo hello world: command not found
```

This is equivalent to what `sshd` does: `echo hello world` is a single token (`argv[3]`, in this example).

Firejail ultimately invokes `src/firejail/cmdline.c:quote_cmdline()` at https://github.com/netblue30/firejail/blob/4522ccb4ef529fe9cafa60178027be139ce0e592/src/firejail/cmdline.c#L67 

`quote_cmdline()` adds an additional set of single quotes around tokens.  The user's shell -- let's assume it's Bash -- is ultimately executed as:

* `argv[0]`: `/bin/bash`
* `argv[1]`: `-c`
* `argv[2]`: `'echo hello world' `

With the extra quotes, Bash won't split up `argv[2]`, and therefore won't find an intrinsic or executable named `echo hello world `.  Bash then rightfully generates an error.

## Case 2: multiple tokens

Consider:

```sh
# Using --quiet for brevity
$ firejail --quiet -c echo hello world
hello world
```

Note that `echo` `hello` `world` are all their own `argv` tokens (`argv[3]` through `argv[5]` in this example).  Firejail's `quote_cmdline()` behavior is therefore different; bash is ultimately executed as:

* `argv[0]`: `/bin/bash`
* `argv[1]`: `-c`
* `argv[2]`: `'echo' 'hello' 'world' `

Bash therefore is able to split up the resulting `argv[2]`, find an `echo` intrinsic or executable, and things proceed as expected (i.e., `hello world` is emitted and we get an exit status of 0).

## Proposed solution

One possible solution is to have `quote_cmdline()` behave differently depending on whether Firejail was invoked by `sshd` or not.

This PR uses the already-set `parent_sshd` flag to tell `build_cmdline()` (which, in turn, invokes `quote_cmdline()`) to *not* add extra quotes around the all-the-tokens-are-in-a-single-argv[x] token.  Bash is therefore ultimately invoked as:

* `argv[0]`: `/bin/bash`
* `argv[1]`: `-c`
* `argv[2]`: `echo hello world `

Which, while this is slightly different than case 2, above (i.e., there's no extra quotes around each sub-token), seems to be sufficient.