### PR TITLE
Correct typo in telegram-desktop profile

### DIFF
--- a/etc/profile-m-z/telegram-desktop.profile
+++ b/etc/profile-m-z/telegram-desktop.profile
@@ -2,7 +2,7 @@
 # Description: Official Telegram Desktop client
 # This file is overwritten after every install/update
 # Persistent local customizations
-include tekegram-desktop.local
+include telegram-desktop.local
 # Persistent global definitions
 # added by included profile
 #include globals.local


### PR DESCRIPTION
I changed `include tekegram-desktop.local` to `include telegram-desktop.local`.