### PR TITLE
Add neovim profile

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -18,6 +18,7 @@ blacklist-nolog ${HOME}/.kde4/share/apps/klipper
 blacklist-nolog ${HOME}/.local/share/fish/fish_history
 blacklist-nolog ${HOME}/.local/share/ibus-typing-booster
 blacklist-nolog ${HOME}/.local/share/klipper
+blacklist-nolog ${HOME}/.local/share/nvim
 blacklist-nolog ${HOME}/.macromedia
 blacklist-nolog ${HOME}/.mupdf.history
 blacklist-nolog ${HOME}/.python-history
@@ -323,6 +324,7 @@ read-only ${HOME}/.ssh/config.d
 # Initialization files that allow arbitrary command execution
 read-only ${HOME}/.caffrc
 read-only ${HOME}/.cargo/env
+read-only ${HOME}/.config/nvim
 read-only ${HOME}/.dotfiles
 read-only ${HOME}/.emacs
 read-only ${HOME}/.emacs.d
@@ -332,6 +334,7 @@ read-only ${HOME}/.homesick
 read-only ${HOME}/.iscreenrc
 read-only ${HOME}/.local/lib
 read-only ${HOME}/.local/share/cool-retro-term
+read-only ${HOME}/.local/share/nvim
 read-only ${HOME}/.mailcap
 read-only ${HOME}/.msmtprc
 read-only ${HOME}/.mutt/muttrc

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -536,6 +536,7 @@ blacklist ${HOME}/.config/newsflash
 blacklist ${HOME}/.config/nheko
 blacklist ${HOME}/.config/nomacs
 blacklist ${HOME}/.config/nuclear
+blacklist ${HOME}/.config/nvim
 blacklist ${HOME}/.config/obs-studio
 blacklist ${HOME}/.config/okularpartrc
 blacklist ${HOME}/.config/okularrc

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -173,6 +173,7 @@ blacklist ${HOME}/.cache/mutt
 blacklist ${HOME}/.cache/mypaint
 blacklist ${HOME}/.cache/netsurf
 blacklist ${HOME}/.cache/nheko
+blacklist ${HOME}/.cache/nvim
 blacklist ${HOME}/.cache/okular
 blacklist ${HOME}/.cache/opera
 blacklist ${HOME}/.cache/opera-beta
@@ -939,6 +940,7 @@ blacklist ${HOME}/.local/share/newsboat
 blacklist ${HOME}/.local/share/nheko
 blacklist ${HOME}/.local/share/nomacs
 blacklist ${HOME}/.local/share/notes
+blacklist ${HOME}/.local/share/nvim
 blacklist ${HOME}/.local/share/ocenaudio
 blacklist ${HOME}/.local/share/okular
 blacklist ${HOME}/.local/share/onlyoffice

--- a/etc/profile-m-z/nvim.profile
+++ b/etc/profile-m-z/nvim.profile
@@ -1,39 +1,46 @@
-# Firejail profile for neovim                                                                                                                                                                                           
+# Firejail profile for neovim
 # Description: Nvim is open source and freely distributable
-# This file is overwritten after every install/update                                                                                                                                                                
-# Persistent local customizations                                                                                                                                                                                    
-include nvim.local                                                                                                                                                                                                    
-# Persistent global definitions                                                                                                                                                                                      
-include globals.local 
+# Persistent local customizations
+include nvim.local
+# Persistent global definitions
+include globals.local
 
-noblacklist ${HOME}/.vim                                                                                                                                                                                             
-                                                                                                                                                                                                                     
-include disable-common.inc                                                                                                                                                                                           
-include disable-programs.inc                                                                                                                                                                                         
-include disable-devel.inc                                                                                                                                                                                            
-include disable-passwdmgr.inc                                                                                                                                                                                        
-include disable-xdg.inc                                                                                                                                                                                              
-include disable-write-mnt.inc                                                                                                                                                                                        
-include whitelist-runuser-common.inc                                                                                                                                                                                 
+noblacklist ${HOME}/.vim
+noblacklist ${HOME}/.cache/nvim
+noblacklist ${HOME}/.local/share/nvim
 
-# Allows files commonly used by IDEs                                                                                                                                                                                 
-include allow-common-devel.inc                                                                                                                                                                                       
-                                                                                                                                                                                                                     
-caps.drop all                                                                                                                                                                                                        
-netfilter                                                                                                                                                                                                            
-nodbus                                                                                                                                                                                                               
-nodvd                                                                                                                                                                                                                
-nogroups                                                                                                                                                                                                             
-noinput                                                                                                                                                                                                              
-nonewprivs                                                                                                                                                                                                           
-noroot                                                                                                                                                                                                               
-notv                                                                                                                                                                                                                 
-nou2f                                                                                                                                                                                                                
-novideo                                                                                                                                                                                                              
-protocol unix,inet,inet6                                                                                                                                                                                             
-seccomp                                                                                                                                                                                                              
-                                                                                                                                                                                                                     
-private-dev                                                                                                                                                                                                          
-                                                                                                                                                                                                                     
+include disable-common.inc
+include disable-devel.inc
+include disable-programs.inc
+include disable-xdg.inc
+
+blacklist ${RUNUSER}/wayland-*
+blacklist ${RUNUSER}
+
+include whitelist-runuser-common.inc
+
+ipc-namespace
+machine-id
+net none
+netfilter
+no3d
+dbus-user none
+dbus-system none
+nodvd
+nogroups
+noinput
+nonewprivs
+noroot
+notv
+nou2f
+novideo
+protocol unix,inet,inet6
+seccomp.block-secondary
+shell none
+tracelog
+x11 none
+
+private-dev
+
 read-write ${HOME}/.vim
 read-only ${HOME}/.config

