### PR TITLE
elinks.profile: Fix missing access to liblua

### DIFF
--- a/etc/profile-a-l/elinks.profile
+++ b/etc/profile-a-l/elinks.profile
@@ -9,6 +9,9 @@ include globals.local
 
 noblacklist ${HOME}/.elinks
 
+# Allow lua (blacklisted by disable-interpreters.inc)
+include allow-lua.inc
+
 mkdir ${HOME}/.elinks
 whitelist ${HOME}/.elinks
 


### PR DESCRIPTION
By including allow-lua.inc.

Error log:

    $ firejail elinks
    elinks: error while loading shared libraries: liblua.so.5.4: cannot open shared object file: Permission denied

Environment: firejail-git (a82c8e021) and elinks 0.14.3-2 on Artix
Linux.

Fixes #4707.

Reported-by: @jose1711
