### PR TITLE
steam.profile: allow "${HOME}/.prey"

### DIFF
--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -35,6 +35,7 @@ noblacklist ${HOME}/.local/share/vpltd
 noblacklist ${HOME}/.local/share/vulkan
 noblacklist ${HOME}/.mbwarband
 noblacklist ${HOME}/.paradoxinteractive
+noblacklist ${HOME}/.prey
 noblacklist ${HOME}/.steam
 noblacklist ${HOME}/.steampath
 noblacklist ${HOME}/.steampid
@@ -82,6 +83,7 @@ mkdir ${HOME}/.local/share/vpltd
 mkdir ${HOME}/.local/share/vulkan
 mkdir ${HOME}/.mbwarband
 mkdir ${HOME}/.paradoxinteractive
+mkdir ${HOME}/.prey
 mkdir ${HOME}/.steam
 mkfile ${HOME}/.steampath
 mkfile ${HOME}/.steampid
@@ -115,6 +117,7 @@ whitelist ${HOME}/.local/share/vpltd
 whitelist ${HOME}/.local/share/vulkan
 whitelist ${HOME}/.mbwarband
 whitelist ${HOME}/.paradoxinteractive
+whitelist ${HOME}/.prey
 whitelist ${HOME}/.steam
 whitelist ${HOME}/.steampath
 whitelist ${HOME}/.steampid


### PR DESCRIPTION
The directory is used by the Linux binary for Prey (2006), available at https://icculus.org/prey.

Not whitelisting the directory results in the game failing to launch:

```
found DLL in pak file: /home/user/.steam/steamapps/common/Prey 2006/base/game01.pk4/gamex86.so
copy gamex86.so to /home/user/.prey/base/gamex86.so
dlopen '/home/user/.prey/base/gamex86.so' failed: /home/user/.prey/base/gamex86.so: failed to map segment from shared object
```