### PR TITLE
Fix newest Steam client and Proton ≥ 5.13

### DIFF
--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -143,7 +143,8 @@ novideo
 protocol unix,inet,inet6,netlink
 # seccomp sometimes causes issues (see #2951, #3267).
 # Add 'ignore seccomp' to your steam.local if you experience this.
-seccomp !ptrace
+# mount, name_to_handle_at, pivot_root and umount2 are used by Proton >= 5.13
+seccomp !mount,!name_to_handle_at,!pivot_root,!ptrace,!umount2
 shell none
 # tracelog breaks integrated browser
 #tracelog

--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -144,7 +144,7 @@ protocol unix,inet,inet6,netlink
 # seccomp sometimes causes issues (see #2951, #3267).
 # Add 'ignore seccomp' to your steam.local if you experience this.
 # mount, name_to_handle_at, pivot_root and umount2 are used by Proton >= 5.13
-seccomp !mount,!name_to_handle_at,!pivot_root,!ptrace,!umount2
+seccomp !chroot,!mount,!name_to_handle_at,!pivot_root,!ptrace,!umount2
 shell none
 # tracelog breaks integrated browser
 #tracelog


### PR DESCRIPTION
Fixes latests Steam client (second commit) and Steam’s Proton versions starting from 5.13 (first commit). See https://github.com/netblue30/firejail/issues/5014#issue-1160458796 and https://github.com/netblue30/firejail/issues/4366#issuecomment-1053756405 for details.  
Afaict #4686 is just a duplicate of #4366 so it too should be fixed by the first commit.