### PR TITLE
gcov: use no-op functions if not enabled

### DIFF
--- a/src/firejail/appimage.c
+++ b/src/firejail/appimage.c
@@ -21,16 +21,13 @@
 // sudo mount -o loop krita-3.0-x86_64.appimage mnt
 
 #include "firejail.h"
+#include "../include/gcov_wrapper.h"
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/mount.h>
 #include <fcntl.h>
 #include <linux/loop.h>
 #include <errno.h>
-
-#ifdef HAVE_GCOV
-#include "../include/gcov_wrapper.h"
-#endif
 
 static char *devloop = NULL;	// device file
 static long unsigned size = 0;	// offset into appimage file
@@ -140,9 +137,8 @@ void appimage_set(const char *appimage) {
 
 	if (cfg.cwd)
 		env_store_name_val("OWD", cfg.cwd, SETENV);
-#ifdef HAVE_GCOV
+
 	__gcov_flush();
-#endif
 #else
 	fprintf(stderr, "Error: /dev/loop-control interface is not supported by your kernel\n");
 	exit(1);

--- a/src/firejail/chroot.c
+++ b/src/firejail/chroot.c
@@ -20,6 +20,7 @@
 
 #ifdef HAVE_CHROOT
 #include "firejail.h"
+#include "../include/gcov_wrapper.h"
 #include <sys/mount.h>
 #include <sys/sendfile.h>
 #include <errno.h>
@@ -27,10 +28,6 @@
 #include <fcntl.h>
 #ifndef O_PATH
 #define O_PATH 010000000
-#endif
-
-#ifdef HAVE_GCOV
-#include "../include/gcov_wrapper.h"
 #endif
 
 // exit if error
@@ -263,9 +260,8 @@ void fs_chroot(const char *rootdir) {
 	// update chroot resolv.conf
 	update_file(parentfd, "etc/resolv.conf");
 
-#ifdef HAVE_GCOV
 	__gcov_flush();
-#endif
+
 	// create /run/firejail/mnt/oroot
 	char *oroot = RUN_OVERLAY_ROOT;
 	if (mkdir(oroot, 0755) == -1)

--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -18,6 +18,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 #include "firejail.h"
+#include "../include/gcov_wrapper.h"
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
@@ -31,10 +32,6 @@
 #include <fcntl.h>
 #ifndef O_PATH
 #define O_PATH 010000000
-#endif
-
-#ifdef HAVE_GCOV
-#include "../include/gcov_wrapper.h"
 #endif
 
 #define MAX_BUF 4096
@@ -1206,9 +1203,8 @@ void fs_overlayfs(void) {
 	fs_logger("whitelist /tmp");
 
 	// chroot in the new filesystem
-#ifdef HAVE_GCOV
 	__gcov_flush();
-#endif
+
 	if (chroot(oroot) == -1)
 		errExit("chroot");
 

--- a/src/firejail/fs_mkdir.c
+++ b/src/firejail/fs_mkdir.c
@@ -18,16 +18,13 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #include "firejail.h"
+#include "../include/gcov_wrapper.h"
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <grp.h>
 #include <sys/wait.h>
 #include <string.h>
-
-#ifdef HAVE_GCOV
-#include "../include/gcov_wrapper.h"
-#endif
 
 static void check(const char *fname) {
 	// manufacture /run/user directory
@@ -98,9 +95,9 @@ void fs_mkdir(const char *name) {
 
 		// create directory
 		mkdir_recursive(expanded);
-#ifdef HAVE_GCOV
+
 		__gcov_flush();
-#endif
+
 		_exit(0);
 	}
 	// wait for the child to finish

--- a/src/firejail/ls.c
+++ b/src/firejail/ls.c
@@ -19,6 +19,7 @@
 */
 
 #include "firejail.h"
+#include "../include/gcov_wrapper.h"
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
@@ -30,10 +31,6 @@
 //#include <dirent.h>
 //#include <stdio.h>
 //#include <stdlib.h>
-
-#ifdef HAVE_GCOV
-#include "../include/gcov_wrapper.h"
-#endif
 
 // uid/gid cache
 static uid_t c_uid = 0;
@@ -353,9 +350,8 @@ void sandboxfs(int op, pid_t pid, const char *path1, const char *path2) {
 			ls(fname1);
 		else
 			cat(fname1);
-#ifdef HAVE_GCOV
+
 		__gcov_flush();
-#endif
 	}
 	// get file from host and store it in the sandbox
 	else if (op == SANDBOX_FS_PUT && path2) {
@@ -387,9 +383,9 @@ void sandboxfs(int op, pid_t pid, const char *path1, const char *path2) {
 			// copy the file
 			if (copy_file(src_fname, tmp_fname, getuid(), getgid(), 0600)) // already a regular user
 				_exit(1);
-#ifdef HAVE_GCOV
+
 			__gcov_flush();
-#endif
+
 			_exit(0);
 		}
 
@@ -419,9 +415,9 @@ void sandboxfs(int op, pid_t pid, const char *path1, const char *path2) {
 			// copy the file
 			if (copy_file(tmp_fname, dest_fname, getuid(), getgid(), 0600)) // already a regular user
 				_exit(1);
-#ifdef HAVE_GCOV
+
 			__gcov_flush();
-#endif
+
 			_exit(0);
 		}
 

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -20,6 +20,7 @@
 #include "firejail.h"
 #include "../include/pid.h"
 #include "../include/firejail_user.h"
+#include "../include/gcov_wrapper.h"
 #include "../include/syscall.h"
 #include "../include/seccomp.h"
 #define _GNU_SOURCE
@@ -42,10 +43,6 @@
 #include <fcntl.h>
 #ifndef O_PATH
 #define O_PATH 010000000
-#endif
-
-#ifdef HAVE_GCOV
-#include "../include/gcov_wrapper.h"
 #endif
 
 #ifdef __ia64__
@@ -3024,9 +3021,9 @@ int main(int argc, char **argv, char **envp) {
 			network_main(child);
 			if (arg_debug)
 				printf("Host network configured\n");
-#ifdef HAVE_GCOV
+
 			__gcov_flush();
-#endif
+
 			_exit(0);
 		}
 

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -18,14 +18,11 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 #include "firejail.h"
+#include "../include/gcov_wrapper.h"
 #include "../include/seccomp.h"
 #include "../include/syscall.h"
 #include <dirent.h>
 #include <sys/stat.h>
-
-#ifdef HAVE_GCOV
-#include "../include/gcov_wrapper.h"
-#endif
 
 extern char *xephyr_screen;
 
@@ -1799,9 +1796,8 @@ void profile_read(const char *fname) {
 //		else {
 //			free(ptr);
 //		}
-#ifdef HAVE_GCOV
+
 		__gcov_flush();
-#endif
 	}
 	fclose(fp);
 }

--- a/src/firejail/rlimit.c
+++ b/src/firejail/rlimit.c
@@ -18,12 +18,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 #include "firejail.h"
+#include "../include/gcov_wrapper.h"
 #include <sys/time.h>
 #include <sys/resource.h>
-
-#ifdef HAVE_GCOV
-#include "../include/gcov_wrapper.h"
-#endif
 
 void set_rlimits(void) {
 	EUID_ASSERT();
@@ -37,9 +34,9 @@ void set_rlimits(void) {
 		// set the new limit
 		rl.rlim_cur = (rlim_t) cfg.rlimit_cpu;
 		rl.rlim_max = (rlim_t) cfg.rlimit_cpu;
-#ifdef HAVE_GCOV
+
 		__gcov_dump();
-#endif
+
 		if (setrlimit(RLIMIT_CPU, &rl) == -1)
 			errExit("setrlimit");
 		if (arg_debug)
@@ -54,9 +51,10 @@ void set_rlimits(void) {
 		// set the new limit
 		rl.rlim_cur = (rlim_t) cfg.rlimit_nofile;
 		rl.rlim_max = (rlim_t) cfg.rlimit_nofile;
-#ifdef HAVE_GCOV	// gcov-instrumented programs might crash at this point
+
+		// gcov-instrumented programs might crash at this point
 		__gcov_dump();
-#endif
+
 		if (setrlimit(RLIMIT_NOFILE, &rl) == -1)
 			errExit("setrlimit");
 		if (arg_debug)
@@ -71,9 +69,9 @@ void set_rlimits(void) {
 		// set the new limit
 		rl.rlim_cur = (rlim_t) cfg.rlimit_nproc;
 		rl.rlim_max = (rlim_t) cfg.rlimit_nproc;
-#ifdef HAVE_GCOV
+
 		__gcov_dump();
-#endif
+
 		if (setrlimit(RLIMIT_NPROC, &rl) == -1)
 			errExit("setrlimit");
 		if (arg_debug)
@@ -88,9 +86,9 @@ void set_rlimits(void) {
 		// set the new limit
 		rl.rlim_cur = (rlim_t) cfg.rlimit_fsize;
 		rl.rlim_max = (rlim_t) cfg.rlimit_fsize;
-#ifdef HAVE_GCOV
+
 		__gcov_dump();
-#endif
+
 		if (setrlimit(RLIMIT_FSIZE, &rl) == -1)
 			errExit("setrlimit");
 		if (arg_debug)
@@ -105,9 +103,9 @@ void set_rlimits(void) {
 		// set the new limit
 		rl.rlim_cur = (rlim_t) cfg.rlimit_sigpending;
 		rl.rlim_max = (rlim_t) cfg.rlimit_sigpending;
-#ifdef HAVE_GCOV
+
 		__gcov_dump();
-#endif
+
 		if (setrlimit(RLIMIT_SIGPENDING, &rl) == -1)
 			errExit("setrlimit");
 		if (arg_debug)
@@ -122,9 +120,9 @@ void set_rlimits(void) {
 		// set the new limit
 		rl.rlim_cur = (rlim_t) cfg.rlimit_as;
 		rl.rlim_max = (rlim_t) cfg.rlimit_as;
-#ifdef HAVE_GCOV
+
 		__gcov_dump();
-#endif
+
 		if (setrlimit(RLIMIT_AS, &rl) == -1)
 			errExit("setrlimit");
 		if (arg_debug)

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -19,6 +19,7 @@
 */
 
 #include "firejail.h"
+#include "../include/gcov_wrapper.h"
 #include "../include/seccomp.h"
 #include <sys/mman.h>
 #include <sys/mount.h>
@@ -47,10 +48,6 @@
 
 #ifdef HAVE_APPARMOR
 #include <sys/apparmor.h>
-#endif
-
-#ifdef HAVE_GCOV
-#include "../include/gcov_wrapper.h"
 #endif
 
 static int force_nonewprivs = 0;
@@ -507,9 +504,8 @@ void start_application(int no_sandbox, int fd, char *set_sandbox_status) {
 			exit(1);
 		}
 
-#ifdef HAVE_GCOV
 		__gcov_dump();
-#endif
+
 		seccomp_install_filters();
 
 		if (set_sandbox_status)
@@ -563,9 +559,8 @@ void start_application(int no_sandbox, int fd, char *set_sandbox_status) {
 		if (!arg_command && !arg_quiet)
 			print_time();
 
-#ifdef HAVE_GCOV
 		__gcov_dump();
-#endif
+
 		seccomp_install_filters();
 
 		if (set_sandbox_status)

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -19,6 +19,7 @@
  */
 #define _XOPEN_SOURCE 500
 #include "firejail.h"
+#include "../include/gcov_wrapper.h"
 #include <ftw.h>
 #include <sys/stat.h>
 #include <sys/mount.h>
@@ -39,10 +40,6 @@
 #include <sys/syscall.h>
 #ifdef __NR_openat2
 #include <linux/openat2.h>
-#endif
-
-#ifdef HAVE_GCOV
-#include "../include/gcov_wrapper.h"
 #endif
 
 #define MAX_GROUPS 1024
@@ -341,9 +338,9 @@ void copy_file_as_user(const char *srcname, const char *destname, uid_t uid, gid
 		int rv = copy_file(srcname, destname, uid, gid, mode); // already a regular user
 		if (rv)
 			fwarning("cannot copy %s\n", srcname);
-#ifdef HAVE_GCOV
+
 		__gcov_flush();
-#endif
+
 		_exit(0);
 	}
 	// wait for the child to finish
@@ -375,9 +372,9 @@ void copy_file_from_user_to_root(const char *srcname, const char *destname, uid_
 			close(src);
 		}
 		close(dst);
-#ifdef HAVE_GCOV
+
 		__gcov_flush();
-#endif
+
 		_exit(0);
 	}
 	// wait for the child to finish
@@ -406,9 +403,9 @@ void touch_file_as_user(const char *fname, mode_t mode) {
 		}
 		else
 			fwarning("cannot create %s\n", fname);
-#ifdef HAVE_GCOV
+
 		__gcov_flush();
-#endif
+
 		_exit(0);
 	}
 	// wait for the child to finish
@@ -1015,9 +1012,9 @@ int remove_overlay_directory(void) {
 			// remove ~/.firejail
 			if (rmdir(path) == -1)
 				errExit("rmdir");
-#ifdef HAVE_GCOV
+
 			__gcov_flush();
-#endif
+
 			_exit(0);
 		}
 		// wait for the child to finish
@@ -1073,9 +1070,9 @@ int create_empty_dir_as_user(const char *dir, mode_t mode) {
 			}
 			else if (arg_debug)
 				printf("Directory %s not created: %s\n", dir, strerror(errno));
-#ifdef HAVE_GCOV
+
 			__gcov_flush();
-#endif
+
 			_exit(0);
 		}
 		waitpid(child, NULL, 0);

--- a/src/firemon/interface.c
+++ b/src/firemon/interface.c
@@ -18,6 +18,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 #include "firemon.h"
+#include "../include/gcov_wrapper.h"
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <netdb.h>
@@ -32,10 +33,6 @@
 
 //#include <net/route.h>
 //#include <linux/if_bridge.h>
-
-#ifdef HAVE_GCOV
-#include "../include/gcov_wrapper.h"
-#endif
 
 // print IP addresses for all interfaces
 static void net_ifprint(void) {
@@ -149,9 +146,9 @@ static void print_sandbox(pid_t pid) {
 		if (rv)
 			return;
 		net_ifprint();
-#ifdef HAVE_GCOV
+
 		__gcov_flush();
-#endif
+
 		_exit(0);
 	}
 

--- a/src/firemon/netstats.c
+++ b/src/firemon/netstats.c
@@ -247,7 +247,7 @@ void netstats(void) {
 			}
 		}
 #ifdef HAVE_GCOV
-			__gcov_flush();
+		__gcov_flush();
 #endif
 	}
 }

--- a/src/firemon/netstats.c
+++ b/src/firemon/netstats.c
@@ -18,15 +18,12 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 #include "firemon.h"
+#include "../include/gcov_wrapper.h"
 #include <termios.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
-
-#ifdef HAVE_GCOV
-#include "../include/gcov_wrapper.h"
-#endif
 
 #define MAXBUF 4096
 
@@ -246,8 +243,7 @@ void netstats(void) {
 				print_proc(i, itv, col);
 			}
 		}
-#ifdef HAVE_GCOV
+
 		__gcov_flush();
-#endif
 	}
 }

--- a/src/firemon/procevent.c
+++ b/src/firemon/procevent.c
@@ -18,6 +18,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 #include "firemon.h"
+#include "../include/gcov_wrapper.h"
 #include <sys/socket.h>
 #include <linux/connector.h>
 #include <linux/netlink.h>
@@ -29,10 +30,6 @@
 #include <time.h>
 #include <fcntl.h>
 #include <sys/uio.h>
-
-#ifdef HAVE_GCOV
-#include "../include/gcov_wrapper.h"
-#endif
 
 #define PIDS_BUFLEN 4096
 #define SERVER_PORT 889	// 889-899 is left unassigned by IANA
@@ -234,9 +231,7 @@ static void __attribute__((noreturn)) procevent_monitor(const int sock, pid_t my
 	tv.tv_usec = 0;
 
 	while (1) {
-#ifdef HAVE_GCOV
 		__gcov_flush();
-#endif
 
 #define BUFFSIZE 4096
 		char __attribute__ ((aligned(NLMSG_ALIGNTO)))buf[BUFFSIZE];

--- a/src/firemon/top.c
+++ b/src/firemon/top.c
@@ -331,7 +331,7 @@ void top(void) {
 		}
 		head_print(col, row);
 #ifdef HAVE_GCOV
-			__gcov_flush();
+		__gcov_flush();
 #endif
 	}
 }

--- a/src/firemon/top.c
+++ b/src/firemon/top.c
@@ -18,15 +18,12 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 #include "firemon.h"
+#include "../include/gcov_wrapper.h"
 #include <termios.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
-
-#ifdef HAVE_GCOV
-#include "../include/gcov_wrapper.h"
-#endif
 
 static unsigned pgs_rss = 0;
 static unsigned pgs_shared = 0;
@@ -330,8 +327,7 @@ void top(void) {
 			}
 		}
 		head_print(col, row);
-#ifdef HAVE_GCOV
+
 		__gcov_flush();
-#endif
 	}
 }

--- a/src/include/gcov_wrapper.h
+++ b/src/include/gcov_wrapper.h
@@ -21,6 +21,7 @@
 #ifndef GCOV_WRAPPER_H
 #define GCOV_WRAPPER_H
 
+#ifdef HAS_GCOV
 #include <gcov.h>
 
 /*
@@ -36,5 +37,10 @@ static void __gcov_flush(void) {
        __gcov_reset();
 }
 #endif
+#else
+#define __gcov_dump() ((void)0)
+#define __gcov_reset() ((void)0)
+#define __gcov_flush() ((void)0)
+#endif /* HAS_GCOV */
 
 #endif /* GCOV_WRAPPER_H */


### PR DESCRIPTION
Instead of wrapping every gcov function call in an ifdef.

Note: The usage of `((void)0)` is based on section 7.2 of the C99
standard (N1256)[1] [2]:

> 7.2 Diagnostics <assert.h>
>
> 1 The header <assert.h> defines the assert macro and refers to another
> macro,
>
>     NDEBUG
>
> which is not defined by <assert.h>. If NDEBUG is defined as a macro
> name at the point in the source file where <assert.h> is included, the
> assert macro is defined simply as
>
>     #define assert(ignore) ((void)0)

See also assert.h(0p) from POSIX.1-2017[3].

Note: This is a continuation of commit b408b20c7 ("gcov: fix build
failure with gcc 11.1.0") / PR #4373.

[1] http://www.open-std.org/JTC1/SC22/WG14/www/docs/n1256.pdf
[2] https://port70.net/~nsz/c/c99/n1256.html#7.2
[3] https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/assert.h.html
