### PR TITLE
build: allow building with address sanitizer

### DIFF
--- a/configure
+++ b/configure
@@ -711,6 +711,7 @@ ac_subst_files=''
 ac_user_opts='
 enable_option_checking
 enable_analyzer
+enable_sanitizer
 enable_apparmor
 enable_selinux
 enable_dbusproxy
@@ -1368,6 +1369,8 @@ Optional Features:
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --enable-analyzer       enable GCC static analyzer
+  --enable-sanitizer=[address | memory | undefined]
+                          enable a compiler-based sanitizer (debug)
   --enable-apparmor       enable apparmor
   --enable-selinux        SELinux labeling support
   --disable-dbusproxy     disable dbus proxy
@@ -3291,6 +3294,57 @@ fi
 if test "x$enable_analyzer" = "xyes"; then :
 
 	EXTRA_CFLAGS="$EXTRA_CFLAGS -fanalyzer -Wno-analyzer-malloc-leak"
+
+fi
+
+# Check whether --enable-sanitizer was given.
+if test "${enable_sanitizer+set}" = set; then :
+  enableval=$enable_sanitizer;
+else
+  enable_sanitizer=no
+fi
+
+if test "x$enable_sanitizer" != "xno" ; then :
+  as_CACHEVAR=`$as_echo "ax_cv_check_cflags__-fsanitize=$enable_sanitizer" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -fsanitize=$enable_sanitizer" >&5
+$as_echo_n "checking whether C compiler accepts -fsanitize=$enable_sanitizer... " >&6; }
+if eval \${$as_CACHEVAR+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS  -fsanitize=$enable_sanitizer"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  eval "$as_CACHEVAR=yes"
+else
+  eval "$as_CACHEVAR=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags
+fi
+eval ac_res=\$$as_CACHEVAR
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_CACHEVAR"\" = x"yes"; then :
+
+		EXTRA_CFLAGS="$EXTRA_CFLAGS -fsanitize=$enable_sanitizer -fno-omit-frame-pointer"
+		EXTRA_LDFLAGS="$EXTRA_LDFLAGS -fsanitize=$enable_sanitizer"
+
+else
+  as_fn_error $? "sanitizer not supported: $enable_sanitizer" "$LINENO" 5
+
+fi
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,15 @@ AS_IF([test "x$enable_analyzer" = "xyes"], [
 	EXTRA_CFLAGS="$EXTRA_CFLAGS -fanalyzer -Wno-analyzer-malloc-leak"
 ])
 
+AC_ARG_ENABLE([sanitizer],
+    AS_HELP_STRING([--enable-sanitizer=@<:@address | memory | undefined@:>@], [enable a compiler-based sanitizer (debug)]), [], [enable_sanitizer=no])
+AS_IF([test "x$enable_sanitizer" != "xno" ],
+	[AX_CHECK_COMPILE_FLAG([-fsanitize=$enable_sanitizer], [
+		EXTRA_CFLAGS="$EXTRA_CFLAGS -fsanitize=$enable_sanitizer -fno-omit-frame-pointer"
+		EXTRA_LDFLAGS="$EXTRA_LDFLAGS -fsanitize=$enable_sanitizer"
+	], [AC_MSG_ERROR([sanitizer not supported: $enable_sanitizer])]
+)])
+
 HAVE_APPARMOR=""
 AC_ARG_ENABLE([apparmor],
     AS_HELP_STRING([--enable-apparmor], [enable apparmor]))


### PR DESCRIPTION
This allows building firejail (and other binaries) with address sanitizer (with `--enable-asan`).
I noticed that some were interested in this in #4592 (ping @rusty-snake @smitsohu).

I didn't rebuild `configure`, as I have a different autoconf version installed and it would only blow up the diff. If someone wants to test it, please run `autoreconf -vfi` before. (In my humble opinion generated files like `configure` should anyway not be part of the repository.)

Right now running some of the tools only finds memory leaks. Running firejail itself does not work for me, it fails with this error:
```
Error: proc 17925 cannot sync with peer: unexpected EOF
```
Running with `--noprofile` works, but I didn't figure out yet which setting is the one that breaks it.
Also so far I only tested it with gcc. clang might give different results.