--- a/etc/profile-m-z/nvim.profile
+++ b/etc/profile-m-z/nvim.profile
@@ -7,7 +7,9 @@ include nvim.local
 include globals.local
 
 noblacklist ${HOME}/.vim
+noblacklist ${HOME}/.vimrc
 noblacklist ${HOME}/.cache/nvim
+noblacklist ${HOME}/.config/nvim
 noblacklist ${HOME}/.local/share/nvim
 
 include disable-common.inc
@@ -43,5 +45,8 @@ private-dev
 dbus-user none
 dbus-system none
 
-read-write ${HOME}/.vim
 read-only ${HOME}/.config
+read-write ${HOME}/.config/nvim
+read-write ${HOME}/.local/share/nvim
+read-write ${HOME}/.vim
+read-write ${HOME}/.vimrc

--- a/etc/profile-m-z/nvim.profile
+++ b/etc/profile-m-z/nvim.profile
@@ -1,5 +1,6 @@
 # Firejail profile for neovim
 # Description: Nvim is open source and freely distributable
+# This file is overwritten after every install/update
 # Persistent local customizations
 include nvim.local
 # Persistent global definitions
@@ -14,7 +15,6 @@ include disable-devel.inc
 include disable-programs.inc
 include disable-xdg.inc
 
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 
 include whitelist-runuser-common.inc
@@ -22,10 +22,7 @@ include whitelist-runuser-common.inc
 ipc-namespace
 machine-id
 net none
-netfilter
 no3d
-dbus-user none
-dbus-system none
 nodvd
 nogroups
 noinput
@@ -35,12 +32,16 @@ notv
 nou2f
 novideo
 protocol unix,inet,inet6
+seccomp
 seccomp.block-secondary
 shell none
 tracelog
 x11 none
 
 private-dev
+
+dbus-user none
+dbus-system none
 
 read-write ${HOME}/.vim
 read-only ${HOME}/.config

--- a/etc/profile-m-z/nvim.profile
+++ b/etc/profile-m-z/nvim.profile
@@ -1,0 +1,39 @@
+# Firejail profile for neovim                                                                                                                                                                                           
+# Description: Nvim is open source and freely distributable
+# This file is overwritten after every install/update                                                                                                                                                                
+# Persistent local customizations                                                                                                                                                                                    
+include nvim.local                                                                                                                                                                                                    
+# Persistent global definitions                                                                                                                                                                                      
+include globals.local 
+
+noblacklist ${HOME}/.vim                                                                                                                                                                                             
+                                                                                                                                                                                                                     
+include disable-common.inc                                                                                                                                                                                           
+include disable-programs.inc                                                                                                                                                                                         
+include disable-devel.inc                                                                                                                                                                                            
+include disable-passwdmgr.inc                                                                                                                                                                                        
+include disable-xdg.inc                                                                                                                                                                                              
+include disable-write-mnt.inc                                                                                                                                                                                        
+include whitelist-runuser-common.inc                                                                                                                                                                                 
+
+# Allows files commonly used by IDEs                                                                                                                                                                                 
+include allow-common-devel.inc                                                                                                                                                                                       
+                                                                                                                                                                                                                     
+caps.drop all                                                                                                                                                                                                        
+netfilter                                                                                                                                                                                                            
+nodbus                                                                                                                                                                                                               
+nodvd                                                                                                                                                                                                                
+nogroups                                                                                                                                                                                                             
+noinput                                                                                                                                                                                                              
+nonewprivs                                                                                                                                                                                                           
+noroot                                                                                                                                                                                                               
+notv                                                                                                                                                                                                                 
+nou2f                                                                                                                                                                                                                
+novideo                                                                                                                                                                                                              
+protocol unix,inet,inet6                                                                                                                                                                                             
+seccomp                                                                                                                                                                                                              
+                                                                                                                                                                                                                     
+private-dev                                                                                                                                                                                                          
+                                                                                                                                                                                                                     
+read-write ${HOME}/.vim
+read-only ${HOME}/.config


### PR DESCRIPTION
I have been sketchy about neovim extensions security, as there are couple extensions that required user to run bash script after pulling some code from git repository. 
My doubts are: 
1. `disable-xdg` is not a problem for me 
2. I am not sure to add it to `firecfg.config` as vim.profile wasn't there
3. There are many plugins manager with various installation path

please let me know if I miss something :) 