### PR TITLE
{lutris,wine}.profile: allow ~/.cache/wine

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -215,6 +215,7 @@ blacklist ${HOME}/.cache/vmware
 blacklist ${HOME}/.cache/warsow-2.1
 blacklist ${HOME}/.cache/waterfox
 blacklist ${HOME}/.cache/wesnoth
+blacklist ${HOME}/.cache/wine
 blacklist ${HOME}/.cache/winetricks
 blacklist ${HOME}/.cache/xmms2
 blacklist ${HOME}/.cache/xournalpp

--- a/etc/profile-a-l/lutris.profile
+++ b/etc/profile-a-l/lutris.profile
@@ -9,6 +9,7 @@ include globals.local
 noblacklist ${PATH}/llvm*
 noblacklist ${HOME}/Games
 noblacklist ${HOME}/.cache/lutris
+noblacklist ${HOME}/.cache/wine
 noblacklist ${HOME}/.cache/winetricks
 noblacklist ${HOME}/.config/lutris
 noblacklist ${HOME}/.local/share/lutris
@@ -34,6 +35,7 @@ include disable-xdg.inc
 
 mkdir ${HOME}/Games
 mkdir ${HOME}/.cache/lutris
+mkdir ${HOME}/.cache/wine
 mkdir ${HOME}/.cache/winetricks
 mkdir ${HOME}/.config/lutris
 mkdir ${HOME}/.local/share/lutris
@@ -41,6 +43,7 @@ mkdir ${HOME}/.local/share/lutris
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/Games
 whitelist ${HOME}/.cache/lutris
+whitelist ${HOME}/.cache/wine
 whitelist ${HOME}/.cache/winetricks
 whitelist ${HOME}/.config/lutris
 whitelist ${HOME}/.local/share/lutris

--- a/etc/profile-m-z/wine.profile
+++ b/etc/profile-m-z/wine.profile
@@ -6,6 +6,7 @@ include wine.local
 # Persistent global definitions
 include globals.local
 
+noblacklist ${HOME}/.cache/wine
 noblacklist ${HOME}/.cache/winetricks
 noblacklist ${HOME}/.Steam
 noblacklist ${HOME}/.local/share/Steam


### PR DESCRIPTION
~/.cache/wine is a directory where wine stores .msi files for wine-gecko and wine-mono that it may download (with user's permission) and reuse every time a new prefix is created.