### PR TITLE
Add DBus filter rules specific to firefox-developer-edition

### DIFF
--- a/etc/profile-a-l/firefox-developer-edition.profile
+++ b/etc/profile-a-l/firefox-developer-edition.profile
@@ -7,8 +7,9 @@ include firefox-developer-edition.local
 # added by included profile
 #include globals.local
 
-# Redirect
-include firefox.profile
-
+# Edition-specific DBus filters
 dbus-user.own org.mozilla.FirefoxDeveloperEdition.*
 dbus-user.own org.mozilla.firefoxdeveloperedition.*
+
+# Redirect
+include firefox.profile

--- a/etc/profile-a-l/firefox-developer-edition.profile
+++ b/etc/profile-a-l/firefox-developer-edition.profile
@@ -9,3 +9,6 @@ include firefox-developer-edition.local
 
 # Redirect
 include firefox.profile
+
+dbus-user.own org.mozilla.FirefoxDeveloperEdition.*
+dbus-user.own org.mozilla.firefoxdeveloperedition.*


### PR DESCRIPTION
Firefox Developer Edition has a slightly different DBus path than stock Firefox. Without these filters, a firejailed browser instance cannot permit other programs to open tabs within it.