### PR TITLE
firejail.config: add warning about allow-tray

### DIFF
--- a/etc/firejail.config
+++ b/etc/firejail.config
@@ -2,7 +2,8 @@
 # keyword-argument pairs, one per line. Most features are enabled by default.
 # Use 'yes' or 'no' as configuration values.
 
-# Allow programs to display a tray icon
+# Allow programs to display a tray icon (warning: allows escaping the sandbox;
+# see https://github.com/netblue30/firejail/discussions/4053)
 # allow-tray no
 
 # Enable AppArmor functionality, default enabled.


### PR DESCRIPTION
According to #4053, there is currently no safe (in the sense of not
allowing to escape the sandbox) implementation of
`org.kde.StatusNotifierWatcher`, but it is required by multiple programs
for tray functionality.  Users may not be aware of this (for example,
see https://github.com/netblue30/firejail/issues/4508), so add a warning about it.

Note: allow-tray was added on commit c86cae2d0 ("Add new condition
ALLOW_TRAY", 2021-09-04) / PR #4510.

Cc: @davidebeatrici