### PR TITLE
keepassx: restore nou2f

### DIFF
--- a/etc/profile-a-l/keepassx.profile
+++ b/etc/profile-a-l/keepassx.profile
@@ -32,6 +32,7 @@ nonewprivs
 noroot
 nosound
 notv
+nou2f
 novideo
 protocol unix
 seccomp
@@ -39,9 +40,6 @@ shell none
 tracelog
 
 private-bin keepassx,keepassx2
-# Note: private-dev prevents the program from seeing new devices (such as
-# hardware keys) on /dev after it has already started; add "ignore private-dev"
-# to keepassxc.local if this is an issue (see #4883).
 private-dev
 private-etc alternatives,fonts,ld.so.cache,ld.so.preload,machine-id
 private-tmp


### PR DESCRIPTION
I could not find anything to confirm that keepassx supports hardware
keys.  And as mentioned by @rusty-snake[1]:

> The yubikey support in kpxc seems to be based on
> https://github.com/kylemanna/keepassx /
> https://github.com/keepassx/keepassx/pull/52
> which was never merged. For me it looks like kpx never got official
> support for it.
>
> keepass seems to support hw keys (via plugin).

Also of note is the PR that added yubikey support to keepassxc:
https://github.com/keepassxreboot/keepassxc/pull/127

This partially reverts commit 09ac1a73e ("keepass*: remove nou2f",
2022-02-05) / PR #4903.  See also commit 91b04172b ("keepass*: fix typo
in private-dev note", 2022-02-06).

Closes #4883.

[1] https://github.com/netblue30/firejail/issues/4883#issuecomment-1031172309
