### PR TITLE
Fix broken DNS resolution on Arch Linux using systemd-resolved

### DIFF
--- a/etc/inc/whitelist-run-common.inc
+++ b/etc/inc/whitelist-run-common.inc
@@ -8,3 +8,4 @@ whitelist /run/dbus/system_bus_socket
 whitelist /run/media
 whitelist /run/resolvconf/resolv.conf
 whitelist /run/systemd/resolve/resolv.conf
+whitelist /run/systemd/resolve/stub-resolv.conf


### PR DESCRIPTION
This is a quick fix of #4482 for distributions that link `/etc/resolv.conf` to `/run/systemd/resolve/stub-resolv.conf`  (Arch Linux is one of them).