### PR TITLE
Keep some groups regardless of nogroups and restore nogroups on nvidia

### DIFF
--- a/etc/profile-a-l/kodi.profile
+++ b/etc/profile-a-l/kodi.profile
@@ -43,7 +43,6 @@ netfilter
 nogroups
 noinput
 nonewprivs
-# Seems to cause issues with Nvidia drivers sometimes (#3501)
 noroot
 nou2f
 protocol unix,inet,inet6,netlink

--- a/etc/profile-m-z/mpsyt.profile
+++ b/etc/profile-m-z/mpsyt.profile
@@ -50,7 +50,6 @@ apparmor
 caps.drop all
 netfilter
 nodvd
-# Seems to cause issues with Nvidia drivers sometimes
 nogroups
 noinput
 nonewprivs

--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -62,7 +62,6 @@ include whitelist-var-common.inc
 apparmor
 caps.drop all
 netfilter
-# nogroups seems to cause issues with Nvidia drivers sometimes
 nogroups
 noinput
 nonewprivs

--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -132,7 +132,6 @@ netfilter
 nodvd
 nogroups
 nonewprivs
-# If you use nVidia you might need to add 'ignore noroot' to your steam.local.
 noroot
 notv
 nou2f

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -324,6 +324,7 @@ extern int arg_whitelist;	// whitelist command
 extern int arg_nosound;	// disable sound
 extern int arg_novideo; //disable video devices in /dev
 extern int arg_no3d;		// disable 3d hardware acceleration
+extern int arg_noprinters;	// disable printers
 extern int arg_quiet;		// no output for scripting
 extern int arg_join_network;	// join only the network namespace
 extern int arg_join_filesystem;	// join only the mount namespace

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -120,6 +120,7 @@ int arg_whitelist = 0;				// whitelist command
 int arg_nosound = 0;				// disable sound
 int arg_novideo = 0;			//disable video devices in /dev
 int arg_no3d;					// disable 3d hardware acceleration
+int arg_noprinters = 0;				// disable printers
 int arg_quiet = 0;				// no output for scripting
 int arg_join_network = 0;			// join only the network namespace
 int arg_join_filesystem = 0;			// join only the mount namespace
