### PR TITLE
Whitelist ${HOME}/.local/opt/tor-browser to make tor-browser work

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -630,3 +630,5 @@ blacklist ${RUNUSER}/inaccessible
 blacklist ${RUNUSER}/pk-debconf-socket
 blacklist ${RUNUSER}/update-notifier.pid
 
+# tor-browser
+blacklist ${HOME}/.local/opt/tor-browser

--- a/etc/profile-m-z/tor-browser.profile
+++ b/etc/profile-m-z/tor-browser.profile
@@ -7,9 +7,12 @@ include tor-browser.local
 #include globals.local
 
 noblacklist ${HOME}/.tor-browser
+noblacklist ${HOME}/.local/opt/tor-browser
 
 mkdir ${HOME}/.tor-browser
 whitelist ${HOME}/.tor-browser
+mkdir ${HOME}/.local/opt/tor-browser
+whitelist ${HOME}/.local/opt/tor-browser
 
 # Redirect
 include torbrowser-launcher.profile


### PR DESCRIPTION
Thank you very much for this amazing project.

tor-browser 11.0.2-1 doesn't work without whitelisting this directory. The following was the message I got before whitelisting this directory.

>     Reading profile /etc/firejail/tor-browser.profile
>     Reading profile /etc/firejail/torbrowser-launcher.profile
>     Reading profile /etc/firejail/allow-python2.inc
>     Reading profile /etc/firejail/allow-python3.inc
>     Reading profile /etc/firejail/disable-common.inc
>     Reading profile /etc/firejail/disable-devel.inc
>     Reading profile /etc/firejail/disable-exec.inc
>     Reading profile /etc/firejail/disable-interpreters.inc
>     Reading profile /etc/firejail/disable-passwdmgr.inc
>     Reading profile /etc/firejail/disable-programs.inc
>     Reading profile /etc/firejail/disable-xdg.inc
>     Reading profile /etc/firejail/whitelist-common.inc
>     Reading profile /etc/firejail/whitelist-var-common.inc
>     Reading profile /etc/firejail/whitelist-runuser-common.inc
>     Reading profile /etc/firejail/whitelist-usr-share-common.inc
>     Warning: Warning: NVIDIA card detected, nogroups command disabled
>     Seccomp list in: !chroot, check list: @default-keep, prelist: unknown,
>     Parent pid 12653, child pid 12654
>     104 programs installed in 153.32 ms
>     Warning: An abstract unix socket for session D-BUS might still be available. Use --net or remove unix from --protocol set.
>     Warning: skipping asound.conf for private /etc
>     Warning: skipping crypto-policies for private /etc
>     Warning fcopy: skipping /etc/fonts/conf.d/11-lcdfilter-default.conf, cannot find inode
>     Warning: skipping pki for private /etc
>     Private /etc installed in 64.84 ms
>     Private /usr/etc installed in 0.00 ms
>     Warning: cleaning all supplementary groups
>     Warning: cleaning all supplementary groups
>     Warning: /sbin directory link was not blacklisted
>     Warning: /usr/sbin directory link was not blacklisted
>     Warning: cleaning all supplementary groups
>     Seccomp list in: !chroot, check list: @default-keep, prelist: unknown,
>     Warning: cleaning all supplementary groups
>     Child process initialized in 325.75 ms
>     /usr/bin/tor-browser: [Error] The tor-browser archive could not be extracted to your home directory.
>     Check the permissions of ~/.local/opt/tor-browser/app.
>     The error log can be found in ~/.local/opt/tor-browser/LOG.
>     /usr/bin/tor-browser: line 218: ~/.local/opt/tor-browser/app/Browser/start-tor-browser: No such file or directory
> 