### PR TITLE
qbittorrent.profile: fix data directory location

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -962,6 +962,7 @@ blacklist ${HOME}/.local/share/plasma_notes
 blacklist ${HOME}/.local/share/profanity
 blacklist ${HOME}/.local/share/psi
 blacklist ${HOME}/.local/share/psi+
+blacklist ${HOME}/.local/share/qBittorrent
 blacklist ${HOME}/.local/share/qpdfview
 blacklist ${HOME}/.local/share/quadrapassel
 blacklist ${HOME}/.local/share/qutebrowser

--- a/etc/profile-m-z/qbittorrent.profile
+++ b/etc/profile-m-z/qbittorrent.profile
@@ -10,6 +10,7 @@ noblacklist ${HOME}/.cache/qBittorrent
 noblacklist ${HOME}/.config/qBittorrent
 noblacklist ${HOME}/.config/qBittorrentrc
 noblacklist ${HOME}/.local/share/data/qBittorrent
+noblacklist ${HOME}/.local/share/qBittorrent
 
 # Allow python (blacklisted by disable-interpreters.inc)
 include allow-python2.inc
@@ -26,11 +27,13 @@ mkdir ${HOME}/.cache/qBittorrent
 mkdir ${HOME}/.config/qBittorrent
 mkfile ${HOME}/.config/qBittorrentrc
 mkdir ${HOME}/.local/share/data/qBittorrent
+mkdir ${HOME}/.local/share/qBittorrent
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.cache/qBittorrent
 whitelist ${HOME}/.config/qBittorrent
 whitelist ${HOME}/.config/qBittorrentrc
 whitelist ${HOME}/.local/share/data/qBittorrent
+whitelist ${HOME}/.local/share/qBittorrent
 include whitelist-common.inc
 include whitelist-var-common.inc
 


### PR DESCRIPTION
Since version 4.3.3 qBittorrent switched to new data directory location (`~/.local/share/qBittorrent` instead of `~/.local/share/data/qBittorrent`).
ChangeLog says that legacy 'data' directory is now used only as a fallback. Also, when using current profile the following warning appears on the terminal:
```
The legacy data directory '/home/avallac_h/.local/share/data/qBittorrent' is used. It is recommended to move its content to '/home/avallac_h/.local/share/qBittorrent'
```
The proposed pull request should fix this issue.