@@ -2160,6 +2161,7 @@ int main(int argc, char **argv, char **envp) {
 		else if (strcmp(argv[i], "--no3d") == 0)
 			arg_no3d = 1;
 		else if (strcmp(argv[i], "--noprinters") == 0) {
+			arg_noprinters = 1;
 			profile_add("blacklist /dev/lp*");
 			profile_add("blacklist /run/cups/cups.sock");
 		}
@@ -3147,6 +3149,47 @@ int main(int argc, char **argv, char **envp) {
 		// add video group
 		if (!arg_novideo) {
 			g = get_group_id("video");
+			if (g) {
+				sprintf(ptr, "%d %d 1\n", g, g);
+				ptr += strlen(ptr);
+			}
+		}
+
+		// add render group
+		if (!arg_no3d) {
+			g = get_group_id("render");
+			if (g) {
+				sprintf(ptr, "%d %d 1\n", g, g);
+				ptr += strlen(ptr);
+			}
+		}
+
+		// add lp group
+		if (!arg_noprinters) {
+			g = get_group_id("lp");
+			if (g) {
+				sprintf(ptr, "%d %d 1\n", g, g);
+				ptr += strlen(ptr);
+			}
+		}
+
+		// add cdrom/optical groups
+		if (!arg_nodvd) {
+			g = get_group_id("cdrom");
+			if (g) {
+				sprintf(ptr, "%d %d 1\n", g, g);
+				ptr += strlen(ptr);
+			}
+			g = get_group_id("optical");
+			if (g) {
+				sprintf(ptr, "%d %d 1\n", g, g);
+				ptr += strlen(ptr);
+			}
+		}
+
+		// add input group
+		if (!arg_noinput) {
+			g = get_group_id("input");
 			if (g) {
 				sprintf(ptr, "%d %d 1\n", g, g);
 				ptr += strlen(ptr);

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -3134,9 +3134,28 @@ int main(int argc, char **argv, char **envp) {
 		sprintf(ptr, "%d %d 1\n", gid, gid);
 		ptr += strlen(ptr);
 
+		gid_t g;
+		// add audio group
+		if (!arg_nosound) {
+			g = get_group_id("audio");
+			if (g) {
+				sprintf(ptr, "%d %d 1\n", g, g);
+				ptr += strlen(ptr);
+			}
+		}
+
+		// add video group
+		if (!arg_novideo) {
+			g = get_group_id("video");
+			if (g) {
+				sprintf(ptr, "%d %d 1\n", g, g);
+				ptr += strlen(ptr);
+			}
+		}
+
 		if (!arg_nogroups) {
 			// add firejail group
-			gid_t g = get_group_id("firejail");
+			g = get_group_id("firejail");
 			if (g) {
 				sprintf(ptr, "%d %d 1\n", g, g);
 				ptr += strlen(ptr);
@@ -3147,24 +3166,6 @@ int main(int argc, char **argv, char **envp) {
 			if (g) {
 				sprintf(ptr, "%d %d 1\n", g, g);
 				ptr += strlen(ptr);
-			}
-
-			// add audio group
-			if (!arg_nosound) {
-				g = get_group_id("audio");
-				if (g) {
-					sprintf(ptr, "%d %d 1\n", g, g);
-					ptr += strlen(ptr);
-				}
-			}
-
-			// add video group
-			if (!arg_novideo) {
-				g = get_group_id("video");
-				if (g) {
-					sprintf(ptr, "%d %d 1\n", g, g);
-					ptr += strlen(ptr);
-				}
 			}
 
 			// add games group

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -416,13 +416,7 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		return 0;
 	}
 	else if (strcmp(ptr, "nogroups") == 0) {
-		// nvidia cards require video group; disable nogroups
-		if (access("/dev/nvidiactl", R_OK) == 0 && arg_no3d == 0) {
-			fwarning("Warning: NVIDIA card detected, nogroups command disabled\n");
-			arg_nogroups = 0;
-		}
-		else
-			arg_nogroups = 1;
+		arg_nogroups = 1;
 		return 0;
 	}
 	else if (strcmp(ptr, "nosound") == 0) {

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -450,6 +450,7 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		return 0;
 	}
 	else if (strcmp(ptr, "noprinters") == 0) {
+		arg_noprinters = 1;
 		profile_add("blacklist /dev/lp*");
 		profile_add("blacklist /run/cups/cups.sock");
 		return 0;

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -168,6 +168,28 @@ static void clean_supplementary_groups(gid_t gid) {
 		                  new_groups, &new_ngroups, MAX_GROUPS);
 	}
 
+	if (!arg_no3d) {
+		copy_group_ifcont("render", groups, ngroups,
+		                  new_groups, &new_ngroups, MAX_GROUPS);
+	}
+
+	if (!arg_noprinters) {
+		copy_group_ifcont("lp", groups, ngroups,
+		                  new_groups, &new_ngroups, MAX_GROUPS);
+	}
+
+	if (!arg_nodvd) {
+		copy_group_ifcont("cdrom", groups, ngroups,
+		                  new_groups, &new_ngroups, MAX_GROUPS);
+		copy_group_ifcont("optical", groups, ngroups,
+		                  new_groups, &new_ngroups, MAX_GROUPS);
+	}
+
+	if (!arg_noinput) {
+		copy_group_ifcont("input", groups, ngroups,
+		                  new_groups, &new_ngroups, MAX_GROUPS);
+	}
+
 	if (new_ngroups) {
 		rv = setgroups(new_ngroups, new_groups);
 		if (rv)


### PR DESCRIPTION
```console
$ git log --reverse --pretty='* %s' master..
* Keep audio and video groups regardless of nogroups
* Keep render, lp, input and other groups regardless of nogroups
* Make nogroups work on nvidia again
* etc: Remove comments about nogroups and noroot on nvidia
```

This should fix audio on seatd (#4531/#4603) and also make `nogroups` work
regardless of `no3d` on nvidia (#841/#3644).

Note: This is a continuation of #4632.

Note2: I have not tested this yet.

Cc: @crocket (from #4603) @hlein (from #4632)
