### PR TITLE
Added ${HOME}/Private blacklist to disable-common

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -398,6 +398,7 @@ blacklist /home/.fscrypt
 blacklist ${HOME}/*.kdb
 blacklist ${HOME}/*.kdbx
 blacklist ${HOME}/*.key
+blacklist ${HOME}/Private
 blacklist ${HOME}/.Private
 blacklist ${HOME}/.caff
 blacklist ${HOME}/.cargo/credentials


### PR DESCRIPTION
/etc/firejail/disable-common.inc has a blacklist for "${HOME}/.Private" but not for "${HOME}/Private"