### PR TITLE
profiles: enable deterministic shutdown for ssh

### DIFF
--- a/etc/profile-m-z/ssh.profile
+++ b/etc/profile-m-z/ssh.profile
@@ -50,4 +50,5 @@ writable-run-user
 dbus-user none
 dbus-system none
 
+deterministic-shutdown
 memory-deny-write-execute


### PR DESCRIPTION
ssh can start in master mode, which will spawn an additional long
running process, which keeps connections to a server open, so that
it can be reused by later connection attempts.

But the lingering master process will prevent the jail from shutting
down, when `firejail ssh` tries to exit.
This breaks for example ansible when using a firejailed ssh, as it
calls ssh with ControlMaster flags.

deterministic-shutdown will kill the other process when the parent
exits.

---

does anyone see something negative with enabling this flag?