### PR TITLE
Consider nosound and novideo when keeping groups & misc refactors

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -3144,17 +3144,21 @@ int main(int argc, char **argv, char **envp) {
 			}
 
 			// add audio group
-			g = get_group_id("audio");
-			if (g) {
-				sprintf(ptr, "%d %d 1\n", g, g);
-				ptr += strlen(ptr);
+			if (!arg_nosound) {
+				g = get_group_id("audio");
+				if (g) {
+					sprintf(ptr, "%d %d 1\n", g, g);
+					ptr += strlen(ptr);
+				}
 			}
 
 			// add video group
-			g = get_group_id("video");
-			if (g) {
-				sprintf(ptr, "%d %d 1\n", g, g);
-				ptr += strlen(ptr);
+			if (!arg_novideo) {
+				g = get_group_id("video");
+				if (g) {
+					sprintf(ptr, "%d %d 1\n", g, g);
+					ptr += strlen(ptr);
+				}
 			}
 
 			// add games group

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -3088,94 +3088,94 @@ int main(int argc, char **argv, char **envp) {
 	}
 	EUID_ASSERT();
 
- 	// close each end of the unused pipes
- 	close(parent_to_child_fds[0]);
- 	close(child_to_parent_fds[1]);
+	// close each end of the unused pipes
+	close(parent_to_child_fds[0]);
+	close(child_to_parent_fds[1]);
 
 	// notify child that base setup is complete
- 	notify_other(parent_to_child_fds[1]);
+	notify_other(parent_to_child_fds[1]);
 
- 	// wait for child to create new user namespace with CLONE_NEWUSER
- 	wait_for_other(child_to_parent_fds[0]);
- 	close(child_to_parent_fds[0]);
+	// wait for child to create new user namespace with CLONE_NEWUSER
+	wait_for_other(child_to_parent_fds[0]);
+	close(child_to_parent_fds[0]);
 
- 	if (arg_noroot) {
-	 	// update the UID and GID maps in the new child user namespace
+	if (arg_noroot) {
+		// update the UID and GID maps in the new child user namespace
 		// uid
-	 	char *map_path;
-	 	if (asprintf(&map_path, "/proc/%d/uid_map", child) == -1)
-	 		errExit("asprintf");
+		char *map_path;
+		if (asprintf(&map_path, "/proc/%d/uid_map", child) == -1)
+			errExit("asprintf");
 
-	 	char *map;
-	 	uid_t uid = getuid();
-	 	if (asprintf(&map, "%d %d 1", uid, uid) == -1)
-	 		errExit("asprintf");
- 		EUID_ROOT();
-	 	update_map(map, map_path);
-	 	EUID_USER();
-	 	free(map);
-	 	free(map_path);
+		char *map;
+		uid_t uid = getuid();
+		if (asprintf(&map, "%d %d 1", uid, uid) == -1)
+			errExit("asprintf");
+		EUID_ROOT();
+		update_map(map, map_path);
+		EUID_USER();
+		free(map);
+		free(map_path);
 
-	 	// gid file
+		// gid file
 		if (asprintf(&map_path, "/proc/%d/gid_map", child) == -1)
 			errExit("asprintf");
-	 	char gidmap[1024];
-	 	char *ptr = gidmap;
-	 	*ptr = '\0';
+		char gidmap[1024];
+		char *ptr = gidmap;
+		*ptr = '\0';
 
-	 	// add user group
-	 	gid_t gid = getgid();
-	 	sprintf(ptr, "%d %d 1\n", gid, gid);
-	 	ptr += strlen(ptr);
+		// add user group
+		gid_t gid = getgid();
+		sprintf(ptr, "%d %d 1\n", gid, gid);
+		ptr += strlen(ptr);
 
-	 	if (!arg_nogroups) {
-		 	//  add firejail group
-		 	gid_t g = get_group_id("firejail");
-		 	if (g) {
-		 		sprintf(ptr, "%d %d 1\n", g, g);
-		 		ptr += strlen(ptr);
-		 	}
+		if (!arg_nogroups) {
+			// add firejail group
+			gid_t g = get_group_id("firejail");
+			if (g) {
+				sprintf(ptr, "%d %d 1\n", g, g);
+				ptr += strlen(ptr);
+			}
 
-		 	//  add tty group
-		 	g = get_group_id("tty");
-		 	if (g) {
-		 		sprintf(ptr, "%d %d 1\n", g, g);
-		 		ptr += strlen(ptr);
-		 	}
+			// add tty group
+			g = get_group_id("tty");
+			if (g) {
+				sprintf(ptr, "%d %d 1\n", g, g);
+				ptr += strlen(ptr);
+			}
 
-		 	//  add audio group
-		 	g = get_group_id("audio");
-		 	if (g) {
-		 		sprintf(ptr, "%d %d 1\n", g, g);
-		 		ptr += strlen(ptr);
-		 	}
+			// add audio group
+			g = get_group_id("audio");
+			if (g) {
+				sprintf(ptr, "%d %d 1\n", g, g);
+				ptr += strlen(ptr);
+			}
 
-		 	//  add video group
-		 	g = get_group_id("video");
-		 	if (g) {
-		 		sprintf(ptr, "%d %d 1\n", g, g);
-		 		ptr += strlen(ptr);
-		 	}
+			// add video group
+			g = get_group_id("video");
+			if (g) {
+				sprintf(ptr, "%d %d 1\n", g, g);
+				ptr += strlen(ptr);
+			}
 
-		 	//  add games group
-		 	g = get_group_id("games");
-		 	if (g) {
-		 		sprintf(ptr, "%d %d 1\n", g, g);
-		 	}
-		 }
+			// add games group
+			g = get_group_id("games");
+			if (g) {
+				sprintf(ptr, "%d %d 1\n", g, g);
+			}
+		}
 
- 		EUID_ROOT();
-	 	update_map(gidmap, map_path);
-	 	EUID_USER();
-	 	free(map_path);
- 	}
+		EUID_ROOT();
+		update_map(gidmap, map_path);
+		EUID_USER();
+		free(map_path);
+	}
 	EUID_ASSERT();
 
- 	// notify child that UID/GID mapping is complete
- 	notify_other(parent_to_child_fds[1]);
- 	close(parent_to_child_fds[1]);
+	// notify child that UID/GID mapping is complete
+	notify_other(parent_to_child_fds[1]);
+	close(parent_to_child_fds[1]);
 
- 	EUID_ROOT();
+	EUID_ROOT();
 	if (lockfd_network != -1) {
 		flock(lockfd_network, LOCK_UN);
 		close(lockfd_network);

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -142,14 +142,11 @@ static void clean_supplementary_groups(gid_t gid) {
 		goto clean_all;
 
 	// clean supplementary group list
-	// allow only firejail, tty, audio, video, games
 	gid_t new_groups[MAX_GROUPS];
 	int new_ngroups = 0;
 	char *allowed[] = {
 		"firejail",
 		"tty",
-		"audio",
-		"video",
 		"games",
 		NULL
 	};
@@ -159,6 +156,16 @@ static void clean_supplementary_groups(gid_t gid) {
 		copy_group_ifcont(allowed[i], groups, ngroups,
 		                  new_groups, &new_ngroups, MAX_GROUPS);
 		i++;
+	}
+
+	if (!arg_nosound) {
+		copy_group_ifcont("audio", groups, ngroups,
+		                  new_groups, &new_ngroups, MAX_GROUPS);
+	}
+
+	if (!arg_novideo) {
+		copy_group_ifcont("video", groups, ngroups,
+		                  new_groups, &new_ngroups, MAX_GROUPS);
 	}
 
 	if (new_ngroups) {


### PR DESCRIPTION
Even when `nogroups` is not used, avoid keeping the audio and video
groups when `nosound` and `novideo` are used, respectively.

Based on @rusty-snake's suggestion:
https://github.com/netblue30/firejail/issues/4603#issuecomment-944046299

Relates to #4603.

---

Note: I haven't tested this.
