### PR TITLE
Update telegram.profile

### DIFF
--- a/etc/profile-m-z/telegram.profile
+++ b/etc/profile-m-z/telegram.profile
@@ -48,6 +48,7 @@ private-etc alsa,alternatives,ca-certificates,crypto-policies,fonts,group,ld.so.
 private-tmp
 
 dbus-user filter
+dbus-user.own org.telegram.desktop.*
 dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.kde.StatusNotifierWatcher
 dbus-user.talk org.gnome.Mutter.IdleMonitor


### PR DESCRIPTION
Recently I have noticed these two-
- org.telegram.desktop.BaseGtkIntegration-0fe332cb424bfc37f394ccb976afec41
- org.telegram.desktop.GtkIntegration-0fe332cb424bfc37f394ccb976afec41
 
& without **dbus** rule for these two, telegram isn't quitting.
