### PR TITLE
Blacklist Exodus wallet

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -77,6 +77,7 @@ blacklist ${HOME}/.config/Element
 blacklist ${HOME}/.config/Element (Riot)
 blacklist ${HOME}/.config/Enox
 blacklist ${HOME}/.config/Epic
+blacklist ${HOME}/.config/Exodus
 blacklist ${HOME}/.config/Ferdi
 blacklist ${HOME}/.config/Flavio Tordini
 blacklist ${HOME}/.config/Franz


### PR DESCRIPTION
Just blacklisting [Exodus](https://www.exodus.com). Haven't created a profile for it yet.