### PR TITLE
drop private-dev from wireshark.profile

### DIFF
--- a/etc/profile-m-z/wireshark.profile
+++ b/etc/profile-m-z/wireshark.profile
@@ -45,6 +45,9 @@ tracelog
 
 # private-bin wireshark
 private-cache
+# private-dev prevents (some) interfaces from being shown.
+# Add the below line to your wirehsark.local if you only want to inspect pcap files.
+#private-dev
 # private-etc alternatives,ca-certificates,crypto-policies,fonts,group,hosts,machine-id,passwd,pki,ssl
 private-tmp
 

--- a/etc/profile-m-z/wireshark.profile
+++ b/etc/profile-m-z/wireshark.profile
@@ -45,7 +45,6 @@ tracelog
 
 # private-bin wireshark
 private-cache
-private-dev
 # private-etc alternatives,ca-certificates,crypto-policies,fonts,group,hosts,machine-id,passwd,pki,ssl
 private-tmp
 


### PR DESCRIPTION
This came up in https://github.com/netblue30/firejail/discussions/4949. I can reproduce that `private-dev` stops tshark/wireshark from showing interfaces.