### PR TITLE
Add profiles for build-systems (/package-managers)

### DIFF
--- a/etc/inc/allow-common-devel.inc
+++ b/etc/inc/allow-common-devel.inc
@@ -27,5 +27,8 @@ noblacklist ${HOME}/.python-history
 noblacklist ${HOME}/.python_history
 noblacklist ${HOME}/.pythonhist
 
+# Ruby
+noblacklist ${HOME}/.bundle
+
 # Rust
-noblacklist ${HOME}/.cargo/*
+noblacklist ${HOME}/.cargo

--- a/etc/inc/allow-ruby.inc
+++ b/etc/inc/allow-ruby.inc
@@ -4,3 +4,4 @@ include allow-ruby.local
 
 noblacklist ${PATH}/ruby
 noblacklist /usr/lib/ruby
+noblacklist /usr/lib64/ruby

--- a/etc/inc/disable-interpreters.inc
+++ b/etc/inc/disable-interpreters.inc
@@ -48,6 +48,7 @@ blacklist /usr/share/php*
 # Ruby
 blacklist ${PATH}/ruby
 blacklist /usr/lib/ruby
+blacklist /usr/lib64/ruby
 
 # Programs using python: deluge, firefox addons, filezilla, cherrytree, xchat, hexchat, libreoffice, scribus
 # Python 2

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -49,8 +49,9 @@ blacklist ${HOME}/.bibletime
 blacklist ${HOME}/.bitcoin
 blacklist ${HOME}/.blobby
 blacklist ${HOME}/.bogofilter
+blacklist ${HOME}/.bundle
 blacklist ${HOME}/.bzf
-blacklist ${HOME}/.cargo/*
+blacklist ${HOME}/.cargo
 blacklist ${HOME}/.claws-mail
 blacklist ${HOME}/.cliqz
 blacklist ${HOME}/.clion*

--- a/etc/profile-a-l/build-systems-common.profile
+++ b/etc/profile-a-l/build-systems-common.profile
@@ -28,9 +28,10 @@ include disable-shell.inc
 include disable-X11.inc
 include disable-xdg.inc
 
-whitelist ${HOME}/Projects
+#whitelist ${HOME}/Projects
+#include whitelist-common.inc
+
 whitelist /usr/share/pkgconfig
-include whitelist-common.inc
 include whitelist-run-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc

--- a/etc/profile-a-l/build-systems-common.profile
+++ b/etc/profile-a-l/build-systems-common.profile
@@ -1,0 +1,65 @@
+# Firejail profile for build-systems-common
+# This file is overwritten after every install/update
+# Persistent local customizations
+include build-systems-common.local
+# Persistent global definitions
+# added by caller profile
+#include globals.local
+
+ignore noexec ${HOME}
+ignore noexec /tmp
+
+# Allow /bin/sh (blacklisted by disable-shell.inc)
+include allow-bin-sh.inc
+
+# Allows files commonly used by IDEs
+include allow-common-devel.inc
+
+# Allow ssh (blacklisted by disable-common.inc)
+#include allow-ssh.inc
+
+blacklist ${RUNUSER}
+
+include disable-common.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-programs.inc
+include disable-shell.inc
+include disable-X11.inc
+include disable-xdg.inc
+
+whitelist ${HOME}/Projects
+whitelist /usr/share/pkgconfig
+include whitelist-common.inc
+include whitelist-run-common.inc
+include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
+
+caps.drop all
+ipc-namespace
+machine-id
+# net none
+netfilter
+no3d
+nodvd
+nogroups
+noinput
+nonewprivs
+noroot
+nosound
+notv
+nou2f
+novideo
+protocol unix,inet,inet6
+seccomp
+seccomp.block-secondary
+shell none
+tracelog
+
+disable-mnt
+private-cache
+private-dev
+private-tmp
+
+dbus-user none
+dbus-system none

--- a/etc/profile-a-l/bundle.profile
+++ b/etc/profile-a-l/bundle.profile
@@ -1,0 +1,24 @@
+# Firejail profile for bundle
+# Description: Ruby Dependency Management
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include bundle.local
+# Persistent global definitions
+include globals.local
+
+noblacklist ${HOME}/.bundle
+
+# Allow ruby (blacklisted by disable-interpreters.inc)
+include allow-ruby.inc
+
+mkdir ${HOME}/.bundle
+whitelist ${HOME}/.bundle
+whitelist /usr/share/gems
+whitelist /usr/share/ruby
+whitelist /usr/share/rubygems
+
+private-bin bundle,bundler,ruby,ruby-mri
+
+# Redirect
+include build-systems-common.profile

--- a/etc/profile-a-l/bundle.profile
+++ b/etc/profile-a-l/bundle.profile
@@ -19,7 +19,5 @@ whitelist /usr/share/gems
 whitelist /usr/share/ruby
 whitelist /usr/share/rubygems
 
-private-bin bundle,bundler,ruby,ruby-mri
-
 # Redirect
 include build-systems-common.profile

--- a/etc/profile-a-l/bundle.profile
+++ b/etc/profile-a-l/bundle.profile
@@ -12,8 +12,9 @@ noblacklist ${HOME}/.bundle
 # Allow ruby (blacklisted by disable-interpreters.inc)
 include allow-ruby.inc
 
-mkdir ${HOME}/.bundle
-whitelist ${HOME}/.bundle
+#whitelist ${HOME}/.bundle
+#whitelist ${HOME}/.gem
+#whitelist ${HOME}/.local/share/gem
 whitelist /usr/share/gems
 whitelist /usr/share/ruby
 whitelist /usr/share/rubygems

--- a/etc/profile-a-l/cargo.profile
+++ b/etc/profile-a-l/cargo.profile
@@ -7,66 +7,19 @@ include cargo.local
 # Persistent global definitions
 include globals.local
 
-ignore noexec ${HOME}
-ignore noexec /tmp
-
-blacklist /tmp/.X11-unix
-blacklist ${RUNUSER}
+ignore read-only ${HOME}/.cargo/bin
 
 noblacklist ${HOME}/.cargo/credentials
 noblacklist ${HOME}/.cargo/credentials.toml
 
-# Allows files commonly used by IDEs
-include allow-common-devel.inc
+mkdir ${HOME}/.cargo
+whitelist ${HOME}/.cargo
+whitelist ${HOME}/.rustup
 
-# Allow ssh (blacklisted by disable-common.inc)
-#include allow-ssh.inc
-
-include disable-common.inc
-include disable-exec.inc
-include disable-interpreters.inc
-include disable-programs.inc
-include disable-xdg.inc
-
-#mkdir ${HOME}/.cargo
-#whitelist ${HOME}/YOUR_CARGO_PROJECTS
-#whitelist ${HOME}/.cargo
-#whitelist ${HOME}/.rustup
-#include whitelist-common.inc
-whitelist /usr/share/pkgconfig
-include whitelist-runuser-common.inc
-include whitelist-usr-share-common.inc
-include whitelist-var-common.inc
-
-caps.drop all
-ipc-namespace
-machine-id
-netfilter
-no3d
-nodvd
-nogroups
-noinput
-nonewprivs
-noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix,inet,inet6
-seccomp
-seccomp.block-secondary
-shell none
-tracelog
-
-disable-mnt
 #private-bin cargo,rustc
-private-cache
-private-dev
 private-etc alternatives,ca-certificates,crypto-policies,group,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,magic,magic.mgc,nsswitch.conf,passwd,pki,protocols,resolv.conf,rpc,services,ssl
-private-tmp
-
-dbus-user none
-dbus-system none
 
 memory-deny-write-execute
-read-write ${HOME}/.cargo/bin
+
+# Redirect
+include build-systems-common.profile

--- a/etc/profile-a-l/cargo.profile
+++ b/etc/profile-a-l/cargo.profile
@@ -12,9 +12,8 @@ ignore read-only ${HOME}/.cargo/bin
 noblacklist ${HOME}/.cargo/credentials
 noblacklist ${HOME}/.cargo/credentials.toml
 
-mkdir ${HOME}/.cargo
-whitelist ${HOME}/.cargo
-whitelist ${HOME}/.rustup
+#whitelist ${HOME}/.cargo
+#whitelist ${HOME}/.rustup
 
 #private-bin cargo,rustc
 private-etc alternatives,ca-certificates,crypto-policies,group,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,magic,magic.mgc,nsswitch.conf,passwd,pki,protocols,resolv.conf,rpc,services,ssl

--- a/etc/profile-a-l/cmake.profile
+++ b/etc/profile-a-l/cmake.profile
@@ -7,8 +7,6 @@ include cargo.local
 # Persistent global definitions
 include globals.local
 
-private-bin cmake
-
 memory-deny-write-execute
 
 # Redirect

--- a/etc/profile-a-l/cmake.profile
+++ b/etc/profile-a-l/cmake.profile
@@ -1,0 +1,15 @@
+# Firejail profile for cargo
+# Description: The Rust package manager
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include cargo.local
+# Persistent global definitions
+include globals.local
+
+private-bin cmake
+
+memory-deny-write-execute
+
+# Redirect
+include build-systems-common.profile

--- a/etc/profile-m-z/make.profile
+++ b/etc/profile-m-z/make.profile
@@ -1,0 +1,13 @@
+# Firejail profile for make
+# Description: GNU make utility to maintain groups of programs
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include make.local
+# Persistent global definitions
+include globals.local
+
+memory-deny-write-execute
+
+# Redirect
+include build-systems-common.profile

--- a/etc/profile-m-z/meson.profile
+++ b/etc/profile-m-z/meson.profile
@@ -10,7 +10,5 @@ include globals.local
 # Allow python3 (blacklisted by disable-interpreters.inc)
 include allow-python3.inc
 
-private-bin meson,python3*
-
 # Redirect
 include build-systems-common.profile

--- a/etc/profile-m-z/meson.profile
+++ b/etc/profile-m-z/meson.profile
@@ -1,0 +1,16 @@
+# Firejail profile for meson
+# Description: A high productivity build system
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include meson.local
+# Persistent global definitions
+include globals.local
+
+# Allow python3 (blacklisted by disable-interpreters.inc)
+include allow-python3.inc
+
+private-bin meson,python3*
+
+# Redirect
+include build-systems-common.profile

--- a/etc/profile-m-z/pip.profile
+++ b/etc/profile-m-z/pip.profile
@@ -1,0 +1,20 @@
+# Firejail profile for pip
+# Description: package manager for Python packages
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include meson.local
+# Persistent global definitions
+include globals.local
+
+ignore read-only ${HOME}/.local/lib
+
+# Allow python3 (blacklisted by disable-interpreters.inc)
+include allow-python3.inc
+
+whitelist ${HOME}/.local/lib/python*
+
+private-bin pip,pip[0-9].[0-9],pip[0-9].[0-9],python3*
+
+# Redirect
+include build-systems-common.profile

--- a/etc/profile-m-z/pip.profile
+++ b/etc/profile-m-z/pip.profile
@@ -14,7 +14,5 @@ include allow-python3.inc
 
 #whitelist ${HOME}/.local/lib/python*
 
-private-bin pip,pip[0-9].[0-9],pip[0-9].[0-9],python3*
-
 # Redirect
 include build-systems-common.profile

--- a/etc/profile-m-z/pip.profile
+++ b/etc/profile-m-z/pip.profile
@@ -12,7 +12,7 @@ ignore read-only ${HOME}/.local/lib
 # Allow python3 (blacklisted by disable-interpreters.inc)
 include allow-python3.inc
 
-whitelist ${HOME}/.local/lib/python*
+#whitelist ${HOME}/.local/lib/python*
 
 private-bin pip,pip[0-9].[0-9],pip[0-9].[0-9],python3*
 


### PR DESCRIPTION
Profiles: bunler, cargo (refactor), cmake (untested), make, meson, pip
All redirect to build-systems-common.profile

Other fixes:
 - blacklist ${HOME}/.bundle
 - blacklist ${HOME}/.cargo/* -> blacklist ${HOME}/.cargo
 - blacklist /usr/lib64/ruby


You can now `firejail make` firejail :laughing:.
