### PR TITLE
opera fixes/hardening

### DIFF
--- a/etc/profile-m-z/opera-beta.profile
+++ b/etc/profile-m-z/opera-beta.profile
@@ -5,11 +5,6 @@ include opera-beta.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see https://www.tutorialspoint.com/difference-between-void-main-and-int-main-in-c-cplusplus
-ignore whitelist /usr/share/chromium
-ignore include whitelist-runuser-common.inc
-ignore include whitelist-usr-share-common.inc
-
 noblacklist ${HOME}/.cache/opera
 noblacklist ${HOME}/.config/opera-beta
 

--- a/etc/profile-m-z/opera.profile
+++ b/etc/profile-m-z/opera.profile
@@ -6,11 +6,6 @@ include opera.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see https://www.tutorialspoint.com/difference-between-void-main-and-int-main-in-c-cplusplus
-ignore whitelist /usr/share/chromium
-ignore include whitelist-runuser-common.inc
-ignore include whitelist-usr-share-common.inc
-
 noblacklist ${HOME}/.cache/opera
 noblacklist ${HOME}/.config/opera
 noblacklist ${HOME}/.opera


### PR DESCRIPTION
The URL for the 'Disable for now' comment seems out of place. After testing it looks like we can actually harden the profiles by dropping the disabled includes alltogether.