### PR TITLE
Fix shellcheck warnings

### DIFF
--- a/gcov.sh
+++ b/gcov.sh
@@ -4,7 +4,7 @@
 # License GPL v2
 
 gcov_init() {
-	USER=`whoami`
+	USER="$(whoami)"
 	firejail --help > /dev/null
 	firemon --help > /dev/null
 	/usr/lib/firejail/fnet --help > /dev/null
@@ -20,7 +20,7 @@ gcov_init() {
 	/usr/lib/firejail/faudit --help > /dev/null
 	/usr/lib/firejail/fbuilder --help > /dev/null
 
-	sudo chown $USER:$USER `find .`
+	find . -exec sudo chown "$USER:$USER" '{}' +
 }
 
 generate() {
@@ -28,7 +28,7 @@ generate() {
 	lcov --add-tracefile gcov-file-old --add-tracefile gcov-file-new  --output-file gcov-file
 	rm -fr gcov-dir
 	genhtml -q gcov-file --output-directory gcov-dir
-	sudo rm `find . -name *.gcda`
+	find . -name '*.gcda' -exec sudo rm '{}' +
 	cp gcov-file gcov-file-old
 	gcov_init
 }

--- a/linecnt.sh
+++ b/linecnt.sh
@@ -4,7 +4,7 @@
 # License GPL v2
 
 gcov_init() {
-	USER=`whoami`
+	USER="$(whoami)"
 	firejail --help > /dev/null
 	firemon --help > /dev/null
 	/usr/lib/firejail/fnet --help > /dev/null
@@ -20,7 +20,7 @@ gcov_init() {
 	/usr/lib/firejail/faudit --help > /dev/null
 	/usr/lib/firejail/fbuilder --help > /dev/null
 
-	sudo chown $USER:$USER `find .`
+	find . -exec sudo chown "$USER:$USER" '{}' +
 }
 
 rm -fr gcov-dir

--- a/mkasc.sh
+++ b/mkasc.sh
@@ -5,9 +5,9 @@
 
 echo "Calculating SHA256 for all files in /transfer - firejail version $1"
 
-cd /transfer
-sha256sum * > firejail-$1-unsigned
-gpg --clearsign --digest-algo SHA256 < firejail-$1-unsigned > firejail-$1.asc
-gpg --verify firejail-$1.asc
-gpg --detach-sign --armor firejail-$1.tar.xz
-rm firejail-$1-unsigned
+cd /transfer || exit 1
+sha256sum ./* > "firejail-$1-unsigned"
+gpg --clearsign --digest-algo SHA256 < "firejail-$1-unsigned" > "firejail-$1.asc"
+gpg --verify "firejail-$1.asc"
+gpg --detach-sign --armor "firejail-$1.tar.xz"
+rm "firejail-$1-unsigned"

--- a/mkdeb.sh.in
+++ b/mkdeb.sh.in
@@ -22,7 +22,7 @@ if [ -n "$HAVE_SELINUX" ]; then
     CONFIG_ARGS="$CONFIG_ARGS --enable-selinux"
 fi
 
-TOP=`pwd`
+TOP="$PWD"
 CODE_ARCHIVE="$NAME-$VERSION.tar.xz"
 CODE_DIR="$NAME-$VERSION"
 INSTALL_DIR="${INSTALL_DIR}${CODE_DIR}/debian"
@@ -35,9 +35,9 @@ echo "install directory: $INSTALL_DIR"
 echo "debian control directory: $DEBIAN_CTRL_DIR"
 echo "*****************************************"
 
-tar -xJvf $CODE_ARCHIVE
-#mkdir -p $INSTALL_DIR
-cd $CODE_DIR
+tar -xJvf "$CODE_ARCHIVE"
+#mkdir -p "$INSTALL_DIR"
+cd "$CODE_DIR"
 ./configure $CONFIG_ARGS
 make -j2
 mkdir debian
@@ -45,26 +45,26 @@ DESTDIR=debian make install-strip
 
 cd ..
 echo "*****************************************"
-SIZE=`du -s $INSTALL_DIR`
+SIZE="$(du -s "$INSTALL_DIR")"
 echo "install size $SIZE"
 echo "*****************************************"
 
-mv $INSTALL_DIR/usr/share/doc/firejail/RELNOTES $INSTALL_DIR/usr/share/doc/firejail/changelog.Debian
-gzip -9 -n $INSTALL_DIR/usr/share/doc/firejail/changelog.Debian
-rm $INSTALL_DIR/usr/share/doc/firejail/COPYING
-install -m644 $CODE_DIR/platform/debian/copyright $INSTALL_DIR/usr/share/doc/firejail/.
-mkdir -p $DEBIAN_CTRL_DIR
-sed "s/FIREJAILVER/$VERSION/g"  $CODE_DIR/platform/debian/control.$(dpkg-architecture -qDEB_HOST_ARCH) > $DEBIAN_CTRL_DIR/control
+mv "$INSTALL_DIR/usr/share/doc/firejail/RELNOTES" "$INSTALL_DIR/usr/share/doc/firejail/changelog.Debian"
+gzip -9 -n "$INSTALL_DIR/usr/share/doc/firejail/changelog.Debian"
+rm "$INSTALL_DIR/usr/share/doc/firejail/COPYING"
+install -m644 "$CODE_DIR/platform/debian/copyright" "$INSTALL_DIR/usr/share/doc/firejail/."
+mkdir -p "$DEBIAN_CTRL_DIR"
+sed "s/FIREJAILVER/$VERSION/g" "$CODE_DIR/platform/debian/control.$(dpkg-architecture -qDEB_HOST_ARCH)" > "$DEBIAN_CTRL_DIR/control"
 
-mkdir -p $INSTALL_DIR/usr/share/lintian/overrides/
-install -m644 $CODE_DIR/platform/debian/firejail.lintian-overrides $INSTALL_DIR/usr/share/lintian/overrides/firejail
+mkdir -p "$INSTALL_DIR/usr/share/lintian/overrides/"
+install -m644 "$CODE_DIR/platform/debian/firejail.lintian-overrides" "$INSTALL_DIR/usr/share/lintian/overrides/firejail"
 
-find $INSTALL_DIR/etc -type f | sed "s,^$INSTALL_DIR,," | LC_ALL=C sort > $DEBIAN_CTRL_DIR/conffiles
-chmod 644 $DEBIAN_CTRL_DIR/conffiles
-find $INSTALL_DIR  -type d | xargs chmod 755
-cd $CODE_DIR
+find "$INSTALL_DIR/etc" -type f | sed "s,^$INSTALL_DIR,," | LC_ALL=C sort > "$DEBIAN_CTRL_DIR/conffiles"
+chmod 644 "$DEBIAN_CTRL_DIR/conffiles"
+find "$INSTALL_DIR" -type d -exec chmod 755 '{}' +
+cd "$CODE_DIR"
 fakeroot dpkg-deb --build debian
 lintian --no-tag-display-limit debian.deb
-mv debian.deb ../firejail_${VERSION}${EXTRA_VERSION}_1_$(dpkg-architecture -qDEB_HOST_ARCH).deb
+mv debian.deb "../firejail_${VERSION}${EXTRA_VERSION}_1_$(dpkg-architecture -qDEB_HOST_ARCH).deb"
 cd ..
-rm -fr $CODE_DIR
+rm -fr "$CODE_DIR"

--- a/mkman.sh
+++ b/mkman.sh
@@ -5,8 +5,8 @@
 
 set -e
 
-sed "s/VERSION/$1/g" $2 > $3
-MONTH=`LC_ALL=C date -u --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%b`
-sed -i "s/MONTH/$MONTH/g" $3
-YEAR=`LC_ALL=C date -u --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y`
-sed -i "s/YEAR/$YEAR/g" $3
+sed "s/VERSION/$1/g" "$2" > "$3"
+MONTH="$(LC_ALL=C date -u --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%b)"
+sed -i "s/MONTH/$MONTH/g" "$3"
+YEAR="$(LC_ALL=C date -u --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y)"
+sed -i "s/YEAR/$YEAR/g" "$3"

--- a/mkuid.sh
+++ b/mkuid.sh
@@ -9,8 +9,8 @@ echo "#define FIREJAIL_UIDS_H" >> uids.h
 
 if [ -r /etc/login.defs ]
 then
-	UID_MIN=`awk '/^\s*UID_MIN\s*([0-9]*).*?$/ {print $2}' /etc/login.defs`
-	GID_MIN=`awk '/^\s*GID_MIN\s*([0-9]*).*?$/ {print $2}' /etc/login.defs`
+	UID_MIN="$(awk '/^\s*UID_MIN\s*([0-9]*).*?$/ {print $2}' /etc/login.defs)"
+	GID_MIN="$(awk '/^\s*GID_MIN\s*([0-9]*).*?$/ {print $2}' /etc/login.defs)"
 fi
 
 # use default values if not found


### PR DESCRIPTION
Split from  #4497 for further discussion.

I did not modify the configure script, which is a source of a lot of the remaining shellcheck warnings, because it comes from autoconf and so it makes little sense to try to fix it here.

I also did not modify the scripts in contrib, because they possibly are maintained at some other place. Similarly with the other scripts that don't appear to be called from any of the makefiles.