### PR TITLE
push changelog date, so that it's different from the previous one

### DIFF
--- a/RELNOTES
+++ b/RELNOTES
@@ -1,6 +1,6 @@
 firejail (0.9.69) baseline; urgency=low
   * work in progress
- -- netblue30 <netblue30@yahoo.com>  Sun, 6 Feb 2022 09:00:00 -0500
+ -- netblue30 <netblue30@yahoo.com>  Mon, 7 Feb 2022 09:00:00 -0500
 
 firejail (0.9.68) baseline; urgency=low
   * security: on Ubuntu, the PPA is now recommended over the distro package


### PR DESCRIPTION
... otherwise the gitlab CI will complain.

---

Btw. does anyone have experience with Redhat/CentOS?
There is another job failing with this error:
```
$ dnf update -y
CentOS Linux 8 - AppStream                      276  B/s |  38  B     00:00    
Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
```
https://gitlab.com/Firejail/firejail_ci/-/jobs/2062852936