### PR TITLE
Fix #4555 - Allow evince to read .cbz file format

### DIFF
--- a/etc/profile-a-l/evince.profile
+++ b/etc/profile-a-l/evince.profile
@@ -56,7 +56,7 @@ private-cache
 private-dev
 private-etc alternatives,fonts,group,ld.so.cache,machine-id,passwd
 # private-lib might break two-page-view on some systems
-private-lib evince,gcc/*/*/libgcc_s.so.*,gcc/*/*/libstdc++.so.*,gconv,gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libdjvulibre.so.*,libgconf-2.so.*,libgraphite2.so.*,libpoppler-glib.so.*,librsvg-2.so.*,libspectre.so.*
+private-lib evince,gcc/*/*/libgcc_s.so.*,gcc/*/*/libstdc++.so.*,gconv,gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libarchive.so.*,libdjvulibre.so.*,libgconf-2.so.*,libgraphite2.so.*,libpoppler-glib.so.*,librsvg-2.so.*,libspectre.so.*
 private-tmp
 
 # dbus-user filtering might break two-page-view on some systems


### PR DESCRIPTION
Enable evince to display archived images (.cbz) file with plugin installed.

libarchive.so should be added to the private-lib option so that evince can extract images from the archived file.

Related issue: #4555 