### PR TITLE
ping: (extra) hardening  

### DIFF
--- a/etc/profile-m-z/ping-hardened.inc.profile
+++ b/etc/profile-m-z/ping-hardened.inc.profile
@@ -1,0 +1,11 @@
+# This file is overwritten during software install.
+# Persistent customizations should go in a .local file.
+include ping-hardened.inc.local
+
+caps.drop all
+nonewprivs
+noroot
+protocol unix,inet,inet6
+seccomp
+
+memory-deny-write-execute

--- a/etc/profile-m-z/ping.profile
+++ b/etc/profile-m-z/ping.profile
@@ -7,23 +7,30 @@ include ping.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
 
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
+include disable-proc.inc
 include disable-programs.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 include whitelist-common.inc
+include whitelist-run-common.inc
+include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
+
+# Add the next line to your ping.local if your kernel allows unprivileged userns clone.
+include ping-hardened.inc.profile
 
 apparmor
 caps.keep net_raw
 ipc-namespace
+machine-id
 #net tun0
 #netfilter /etc/firejail/ping.net
 netfilter
@@ -31,8 +38,9 @@ no3d
 nodvd
 nogroups
 noinput
-# ping needs to rise privileges, noroot and nonewprivs will kill it
+# ping needs to raise privileges, nonewprivs and noroot will kill it
 #nonewprivs
+noprinters
 #noroot
 nosound
 notv
@@ -40,15 +48,18 @@ nou2f
 novideo
 # protocol command is built using seccomp; nonewprivs will kill it
 #protocol unix,inet,inet6,netlink,packet
-# killed by no-new-privs
 #seccomp
+shell none
+tracelog
 
 disable-mnt
 private
-#private-bin has mammoth problems with execvp: "No such file or directory"
+#private-bin ping - has mammoth problems with execvp: "No such file or directory"
+private-cache
 private-dev
 # /etc/hosts is required in private-etc; however, just adding it to the list doesn't solve the problem!
 #private-etc ca-certificates,crypto-policies,hosts,pki,resolv.conf,ssl
+private-lib
 private-tmp
 
 # memory-deny-write-execute is built using seccomp; nonewprivs will kill it
@@ -56,3 +67,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+read-only ${HOME}

--- a/etc/profile-m-z/ping.profile
+++ b/etc/profile-m-z/ping.profile
@@ -25,7 +25,7 @@ include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
 # Add the next line to your ping.local if your kernel allows unprivileged userns clone.
-include ping-hardened.inc.profile
+#include ping-hardened.inc.profile
 
 apparmor
 caps.keep net_raw


### PR DESCRIPTION
This started out as a simple typo fix. By sheer coincidence I noticed there were some comments in the profile that seemed odd to me and I started experimenting. Turns out quite a lot of hardening could be done. I've been running for a while with all of these added options without hiccups.

Makes me wonder if there are any distro differences out there that could explain the former comments. I've left them untouched, because I don't know where they stem from.