### PR TITLE
Stop creating unused ~/.TelegramDesktop

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -19,7 +19,6 @@ blacklist ${HOME}/.Sayonara
 blacklist ${HOME}/.Steam
 blacklist ${HOME}/.Steampath
 blacklist ${HOME}/.Steampid
-blacklist ${HOME}/.TelegramDesktop
 blacklist ${HOME}/.VSCodium
 blacklist ${HOME}/.ViberPC
 blacklist ${HOME}/.VirtualBox

--- a/etc/profile-m-z/telegram.profile
+++ b/etc/profile-m-z/telegram.profile
@@ -5,7 +5,6 @@ include telegram.local
 # Persistent global definitions
 include globals.local
 
-noblacklist ${HOME}/.TelegramDesktop
 noblacklist ${HOME}/.local/share/TelegramDesktop
 
 include disable-common.inc
@@ -16,9 +15,7 @@ include disable-programs.inc
 include disable-shell.inc
 include disable-xdg.inc
 
-mkdir ${HOME}/.TelegramDesktop
 mkdir ${HOME}/.local/share/TelegramDesktop
-whitelist ${HOME}/.TelegramDesktop
 whitelist ${HOME}/.local/share/TelegramDesktop
 whitelist ${DOWNLOADS}
 whitelist /usr/share/TelegramDesktop


### PR DESCRIPTION
Telegram does not use this directory, and these directives result in
filejail creating an empty directory in `$HOME` each time telegram is run.