### PR TITLE
gcov: fix build failure with gcc 11.1.0

### DIFF
--- a/src/firejail/appimage.c
+++ b/src/firejail/appimage.c
@@ -29,7 +29,7 @@
 #include <errno.h>
 
 #ifdef HAVE_GCOV
-#include <gcov.h>
+#include "../include/gcov_wrapper.h"
 #endif
 
 static char *devloop = NULL;	// device file

--- a/src/firejail/chroot.c
+++ b/src/firejail/chroot.c
@@ -30,7 +30,7 @@
 #endif
 
 #ifdef HAVE_GCOV
-#include <gcov.h>
+#include "../include/gcov_wrapper.h"
 #endif
 
 // exit if error

--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -34,7 +34,7 @@
 #endif
 
 #ifdef HAVE_GCOV
-#include <gcov.h>
+#include "../include/gcov_wrapper.h"
 #endif
 
 #define MAX_BUF 4096

--- a/src/firejail/fs_mkdir.c
+++ b/src/firejail/fs_mkdir.c
@@ -26,7 +26,7 @@
 #include <string.h>
 
 #ifdef HAVE_GCOV
-#include <gcov.h>
+#include "../include/gcov_wrapper.h"
 #endif
 
 static void check(const char *fname) {

--- a/src/firejail/ls.c
+++ b/src/firejail/ls.c
@@ -32,7 +32,7 @@
 //#include <stdlib.h>
 
 #ifdef HAVE_GCOV
-#include <gcov.h>
+#include "../include/gcov_wrapper.h"
 #endif
 
 // uid/gid cache

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -45,7 +45,7 @@
 #endif
 
 #ifdef HAVE_GCOV
-#include <gcov.h>
+#include "../include/gcov_wrapper.h"
 #endif
 
 #ifdef __ia64__

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -24,7 +24,7 @@
 #include <sys/stat.h>
 
 #ifdef HAVE_GCOV
-#include <gcov.h>
+#include "../include/gcov_wrapper.h"
 #endif
 
 extern char *xephyr_screen;

--- a/src/firejail/rlimit.c
+++ b/src/firejail/rlimit.c
@@ -22,7 +22,7 @@
 #include <sys/resource.h>
 
 #ifdef HAVE_GCOV
-#include <gcov.h>
+#include "../include/gcov_wrapper.h"
 #endif
 
 void set_rlimits(void) {

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -50,7 +50,7 @@
 #endif
 
 #ifdef HAVE_GCOV
-#include <gcov.h>
+#include "../include/gcov_wrapper.h"
 #endif
 
 static int force_nonewprivs = 0;

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -42,7 +42,7 @@
 #endif
 
 #ifdef HAVE_GCOV
-#include <gcov.h>
+#include "../include/gcov_wrapper.h"
 #endif
 
 #define MAX_GROUPS 1024

--- a/src/firemon/interface.c
+++ b/src/firemon/interface.c
@@ -34,7 +34,7 @@
 //#include <linux/if_bridge.h>
 
 #ifdef HAVE_GCOV
-#include <gcov.h>
+#include "../include/gcov_wrapper.h"
 #endif
 
 // print IP addresses for all interfaces

--- a/src/firemon/netstats.c
+++ b/src/firemon/netstats.c
@@ -25,7 +25,7 @@
 #include <unistd.h>
 
 #ifdef HAVE_GCOV
-#include <gcov.h>
+#include "../include/gcov_wrapper.h"
 #endif
 
 #define MAXBUF 4096

--- a/src/firemon/procevent.c
+++ b/src/firemon/procevent.c
@@ -31,7 +31,7 @@
 #include <sys/uio.h>
 
 #ifdef HAVE_GCOV
-#include <gcov.h>
+#include "../include/gcov_wrapper.h"
 #endif
 
 #define PIDS_BUFLEN 4096

--- a/src/firemon/top.c
+++ b/src/firemon/top.c
@@ -25,7 +25,7 @@
 #include <unistd.h>
 
 #ifdef HAVE_GCOV
-#include <gcov.h>
+#include "../include/gcov_wrapper.h"
 #endif
 
 static unsigned pgs_rss = 0;

--- a/src/include/gcov_wrapper.h
+++ b/src/include/gcov_wrapper.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2021 Firejail Authors
+ *
+ * This file is part of firejail project
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef GCOV_WRAPPER_H
+#define GCOV_WRAPPER_H
+
+#include <gcov.h>
+
+/*
+ * __gcov_flush was removed on gcc 11.1.0 (as it's no longer needed), but it
+ * appears to be the safe/"correct" way to do things on previous versions (as
+ * it ensured proper locking, which is now done elsewhere).  Thus, keep using
+ * it in the code and ensure that it exists, in order to support gcc <11.1.0
+ * and gcc >=11.1.0, respectively.
+ */
+#if __GNUC__ > 11 || (__GNUC__ == 11 && __GNUC_MINOR__ >= 1)
+static void __gcov_flush(void) {
+       __gcov_dump();
+       __gcov_reset();
+}
+#endif
+
+#endif /* GCOV_WRAPPER_H */


### PR DESCRIPTION
The build currently fails if gcov support is enabled:

    $ pacman -Q gcc
    gcc 11.1.0-1
    $ ./configure --prefix=/usr --enable-apparmor --enable-gcov >/dev/null
    $ make >/dev/null
    [...]
    netstats.c: In function ‘netstats’:
    netstats.c:250:25: warning: implicit declaration of function ‘__gcov_flush’; did you mean ‘__gcov_dump’? [-Wimplicit-function-declaration]
      250 |                         __gcov_flush();
          |                         ^~~~~~~~~~~~
          |                         __gcov_dump
    [...]
    /usr/bin/ld: netstats.o: in function `netstats':
    /tmp/firejail-git/src/firejail-git/src/firemon/netstats.c:250: undefined reference to `__gcov_flush'
    [...]
    collect2: error: ld returned 1 exit status
    make[1]: *** [Makefile:10: firemon] Error 1
    make: *** [Makefile:42: src/firemon/firemon] Error 2
    [...]

This happens because __gcov_flush was removed on gcc 11.1.0[1] [2] [3].
See the following gcc commits:

* d39f7dc8d5 ("Do locking for __gcov_dump and __gcov_reset as well.")
* c0532db47d ("Use __gcov_dump and __gcov_reset in execv and fork context.")
* 811b7636cb ("Remove __gcov_flush.")

Its implementation did the following[4]:

      __gcov_lock ();
      __gcov_dump_int ();
      __gcov_reset_int ();
      __gcov_unlock ();

As hinted in the commit messages above, the function is no longer needed
because locking is now done inside each of __gcov_dump and __gcov_reset.

So add an implementation of __gcov_flush (on a new gcov_wrapper.h file)
for gcc >= 11.1.0, which just calls __gcov_dump and then __gcov_reset.

Commands used to search and replace:

    $ git grep -Flz '#include <gcov.h>' -- '*.c' |
      xargs -0 -I '{}' sh -c \
      "printf '%s\n' \"\`sed 's|<gcov\\.h>|\"../include/gcov_wrapper.h\"|' '{}'\`\" >'{}'"

Note: This is the continuation of commit 31557e9c7 ("gcov: add missing
gcov.h includes") / PR #4360.

[1] https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=d39f7dc8d558ca31a661b02d08ff090ce65e6652
[2] https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=c0532db47d092430f8e8f497b2dc53343527bb13
[3] https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=811b7636cb8c10f1a550a76242b5666c7ae36da2
[4] https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=libgcc/libgcov-interface.c;h=855e8612018d1c9caf90396a3271337aaefdb9b3#l86
