### PR TITLE
profiles: allow /usr/share/webext in chromium profile

### DIFF
--- a/etc/profile-a-l/chromium-common.profile
+++ b/etc/profile-a-l/chromium-common.profile
@@ -29,6 +29,8 @@ mkdir ${HOME}/.local/share/pki
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.pki
 whitelist ${HOME}/.local/share/pki
+whitelist /usr/share/mozilla/extensions
+whitelist /usr/share/webext
 include whitelist-common.inc
 include whitelist-run-common.inc
 include whitelist-runuser-common.inc

--- a/etc/profile-a-l/chromium.profile
+++ b/etc/profile-a-l/chromium.profile
@@ -16,8 +16,6 @@ whitelist ${HOME}/.cache/chromium
 whitelist ${HOME}/.config/chromium
 whitelist ${HOME}/.config/chromium-flags.conf
 whitelist /usr/share/chromium
-whitelist /usr/share/mozilla/extensions
-whitelist /usr/share/webext
 
 # private-bin chromium,chromium-browser,chromedriver
 

--- a/etc/profile-a-l/chromium.profile
+++ b/etc/profile-a-l/chromium.profile
@@ -17,6 +17,7 @@ whitelist ${HOME}/.config/chromium
 whitelist ${HOME}/.config/chromium-flags.conf
 whitelist /usr/share/chromium
 whitelist /usr/share/mozilla/extensions
+whitelist /usr/share/webext
 
 # private-bin chromium,chromium-browser,chromedriver
 


### PR DESCRIPTION
Debian packages can distribute browser extensions in `/usr/share/webext`.
The directory is already allowed in Firefox (and related) profiles, but not yet for chromium.

For now I have added it to the chromium.profile, as this profile also contains whitelists another extension directory (`/usr/share/mozilla/extensions`), but maybe it would make sense to move both to chromium-common.profile?

Bug-Debian: https://bugs.debian.org/1003234