### PR TITLE
disable-common.inc: fix paths of slock and physlock

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -507,8 +507,8 @@ blacklist /usr/lib/chromium/chrome-sandbox
 blacklist /usr/lib/vmware
 blacklist ${PATH}/suexec
 blacklist /usr/lib/squid/basic_pam_auth
-blacklist ${PATH}/sloc
-blacklist ${PATH}/physloc
+blacklist ${PATH}/slock
+blacklist ${PATH}/physlock
 blacklist ${PATH}/schroot
 blacklist ${PATH}/wshowkeys
 blacklist ${PATH}/pmount


### PR DESCRIPTION
Added on commit f0adf06c3 ("disable-common.inc: more SUID", 2021-11-09).

Relates to #4668.
