### PR TITLE
Allow common access to EGL External platform configuration directory

### DIFF
--- a/etc/inc/whitelist-usr-share-common.inc
+++ b/etc/inc/whitelist-usr-share-common.inc
@@ -12,6 +12,7 @@ whitelist /usr/share/cursors
 whitelist /usr/share/dconf
 whitelist /usr/share/distro-info
 whitelist /usr/share/drirc.d
+whitelist /usr/share/egl
 whitelist /usr/share/enchant
 whitelist /usr/share/enchant-2
 whitelist /usr/share/file


### PR DESCRIPTION
This commit fixes #4893 by allowing access to the configuration directory for the Wayland EGL external platform library