### PR TITLE
Fix iridium.profile

### DIFF
--- a/etc/profile-a-l/iridium.profile
+++ b/etc/profile-a-l/iridium.profile
@@ -5,11 +5,6 @@ include iridium.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
-ignore whitelist /usr/share/chromium
-ignore include whitelist-runuser-common.inc
-ignore include whitelist-usr-share-common.inc
-
 noblacklist ${HOME}/.cache/iridium
 noblacklist ${HOME}/.config/iridium
 


### PR DESCRIPTION
0319fbd enabled whitelisting in /usr/share for iridium but wusc
was still ignore causing iridium to crash.

Fixes  #4917

cc @frcl