### PR TITLE
Skype profile tweaks

### DIFF
--- a/etc/profile-m-z/skypeforlinux.profile
+++ b/etc/profile-m-z/skypeforlinux.profile
@@ -14,8 +14,8 @@ ignore include whitelist-var-common.inc
 ignore nou2f
 ignore novideo
 ignore private-dev
+
 ignore dbus-user none
-ignore dbus-system none
 
 # breaks Skype
 ignore apparmor
@@ -27,6 +27,12 @@ mkdir ${HOME}/.config/skypeforlinux
 whitelist ${HOME}/.config/skypeforlinux
 
 # private-dev - needs /dev/disk
+
+dbus-user filter
+dbus-user.talk org.freedesktop.Notifications
+dbus-user.talk org.freedesktop.secrets
+# Note: Skype will log out the current session on start-up without this:
+dbus-user.talk org.kde.StatusNotifierWatcher
 
 # Redirect
 include electron.profile

--- a/etc/profile-m-z/skypeforlinux.profile
+++ b/etc/profile-m-z/skypeforlinux.profile
@@ -23,6 +23,9 @@ ignore noexec /tmp
 
 noblacklist ${HOME}/.config/skypeforlinux
 
+mkdir ${HOME}/.config/skypeforlinux
+whitelist ${HOME}/.config/skypeforlinux
+
 # private-dev - needs /dev/disk
 
 # Redirect


### PR DESCRIPTION
I hope these are in-order, since this profile is a bit of an unusual one.

I added Skype's config directory to `whitelist` and `mkdir`, since otherwise the session is lost when closing and re-running it, requiring logging in again each time it's run.

I also hardened the D-Bus aspect of the profile: I started out blocking everything, and then unblocked the necessary bit. Surprisingly, Skype will log out immediately after starting _without_ `org.kde.StatusNotifierWatcher`, I've no idea about the correlation. It's probably good to keep it around for tray users too anyway.

Ran a test call and it worked fine. User session is retained when quitting/re-running too.
