### PR TITLE
Add OpenStego profile

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -1120,6 +1120,7 @@ blacklist ${HOME}/TeamSpeak3-Client-linux_x86
 blacklist ${HOME}/hyperrogue.ini
 blacklist ${HOME}/i2p
 blacklist ${HOME}/mps
+blacklist ${HOME}/openstego.ini
 blacklist ${HOME}/wallet.dat
 blacklist ${HOME}/yt-dlp.conf
 blacklist ${RUNUSER}/*firefox*

--- a/etc/profile-m-z/openstego.profile
+++ b/etc/profile-m-z/openstego.profile
@@ -15,8 +15,8 @@ include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
+include disable-proc.inc
 include disable-programs.inc
-include disable-passwdmgr.inc
 
 mkfile ${HOME}/openstego.ini
 whitelist ${HOME}/openstego.ini
@@ -24,20 +24,14 @@ whitelist ${HOME}/.java
 whitelist ${PICTURES}
 whitelist ${DOCUMENTS}
 whitelist ${DESKTOP}
-include whitelist-common.inc
-
 whitelist /usr/share/java
+include whitelist-common.inc
+include whitelist-run-common.inc
+include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
-# AppArmor breaks Java interpreter
-ignore apparmor
-
 caps.drop all
-
-# Makes fonts look grainy
-#ipc-namespace
-
 machine-id
 net none
 no3d
@@ -50,6 +44,7 @@ notv
 nou2f
 novideo
 seccomp
+seccomp.block-secondary
 shell none
 tracelog
 

--- a/etc/profile-m-z/openstego.profile
+++ b/etc/profile-m-z/openstego.profile
@@ -1,0 +1,63 @@
+# Firejail profile for OpenStego
+# Description: Steganography application that provides data hiding and watermarking functionality
+# This file is overwritten after every install/update
+# Persistent local customizations
+include openstego.local
+# Persistent global definitions
+include globals.local
+
+noblacklist ${HOME}/openstego.ini
+
+# Allow java (blacklisted by disable-devel.inc)
+include allow-java.inc
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-programs.inc
+include disable-passwdmgr.inc
+
+mkfile ${HOME}/openstego.ini
+whitelist ${HOME}/openstego.ini
+whitelist ${HOME}/.java
+whitelist ${PICTURES}
+whitelist ${DOCUMENTS}
+whitelist ${DESKTOP}
+include whitelist-common.inc
+
+whitelist /usr/share/java
+include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
+
+# AppArmor breaks Java interpreter
+ignore apparmor
+
+caps.drop all
+
+# Makes fonts look grainy
+#ipc-namespace
+
+machine-id
+net none
+no3d
+nogroups
+noinput
+nonewprivs
+noroot
+nosound
+notv
+nou2f
+novideo
+seccomp
+shell none
+tracelog
+
+disable-mnt
+private-bin openstego,readlink,dirname,bash,sh
+private-cache
+private-dev
+private-tmp
+
+dbus-user none
+dbus-system none

--- a/etc/profile-m-z/openstego.profile
+++ b/etc/profile-m-z/openstego.profile
@@ -54,7 +54,7 @@ shell none
 tracelog
 
 disable-mnt
-private-bin openstego,readlink,dirname,bash,sh
+private-bin bash,dirname,openstego,readlink,sh
 private-cache
 private-dev
 private-tmp

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -615,6 +615,7 @@ openmw-launcher
 openoffice.org
 openshot
 openshot-qt
+openstego
 openttd
 opera
 opera-beta


### PR DESCRIPTION
This PR adds a profile for OpenStego as requested in #4677 

Advice regarding the proper whitelisting of XDG user directories would be welcome since I am not sure how restrictive this is supposed to be. A user probably would like to files access in all user dirs for convenience. Is there a standard regarding that?

I couldn't write a sensible `private-etc` since this seems very dependent on the specific Java environment used and is probably hard to maintain.

Have a nice day!