### PR TITLE
profiles: add profile for tin news reader

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -810,6 +810,7 @@ blacklist ${HOME}/.netactview
 blacklist ${HOME}/.neverball
 blacklist ${HOME}/.newsbeuter
 blacklist ${HOME}/.newsboat
+blacklist ${HOME}/.newsrc
 blacklist ${HOME}/.nicotine
 blacklist ${HOME}/.node-gyp
 blacklist ${HOME}/.npm
@@ -867,6 +868,7 @@ blacklist ${HOME}/.teeworlds
 blacklist ${HOME}/.texlive20*
 blacklist ${HOME}/.thunderbird
 blacklist ${HOME}/.tilp
+blacklist ${HOME}/.tin
 blacklist ${HOME}/.tooling
 blacklist ${HOME}/.tor-browser*
 blacklist ${HOME}/.torcs

--- a/etc/profile-m-z/rtin.profile
+++ b/etc/profile-m-z/rtin.profile
@@ -1,0 +1,8 @@
+# Firejail profile for rtin
+# Description: ncurses-based Usenet newsreader
+#              symlink to tin, same as `tin -r`
+# This file is overwritten after every install/update
+# Persistent local customizations
+include rtin.local
+
+include tin.profile

--- a/etc/profile-m-z/tin.profile
+++ b/etc/profile-m-z/tin.profile
@@ -1,0 +1,69 @@
+# Firejail profile for tin
+# Description: ncurses-based Usenet newsreader
+# This file is overwritten after every install/update
+# Persistent local customizations
+include tin.local
+# Persistent global definitions
+include globals.local
+
+noblacklist ${HOME}/.newsrc
+noblacklist ${HOME}/.tin
+
+blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}
+blacklist /usr/libexec
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-passwdmgr.inc
+include disable-programs.inc
+include disable-shell.inc
+include disable-xdg.inc
+
+mkdir ${HOME}/.tin
+mkfile ${HOME}/.newsrc
+# Note: files/directories directly in ${HOME} can't be whitelisted, as
+#       tin saves .newsrc by renaming a temporary file, which is not possible for
+#       bind-mounted files.
+#whitelist ${HOME}/.newsrc
+#whitelist ${HOME}/.tin
+#include whitelist-common.inc
+include whitelist-runuser-common.inc
+include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
+
+apparmor
+caps.drop all
+ipc-namespace
+machine-id
+netfilter
+no3d
+nodvd
+nogroups
+noinput
+nonewprivs
+noroot
+nosound
+notv
+nou2f
+novideo
+protocol inet,inet6
+seccomp
+seccomp.block-secondary
+shell none
+tracelog
+
+disable-mnt
+private-bin rtin,tin
+private-cache
+private-dev
+private-etc passwd,resolv.conf,terminfo,tin
+private-lib terminfo
+private-tmp
+
+dbus-user none
+dbus-system none
+
+memory-deny-write-execute


### PR DESCRIPTION
Profile for the tin newsreader.

Tested subscribing + reading mailinglists via gmane.
Did not test reading local spool or replying by mail, which is not allowed in the profile (not sure if anyone uses that feature).

Also I can't whitelist files directly in $HOME, as it was not possible to overwrite files via rename. Is there any workaround?