### PR TITLE
.git-blame-ignore-revs: add revert of allow/deny move

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # move whitelist/blacklist to allow/deny
 fe0f975f447d59977d90c3226cc8c623b31b20b3
+# Revert "move whitelist/blacklist to allow/deny"
+f43382f1e9707b4fd5e63c7bfe881912aa4ee994


### PR DESCRIPTION
Add commit f43382f1e ("Revert "move whitelist/blacklist to allow/deny"")
from PR #4410.

As mentioned on commit b023b9a6f ("Exclude allow/deny move in profile
from git blame") / PR #4390, commit fe0f975f4 ("move whitelist/blacklist
to allow/deny") "is just a huge rename", and so is the revert of it.

Note that there is a follow-up to f43382f1e: commit 2e4d52ec6 ("Revert
allow/deny additional files") (sort of related to #4421).  It renames a
bit too much, which is later fixed by commit 3836131f3 ("Fix zim and
rednotebook").  Since these are small changes and since they involve
regressions, neither commit is added.
