### PR TITLE
fix sylpheed

### DIFF
--- a/etc/profile-a-l/email-common.profile
+++ b/etc/profile-a-l/email-common.profile
@@ -66,7 +66,7 @@ tracelog
 # disable-mnt
 private-cache
 private-dev
-private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gcrypt,gnupg,groups,gtk-2.0,gtk-3.0,hostname,hosts,hosts.conf,ld.so.cache,ld.so.preload,mailname,nsswitch.conf,passwd,pki,resolv.conf,selinux,ssl,xdg
+private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gcrypt,gnupg,groups,gtk-2.0,gtk-3.0,hostname,hosts,hosts.conf,ld.so.cache,ld.so.preload,machine-id,mailname,nsswitch.conf,passwd,pki,resolv.conf,selinux,ssl,xdg
 private-tmp
 # encrypting and signing email
 writable-run-user


### PR DESCRIPTION
Sylpheed needs access to /var/lib/dbus/machine-id, which usually is a symlink to /etc/machine-id. Fix for https://github.com/netblue30/firejail/issues/4995. Technically speaking we could add a private-etc to sylpheed.profile. I decided to add it in email-common.profile instead for ease-of-use/maintainability.