### PR TITLE
fix globals.local in mupdf & redirects

### DIFF
--- a/etc/profile-m-z/mupdf.profile
+++ b/etc/profile-m-z/mupdf.profile
@@ -4,7 +4,7 @@
 # Persistent local customizations
 include mupdf.local
 # Persistent global definitions
-#include globals.local
+include globals.local
 
 noblacklist ${DOCUMENTS}
 


### PR DESCRIPTION
All mupdf redirect profiles rely on mupdf.profile for including globals.local. Due to the include being commented in that file globals.local never makes it into the sandbox setup. Let's fix this.

This came up while trying to help in https://github.com/netblue30/firejail/discussions/4975.