### PR TITLE
Keep vglusers group unless no3d is used (virtualgl)

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -3150,9 +3150,14 @@ int main(int argc, char **argv, char **envp) {
 				}
 			}
 
-			// add render group
+			// add render/vglusers group
 			if (!arg_no3d) {
 				g = get_group_id("render");
+				if (g) {
+					sprintf(ptr, "%d %d 1\n", g, g);
+					ptr += strlen(ptr);
+				}
+				g = get_group_id("vglusers");
 				if (g) {
 					sprintf(ptr, "%d %d 1\n", g, g);
 					ptr += strlen(ptr);

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -209,6 +209,8 @@ static void clean_supplementary_groups(gid_t gid) {
 	if (!arg_no3d) {
 		copy_group_ifcont("render", groups, ngroups,
 		                  new_groups, &new_ngroups, MAX_GROUPS);
+		copy_group_ifcont("vglusers", groups, ngroups,
+		                  new_groups, &new_ngroups, MAX_GROUPS);
 	}
 
 	if (!arg_noprinters) {


### PR DESCRIPTION
virtualgl[1] runs `chown root:vglusers` on `/dev/nvidia*` and on devices
usually owned by the "render" group[2].  This makes them unavailable in
the sandbox if `noroot` (which causes groups to be dropped) is used.

Since firejail classifies all of the aforementioned devices as being
`DEV_3D` on fs_dev.c (which means that they are controlled by `no3d`),
treat the "vglusers" group the same as the "render" group (by always
keeping "vglusers" unless `no3d` is used).

See the discussion on #2042 (from this comment[3] onwards).

[1] https://virtualgl.org
[2] https://github.com/VirtualGL/virtualgl/blob/6f0b90be02d13171dfdfffb112485f4091a5904f/server/vglserver_config#L393
[3] https://github.com/netblue30/firejail/issues/2042#issuecomment-1007468715

Reported-by: @JCallicoat
