### PR TITLE
Update weechat.profile

### DIFF
--- a/etc/profile-m-z/weechat.profile
+++ b/etc/profile-m-z/weechat.profile
@@ -11,6 +11,8 @@ noblacklist ${HOME}/.weechat
 include disable-common.inc
 include disable-programs.inc
 
+whitelist /usr/share/weechat
+
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 

--- a/etc/profile-m-z/weechat.profile
+++ b/etc/profile-m-z/weechat.profile
@@ -12,7 +12,6 @@ include disable-common.inc
 include disable-programs.inc
 
 whitelist /usr/share/weechat
-
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 


### PR DESCRIPTION
weechat needs access to `/usr/share/weechat` if you have any global scripts installed. The directory is empty by default, so there is no additional risk here.