### PR TITLE
ffplay: fix private-etc

### DIFF
--- a/etc/profile-a-l/ffplay.profile
+++ b/etc/profile-a-l/ffplay.profile
@@ -14,7 +14,7 @@ ignore nogroups
 ignore nosound
 
 private-bin ffplay
-private-etc alsa,alternatives,asound.conf,group,ld.so.cache,ld.so.preload
+private-etc alsa,asound.conf,group
 
 # Redirect
 include ffmpeg.profile


### PR DESCRIPTION
ffplay redirects to ffmpeg, which already has several of the same items in its private-bin. I suspect this is fallout from https://github.com/netblue30/firejail/commit/23c4234d709fccc4a78d64aec0adbd6a22db5909. There might be similar potential cleanups, I'll look into that. 