### PR TITLE
Electron app fixes

### DIFF
--- a/etc/profile-a-l/atom.profile
+++ b/etc/profile-a-l/atom.profile
@@ -11,6 +11,8 @@ ignore include disable-devel.inc
 ignore include disable-interpreters.inc
 ignore include disable-xdg.inc
 ignore whitelist ${DOWNLOADS}
+ignore whitelist ${HOME}/.config/Electron
+ignore whitelist ${HOME}/.config/electron-flag*.conf
 ignore include whitelist-common.inc
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/code.profile
+++ b/etc/profile-a-l/code.profile
@@ -11,6 +11,8 @@ ignore include disable-exec.inc
 ignore include disable-interpreters.inc
 ignore include disable-xdg.inc
 ignore whitelist ${DOWNLOADS}
+ignore whitelist ${HOME}/.config/Electron
+ignore whitelist ${HOME}/.config/electron-flag*.conf
 ignore include whitelist-common.inc
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/github-desktop.profile
+++ b/etc/profile-a-l/github-desktop.profile
@@ -14,6 +14,8 @@ include globals.local
 # Disabled until someone reported positive feedback
 ignore include disable-xdg.inc
 ignore whitelist ${DOWNLOADS}
+ignore whitelist ${HOME}/.config/Electron
+ignore whitelist ${HOME}/.config/electron-flag*.conf
 ignore include whitelist-common.inc
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-m-z/skypeforlinux.profile
+++ b/etc/profile-m-z/skypeforlinux.profile
@@ -6,26 +6,22 @@ include skypeforlinux.local
 include globals.local
 
 # Disabled until someone reported positive feedback
-ignore include whitelist-common.inc
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc
 ignore include whitelist-var-common.inc
 ignore nou2f
-ignore novideo
-ignore private-dev
-
-ignore dbus-user none
 
 # breaks Skype
 ignore apparmor
+ignore dbus-user none
 ignore noexec /tmp
+ignore novideo
+ignore private-dev # needs /dev/disk
 
 noblacklist ${HOME}/.config/skypeforlinux
 
 mkdir ${HOME}/.config/skypeforlinux
 whitelist ${HOME}/.config/skypeforlinux
-
-# private-dev - needs /dev/disk
 
 dbus-user filter
 dbus-user.talk org.freedesktop.Notifications


### PR DESCRIPTION
From discussion in #5012

skypeforlinux is whitelist profile, so adding more whitelisted paths will not break anything. Just cleaning up that profile.

notable.profile has 
```
ignore whitelist ${HOME}/.config/Electron
ignore whitelist ${HOME}/.config/electron-flag*.conf
```
already.