### PR TITLE
man: mention that the protocol command accumulates

### DIFF
--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -505,7 +505,7 @@ There is no root account (uid 0) defined in the namespace.
 Enable protocol filter. The filter is based on seccomp and checks the
 first argument to socket system call. Recognized values: \fBunix\fR,
 \fBinet\fR, \fBinet6\fR, \fBnetlink\fR, \fBpacket\fR, and \fBbluetooth\fR.
-Multiple protocol commands are allowed.
+Multiple protocol commands are allowed and they accumulate.
 .TP
 \fBseccomp
 Enable seccomp filter and blacklist the syscalls in the default list. See man 1 firejail for more details.

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -2167,6 +2167,7 @@ $ firejail \-\-profile.print=browser
 \fB\-\-protocol=protocol,protocol,protocol
 Enable protocol filter. The filter is based on seccomp and checks the first argument to socket system call.
 Recognized values: unix, inet, inet6, netlink, packet, and bluetooth. This option is not supported for i386 architecture.
+Multiple protocol commands are allowed and they accumulate.
 .br
 
 .br


### PR DESCRIPTION
As mentioned by @rusty-snake[1].

This amends commit 39654d016 ("adding netlink to --protocol list
(#4605)", 2022-01-21).

See also commit 75073e0e4 ("man: mention that private-bin and
private-etc are cumulative", 2022-01-22) and issue #4078.

[1] https://github.com/netblue30/firejail/pull/5042/files#r825477891
