### PR TITLE
drop redundant ignore in chromium-based browsers

### DIFF
--- a/etc/profile-a-l/bnox.profile
+++ b/etc/profile-a-l/bnox.profile
@@ -6,7 +6,6 @@ include bnox.local
 include globals.local
 
 # Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
-ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-a-l/dnox.profile
+++ b/etc/profile-a-l/dnox.profile
@@ -6,7 +6,6 @@ include dnox.local
 include globals.local
 
 # Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
-ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-a-l/enox.profile
+++ b/etc/profile-a-l/enox.profile
@@ -6,7 +6,6 @@ include enox.local
 include globals.local
 
 # Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
-ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-a-l/flashpeak-slimjet.profile
+++ b/etc/profile-a-l/flashpeak-slimjet.profile
@@ -6,7 +6,6 @@ include flashpeak-slimjet.local
 include globals.local
 
 # Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
-ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-a-l/google-chrome-beta.profile
+++ b/etc/profile-a-l/google-chrome-beta.profile
@@ -6,7 +6,6 @@ include google-chrome-beta.local
 include globals.local
 
 # Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
-ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-a-l/google-chrome-unstable.profile
+++ b/etc/profile-a-l/google-chrome-unstable.profile
@@ -6,7 +6,6 @@ include google-chrome-unstable.local
 include globals.local
 
 # Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
-ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-a-l/google-chrome.profile
+++ b/etc/profile-a-l/google-chrome.profile
@@ -6,7 +6,6 @@ include google-chrome.local
 include globals.local
 
 # Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
-ignore whitelist /usr/share/chromium
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-m-z/snox.profile
+++ b/etc/profile-m-z/snox.profile
@@ -5,8 +5,7 @@ include snox.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see https://www.tutorialspoint.com/difference-between-void-main-and-int-main-in-c-cplusplus
-ignore whitelist /usr/share/chromium
+# Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 

--- a/etc/profile-m-z/yandex-browser.profile
+++ b/etc/profile-m-z/yandex-browser.profile
@@ -5,8 +5,7 @@ include yandex-browser.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see https://www.tutorialspoint.com/difference-between-void-main-and-int-main-in-c-cplusplus
-ignore whitelist /usr/share/chromium
+# Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 


### PR DESCRIPTION
The `ignore whitelist /usr/share/chromium` can be dropped from profiles redirecting to chromium-common.profile, as that path is only whitelisted in chromium.profile.