### PR TITLE
creating googler and ddgr profiles

### DIFF
--- a/etc/profile-a-l/ddgr.profile
+++ b/etc/profile-a-l/ddgr.profile
@@ -1,5 +1,5 @@
 # Firejail profile for ddgr
-# Description:  Search DuckDuckGo from your terminal
+# Description: Search DuckDuckGo from your terminal
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/etc/profile-a-l/ddgr.profile
+++ b/etc/profile-a-l/ddgr.profile
@@ -1,0 +1,13 @@
+# Firejail profile for ddgr
+# Description:  Search DuckDuckGo from your terminal
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include ddgr.local
+# Persistent global definitions
+include globals.local
+
+private-bin ddgr
+
+# Redirect
+include googler-common.profile

--- a/etc/profile-a-l/googler-common.profile
+++ b/etc/profile-a-l/googler-common.profile
@@ -49,7 +49,7 @@ disable-mnt
 private-bin env,python3*,sh,w3m
 private-cache
 private-dev
-private-etc ssl,hosts,inputrc,terminfo,
+private-etc hosts,inputrc,ssl,terminfo
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/googler-common.profile
+++ b/etc/profile-a-l/googler-common.profile
@@ -10,6 +10,7 @@ include googler-common.local
 blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
 
+noblacklist ${DOWNLOADS}
 noblacklist ${HOME}/.w3m
 
 # Allow /bin/sh (blacklisted by disable-shell.inc)
@@ -54,7 +55,7 @@ disable-mnt
 private-bin env,python3*,sh,w3m
 private-cache
 private-dev
-private-etc hosts,inputrc,ssl,terminfo
+private-etc ca-certificates,crypto-policies,host.conf,hostname,hosts,nsswitch.conf,pki,protocols,resolv.conf,services,rpc,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/googler-common.profile
+++ b/etc/profile-a-l/googler-common.profile
@@ -1,0 +1,56 @@
+# Firejail profile for googler clones
+# Description: common profile for googler clones
+# This file is overwritten after every install/update
+# Persistent local customizations
+include googler-common.local
+# Persistent global definitions
+# added by caller profile
+#include globals.local
+
+blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
+
+noblacklist ${HOME}/.w3m
+
+# Allow python (blacklisted by disable-interpreters.inc)
+include allow-python3.inc
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
+include disable-xdg.inc
+
+whitelist ${HOME}/.w3m
+include whitelist-var-common.inc
+
+apparmor
+caps.drop all
+machine-id
+netfilter
+no3d
+nodvd
+nogroups
+noinput
+nonewprivs
+noroot
+nosound
+notv
+nou2f
+novideo
+protocol unix,inet,inet6
+seccomp
+shell none
+tracelog
+
+disable-mnt
+private-bin env,python3*,sh,w3m
+private-cache
+private-dev
+private-etc ssl,hosts,inputrc,terminfo,
+private-tmp
+
+dbus-user none
+dbus-system none

--- a/etc/profile-a-l/googler-common.profile
+++ b/etc/profile-a-l/googler-common.profile
@@ -12,7 +12,7 @@ blacklist ${RUNUSER}
 
 noblacklist ${HOME}/.w3m
 
-# Allow python (blacklisted by disable-interpreters.inc)
+# Allow python and shell (blacklisted by disable-interpreters.inc)
 include allow-bin-sh.inc
 include allow-python3.inc
 

--- a/etc/profile-a-l/googler-common.profile
+++ b/etc/profile-a-l/googler-common.profile
@@ -10,7 +10,6 @@ include googler-common.local
 blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
 
-noblacklist ${DOWNLOADS}
 noblacklist ${HOME}/.w3m
 
 # Allow /bin/sh (blacklisted by disable-shell.inc)

--- a/etc/profile-a-l/googler-common.profile
+++ b/etc/profile-a-l/googler-common.profile
@@ -8,11 +8,12 @@ include googler-common.local
 #include globals.local
 
 blacklist /tmp/.X11-unix
-blacklist ${RUNUSER}/wayland-*
+blacklist ${RUNUSER}
 
 noblacklist ${HOME}/.w3m
 
 # Allow python (blacklisted by disable-interpreters.inc)
+include allow-bin-sh.inc
 include allow-python3.inc
 
 include disable-common.inc
@@ -21,13 +22,16 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-passwdmgr.inc
 include disable-programs.inc
+include disable-shell.inc
 include disable-xdg.inc
 
 whitelist ${HOME}/.w3m
+include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
 apparmor
 caps.drop all
+ipc-namespace
 machine-id
 netfilter
 no3d
@@ -41,7 +45,7 @@ notv
 nou2f
 novideo
 protocol unix,inet,inet6
-seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-a-l/googler-common.profile
+++ b/etc/profile-a-l/googler-common.profile
@@ -55,7 +55,7 @@ disable-mnt
 private-bin env,python3*,sh,w3m
 private-cache
 private-dev
-private-etc ca-certificates,crypto-policies,host.conf,hostname,hosts,nsswitch.conf,pki,protocols,resolv.conf,services,rpc,ssl
+private-etc ca-certificates,crypto-policies,host.conf,hostname,hosts,nsswitch.conf,pki,protocols,resolv.conf,rpc,services,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/googler-common.profile
+++ b/etc/profile-a-l/googler-common.profile
@@ -12,8 +12,9 @@ blacklist ${RUNUSER}
 
 noblacklist ${HOME}/.w3m
 
-# Allow python and shell (blacklisted by disable-interpreters.inc)
+# Allow /bin/sh (blacklisted by disable-shell.inc)
 include allow-bin-sh.inc
+# Allow python (blacklisted by disable-interpreters.inc)
 include allow-python3.inc
 
 include disable-common.inc

--- a/etc/profile-a-l/googler.profile
+++ b/etc/profile-a-l/googler.profile
@@ -1,0 +1,13 @@
+# Firejail profile for googler
+# Description:  Search Google from your terminal
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include googler.local
+# Persistent global definitions
+include globals.local
+
+private-bin googler
+
+# Redirect
+include googler-common.profile

--- a/etc/profile-a-l/googler.profile
+++ b/etc/profile-a-l/googler.profile
@@ -1,5 +1,5 @@
 # Firejail profile for googler
-# Description:  Search Google from your terminal
+# Description: Search Google from your terminal
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -167,6 +167,7 @@ cvlc
 cyberfox
 darktable
 dconf-editor
+ddgr
 ddgtk
 deadbeef
 deluge
@@ -350,6 +351,7 @@ google-chrome-unstable
 google-earth
 google-earth-pro
 google-play-music-desktop-player
+googler
 gpa
 gpicview
 gpredict


### PR DESCRIPTION
search google and duckduckgo from the terminal.

They are practically the same, from the same dev
i added w3m, so that it can launch a browser.
They have no configuration files
added noinput

googler doesn't use google's API, so it quickly bitrots in the repositories, the pip3 version was broken.
if it's broken in the repo
https://github.com/jarun/googler#downloading-a-single-file

ddgr page if needed, the repo version should be fine
https://github.com/jarun/ddgr/releases/latest