### PR TITLE
Fix teams ignoring input sources e.g. microphones

### DIFF
--- a/etc/profile-m-z/teams-for-linux.profile
+++ b/etc/profile-m-z/teams-for-linux.profile
@@ -10,6 +10,7 @@ include globals.local
 ignore include disable-xdg.inc
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
+ignore noinput
 
 ignore dbus-user none
 ignore dbus-system none

--- a/etc/profile-m-z/teams-for-linux.profile
+++ b/etc/profile-m-z/teams-for-linux.profile
@@ -10,6 +10,7 @@ include globals.local
 ignore include disable-xdg.inc
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
+
 ignore noinput
 
 ignore dbus-user none

--- a/etc/profile-m-z/teams.profile
+++ b/etc/profile-m-z/teams.profile
@@ -10,9 +10,10 @@ include globals.local
 ignore include disable-xdg.inc
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
-ignore noinput
 ignore novideo
 ignore private-tmp
+
+ignore novideo
 
 # see #3404
 ignore apparmor

--- a/etc/profile-m-z/teams.profile
+++ b/etc/profile-m-z/teams.profile
@@ -10,6 +10,7 @@ include globals.local
 ignore include disable-xdg.inc
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
+ignore noinput
 ignore novideo
 ignore private-tmp
 


### PR DESCRIPTION
`teams-for-linux.profile` and `teams.profile` both include `electron.profile`, which has the `noinput` option, which blocks microphones and other input sources, so this option needs to be ignored.