### PR TITLE
shellcheck.profile: remove mdwe

### DIFF
--- a/etc/profile-m-z/shellcheck.profile
+++ b/etc/profile-m-z/shellcheck.profile
@@ -50,5 +50,3 @@ private-tmp
 
 dbus-user none
 dbus-system none
-
-memory-deny-write-execute


### PR DESCRIPTION
It breaks non-binary builds of shellcheck on Arch (e.g.: shellcheck-bin
vs shellcheck-git from the AUR).

Fixes #4875.

Reported-by: @redxef
