### PR TITLE
Update firejail-local for Brave + ipfs

### DIFF
--- a/etc/apparmor/firejail-local
+++ b/etc/apparmor/firejail-local
@@ -8,6 +8,9 @@
 #owner @HOME/bin/** ix
 #owner @HOME/.local/bin/** ix
 
+# Uncomment to opt-in to apparmor for brave + ipfs
+#owner @{HOME}/.config/BraveSoftware/Brave-Browser/oecghfpdmkjlhnfpmmjegjacfimiafjp/*/** ix,
+
 # Uncomment to opt-in to apparmor for brave + tor
 #owner @{HOME}/.config/BraveSoftware/Brave-Browser/biahpgbdmdkfgndcmfiipgcebobojjkp/*/** ix,
 


### PR DESCRIPTION
Hi,

The Ipfs network of Brave is broken by firejail if in the profile of chromium-common 'apparmor' is activated.

Regards.