### PR TITLE
allow access to pkgconfig

### DIFF
--- a/etc/profile-a-l/cargo.profile
+++ b/etc/profile-a-l/cargo.profile
@@ -34,6 +34,7 @@ include disable-xdg.inc
 #whitelist ${HOME}/.cargo
 #whitelist ${HOME}/.rustup
 #include whitelist-common.inc
+whitelist /usr/share/pkgconfig
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc


### PR DESCRIPTION
Building (specific) packages on Arch Linux (from AUR) needs access to /usr/share/pkgconfig. I've only seen it happen with cargo, so I added the whitelist to cargo.profile. We might want to add it to wusc instead. Suggestions welcome!