### PR TITLE
Remove /etc/hosts is_link check

### DIFF
--- a/src/firejail/fs_hostname.c
+++ b/src/firejail/fs_hostname.c
@@ -154,9 +154,6 @@ void fs_mount_hosts_file(void) {
 	struct stat s;
 	if (stat("/etc/hosts", &s) == -1)
 		goto errexit;
-	// not a link
-	if (is_link("/etc/hosts"))
-		goto errexit;
 	// owned by root
 	if (s.st_uid != 0)
 		goto errexit;

--- a/src/firejail/fs_hostname.c
+++ b/src/firejail/fs_hostname.c
@@ -132,10 +132,6 @@ char *fs_check_hosts_file(const char *fname) {
 	invalid_filename(fname);
 	char *rv = expand_home(fname, cfg.homedir);
 
-	// no a link
-	if (is_link(rv))
-		goto errexit;
-
 	// the user has read access to the file
 	if (access(rv, R_OK))
 		goto errexit;


### PR DESCRIPTION
This patch fixes https://github.com/netblue30/firejail/issues/2758#issuecomment-805174951 . Especially for NixOS users, the file `/etc/hosts` is a symlink and firejail fails with exiting after `is_link()` check.
Removing this check fixes the issue.