### PR TITLE
add onionshare redirects

### DIFF
--- a/etc/profile-m-z/onionshare-cli.profile
+++ b/etc/profile-m-z/onionshare-cli.profile
@@ -1,0 +1,12 @@
+# Firejail profile for onionshare-cli
+# Description: Share a file over Tor Hidden Services anonymously and securely (CLI)
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include onionshare-cli.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+# Redirect
+include onionshare-gui.profile

--- a/etc/profile-m-z/onionshare.profile
+++ b/etc/profile-m-z/onionshare.profile
@@ -1,0 +1,11 @@
+# Firejail profile for onionshare
+# Description: Share a file over Tor Hidden Services anonymously and securely (GUI)
+# This file is overwritten after every install/update
+# Persistent local customizations
+include onionshare.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+# Redirect
+include onionshare-gui.profile

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -608,6 +608,8 @@ odt2txt
 oggsplt
 okular
 onboard
+onionshare
+onionshare-cli
 onionshare-gui
 ooffice
 ooviewdoc


### PR DESCRIPTION
On Arch Linux the [onionshare](https://archlinux.org/packages/community/any/onionshare/) package from the community repo doesn't have the `onionshare-gui` executable. Instead it comes with `onionshare` and `onionshare-cli`. This PR adds redirect profiles for both of those commands and enables them in firecfg.