### PR TITLE
Noblacklist rxvt in allow-perl.inc

### DIFF
--- a/etc/inc/allow-perl.inc
+++ b/etc/inc/allow-perl.inc
@@ -10,3 +10,6 @@ noblacklist ${PATH}/vendor_perl
 noblacklist /usr/lib/perl*
 noblacklist /usr/lib64/perl*
 noblacklist /usr/share/perl*
+
+# rxvt is also blacklisted in disable-interpreters.inc
+noblacklist ${PATH}/rxvt


### PR DESCRIPTION
This is the counterpart of the blacklist of rxvt in commit ed5c259f,
as suggested in the discussion of pull request #4831.