### PR TITLE
gcov: add missing gcov.h includes

### DIFF
--- a/src/firejail/appimage.c
+++ b/src/firejail/appimage.c
@@ -28,6 +28,10 @@
 #include <linux/loop.h>
 #include <errno.h>
 
+#ifdef HAVE_GCOV
+#include <gcov.h>
+#endif
+
 static char *devloop = NULL;	// device file
 static long unsigned size = 0;	// offset into appimage file
 #define MAXBUF 4096

--- a/src/firejail/chroot.c
+++ b/src/firejail/chroot.c
@@ -29,6 +29,9 @@
 #define O_PATH 010000000
 #endif
 
+#ifdef HAVE_GCOV
+#include <gcov.h>
+#endif
 
 // exit if error
 void fs_check_chroot_dir(void) {

--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -33,6 +33,10 @@
 #define O_PATH 010000000
 #endif
 
+#ifdef HAVE_GCOV
+#include <gcov.h>
+#endif
+
 #define MAX_BUF 4096
 #define EMPTY_STRING ("")
 // check noblacklist statements not matched by a proper blacklist in disable-*.inc files

--- a/src/firejail/fs_mkdir.c
+++ b/src/firejail/fs_mkdir.c
@@ -25,6 +25,9 @@
 #include <sys/wait.h>
 #include <string.h>
 
+#ifdef HAVE_GCOV
+#include <gcov.h>
+#endif
 
 static void check(const char *fname) {
 	// manufacture /run/user directory

--- a/src/firejail/ls.c
+++ b/src/firejail/ls.c
@@ -31,6 +31,10 @@
 //#include <stdio.h>
 //#include <stdlib.h>
 
+#ifdef HAVE_GCOV
+#include <gcov.h>
+#endif
+
 // uid/gid cache
 static uid_t c_uid = 0;
 static char *c_uid_name = NULL;

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -44,6 +44,10 @@
 #define O_PATH 010000000
 #endif
 
+#ifdef HAVE_GCOV
+#include <gcov.h>
+#endif
+
 #ifdef __ia64__
 /* clone(2) has a different interface on ia64, as it needs to know
    the size of the stack */

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -22,6 +22,11 @@
 #include "../include/syscall.h"
 #include <dirent.h>
 #include <sys/stat.h>
+
+#ifdef HAVE_GCOV
+#include <gcov.h>
+#endif
+
 extern char *xephyr_screen;
 
 #define MAX_READ 8192				  // line buffer for profile files

--- a/src/firejail/rlimit.c
+++ b/src/firejail/rlimit.c
@@ -21,6 +21,10 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 
+#ifdef HAVE_GCOV
+#include <gcov.h>
+#endif
+
 void set_rlimits(void) {
 	EUID_ASSERT();
 	// resource limits

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -49,6 +49,9 @@
 #include <sys/apparmor.h>
 #endif
 
+#ifdef HAVE_GCOV
+#include <gcov.h>
+#endif
 
 static int force_nonewprivs = 0;
 

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -41,6 +41,10 @@
 #include <linux/openat2.h>
 #endif
 
+#ifdef HAVE_GCOV
+#include <gcov.h>
+#endif
+
 #define MAX_GROUPS 1024
 #define MAXBUF 4098
 #define EMPTY_STRING ("")

--- a/src/firemon/interface.c
+++ b/src/firemon/interface.c
@@ -33,6 +33,10 @@
 //#include <net/route.h>
 //#include <linux/if_bridge.h>
 
+#ifdef HAVE_GCOV
+#include <gcov.h>
+#endif
+
 // print IP addresses for all interfaces
 static void net_ifprint(void) {
 	uint32_t ip;

--- a/src/firemon/netstats.c
+++ b/src/firemon/netstats.c
@@ -24,6 +24,10 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#ifdef HAVE_GCOV
+#include <gcov.h>
+#endif
+
 #define MAXBUF 4096
 
 // ip -s link: device stats

--- a/src/firemon/procevent.c
+++ b/src/firemon/procevent.c
@@ -30,6 +30,10 @@
 #include <fcntl.h>
 #include <sys/uio.h>
 
+#ifdef HAVE_GCOV
+#include <gcov.h>
+#endif
+
 #define PIDS_BUFLEN 4096
 #define SERVER_PORT 889	// 889-899 is left unassigned by IANA
 

--- a/src/firemon/top.c
+++ b/src/firemon/top.c
@@ -24,6 +24,10 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#ifdef HAVE_GCOV
+#include <gcov.h>
+#endif
+
 static unsigned pgs_rss = 0;
 static unsigned pgs_shared = 0;
 static unsigned clocktick = 0;


### PR DESCRIPTION
Fixes the following "implicit declaration" warning (13 occurrences in
total) when building with gcov support:

    $ pacman -Q gcc10
    gcc10 1:10.2.0-3
    $ CC=gcc-10 && export CC
    $ ./configure --prefix=/usr --enable-apparmor --enable-gcov >/dev/null
    $ make >/dev/null
    appimage.c: In function ‘appimage_set’:
    appimage.c:140:2: warning: implicit declaration of function ‘__gcov_flush’ [-Wimplicit-function-declaration]
      140 |  __gcov_flush();
          |  ^~~~~~~~~~~~
    interface.c: In function ‘print_sandbox’:
    interface.c:149:3: warning: implicit declaration of function ‘__gcov_flush’ [-Wimplicit-function-declaration]
      149 |   __gcov_flush();
          |   ^~~~~~~~~~~~
    netstats.c: In function ‘netstats’:
    netstats.c:246:4: warning: implicit declaration of function ‘__gcov_flush’ [-Wimplicit-function-declaration]
      246 |    __gcov_flush();
          |    ^~~~~~~~~~~~
    [...]

Note: The commands above were executed from makepkg, while building
firejail-git from the AUR.

Note2: gcc-10 was used because the build fails with the current gcc
version (11.1.0) on Artix Linux.  The failure happens because
__gcov_flush was removed on gcc 11.1.0[1]; this will be addressed later.

Note3: The following command helped find the affected files:

    $ git grep -Fl __gcov -- src

[1] https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=811b7636cb8c10f1a550a76242b5666c7ae36da2
