### PR TITLE
Add support for changing appearance of the Qt6 apps with qt6ct

### DIFF
--- a/etc/inc/whitelist-1793-workaround.inc
+++ b/etc/inc/whitelist-1793-workaround.inc
@@ -23,6 +23,7 @@ noblacklist ${HOME}/.config/kio_httprc
 noblacklist ${HOME}/.config/kioslaverc
 noblacklist ${HOME}/.config/ksslcablacklist
 noblacklist ${HOME}/.config/qt5ct
+noblacklist ${HOME}/.config/qt6ct
 noblacklist ${HOME}/.config/qtcurve
 
 blacklist ${HOME}/.config/*

--- a/etc/inc/whitelist-common.inc
+++ b/etc/inc/whitelist-common.inc
@@ -69,6 +69,7 @@ whitelist ${HOME}/.config/kio_httprc
 whitelist ${HOME}/.config/kioslaverc
 whitelist ${HOME}/.config/ksslcablacklist
 whitelist ${HOME}/.config/qt5ct
+whitelist ${HOME}/.config/qt6ct
 whitelist ${HOME}/.config/qtcurve
 whitelist ${HOME}/.kde/share/config/kdeglobals
 whitelist ${HOME}/.kde/share/config/kio_httprc
@@ -83,3 +84,4 @@ whitelist ${HOME}/.kde4/share/config/ksslcablacklist
 whitelist ${HOME}/.kde4/share/config/oxygenrc
 whitelist ${HOME}/.kde4/share/icons
 whitelist ${HOME}/.local/share/qt5ct
+whitelist ${HOME}/.local/share/qt6ct

--- a/etc/inc/whitelist-usr-share-common.inc
+++ b/etc/inc/whitelist-usr-share-common.inc
@@ -55,6 +55,7 @@ whitelist /usr/share/qt
 whitelist /usr/share/qt4
 whitelist /usr/share/qt5
 whitelist /usr/share/qt5ct
+whitelist /usr/share/qt6ct
 whitelist /usr/share/sounds
 whitelist /usr/share/tcl8.6
 whitelist /usr/share/tcltk

--- a/etc/profile-a-l/bibletime.profile
+++ b/etc/profile-a-l/bibletime.profile
@@ -49,7 +49,7 @@ seccomp !chroot
 shell none
 
 disable-mnt
-# private-bin bibletime,qt5ct
+# private-bin bibletime
 private-cache
 private-dev
 private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,login.defs,machine-id,passwd,pki,resolv.conf,ssl,sword,sword.conf

--- a/etc/profile-m-z/zeal.profile
+++ b/etc/profile-m-z/zeal.profile
@@ -19,7 +19,6 @@ include disable-shell.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.cache/Zeal
-mkdir ${HOME}/.config/qt5ct
 mkdir ${HOME}/.config/Zeal
 mkdir ${HOME}/.local/share/Zeal
 whitelist ${HOME}/.cache/Zeal


### PR DESCRIPTION
In Arch this applies at least to telegram-desktop, qmmp, qbittorrent and strawberry which are now built using Qt6 libraries. But I'm unsure about `whitelist-1793-workaround.inc` which is currently used by `neochat.profile` only.

Also I found a strange artifact in zeal.profile: https://github.com/netblue30/firejail/blob/070e78a8892d86687a1a3e74262628ee9c562c46/etc/profile-m-z/zeal.profile#L22