### PR TITLE
Fix tremulous profile for Arch users

### DIFF
--- a/etc/profile-m-z/tremulous.profile
+++ b/etc/profile-m-z/tremulous.profile
@@ -8,6 +8,7 @@ include globals.local
 
 noblacklist ${HOME}/.tremulous
 
+# Allow /bin/sh (blacklisted by disable-shell.inc)
 include allow-bin-sh.inc
 
 include disable-common.inc

--- a/etc/profile-m-z/tremulous.profile
+++ b/etc/profile-m-z/tremulous.profile
@@ -9,6 +9,7 @@ include globals.local
 noblacklist ${HOME}/.tremulous
 
 include allow-bin-sh.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/profile-m-z/tremulous.profile
+++ b/etc/profile-m-z/tremulous.profile
@@ -44,7 +44,7 @@ shell none
 tracelog
 
 disable-mnt
-private-bin tremded,tremulous,tremulous-wrapper,env,sh
+private-bin env,sh,tremded,tremulous,tremulous-wrapper
 private-cache
 private-dev
 private-tmp

--- a/etc/profile-m-z/tremulous.profile
+++ b/etc/profile-m-z/tremulous.profile
@@ -8,6 +8,7 @@ include globals.local
 
 noblacklist ${HOME}/.tremulous
 
+include allow-bin-sh.inc
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
@@ -41,7 +42,7 @@ shell none
 tracelog
 
 disable-mnt
-private-bin tremded,tremulous,tremulous-wrapper
+private-bin tremded,tremulous,tremulous-wrapper,env,sh
 private-cache
 private-dev
 private-tmp


### PR DESCRIPTION
Tremulous on Arch (`tremulous-grangerhub-bin` in AUR) uses wrapper hence needs some modifications.