### PR TITLE
Issue template improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,31 +6,39 @@ labels: ''
 assignees: ''
 
 ---
+
 Write clear, concise and in textual form.
 
 **Bug and expected behavior**
+
 - Describe the bug.
 - What did you expect to happen?
 
 **No profile and disabling firejail**
+
 - What changed calling `firejail --noprofile /path/to/program` in a terminal?
 - What changed calling the program by path (e.g. `/usr/bin/vlc`)?
 
 **Reproduce**
+
 Steps to reproduce the behavior:
+
 1. Run in bash `firejail PROGRAM`
 2. See error `ERROR`
 3. Click on '....'
 4. Scroll down to '....'
 
 **Environment**
+
  - Linux distribution and version (ie output of `lsb_release -a`, `screenfetch` or `cat /etc/os-release`)
  - Firejail version (output of `firejail --version`) exclusive or used git commit (`git rev-parse HEAD`)
 
 **Additional context**
+
 Other context about the problem like related errors to understand the problem.
 
 **Checklist**
+
  - [ ] The profile (and redirect profile if exists) hasn't already been fixed [upstream](https://github.com/netblue30/firejail/tree/master/etc).
  - [ ] The program has a profile. (If not, request one in `https://github.com/netblue30/firejail/issues/1139`)
  - [ ] I have performed a short search for similar issues (to avoid opening a duplicate).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -47,6 +47,8 @@ Other context about the problem like related errors to understand the problem.
 - [ ] I'm aware of `browser-allow-drm yes`/`browser-disable-u2f no` in `firejail.config` to allow DRM/U2F in browsers.
 - [ ] This is not a question. Questions should be asked in https://github.com/netblue30/firejail/discussions.
 
+### Log
+
 <details>
 <summary>debug output</summary>
 <p>

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -47,11 +47,13 @@ Other context about the problem like related errors to understand the problem.
 - [ ] I'm aware of `browser-allow-drm yes`/`browser-disable-u2f no` in `firejail.config` to allow DRM/U2F in browsers.
 - [ ] This is not a question. Questions should be asked in https://github.com/netblue30/firejail/discussions.
 
-
-<details><summary> debug output </summary>
+<details>
+<summary>debug output</summary>
+<p>
 
 ```
 OUTPUT OF `firejail --debug PROGRAM`
 ```
 
+</p>
 </details>

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,8 +30,8 @@ Steps to reproduce the behavior:
 
 ### Environment
 
- - Linux distribution and version (ie output of `lsb_release -a`, `screenfetch` or `cat /etc/os-release`)
- - Firejail version (output of `firejail --version`) exclusive or used git commit (`git rev-parse HEAD`)
+- Linux distribution and version (ie output of `lsb_release -a`, `screenfetch` or `cat /etc/os-release`)
+- Firejail version (output of `firejail --version`) exclusive or used git commit (`git rev-parse HEAD`)
 
 ### Additional context
 
@@ -39,13 +39,13 @@ Other context about the problem like related errors to understand the problem.
 
 ### Checklist
 
- - [ ] The profile (and redirect profile if exists) hasn't already been fixed [upstream](https://github.com/netblue30/firejail/tree/master/etc).
- - [ ] The program has a profile. (If not, request one in `https://github.com/netblue30/firejail/issues/1139`)
- - [ ] I have performed a short search for similar issues (to avoid opening a duplicate).
- - [ ] If it is a AppImage, `--profile=PROFILENAME` is used to set the right profile.
- - [ ] Used `LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 PROGRAM` to get english error-messages.
- - [ ] I'm aware of `browser-allow-drm yes`/`browser-disable-u2f no` in `firejail.config` to allow DRM/U2F in browsers.
- - [ ] This is not a question. Questions should be asked in https://github.com/netblue30/firejail/discussions.
+- [ ] The profile (and redirect profile if exists) hasn't already been fixed [upstream](https://github.com/netblue30/firejail/tree/master/etc).
+- [ ] The program has a profile. (If not, request one in `https://github.com/netblue30/firejail/issues/1139`)
+- [ ] I have performed a short search for similar issues (to avoid opening a duplicate).
+- [ ] If it is a AppImage, `--profile=PROFILENAME` is used to set the right profile.
+- [ ] Used `LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 PROGRAM` to get english error-messages.
+- [ ] I'm aware of `browser-allow-drm yes`/`browser-disable-u2f no` in `firejail.config` to allow DRM/U2F in browsers.
+- [ ] This is not a question. Questions should be asked in https://github.com/netblue30/firejail/discussions.
 
 
 <details><summary> debug output </summary>

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,17 +9,17 @@ assignees: ''
 
 Write clear, concise and in textual form.
 
-**Bug and expected behavior**
+### Bug and expected behavior
 
 - Describe the bug.
 - What did you expect to happen?
 
-**No profile and disabling firejail**
+### No profile and disabling firejail
 
 - What changed calling `firejail --noprofile /path/to/program` in a terminal?
 - What changed calling the program by path (e.g. `/usr/bin/vlc`)?
 
-**Reproduce**
+### Reproduce
 
 Steps to reproduce the behavior:
 
@@ -28,16 +28,16 @@ Steps to reproduce the behavior:
 3. Click on '....'
 4. Scroll down to '....'
 
-**Environment**
+### Environment
 
  - Linux distribution and version (ie output of `lsb_release -a`, `screenfetch` or `cat /etc/os-release`)
  - Firejail version (output of `firejail --version`) exclusive or used git commit (`git rev-parse HEAD`)
 
-**Additional context**
+### Additional context
 
 Other context about the problem like related errors to understand the problem.
 
-**Checklist**
+### Checklist
 
  - [ ] The profile (and redirect profile if exists) hasn't already been fixed [upstream](https://github.com/netblue30/firejail/tree/master/etc).
  - [ ] The program has a profile. (If not, request one in `https://github.com/netblue30/firejail/issues/1139`)


### PR DESCRIPTION
Make sections easier to see and edit.

By the way, I've intended to do this for a while, as I always thought that the
template looked rather crooked.  I had assumed that it was just created from
scratch by hand like any other file, but recently I learned that GitHub is what
generates issue templates using such unusual markup for some reason.  Now I see
that it's even mentioned in the commit that adds the template:

```console
$ git show --pretty='%h %ai %s%n%n%b' --name-status bd29bf7202
bd29bf720 2020-04-07 16:40:07 -0500 Add bug report template

(Mostly) auto-generated with GitHub, will need tweaking over time

A       .github/ISSUE_TEMPLATE/bug_report.md
```

Cc: @Fred-Barclay (from the commit) @reinerh @rusty-snake (from #4468)
