### PR TITLE
Fix TOCTOU/CodeQL CWE-367 warnings (easy ones + fs.c)

### DIFF
--- a/src/fids/main.c
+++ b/src/fids/main.c
@@ -210,22 +210,29 @@ static void process_config(const char *fname) {
 		exit(1);
 	}
 
-	// make sure the file is owned by root
-	struct stat s;
-	if (stat(fname, &s)) {
+	fprintf(stderr, "Opening config file %s\n", fname);
+	int fd = open(fname, O_RDONLY|O_CLOEXEC);
+	if (fd < 0) {
 		if (include_level == 1) {
-			fprintf(stderr, "Error ids: config file not found\n");
+			fprintf(stderr, "Error ids: cannot open config file %s\n", fname);
 			exit(1);
 		}
 		return;
+	}
+
+	// make sure the file is owned by root
+	struct stat s;
+	if (fstat(fd, &s)) {
+		fprintf(stderr, "Error ids: cannot stat config file %s\n", fname);
+		exit(1);
 	}
 	if (s.st_uid || s.st_gid) {
 		fprintf(stderr, "Error ids: config file not owned by root\n");
 		exit(1);
 	}
 
-	fprintf(stderr, "Loading %s config file\n", fname);
-	FILE *fp = fopen(fname, "r");
+	fprintf(stderr, "Loading config file %s\n", fname);
+	FILE *fp = fdopen(fd, "r");
 	if (!fp) {
 		fprintf(stderr, "Error fids: cannot open config file %s\n", fname);
 		exit(1);

--- a/src/firejail/seccomp.c
+++ b/src/firejail/seccomp.c
@@ -435,11 +435,11 @@ void seccomp_print_filter(pid_t pid) {
 	if (asprintf(&fname, "/proc/%d/root%s", pid, RUN_SECCOMP_LIST) == -1)
 		errExit("asprintf");
 
-	struct stat s;
-	if (stat(fname, &s) == -1)
+	int fd = open(fname, O_RDONLY|O_CLOEXEC);
+	if (fd < 0)
 		goto errexit;
 
-	FILE *fp = fopen(fname, "re");
+	FILE *fp = fdopen(fd, "r");
 	if (!fp)
 		goto errexit;
 	free(fname);


### PR DESCRIPTION
This should fix all such warnings on the following files:

* src/fids/main.c
* src/firejail/seccomp.c

Misc: Besides the above reason, these are some of the more
straightforward TOCTOU warning fixes and they are done without any
additional refactor commits, so that's the reason for "easy ones".

List of TOCTOU warnings:
https://github.com/netblue30/firejail/security/code-scanning?query=id%3Acpp%2Ftoctou-race-condition

See https://cwe.mitre.org/data/definitions/367.html

Relates to #4503.
