### PR TITLE
dino.profile: netlink protocol is required for audio/video calls.

### DIFF
--- a/etc/profile-a-l/dino.profile
+++ b/etc/profile-a-l/dino.profile
@@ -32,7 +32,7 @@ nonewprivs
 noroot
 notv
 nou2f
-protocol unix,inet,inet6
+protocol unix,inet,inet6,netlink
 seccomp
 seccomp.block-secondary
 shell none


### PR DESCRIPTION
According to my tests, without netlink protocol, audio/video calls keep trying to connect for ever without really connecting.