### PR TITLE
Refer to firejail.config in configuration files

### DIFF
--- a/configure
+++ b/configure
@@ -1380,7 +1380,7 @@ Optional Features:
   --disable-firetunnel    disable firetunnel
   --disable-private-home  disable private home feature
   --disable-chroot        disable chroot
-  --disable-globalcfg     if the global config file firejail.cfg is not
+  --disable-globalcfg     if the global config file firejail.config is not
                           present, continue the program using defaults
   --disable-network       disable network
   --disable-userns        disable user namespace

--- a/configure.ac
+++ b/configure.ac
@@ -150,7 +150,7 @@ HAVE_GLOBALCFG=""
 AC_SUBST([HAVE_GLOBALCFG])
 AC_ARG_ENABLE([globalcfg],
     [AS_HELP_STRING([--disable-globalcfg],
-        [if the global config file firejail.cfg is not present, continue the program using defaults])])
+        [if the global config file firejail.config is not present, continue the program using defaults])])
 AS_IF([test "x$enable_globalcfg" != "xno"], [
 	HAVE_GLOBALCFG="-DHAVE_GLOBALCFG"
 ])


### PR DESCRIPTION
Both configure and configure.ac refer to the non-existing `firejail.cfg`. Use the correct `firejail.config` file name instead.