### PR TITLE
Update security policy for 0.9.68 release

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,9 @@
 
 | Version | Supported by us    | EOL                | Supported by distribution                                                         |
 | ------- | ------------------ | ------------------ | --------------------------------------------------------------------------------- |
-| 0.9.66  | :heavy_check_mark: |                    | :white_check_mark: Debian 11 **backports**, Debian 12 (testing/unstable)          |
-| 0.9.64  | :x:                |                    | :white_check_mark: Debian 10 **backports**, Debian 11, Ubuntu 21.04, Ubuntu 21.10 |
+| 0.9.68  | :heavy_check_mark: |                    |                                                                                   |
+| 0.9.66  | :x:                |                    | :white_check_mark: Debian 11 **backports**, Debian 12 (testing/unstable)          |
+| 0.9.64  | :x:                |                    | :white_check_mark: Debian 10 **backports**, Debian 11, Ubuntu 21.10               |
 | 0.9.62  | :x:                |                    | :white_check_mark: Ubuntu 20.04 LTS, Ubuntu 20.10                                 |
 | 0.9.60  | :x:                | 29 Dec 2019        |                                                                                   |
 | 0.9.58  | :x:                |                    | :white_check_mark: Debian 9 **backports**, Debian 10                              |
@@ -18,7 +19,7 @@
 | 0.9.44  | :x:                |                    | :white_check_mark: Debian 9                                                       |
 | 0.9.42  | :x:                | 22 Oct 2016        |                                                                                   |
 | 0.9.40  | :x:                | 09 Sep 2016        |                                                                                   |
-| 0.9.38  | :x:                |                    | :white_check_mark: Ubuntu 16.04 LTS                                               |
+| 0.9.38  | :x:                | 31 May 2016        |                                                                                   |
 | <0.9.38 | :x:                | Before 05 Feb 2016 |                                                                                   |
 
 ## Security vulnerabilities


### PR DESCRIPTION
Additional fixes:
Ubuntu 16.04 is EOL. This means that Firejail 0.9.38 is (to
reasonable knowledge) not supported by any mainstream distros.

Ubuntu 21.04 is also EOL.
