### PR TITLE
Allow /opt/tor-browser for Tor Browser profile

### DIFF
--- a/etc/profile-m-z/torbrowser-launcher.profile
+++ b/etc/profile-m-z/torbrowser-launcher.profile
@@ -15,7 +15,7 @@ noblacklist ${HOME}/.local/share/torbrowser
 include allow-python2.inc
 include allow-python3.inc
 
-blacklist /opt
+whitelist /opt/tor-browser
 blacklist /srv
 
 include disable-common.inc


### PR DESCRIPTION
This fixes updating local Tor Browser installation in ~/.local/opt/tor-browser on Arch Linux. When package is updated, Tor Browser launcher extracts archive from /opt/tor-browser into user's local directory.

It seems that 
```
noblacklist /opt/tor-browser
blacklist /opt
```
doesn't work, all directories within /opt are blacklisted, and second rule has to be rewritten as `blacklist /opt/*`, but as side effect, in sandbox you can see all the names of directories in /opt, but cannot `cd` into them. I think it would be useful and intuitive if firejail would allow to write rules as I originally tried.