### PR TITLE
etc/profile-a-l/display.profile: additions needed on Gentoo

### DIFF
--- a/etc/profile-a-l/display.profile
+++ b/etc/profile-a-l/display.profile
@@ -40,7 +40,8 @@ shell none
 private-bin display,python*
 private-dev
 # On Debian-based systems, display is a symlink in /etc/alternatives
-private-etc alternatives,ld.so.cache,ld.so.preload
+private-etc alternatives,ImageMagick-6,ImageMagick-7,ld.so.cache,ld.so.preload
+private-lib gcc/*/*/libgcc_s.so.*,gcc/*/*/libgomp.so.*,ImageMagick*,libfreetype.so.*,libltdl.so.*,libMagickWand-*.so.*,libXext.so.*
 private-tmp
 
 dbus-user none


### PR DESCRIPTION
Various .so's are needed to allow execution, /etc/ImageMagick-7/ is
needed for various policy XML files, and /usr/$(libdir)/ImageMagick-x.y.z/
is needed in order to have access to decoders.

Tested on Gentoo; I don't know if other distros put the relevant bits
in different paths.

Signed-off-by: Hank Leininger <hlein@korelogic.com>