### PR TITLE
more ssh fixes

### DIFF
--- a/etc/inc/allow-ssh.inc
+++ b/etc/inc/allow-ssh.inc
@@ -7,7 +7,9 @@ noblacklist /etc/ssh
 noblacklist /etc/ssh/ssh_config
 noblacklist ${PATH}/ssh
 noblacklist /tmp/ssh-*
-# Debian/Ubuntu and derivatives
-noblacklist /usr/lib/openssh
 # Arch Linux and derivatives
 noblacklist /usr/lib/ssh
+# Debian/Ubuntu and derivatives
+noblacklist /usr/lib/openssh
+# Fedora and derivatives
+noblacklist /usr/libexec/openssh

--- a/etc/inc/allow-ssh.inc
+++ b/etc/inc/allow-ssh.inc
@@ -5,6 +5,9 @@ include allow-ssh.local
 noblacklist ${HOME}/.ssh
 noblacklist /etc/ssh
 noblacklist /etc/ssh/ssh_config
-noblacklist /tmp/ssh-*
 noblacklist ${PATH}/ssh
-noblacklist /usr/lib/openssh/ssh-keysign
+noblacklist /tmp/ssh-*
+# Debian/Ubuntu and derivatives
+noblacklist /usr/lib/openssh
+# Arch Linux and derivatives
+noblacklist /usr/lib/ssh

--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -497,6 +497,7 @@ blacklist ${PATH}/xinput
 blacklist ${PATH}/ssh
 blacklist /usr/lib/openssh
 blacklist /usr/lib/ssh
+blacklist /usr/libexec/openssh/ssh-keysign
 blacklist ${PATH}/passwd
 blacklist /usr/lib/xorg/Xorg.wrap
 blacklist /usr/lib/policykit-1/polkit-agent-helper-1

--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -495,7 +495,8 @@ blacklist ${PATH}/xev
 blacklist ${PATH}/xinput
 # from 0.9.67
 blacklist ${PATH}/ssh
-blacklist /usr/lib/openssh/ssh-keysign
+blacklist /usr/lib/openssh
+blacklist /usr/lib/ssh
 blacklist ${PATH}/passwd
 blacklist /usr/lib/xorg/Xorg.wrap
 blacklist /usr/lib/policykit-1/polkit-agent-helper-1

--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -497,7 +497,7 @@ blacklist ${PATH}/xinput
 blacklist ${PATH}/ssh
 blacklist /usr/lib/openssh
 blacklist /usr/lib/ssh
-blacklist /usr/libexec/openssh/ssh-keysign
+blacklist /usr/libexec/openssh
 blacklist ${PATH}/passwd
 blacklist /usr/lib/xorg/Xorg.wrap
 blacklist /usr/lib/policykit-1/polkit-agent-helper-1


### PR DESCRIPTION
See https://github.com/netblue30/firejail/commit/9a81078ddbbb4215d06f7d1861481ece05ebda99#commitcomment-59921139 for details. Basically this PR (no)blacklists /usr/lib/{open,}ssh instead of referencing all possible individual files that might get installed there depending on OS and versioning.