### PR TITLE
Disable/comment message about nogroups being ignored

### DIFF
--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -125,7 +125,8 @@ int check_can_drop_all_groups() {
 	 * and #4603.
 	 */
 	if (access("/run/systemd/seats/", F_OK) != 0) {
-		fwarning("logind not detected, nogroups command ignored\n");
+		// TODO: wrc causes this to be printed even with (e)logind (see #4930)
+		//fwarning("logind not detected, nogroups command ignored\n");
 		can_drop_all_groups = 0;
 		goto out;
 	}


### PR DESCRIPTION
Added on commit 7abce0b4c ("Fix keeping certain groups with nogroups",
2021-11-30) / PR #4732.

As reported by @rusty-snake on #4930, conflicting messages are printed
when using whitelist-run-common.inc with nogroups:

    $ cat test.profile
    include whitelist-run-common.inc
    nogroups
    $ firejail --profile=./test.profile groups
    Reading profile ./test.profile
    Reading profile /etc/firejail/whitelist-run-common.inc
    Parent pid 1234, child pid 1235
    Warning: logind not detected, nogroups command ignored     <--- is a lie
    Warning: cleaning all supplementary groups
    Child process initialized in 30.00 ms
    rusty-snake    <---- running `groups` outside of the sandbox shows more so groups are actually cleaned

    Parent is shutting down, bye...

This probably happens because wrc causes /run/systemd to be hidden in
the sandbox and because check_can_drop_all_groups is called multiple
times, seemingly both before and after the whitelisting goes into
effect.  So disable the message about nogroups being ignored, but keep
the message about cleaning all supplementary groups (which is unlikely
to be printed unless it really happens).

Fixes #4930.
