### PR TITLE
Relocate firecfg.config to /etc/firejail/

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -116,7 +116,7 @@ endif
 	install -m 0755 src/jailcheck/jailcheck $(DESTDIR)$(bindir)
 	# libraries and plugins
 	install -m 0755 -d $(DESTDIR)$(libdir)/firejail
-	install -m 0644 -t $(DESTDIR)$(libdir)/firejail $(MYLIBS) $(SECCOMP_FILTERS) src/firecfg/firecfg.config
+	install -m 0644 -t $(DESTDIR)$(libdir)/firejail $(MYLIBS) $(SECCOMP_FILTERS)
 	install -m 0755 -t $(DESTDIR)$(libdir)/firejail $(SBOX_APPS)
 	# plugins w/o read permission (non-dumpable)
 	install -m 0711 -t $(DESTDIR)$(libdir)/firejail $(SBOX_APPS_NON_DUMPABLE)
@@ -135,6 +135,7 @@ endif
 	install -m 0644 -t $(DESTDIR)$(DOCDIR) COPYING README RELNOTES etc/templates/*
 	# profiles and settings
 	install -m 0755 -d $(DESTDIR)$(sysconfdir)/firejail
+	install -m 0644 -t $(DESTDIR)$(sysconfdir)/firejail src/firecfg/firecfg.config
 	install -m 0644 -t $(DESTDIR)$(sysconfdir)/firejail etc/profile-a-l/*.profile etc/profile-m-z/*.profile etc/inc/*.inc etc/net/*.net etc/firejail.config etc/ids.config
 	sh -c "if [ ! -f $(DESTDIR)/$(sysconfdir)/firejail/login.users ]; then install -c -m 0644 etc/login.users $(DESTDIR)/$(sysconfdir)/firejail/.; fi;"
 ifeq ($(BUSYBOX_WORKAROUND),yes)

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ PulseAudio changes.
 Start your programs the way you are used to: desktop manager menus, file manager, desktop launchers.
 The integration applies to any program supported by default by Firejail. There are about 250 default applications
 in current Firejail version, and the number goes up with every new release.
-We keep the application list in [/usr/lib/firejail/firecfg.config](https://github.com/netblue30/firejail/blob/master/src/firecfg/firecfg.config) file.
+We keep the application list in [/etc/firejail/firecfg.config](https://github.com/netblue30/firejail/blob/master/src/firecfg/firecfg.config) file.
 
 ## Security profiles
 

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -1,4 +1,4 @@
-# /usr/lib/firejail/firecfg.config - firecfg utility configuration file
+# /etc/firejail/firecfg.config - firecfg utility configuration file
 # This is the list of programs in alphabetical order handled by firecfg utility
 #
 0ad

--- a/src/firecfg/main.c
+++ b/src/firecfg/main.c
@@ -171,17 +171,17 @@ static void set_file(const char *name, const char *firejail_exec) {
 	free(fname);
 }
 
-// parse /usr/lib/firejail/firecfg.cfg file
+// parse /etc/firejail/firecfg.config file
 static void set_links_firecfg(void) {
 	char *cfgfile;
-	if (asprintf(&cfgfile, "%s/firejail/firecfg.config", LIBDIR) == -1)
+	if (asprintf(&cfgfile, "%s/firecfg.config", SYSCONFDIR) == -1)
 		errExit("asprintf");
 
 	char *firejail_exec;
 	if (asprintf(&firejail_exec, "%s/bin/firejail", PREFIX) == -1)
 		errExit("asprintf");
 
-	// parse /usr/lib/firejail/firecfg.cfg file
+	// parse /etc/firejail/firecfg.config file
 	FILE *fp = fopen(cfgfile, "r");
 	if (!fp) {
 		perror("fopen");
@@ -440,7 +440,7 @@ int main(int argc, char **argv) {
 	// clear all symlinks
 	clean();
 
-	// set new symlinks based on /usr/lib/firejail/firecfg.cfg
+	// set new symlinks based on /etc/firejail/firecfg.config
 	set_links_firecfg();
 
 	if (getuid() == 0) {

--- a/src/firejail/appimage.c
+++ b/src/firejail/appimage.c
@@ -45,10 +45,10 @@ int appimage_find_profile(const char *archive) {
 	assert(archive);
 	assert(strlen(archive));
 
-	// try to match the name of the archive with the list of programs in /usr/lib/firejail/firecfg.config
-	FILE *fp = fopen(LIBDIR "/firejail/firecfg.config", "r");
+	// try to match the name of the archive with the list of programs in /etc/firejail/firecfg.config
+	FILE *fp = fopen(SYSCONFDIR "/firecfg.config", "r");
 	if (!fp) {
-		fprintf(stderr, "Error: cannot find %s, firejail is not correctly installed\n", LIBDIR "/firejail/firecfg.config");
+		fprintf(stderr, "Error: cannot find %s, firejail is not correctly installed\n", SYSCONFDIR "/firecfg.config");
 		exit(1);
 	}
 	char buf[MAXBUF];

--- a/src/man/firecfg.txt
+++ b/src/man/firecfg.txt
@@ -27,7 +27,7 @@ desktop managers are supported in this moment
 To set it up, run "sudo firecfg" after installing Firejail software.
 The same command should also be run after
 installing new programs. If the program is supported by Firejail, the symbolic link in /usr/local/bin
-will be created. For a full list of programs supported by default run "cat /usr/lib/firejail/firecfg.config".
+will be created. For a full list of programs supported by default run "cat /etc/firejail/firecfg.config".
 
 For user-driven manual integration, see \fBDESKTOP INTEGRATION\fR section in \fBman 1 firejail\fR.
 .SH DEFAULT ACTIONS


### PR DESCRIPTION
This should make it easier for users, and distributions, to customize
which programs they want firejail to wrap.

Signed-off-by: Hank Leininger <hlein@korelogic.com>
Closes: https://github.com/netblue30/firejail/issues/408
Bug: https://github.com/netblue30/firejail/issues/2097
Bug: https://github.com/netblue30/firejail/issues/2829
Bug: https://github.com/netblue30/firejail/issues/3665