### PR TITLE
yt-dlp: add missing paths & mpv.profile: whitelist paths for yt-dlp

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -637,6 +637,7 @@ blacklist ${HOME}/.config/youtube-music-desktop-app
 blacklist ${HOME}/.config/youtube-viewer
 blacklist ${HOME}/.config/youtubemusic-nativefier-040164
 blacklist ${HOME}/.config/yt-dlp
+blacklist ${HOME}/.config/yt-dlp.conf
 blacklist ${HOME}/.config/zathura
 blacklist ${HOME}/.config/zim
 blacklist ${HOME}/.config/zoomus.conf
@@ -1128,6 +1129,7 @@ blacklist ${HOME}/mps
 blacklist ${HOME}/openstego.ini
 blacklist ${HOME}/wallet.dat
 blacklist ${HOME}/yt-dlp.conf
+blacklist ${HOME}/yt-dlp.conf.txt
 blacklist ${RUNUSER}/*firefox*
 blacklist /tmp/.wine-*
 blacklist /tmp/akonadi-*

--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -46,7 +46,6 @@ include disable-shell.inc
 
 read-only ${DESKTOP}
 mkdir ${HOME}/.config/mpv
-mkdir ${HOME}/.config/youtube-dl
 mkfile ${HOME}/.netrc
 whitelist ${HOME}/.config/mpv
 whitelist ${HOME}/.config/youtube-dl

--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -50,11 +50,11 @@ mkfile ${HOME}/.netrc
 whitelist ${HOME}/.config/mpv
 whitelist ${HOME}/.config/youtube-dl
 whitelist ${HOME}/.netrc
-include whitelist-common.inc
-include whitelist-player-common.inc
 whitelist /usr/share/lua
 whitelist /usr/share/lua*
 whitelist /usr/share/vulkan
+include whitelist-common.inc
+include whitelist-player-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 

--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -26,7 +26,11 @@ include globals.local
 
 noblacklist ${HOME}/.config/mpv
 noblacklist ${HOME}/.config/youtube-dl
+noblacklist ${HOME}/.config/yt-dlp
+noblacklist ${HOME}/.config/yt-dlp.conf
 noblacklist ${HOME}/.netrc
+noblacklist ${HOME}/yt-dlp.conf
+noblacklist ${HOME}/yt-dlp.conf.txt
 
 # Allow lua (blacklisted by disable-interpreters.inc)
 include allow-lua.inc
@@ -49,7 +53,11 @@ mkdir ${HOME}/.config/mpv
 mkfile ${HOME}/.netrc
 whitelist ${HOME}/.config/mpv
 whitelist ${HOME}/.config/youtube-dl
+whitelist ${HOME}/.config/yt-dlp
+whitelist ${HOME}/.config/yt-dlp.conf
 whitelist ${HOME}/.netrc
+whitelist ${HOME}/yt-dlp.conf
+whitelist ${HOME}/yt-dlp.conf.txt
 whitelist /usr/share/lua
 whitelist /usr/share/lua*
 whitelist /usr/share/vulkan

--- a/etc/profile-m-z/yt-dlp.profile
+++ b/etc/profile-m-z/yt-dlp.profile
@@ -10,7 +10,9 @@ include yt-dlp.local
 
 noblacklist ${HOME}/.cache/yt-dlp
 noblacklist ${HOME}/.config/yt-dlp
+noblacklist ${HOME}/.config/yt-dlp.conf
 noblacklist ${HOME}/yt-dlp.conf
+noblacklist ${HOME}/yt-dlp.conf.txt
 
 private-bin ffprobe,yt-dlp
 private-etc alternatives,ld.so.cache,ld.so.preload,yt-dlp.conf


### PR DESCRIPTION
Fixes #4754.

Relates to #3472, #4634 and <https://github.com/yt-dlp/yt-dlp/issues/19>.

Cc: @Fred-Barclay @NetSysFire @pirate486743186
