### PR TITLE
s/S_IWRITE/S_IWUSR/

### DIFF
--- a/src/firejail/chroot.c
+++ b/src/firejail/chroot.c
@@ -86,7 +86,7 @@ static void update_file(int parentfd, const char *relpath) {
 	if (arg_debug)
 		printf("Updating chroot /%s\n", relpath);
 	unlinkat(parentfd, relpath, 0);
-	int out = openat(parentfd, relpath, O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC, S_IRUSR | S_IWRITE | S_IRGRP | S_IROTH);
+	int out = openat(parentfd, relpath, O_WRONLY|O_CREAT|O_EXCL|O_CLOEXEC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 	if (out == -1) {
 		close(in);
 		goto errout;

--- a/src/firejail/fs_hostname.c
+++ b/src/firejail/fs_hostname.c
@@ -33,7 +33,7 @@ void fs_hostname(const char *hostname) {
 		if (arg_debug)
 			printf("Creating a new /etc/hostname file\n");
 
-		create_empty_file_as_root(RUN_HOSTNAME_FILE, S_IRUSR | S_IWRITE | S_IRGRP | S_IROTH);
+		create_empty_file_as_root(RUN_HOSTNAME_FILE, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 
 		// bind-mount the file on top of /etc/hostname
 		if (mount(RUN_HOSTNAME_FILE, "/etc/hostname", NULL, MS_BIND|MS_REC, NULL) < 0)
@@ -75,7 +75,7 @@ void fs_hostname(const char *hostname) {
 		}
 		fclose(fp1);
 		// mode and owner
-		SET_PERMS_STREAM(fp2, 0, 0, S_IRUSR | S_IWRITE | S_IRGRP | S_IROTH);
+		SET_PERMS_STREAM(fp2, 0, 0, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 		fclose(fp2);
 
 		// bind-mount the file on top of /etc/hostname

--- a/src/firejail/fs_trace.c
+++ b/src/firejail/fs_trace.c
@@ -36,7 +36,7 @@ void fs_trace_preload(void) {
 		FILE *fp = fopen("/etc/ld.so.preload", "wxe");
 		if (!fp)
 			errExit("fopen");
-		SET_PERMS_STREAM(fp, 0, 0, S_IRUSR | S_IWRITE | S_IRGRP | S_IROTH);
+		SET_PERMS_STREAM(fp, 0, 0, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 		fclose(fp);
 		fs_logger("touch /etc/ld.so.preload");
 	}
@@ -47,7 +47,7 @@ void fs_tracefile(void) {
 	if (arg_debug)
 		printf("Creating an empty trace log file: %s\n", arg_tracefile);
 	EUID_USER();
-	int fd = open(arg_tracefile, O_CREAT|O_WRONLY|O_CLOEXEC, S_IRUSR | S_IWRITE | S_IRGRP | S_IROTH);
+	int fd = open(arg_tracefile, O_CREAT|O_WRONLY|O_CLOEXEC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 	if (fd == -1) {
 		perror("open");
 		fprintf(stderr, "Error: cannot open trace log file %s for writing\n", arg_tracefile);
@@ -100,7 +100,7 @@ void fs_trace(void) {
 		fmessage("Post-exec seccomp protector enabled\n");
 	}
 
-	SET_PERMS_STREAM(fp, 0, 0, S_IRUSR | S_IWRITE | S_IRGRP | S_IROTH);
+	SET_PERMS_STREAM(fp, 0, 0, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 	fclose(fp);
 
 	// mount the new preload file

--- a/src/firejail/fs_var.c
+++ b/src/firejail/fs_var.c
@@ -129,7 +129,7 @@ void fs_var_log(void) {
 		/* coverity[toctou] */
 		FILE *fp = fopen("/var/log/wtmp", "wxe");
 		if (fp) {
-			SET_PERMS_STREAM(fp, 0, wtmp_group, S_IRUSR | S_IWRITE | S_IRGRP | S_IWGRP | S_IROTH);
+			SET_PERMS_STREAM(fp, 0, wtmp_group, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
 			fclose(fp);
 		}
 		fs_logger("touch /var/log/wtmp");
@@ -137,7 +137,7 @@ void fs_var_log(void) {
 		// create an empty /var/log/btmp file
 		fp = fopen("/var/log/btmp", "wxe");
 		if (fp) {
-			SET_PERMS_STREAM(fp, 0, wtmp_group, S_IRUSR | S_IWRITE | S_IRGRP | S_IWGRP);
+			SET_PERMS_STREAM(fp, 0, wtmp_group, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
 			fclose(fp);
 		}
 		fs_logger("touch /var/log/btmp");
@@ -314,7 +314,7 @@ void fs_var_utmp(void) {
 	// save new utmp file
 	int rv = fwrite(&u_boot, sizeof(u_boot), 1, fp);
 	(void) rv;
-	SET_PERMS_STREAM(fp, 0, utmp_group, S_IRUSR | S_IWRITE | S_IRGRP | S_IWGRP | S_IROTH);
+	SET_PERMS_STREAM(fp, 0, utmp_group, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
 	fclose(fp);
 
 	// mount the new utmp file

--- a/src/firejail/ls.c
+++ b/src/firejail/ls.c
@@ -305,7 +305,7 @@ void sandboxfs(int op, pid_t pid, const char *path1, const char *path2) {
 		}
 		// create destination file if necessary
 		EUID_ASSERT();
-		int fd = open(dest_fname, O_WRONLY|O_CREAT|O_CLOEXEC, S_IRUSR | S_IWRITE);
+		int fd = open(dest_fname, O_WRONLY|O_CREAT|O_CLOEXEC, S_IRUSR | S_IWUSR);
 		if (fd == -1) {
 			fprintf(stderr, "Error: cannot open %s for writing\n", dest_fname);
 			exit(1);

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -204,7 +204,7 @@ static void save_umask(void) {
 }
 
 static char *create_join_file(void) {
-	int fd = open(RUN_JOIN_FILE, O_RDWR|O_CREAT|O_EXCL|O_CLOEXEC, S_IRUSR | S_IWRITE | S_IRGRP | S_IROTH);
+	int fd = open(RUN_JOIN_FILE, O_RDWR|O_CREAT|O_EXCL|O_CLOEXEC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 	if (fd == -1)
 		errExit("open");
 	if (ftruncate(fd, 1) == -1)


### PR DESCRIPTION
They are equivalent, but only the latter is POSIX.  See sys_stat.h(0p)
of POSIX.1-2017[1].  From Section 14.9.5, The Mode Bits for Access
Permission of the glibc manual[2]:

> S_IWUSR
> S_IWRITE
>
>     Write permission bit for the owner of the file.  Usually 0200.
>     S_IWRITE is an obsolete synonym provided for BSD compatibility.

Current usage:

    $ git grep -F S_IWRITE -- src | wc -l
    11
    $ git grep -F S_IWUSR -- src | wc -l
    26

Commands used to search and replace:

    $ git grep -l -z S_IWRITE -- src | xargs -0 -I '{}' sh -c \
      "printf '%s\n' \"\`sed 's/S_IWRITE/S_IWUSR/g' '{}'\`\" >'{}'"

Note: The other related non-POSIX macros are not used anywhere:

    $ git grep -F -e S_IREAD -e S_IEXEC -- src
    $

[1] https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_stat.h.html
[2] https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html

---

Misc: I noticed this on #4586.

Since this conflicts with #4586, I'm marking this as a draft until that is
merged.

Note to self: This will need to be rebased/reworded.
