### PR TITLE
Fix misc in get_group_id

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -532,7 +532,7 @@ void update_map(char *mapping, char *map_file);
 void wait_for_other(int fd);
 void notify_other(int fd);
 uid_t pid_get_uid(pid_t pid);
-gid_t get_group_id(const char *group);
+gid_t get_group_id(const char *groupname);
 void flush_stdin(void);
 int create_empty_dir_as_user(const char *dir, mode_t mode);
 void create_empty_dir_as_root(const char *dir, mode_t mode);

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -532,7 +532,7 @@ void update_map(char *mapping, char *map_file);
 void wait_for_other(int fd);
 void notify_other(int fd);
 uid_t pid_get_uid(pid_t pid);
-uid_t get_group_id(const char *group);
+gid_t get_group_id(const char *group);
 void flush_stdin(void);
 int create_empty_dir_as_user(const char *dir, mode_t mode);
 void create_empty_dir_as_root(const char *dir, mode_t mode);

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -959,7 +959,7 @@ uid_t pid_get_uid(pid_t pid) {
 }
 
 
-uid_t get_group_id(const char *group) {
+gid_t get_group_id(const char *group) {
 	gid_t gid = 0;
 	struct group *g = getgrnam(group);
 	if (g)

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -960,7 +960,6 @@ uid_t pid_get_uid(pid_t pid) {
 
 
 uid_t get_group_id(const char *group) {
-	// find tty group id
 	gid_t gid = 0;
 	struct group *g = getgrnam(group);
 	if (g)

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -959,9 +959,9 @@ uid_t pid_get_uid(pid_t pid) {
 }
 
 
-gid_t get_group_id(const char *group) {
+gid_t get_group_id(const char *groupname) {
 	gid_t gid = 0;
-	struct group *g = getgrnam(group);
+	struct group *g = getgrnam(groupname);
 	if (g)
 		gid = g->gr_gid;
 


### PR DESCRIPTION
```console
$ git log --reverse --pretty='* %s' master..
* util.c: remove tty comment from get_group_id
* util.c: fix return type of get_group_id
* util.c: rename "group" arg to "groupname" in get_group_id
```
