### PR TITLE
gcov: fix gcov functions always declared as dummy

### DIFF
--- a/src/include/gcov_wrapper.h
+++ b/src/include/gcov_wrapper.h
@@ -21,7 +21,7 @@
 #ifndef GCOV_WRAPPER_H
 #define GCOV_WRAPPER_H
 
-#ifdef HAS_GCOV
+#ifdef HAVE_GCOV
 #include <gcov.h>
 
 /*
@@ -41,6 +41,6 @@ static void __gcov_flush(void) {
 #define __gcov_dump() ((void)0)
 #define __gcov_reset() ((void)0)
 #define __gcov_flush() ((void)0)
-#endif /* HAS_GCOV */
+#endif /* HAVE_GCOV */
 
 #endif /* GCOV_WRAPPER_H */


### PR DESCRIPTION
Currently, the check to enable gcov relies on a non-existent macro due
to a typo, which looks like it would cause the dummy/empty versions of
the gcov functions to always be declared (even with --enable-gcov),
instead of the real ones from gcov.h.  This commit fixes the typo
(HAS_GCOV -> HAVE_GCOV).  See configure.ac for the macro declaration.

This amends commit 5106b2ec4 ("gcov: use no-op functions if not
enabled", 2021-06-20) / PR #4376.

Occurrences of each macro with this commit applied:

    $ git grep -F HAVE_GCOV | wc -l
    16
    $ git grep -F HAS_GCOV | wc -l
    0
