### PR TITLE
telegram.profile: whitelist /usr/share/TelegramDesktop

### DIFF
--- a/etc/profile-m-z/telegram.profile
+++ b/etc/profile-m-z/telegram.profile
@@ -21,6 +21,7 @@ mkdir ${HOME}/.local/share/TelegramDesktop
 whitelist ${HOME}/.TelegramDesktop
 whitelist ${HOME}/.local/share/TelegramDesktop
 whitelist ${DOWNLOADS}
+whitelist /usr/share/TelegramDesktop
 include whitelist-common.inc
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc


### PR DESCRIPTION
Telegram loads packed resources dynamically since https://github.com/telegramdesktop/tdesktop/commit/443eef3202ee43c2e820cc550fbcc70a7609f452.

In the [official Debian package](https://packages.debian.org/bullseye/telegram-desktop), the relevant file can be found at `/usr/share/TelegramDesktop/tresources.rcc`.

If the file cannot be loaded, the program fails to launch and prints "Packed resources not found".

---

~Please note that a known issue remains: the tray icon is missing.~

The tray icon appears with Telegram Desktop 2.9.2.