### PR TITLE
README.md: add artix linux to distro list

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ https://unparalleled.eu/blog/2021/20210208-rigged-race-against-firejail-for-loca
 
 ## Installing
 
-Try installing Firejail from your system packages first. Firejail is included in Alpine, ALT Linux, Arch, Chakra, Debian, Deepin, Devuan, Fedora, Gentoo, Manjaro, Mint, NixOS, Parabola, Parrot, PCLinuxOS, ROSA, Solus, Slackware/SlackBuilds, Trisquel, Ubuntu, Void and possibly others.
+Try installing Firejail from your system packages first. Firejail is included in Alpine, ALT Linux, Arch, Artix, Chakra, Debian, Deepin, Devuan, Fedora, Gentoo, Manjaro, Mint, NixOS, Parabola, Parrot, PCLinuxOS, ROSA, Solus, Slackware/SlackBuilds, Trisquel, Ubuntu, Void and possibly others.
 
 The firejail 0.9.52-LTS version is deprecated. On Ubuntu 18.04 LTS users are advised to use the [PPA](https://launchpad.net/~deki/+archive/ubuntu/firejail). On Debian buster we recommend to use the [backports](https://packages.debian.org/buster-backports/firejail) package.
 


### PR DESCRIPTION
Home page: https://artixlinux.org

A few months ago, running `pacman -S firejail` would install it from
Arch's "community" repository by default.  But currently, Artix has its
own firejail package, in the "galaxy" repository:

* https://gitea.artixlinux.org/packagesF/firejail
* https://repology.org/project/firejail/versions

See also the following article from 2021-06-09:

https://artixlinux.org/news.php#Arch_repositories_made_optional

> Arch repositories made optional
>
> Artix has reached the stage where it can operate without the help of
> the Arch repositories, including the preparation of its installation
> media.  As such, all new weekly ISO images will ship without [extra],
> [community] and [multilib] enabled in pacman.conf.  Existing setups
> will not be affected, but new users may want to enable them and
> benefit from the additional packages.  Instructions are provided in
> our wiki[1].
>
> TL;DR:
>
>     # pacman -Syu artix-archlinux-support

For reference, the distro list was added on commit ee03888ab
("prioritize installing via OS (#3442)") / PR #3442.

[1] https://wiki.artixlinux.org/Main/Repositories#Arch_repositories

Cc: @glitsj16 (as the author of #3442)
