### PR TITLE
man.profile: remove read-only tmp to fix mandoc

### DIFF
--- a/etc/profile-m-z/man.profile
+++ b/etc/profile-m-z/man.profile
@@ -66,4 +66,4 @@ dbus-system none
 
 memory-deny-write-execute
 read-only ${HOME}
-read-only /tmp
+#read-only /tmp # breaks mandoc (see #4927)


### PR DESCRIPTION
Having `read-only /tmp` yields the following:

    $ man ls
    [...]
    man: /usr/share/man/man1/ls.1.gz: SYSERR: mkstemp: /tmp/man.XXXXxxxxxx: Read-only file system
    [...]

It also causes the pager (e.g.: less(1)) to not be called, which means
that the entire man page is just printed all at once on the terminal.

Environment: mandoc 1.14.6-1 on Artix Linux.

Fixes #4927.

Reported-by: @hyder365
