### PR TITLE
skypeforlinux: Whitelist downloads directory

### DIFF
--- a/etc/profile-m-z/skypeforlinux.profile
+++ b/etc/profile-m-z/skypeforlinux.profile
@@ -6,7 +6,6 @@ include skypeforlinux.local
 include globals.local
 
 # Disabled until someone reported positive feedback
-ignore whitelist ${DOWNLOADS}
 ignore include whitelist-common.inc
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc


### PR DESCRIPTION
The downloads directory is used by skype to download files send by other parties.