### PR TITLE
Trim excess whitespace

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,3 @@
-
 If your PR isn't about profiles or you have no idea how to do one of these, skip the following and go ahead with this PR.
 
 If you submit a PR for new profiles or changing profiles, please do the following:

--- a/.github/workflows/sort.yml
+++ b/.github/workflows/sort.yml
@@ -19,4 +19,3 @@ jobs:
     - uses: actions/checkout@v2
     - name: check profiles
       run: ./contrib/sort.py etc/*/{*.inc,*.profile}
-

--- a/README
+++ b/README
@@ -1,13 +1,13 @@
-Firejail  is  a  SUID sandbox program that reduces the risk of security
-breaches by restricting the running environment of  untrusted  applications
+Firejail is a SUID sandbox program that reduces the risk of security
+breaches by restricting the running environment of untrusted applications
 using Linux namespaces and seccomp-bpf. It includes sandbox profiles for
 Iceweasel/Mozilla Firefox, Chromium, Midori, Opera, Evince, Transmission,
 VLC, Audacious, Clementine, Rhythmbox, Totem, Deluge, qBittorrent.
 DeaDBeeF, Dropbox, Empathy, FileZilla, IceCat, Thunderbird/Icedove,
 Pidgin, Quassel, and XChat.
 
-Firejail also expands the restricted shell facility found  in  bash  by adding
-Linux  namespace support. It supports sandboxing specific users upon login.
+Firejail also expands the restricted shell facility found in bash by adding
+Linux namespace support. It supports sandboxing specific users upon login.
 
 Download: https://sourceforge.net/projects/firejail/files/
 Build and install: ./configure && make && sudo make install
@@ -460,7 +460,7 @@ hawkey116477 (https://github.com/hawkeye116477)
 Helmut Grohne (https://github.com/helmutg)
 	-  compiler support in the build system - Debian bug #869707
 hhzek0014 (https://github.com/hhzek0014)
-	- updated  bibletime.profile
+	- updated bibletime.profile
 hlein (https://github.com/hlein)
 	- strip out \r's from jail prober
 Holger Heinz (https://github.com/hheinz)
@@ -579,7 +579,7 @@ Kishore96in (https://github.com/Kishore96in)
 	- added falkon profile
 	- kxmlgui fixes
 	- okular profile fixes
-	-  jitsi-meet-desktop profile
+	- jitsi-meet-desktop profile
 	- konversatin profile fix
 	- added Neochat profile
 	- added whitelist-1793-workaround.inc
@@ -715,7 +715,7 @@ Ondra Nekola (https://github.com/satai)
 OndrejMalek (https://github.com/OndrejMalek)
 	- various manpage fixes
 Ondřej Nový (https://github.com/onovy)
-	-  allow video for Signal profile
+	- allow video for Signal profile
 	- added Mattermost desktop profile
 	- hardened Zoom profile
 	- hardened Signal desktop profile
@@ -732,7 +732,7 @@ Patrick Toomey (https://sourceforge.net/u/ptoomey/profile/)
 Paul Moore <pmoore@redhat.com>
 	-src/fsec-print/print.c extracted from libseccomp software package
 Paupiah Yash (https://github.com/CaffeinatedStud)
-	- gzip  profile
+	- gzip profile
 Pawel (https://github.com/grimskies)
 	- make --join return exit code of the invoked program
 Peter Millerchip (https://github.com/pmillerchip)
@@ -960,7 +960,7 @@ SYN-cook (https://github.com/SYN-cook)
 	- gnome-calculator changes
 startx2017 (https://github.com/startx2017)
 	- syscall list update
-	- updated default seccomp filters - added  bpf, clock_settime, personality, process_vm_writev, query_module,
+	- updated default seccomp filters - added bpf, clock_settime, personality, process_vm_writev, query_module,
 	              settimeofday, stime, umount, userfaultfd, ustat, vm86, and vm86old
 	- enable/disable join support in /etc/firejail/firejail.config
 	- firecfg fix: create ~/.local/share/applications directory if it doesn't exist
@@ -1011,7 +1011,7 @@ Topi Miettinen (https://github.com/topimiettinen)
 	- improve loading of seccomp filter and memory-deny-write-execute feature
 	- private-lib feature
 	- make --nodbus block also system D-Bus socket
-Ted Robertson  (https://github.com/tredondo)
+Ted Robertson (https://github.com/tredondo)
 	- webstorm profile fixes
 	- added bcompare profile
 	- various documentation fixes
@@ -1071,7 +1071,7 @@ vismir2 (https://github.com/vismir2)
 	- feh, ranger, 7z, keepass, keepassx and zathura profiles
 	- claws-mail, mutt, git, emacs, vim profiles
 	- lots of profile fixes
-	-  support for truecrypt and zuluCrypt
+	- support for truecrypt and zuluCrypt
 viq (https://github.com/viq)
 	- discord-canary profile
 Vladimir Gorelov (https://github.com/larkvirtual)

--- a/RELNOTES
+++ b/RELNOTES
@@ -59,7 +59,7 @@ firejail (0.9.64.4) baseline; urgency=low
 
 firejail (0.9.64.2) baseline; urgency=low
   * allow --tmpfs inside $HOME for unprivileged users
-  * --disable-usertmpfs  compile time option
+  * --disable-usertmpfs compile time option
   * allow AF_BLUETOOTH via --protocol=bluetooth
   * Setup guide for new users: contrib/firejail-welcome.sh
   * implement netns in profiles
@@ -566,7 +566,7 @@ firejail (0.9.44) baseline; urgency=low
   * feature: disable 3D hardware acceleration (--no3d)
   * feature: x11 xpra, x11 xephyr, x11 block, allusers, no3d profile commands
   * feature: move files in sandbox (--put)
-  * feature: accept wildcard patterns in user  name field of restricted
+  * feature: accept wildcard patterns in user name field of restricted
     shell login feature
   * new profiles: qpdfview, mupdf, Luminance HDR, Synfig Studio, Gimp, Inkscape
   * new profiles: feh, ranger, zathura, 7z, keepass, keepassx,
@@ -608,7 +608,7 @@ firejail (0.9.42) baseline; urgency=low
   * compile time: disable whitelisting (--disable-whitelist)
   * compile time: disable global config (--disable-globalcfg)
   * run time: enable/disable overlayfs (overlayfs yes/no)
-  * run time: enable/disable  quiet as default (quiet-by-default yes/no)
+  * run time: enable/disable quiet as default (quiet-by-default yes/no)
   * run time: user-defined network filter (netfilter-default)
   * run time: enable/disable whitelisting (whitelist yes/no)
   * run time: enable/disable remounting of /proc and /sys
@@ -706,7 +706,7 @@ firejail (0.9.38) baseline; urgency=low
  -- netblue30 <netblue30@yahoo.com>  Tue, 2 Feb 2016 10:00:00 -0500
 
 firejail (0.9.36) baseline; urgency=low
-  * added  unbound, dnscrypt-proxy, BitlBee, HexChat, WeeChat,
+  * added unbound, dnscrypt-proxy, BitlBee, HexChat, WeeChat,
      parole and rtorrent profiles
   * Google Chrome profile rework
   * added google-chrome-stable profile

--- a/contrib/gdb-firejail.sh
+++ b/contrib/gdb-firejail.sh
@@ -21,4 +21,4 @@ else
 fi
 
 bash -c "kill -STOP \$\$; exec \"\$0\" \"\$@\"" "$@" &
-sudo gdb -e  "$FIREJAIL" -p "$!"
+sudo gdb -e "$FIREJAIL" -p "$!"

--- a/etc-fixes/0.9.58/atom.profile
+++ b/etc-fixes/0.9.58/atom.profile
@@ -1,4 +1,3 @@
-
 # Firejail profile for atom
 # Description: A hackable text editor for the 21st Century
 # This file is overwritten after every install/update

--- a/etc-fixes/seccomp-join-bug/README
+++ b/etc-fixes/seccomp-join-bug/README
@@ -8,4 +8,3 @@ on May 21, 2019:
 
 The original discussion thread: https://github.com/netblue30/firejail/issues/2718
 The fix on mainline: https://github.com/netblue30/firejail/commit/eecf35c2f8249489a1d3e512bb07f0d427183134
-

--- a/etc/apparmor/firejail-default
+++ b/etc/apparmor/firejail-default
@@ -129,7 +129,7 @@ signal (receive),
 ##########
 # The list of recognized capabilities varies from one apparmor version to another.
 # For example on Debian 10 (apparmor 2.13.2) checkpoint_restore, perfmon, bpf are not available
-# We allow all caps by default and remove the  ones we don't like:
+# We allow all caps by default and remove the ones we don't like:
 capability,
 deny capability audit_write,
 deny capability audit_control,

--- a/etc/inc/disable-devel.inc
+++ b/etc/inc/disable-devel.inc
@@ -60,9 +60,7 @@ blacklist /usr/lib/tcc
 blacklist ${PATH}/valgrind*
 blacklist /usr/lib/valgrind
 
-
 # Source-Code
-
 blacklist /usr/src
 blacklist /usr/local/src
 blacklist /usr/include

--- a/etc/profile-a-l/email-common.profile
+++ b/etc/profile-a-l/email-common.profile
@@ -12,7 +12,7 @@ noblacklist ${HOME}/.gnupg
 noblacklist ${HOME}/.mozilla
 noblacklist ${HOME}/.signature
 # when storing mail outside the default ${HOME}/Mail path, 'noblacklist' the custom path in your email-common.local
-# and 'blacklist' it in your disable-common.local too so it is  kept hidden from other applications
+# and 'blacklist' it in your disable-common.local too so it is kept hidden from other applications
 noblacklist ${HOME}/Mail
 
 noblacklist ${DOCUMENTS}

--- a/etc/profile-a-l/kdiff3.profile
+++ b/etc/profile-a-l/kdiff3.profile
@@ -48,7 +48,7 @@ shell none
 tracelog
 
 disable-mnt
-private-bin  kdiff3
+private-bin kdiff3
 private-cache
 private-dev
 

--- a/etc/profile-a-l/links-common.profile
+++ b/etc/profile-a-l/links-common.profile
@@ -47,7 +47,7 @@ shell none
 tracelog
 
 disable-mnt
-# Add  'private-bin PROGRAM1,PROGRAM2' to your links-common.local  if you want to use user-configured programs.
+# Add 'private-bin PROGRAM1,PROGRAM2' to your links-common.local if you want to use user-configured programs.
 private-bin sh
 private-cache
 private-dev

--- a/etc/profile-m-z/spectacle.profile
+++ b/etc/profile-m-z/spectacle.profile
@@ -22,7 +22,7 @@ include disable-interpreters.inc
 include disable-programs.inc
 include disable-xdg.inc
 
-mkfile  ${HOME}/.config/spectaclerc
+mkfile ${HOME}/.config/spectaclerc
 whitelist ${HOME}/.config/spectaclerc
 whitelist ${PICTURES}
 whitelist /usr/share/kconf_update/spectacle_newConfig.upd

--- a/etc/profile-m-z/sway.profile
+++ b/etc/profile-m-z/sway.profile
@@ -1,5 +1,5 @@
 # Firejail profile for Sway
-# Description: i3-compatible Wayland compositor 
+# Description: i3-compatible Wayland compositor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include sway.local

--- a/gcov.sh
+++ b/gcov.sh
@@ -24,8 +24,8 @@ gcov_init() {
 }
 
 generate() {
-	lcov -q --capture -d src/firejail -d src/firemon -d src/faudit -d src/fbuilder -d  src/fcopy -d  src/fnetfilter -d src/fsec-print -d src/fsec-optimize -d src/fseccomp -d src/fnet -d src/ftee -d src/lib -d src/firecfg -d src/fldd --output-file gcov-file-new
-	lcov --add-tracefile gcov-file-old --add-tracefile gcov-file-new  --output-file gcov-file
+	lcov -q --capture -d src/firejail -d src/firemon -d src/faudit -d src/fbuilder -d src/fcopy -d src/fnetfilter -d src/fsec-print -d src/fsec-optimize -d src/fseccomp -d src/fnet -d src/ftee -d src/lib -d src/firecfg -d src/fldd --output-file gcov-file-new
+	lcov --add-tracefile gcov-file-old --add-tracefile gcov-file-new --output-file gcov-file
 	rm -fr gcov-dir
 	genhtml -q gcov-file --output-directory gcov-dir
 	sudo rm `find . -name *.gcda`
@@ -35,7 +35,7 @@ generate() {
 
 
 gcov_init
-lcov -q --capture -d src/firejail -d src/firemon -d src/faudit -d src/fbuilder -d  src/fcopy -d  src/fnetfilter -d src/fsec-print -d src/fsec-optimize -d src/fseccomp -d src/fnet -d src/ftee -d src/lib -d src/firecfg -d src/fldd  --output-file gcov-file-old
+lcov -q --capture -d src/firejail -d src/firemon -d src/faudit -d src/fbuilder -d src/fcopy -d src/fnetfilter -d src/fsec-print -d src/fsec-optimize -d src/fseccomp -d src/fnet -d src/ftee -d src/lib -d src/firecfg -d src/fldd --output-file gcov-file-old
 
 #make test-utils
 #generate

--- a/linecnt.sh
+++ b/linecnt.sh
@@ -26,6 +26,6 @@ gcov_init() {
 rm -fr gcov-dir
 gcov_init
 lcov -q --capture -d src/firejail -d src/firemon -d src/faudit -d src/fbuilder \
-	-d  src/fcopy -d  src/fnetfilter -d src/fsec-print -d src/fsec-optimize -d src/fseccomp \
-	-d src/fnet -d src/ftee -d src/lib -d src/firecfg -d src/fldd  --output-file gcov-file
+	-d src/fcopy -d src/fnetfilter -d src/fsec-print -d src/fsec-optimize -d src/fseccomp \
+	-d src/fnet -d src/ftee -d src/lib -d src/firecfg -d src/fldd --output-file gcov-file
 genhtml -q gcov-file --output-directory gcov-dir

--- a/src/bash_completion/firejail.bash_completion.in
+++ b/src/bash_completion/firejail.bash_completion.in
@@ -5,7 +5,7 @@
 # http://bash-completion.alioth.debian.org
 #*******************************************************************
 
-__interfaces(){
+__interfaces() {
     cut -f 1 -d ':' /proc/net/dev | tail -n +3 | grep -v lo | xargs
 }
 
@@ -90,11 +90,11 @@ _firejail()
             _filedir
             return 0
             ;;
-         --net)
-         	comps=$(__interfaces)
+        --net)
+            comps=$(__interfaces)
             COMPREPLY=( $(compgen -W '$comps' -- "$cur") )
             return 0
-         	;;
+            ;;
     esac
 
     $split && return 0

--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -78,7 +78,7 @@ in your desktop environment copy the profile file in ~/.config/firejail director
 Several command line options can be passed to the program using
 profile files. Firejail chooses the profile file as follows:
 
-\fB1.\fR If a profile file is provided by the user with \-\-profile option, the profile file is loaded. If a profile name is given, it is searched for first in the ~/.config/firejail directory and if not found then in  /etc/firejail directory. Profile names do not include the .profile suffix.
+\fB1.\fR If a profile file is provided by the user with \-\-profile option, the profile file is loaded. If a profile name is given, it is searched for first in the ~/.config/firejail directory and if not found then in /etc/firejail directory. Profile names do not include the .profile suffix.
 Example:
 .PP
 .RS
@@ -324,16 +324,16 @@ Remount the file or the directory noexec, nodev and nosuid.
 #ifdef HAVE_OVERLAYFS
 .TP
 \fBoverlay
-Mount  a  filesystem  overlay  on top of the current filesystem.
-The overlay is stored in $HOME/.firejail/<PID>  directory.
+Mount a filesystem overlay on top of the current filesystem.
+The overlay is stored in $HOME/.firejail/<PID> directory.
 .TP
 \fBoverlay-named name
-Mount  a  filesystem  overlay  on top of the current filesystem.
-The overlay is stored in $HOME/.firejail/name  directory.
+Mount a filesystem overlay on top of the current filesystem.
+The overlay is stored in $HOME/.firejail/name directory.
 .TP
 \fBoverlay-tmpfs
-Mount  a  filesystem  overlay  on top of the current filesystem.
-All filesystem  modifications are discarded when the sandbox is closed.
+Mount a filesystem overlay on top of the current filesystem.
+All filesystem modifications are discarded when the sandbox is closed.
 #endif
 .TP
 \fBprivate
@@ -487,12 +487,12 @@ does not result in an increase of privilege.
 #ifdef HAVE_USERNS
 .TP
 \fBnoroot
-Use this command  to enable an user namespace. The namespace has only one user, the current user.
+Use this command to enable an user namespace. The namespace has only one user, the current user.
 There is no root account (uid 0) defined in the namespace.
 #endif
 .TP
 \fBprotocol protocol1,protocol2,protocol3
-Enable protocol filter. The filter is based on seccomp and  checks the
+Enable protocol filter. The filter is based on seccomp and checks the
 first argument to socket system call. Recognized values: \fBunix\fR,
 \fBinet\fR, \fBinet6\fR, \fBnetlink\fR, \fBpacket\fR and \fBbluetooth\fR.
 .TP
@@ -873,8 +873,8 @@ a DHCP client and releasing the lease manually.
 
 .TP
 \fBiprange address,address
-Assign  an  IP address in the provided range to the last network
-interface defined by  a  net command.  A  default  gateway  is assigned by default.
+Assign an IP address in the provided range to the last network
+interface defined by a net command.  A default gateway is assigned by default.
 .br
 
 .br

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -45,7 +45,7 @@ firejail {\-? | \-\-debug-caps | \-\-debug-errnos | \-\-debug-syscalls | \-\-deb
 #ifdef HAVE_LTS
 This is Firejail long-term support (LTS), an enterprise focused version of the software,
 LTS is usually supported for two or three years.
-During this time  only bugs and the occasional documentation problems are fixed.
+During this time only bugs and the occasional documentation problems are fixed.
 The attack surface of the SUID executable was greatly reduced by removing some of the features.
 .br
 
@@ -109,7 +109,7 @@ ptrace system call allows a full bypass of the seccomp filter.
 .br
 Example:
 .br
-$ firejail  --allow-debuggers --profile=/etc/firejail/firefox.profile strace -f firefox
+$ firejail --allow-debuggers --profile=/etc/firejail/firefox.profile strace -f firefox
 .TP
 \fB\-\-allusers
 All directories under /home are visible inside the sandbox. By default, only current user home directory is visible.
@@ -947,7 +947,7 @@ $ firejail \-\-net=eth0 \-\-\iprange=192.168.1.100,192.168.1.150
 
 .TP
 \fB\-\-ipc-namespace
-Enable  a new IPC namespace if the sandbox was started as a regular user. IPC namespace is enabled by default
+Enable a new IPC namespace if the sandbox was started as a regular user. IPC namespace is enabled by default
 for sandboxes started as root.
 .br
 
@@ -1014,7 +1014,7 @@ $ sudo firejail --join-network=browser /sbin/iptables -vL
 .br
 
 .br
-# verify  IP addresses
+# verify IP addresses
 .br
 $ sudo firejail --join-network=browser ip addr
 .br
@@ -2134,7 +2134,7 @@ Use k(ilobyte), m(egabyte) or g(igabyte) for size suffix (base 1024).
 .TP
 \fB\-\-rlimit-cpu=number
 Set the maximum limit, in seconds, for the amount of CPU time each
-sandboxed process  can consume. When the limit is reached, the processes are killed.
+sandboxed process can consume. When the limit is reached, the processes are killed.
 
 The CPU limit is a limit on CPU seconds rather than elapsed time. CPU seconds is basically how many seconds
 the CPU has been in use and does not necessarily directly relate to the elapsed time. Linux kernel keeps
@@ -2178,7 +2178,7 @@ $ firejail \-\-net=eth0 \-\-scan
 .TP
 \fB\-\-seccomp
 Enable seccomp filter and blacklist the syscalls in the default list,
-which is  @default-nodebuggers unless \-\-allow-debuggers is specified,
+which is @default-nodebuggers unless \-\-allow-debuggers is specified,
 then it is @default.
 
 .br
@@ -2865,7 +2865,7 @@ and it is installed by default on most Linux distributions. It provides support 
 connection model. Untrusted clients are restricted in certain ways to prevent them from reading window
 contents of other clients, stealing input events, etc.
 
-The untrusted mode has several limitations. A lot of regular programs  assume they are a trusted X11 clients
+The untrusted mode has several limitations. A lot of regular programs assume they are a trusted X11 clients
 and will crash or lock up when run in untrusted mode. Chromium browser and xterm are two examples.
 Firefox and transmission-gtk seem to be working fine.
 A network namespace is not required for this option.
@@ -3256,7 +3256,7 @@ The owner of the sandbox.
 .SH RESTRICTED SHELL
 To configure a restricted shell, replace /bin/bash with /usr/bin/firejail in
 /etc/passwd file for each user that needs to be restricted. Alternatively,
-you can specify /usr/bin/firejail  in adduser command:
+you can specify /usr/bin/firejail in adduser command:
 
 adduser \-\-shell /usr/bin/firejail username
 
@@ -3266,7 +3266,7 @@ Additional arguments passed to firejail executable upon login are declared in /e
 Several command line options can be passed to the program using
 profile files. Firejail chooses the profile file as follows:
 
-1. If a profile file is provided by the user with --profile=FILE option, the profile FILE is loaded. If a profile name is given, it is searched for first in the ~/.config/firejail directory and if not found then in  /etc/firejail directory. Profile names do not include the .profile suffix. If there is a file with the same name as the given profile name, it will be used instead of doing the profile search. To force a profile search, prefix the profile name with a colon (:), eg. --profile=:PROFILE_NAME.
+1. If a profile file is provided by the user with --profile=FILE option, the profile FILE is loaded. If a profile name is given, it is searched for first in the ~/.config/firejail directory and if not found then in /etc/firejail directory. Profile names do not include the .profile suffix. If there is a file with the same name as the given profile name, it will be used instead of doing the profile search. To force a profile search, prefix the profile name with a colon (:), eg. --profile=:PROFILE_NAME.
 Example:
 .PP
 .RS

--- a/src/man/firemon.txt
+++ b/src/man/firemon.txt
@@ -56,7 +56,7 @@ Print route table for each sandbox.
 Print seccomp configuration for each sandbox.
 .TP
 \fB\-\-top
-Monitor the most CPU-intensive sandboxes. This command  is similar to
+Monitor the most CPU-intensive sandboxes. This command is similar to
 the regular UNIX top command, however it applies only to sandboxes.
 .TP
 \fB\-\-tree


### PR DESCRIPTION
Split from #4497 for further discussion.

For trailing whitespace a commit hook/CI check could be implemented, but most of the excess whitespace is within other text which makes it harder for automated tools to deal with. I mainly spotted it when reading through the files.