### PR TITLE
gitlab-ci: fix debian_ci build (dh_missing hostnames)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -67,8 +67,9 @@ debian_ci:
         - cd $CI_PROJECT_DIR/.. && (apt-get source --download-only -t experimental firejail || apt-get source --download-only firejail)
         - cd $CI_PROJECT_DIR && tar xf ../firejail_*.debian.tar.*
         - rm -rf debian/patches/
-        # next line is a temporary fix for dh_missing failure; remove it after next release
+        # next 2 lines are temporary fixes for dh_missing failures; remove them after next release
         - echo "etc/firejail/*.config" >> debian/firejail.install
+        - echo "etc/firejail/hostnames" >> debian/firejail.install
         - VERSION=$(grep ^PACKAGE_VERSION= configure | cut -d"'" -f2) && dch -v ${VERSION}-0.1~ci "Non-maintainer upload." && git archive -o ../firejail_${VERSION}.orig.tar.gz HEAD && pristine-tar commit ../firejail_${VERSION}.orig.tar.gz ci_build && git branch -m pristine-tar origin/pristine-tar
         - git add debian && git commit -m "add debian/"
         - export CI_COMMIT_SHA=$(git rev-parse HEAD)


### PR DESCRIPTION
Likely caused by commit 500a56efd ("more on nettrace", 2022-01-07).

From the build log of "debian_ci" for the above commit[1]:

    make[1]: Leaving directory '/builds/Firejail/firejail_ci'
       dh_fixperms -Nfirejail
       debian/rules override_dh_missing
    make[1]: Entering directory '/builds/Firejail/firejail_ci'
    dh_missing -pfirejail --fail-missing
    dh_missing: warning: etc/firejail/hostnames exists in debian/tmp but is not installed to anywhere
    dh_missing: error: missing files, aborting

[1] https://gitlab.com/Firejail/firejail_ci/-/jobs/1952432676
