### PR TITLE
wireshark.profile: Add dac_read_search to caps.keep

### DIFF
--- a/etc/profile-m-z/wireshark.profile
+++ b/etc/profile-m-z/wireshark.profile
@@ -26,7 +26,7 @@ include whitelist-var-common.inc
 
 apparmor
 # caps.drop all
-caps.keep dac_override,net_admin,net_raw
+caps.keep dac_override,dac_read_search,net_admin,net_raw
 netfilter
 no3d
 # nogroups - breaks network traffic capture for unprivileged users


### PR DESCRIPTION
On gentoo linux, /usr/bin/dumpcap requires dac_read_search instead of dac_override.