### PR TITLE
steam.profile: allow ~/.config/MangoHud

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -281,12 +281,12 @@ blacklist ${HOME}/.config/LibreCAD
 blacklist ${HOME}/.config/Loop_Hero
 blacklist ${HOME}/.config/Luminance
 blacklist ${HOME}/.config/LyX
+blacklist ${HOME}/.config/MangoHud
 blacklist ${HOME}/.config/Mattermost
 blacklist ${HOME}/.config/Meltytech
 blacklist ${HOME}/.config/Mendeley Ltd.
 blacklist ${HOME}/.config/Microsoft
 blacklist ${HOME}/.config/Min
-blacklist ${HOME}/.config/MangoHud
 blacklist ${HOME}/.config/ModTheSpire
 blacklist ${HOME}/.config/Mousepad
 blacklist ${HOME}/.config/Mumble

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -286,6 +286,7 @@ blacklist ${HOME}/.config/Meltytech
 blacklist ${HOME}/.config/Mendeley Ltd.
 blacklist ${HOME}/.config/Microsoft
 blacklist ${HOME}/.config/Min
+blacklist ${HOME}/.config/MangoHud
 blacklist ${HOME}/.config/ModTheSpire
 blacklist ${HOME}/.config/Mousepad
 blacklist ${HOME}/.config/Mumble

--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -8,6 +8,7 @@ include globals.local
 
 noblacklist ${HOME}/.config/Epic
 noblacklist ${HOME}/.config/Loop_Hero
+noblacklist ${HOME}/.config/MangoHud
 noblacklist ${HOME}/.config/ModTheSpire
 noblacklist ${HOME}/.config/RogueLegacy
 noblacklist ${HOME}/.config/RogueLegacyStorageContainer
@@ -55,6 +56,7 @@ include disable-programs.inc
 
 mkdir ${HOME}/.config/Epic
 mkdir ${HOME}/.config/Loop_Hero
+mkdir ${HOME}/.config/MangoHud
 mkdir ${HOME}/.config/ModTheSpire
 mkdir ${HOME}/.config/RogueLegacy
 mkdir ${HOME}/.config/unity3d
@@ -85,6 +87,7 @@ mkfile ${HOME}/.steampath
 mkfile ${HOME}/.steampid
 whitelist ${HOME}/.config/Epic
 whitelist ${HOME}/.config/Loop_Hero
+whitelist ${HOME}/.config/MangoHud
 whitelist ${HOME}/.config/ModTheSpire
 whitelist ${HOME}/.config/RogueLegacy
 whitelist ${HOME}/.config/RogueLegacyStorageContainer

--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -165,3 +165,5 @@ private-tmp
 
 # dbus-user none
 # dbus-system none
+
+read-only ${HOME}/.config/MangoHud


### PR DESCRIPTION
MangoHud is a Vulkan and OpenGL overlay for monitoring FPS, temperatures, CPU/GPU load and more, and it can be configured by user in ~/.config/MangoHud/MangoHud.conf.

This probably could also go into profiles for lutris and wine... But also for every game as well. So maybe ~/.config/MangoHud can be allowed in general in one of the whitelist-*.inc files instead?