### PR TITLE
Fix keeping certain groups with nogroups

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -506,6 +506,7 @@ void errLogExit(char* fmt, ...) __attribute__((noreturn));
 void fwarning(char* fmt, ...);
 void fmessage(char* fmt, ...);
 long long unsigned parse_arg_size(char *str);
+int check_can_drop_all_groups();
 void drop_privs(int force_nogroups);
 int mkpath_as_root(const char* path);
 void extract_command_name(int index, char **argv);

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -506,7 +506,7 @@ void errLogExit(char* fmt, ...) __attribute__((noreturn));
 void fwarning(char* fmt, ...);
 void fmessage(char* fmt, ...);
 long long unsigned parse_arg_size(char *str);
-void drop_privs(int nogroups);
+void drop_privs(int force_nogroups);
 int mkpath_as_root(const char* path);
 void extract_command_name(int index, char **argv);
 void logsignal(int s);

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -3155,62 +3155,64 @@ int main(int argc, char **argv, char **envp) {
 		ptr += strlen(ptr);
 
 		gid_t g;
-		// add audio group
-		if (!arg_nosound) {
-			g = get_group_id("audio");
-			if (g) {
-				sprintf(ptr, "%d %d 1\n", g, g);
-				ptr += strlen(ptr);
+		if (!arg_nogroups || !check_can_drop_all_groups()) {
+			// add audio group
+			if (!arg_nosound) {
+				g = get_group_id("audio");
+				if (g) {
+					sprintf(ptr, "%d %d 1\n", g, g);
+					ptr += strlen(ptr);
+				}
 			}
-		}
 
-		// add video group
-		if (!arg_novideo) {
-			g = get_group_id("video");
-			if (g) {
-				sprintf(ptr, "%d %d 1\n", g, g);
-				ptr += strlen(ptr);
+			// add video group
+			if (!arg_novideo) {
+				g = get_group_id("video");
+				if (g) {
+					sprintf(ptr, "%d %d 1\n", g, g);
+					ptr += strlen(ptr);
+				}
 			}
-		}
 
-		// add render group
-		if (!arg_no3d) {
-			g = get_group_id("render");
-			if (g) {
-				sprintf(ptr, "%d %d 1\n", g, g);
-				ptr += strlen(ptr);
+			// add render group
+			if (!arg_no3d) {
+				g = get_group_id("render");
+				if (g) {
+					sprintf(ptr, "%d %d 1\n", g, g);
+					ptr += strlen(ptr);
+				}
 			}
-		}
 
-		// add lp group
-		if (!arg_noprinters) {
-			g = get_group_id("lp");
-			if (g) {
-				sprintf(ptr, "%d %d 1\n", g, g);
-				ptr += strlen(ptr);
+			// add lp group
+			if (!arg_noprinters) {
+				g = get_group_id("lp");
+				if (g) {
+					sprintf(ptr, "%d %d 1\n", g, g);
+					ptr += strlen(ptr);
+				}
 			}
-		}
 
-		// add cdrom/optical groups
-		if (!arg_nodvd) {
-			g = get_group_id("cdrom");
-			if (g) {
-				sprintf(ptr, "%d %d 1\n", g, g);
-				ptr += strlen(ptr);
+			// add cdrom/optical groups
+			if (!arg_nodvd) {
+				g = get_group_id("cdrom");
+				if (g) {
+					sprintf(ptr, "%d %d 1\n", g, g);
+					ptr += strlen(ptr);
+				}
+				g = get_group_id("optical");
+				if (g) {
+					sprintf(ptr, "%d %d 1\n", g, g);
+					ptr += strlen(ptr);
+				}
 			}
-			g = get_group_id("optical");
-			if (g) {
-				sprintf(ptr, "%d %d 1\n", g, g);
-				ptr += strlen(ptr);
-			}
-		}
 
-		// add input group
-		if (!arg_noinput) {
-			g = get_group_id("input");
-			if (g) {
-				sprintf(ptr, "%d %d 1\n", g, g);
-				ptr += strlen(ptr);
+			// add input group
+			if (!arg_noinput) {
+				g = get_group_id("input");
+				if (g) {
+					sprintf(ptr, "%d %d 1\n", g, g);
+					ptr += strlen(ptr);
+				}
 			}
 		}
 

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -2642,7 +2642,7 @@ int main(int argc, char **argv, char **envp) {
 			else if (cfg.dns4 == NULL)
 				cfg.dns4 = dns;
 			else {
-				fwarning("Warning: up to 4 DNS servers can be specified, %s ignored\n", dns);
+				fwarning("up to 4 DNS servers can be specified, %s ignored\n", dns);
 				free(dns);
 			}
 		}

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -1106,7 +1106,7 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		else if (cfg.dns4 == NULL)
 			cfg.dns4 = dns;
 		else {
-			fwarning("Warning: up to 4 DNS servers can be specified, %s ignored\n", dns);
+			fwarning("up to 4 DNS servers can be specified, %s ignored\n", dns);
 			free(dns);
 		}
 		return 0;

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -1225,7 +1225,7 @@ int sandbox(void* sandbox_arg) {
 	//****************************************
 	// drop privileges
 	//****************************************
-	drop_privs(arg_nogroups);
+	drop_privs(0);
 
 	// kill the sandbox in case the parent died
 	prctl(PR_SET_PDEATHSIG, SIGKILL, 0, 0, 0);

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -215,15 +215,16 @@ clean_all:
 
 
 // drop privileges
-// - for root group or if nogroups is set, supplementary groups are not configured
-void drop_privs(int nogroups) {
+// - for root group or if force_nogroups is set, supplementary groups are not configured
+void drop_privs(int force_nogroups) {
 	gid_t gid = getgid();
 	if (arg_debug)
-		printf("Drop privileges: pid %d, uid %d, gid %d, nogroups %d\n",  getpid(), getuid(), gid, nogroups);
+		printf("Drop privileges: pid %d, uid %d, gid %d, force_nogroups %d\n",
+		       getpid(), getuid(), gid, force_nogroups);
 
 	// configure supplementary groups
 	EUID_ROOT();
-	if (gid == 0 || nogroups) {
+	if (gid == 0 || force_nogroups) {
 		if (setgroups(0, NULL) < 0)
 			errExit("setgroups");
 		if (arg_debug)


### PR DESCRIPTION
This amends commit b828a9047 ("Keep audio and video groups regardless of
nogroups", 2021-11-28) from PR #4725.

The commit above did not change the behavior (the groups are still not
kept).  With this commit, it appears to work properly:

    $ groups | grep audio >/dev/null && echo kept
    kept
    # with check_can_drop_all_groups == 0
    $ firejail --quiet --noprofile --nogroups groups |
      grep audio >/dev/null && echo kept
    kept
    # with check_can_drop_all_groups == 1
    $ firejail --quiet --noprofile --nogroups groups |
      grep audio >/dev/null && echo kept
    $

Add a new check_can_drop_all_groups function to check whether the
supplementary groups can be safely dropped without potentially causing
issues with audio, 3D hardware acceleration or input (and maybe more).
It returns false if nvidia (and no `no3d`) is used or if (e)logind is
not running, as in either case the supplementary groups might be needed.

Note: With this, the behavior from before #4725 is restored on (e)logind
systems (when not using nvidia), as it makes the supplementary groups
always be dropped.

Note2: Even with the static variable, these checks still happen at least
once per translation unit (so twice in total per my testing).

This also amends (/kind of reverts) commit 6ddedeba0 ("Make nogroups
work on nvidia again", 2021-11-29) from PR #4725, as it restores the
nvidia check from it into the new check_can_drop_all_groups function.