### PR TITLE
Exclude allow/deny move in profile from git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# move whitelist/blacklist to allow/deny
+fe0f975f447d59977d90c3226cc8c623b31b20b3


### PR DESCRIPTION
fe0f975f447d59977d90c3226cc8c623b31b20b3 (move whitelist/blacklist to
allow/deny) is just a huge rename¹ w/o effects to the profile. Ignoreing
it in git blame to see which commits actually added/changed a
allow/nodeny command.

Configure git to use .git-blame-ignore-revs:

    git config blame.ignoreRevsFile .git-blame-ignore-revs


EDIT: ¹ but it also https://github.com/netblue30/firejail/commit/fe0f975f447d59977d90c3226cc8c623b31b20b3#diff-7c733ed074575806d2755a48dd858c22c318d0190737f64299fa6dda414ba29b and https://github.com/netblue30/firejail/commit/fe0f975f447d59977d90c3226cc8c623b31b20b3#diff-9f33b84e2dc73f7861f9d367b48fe0e3cf23832184311457b6ebef69714c358c