### PR TITLE
whitelist-common.inc: remove redundant read-only entries

### DIFF
--- a/etc/inc/whitelist-common.inc
+++ b/etc/inc/whitelist-common.inc
@@ -12,14 +12,11 @@ whitelist ${HOME}/.config/mimeapps.list
 whitelist ${HOME}/.config/pkcs11
 read-only ${HOME}/.config/pkcs11
 whitelist ${HOME}/.config/user-dirs.dirs
-read-only ${HOME}/.config/user-dirs.dirs
 whitelist ${HOME}/.config/user-dirs.locale
-read-only ${HOME}/.config/user-dirs.locale
 whitelist ${HOME}/.drirc
 whitelist ${HOME}/.icons
 ?HAS_APPIMAGE: whitelist ${HOME}/.local/share/appimagekit
 whitelist ${HOME}/.local/share/applications
-read-only ${HOME}/.local/share/applications
 whitelist ${HOME}/.local/share/icons
 whitelist ${HOME}/.local/share/mime
 whitelist ${HOME}/.mime.types


### PR DESCRIPTION
They are already present on disable-common.inc.

Misc: read-only entries were first added to disable-common.inc on commit
2b37849db ("Protect shell startup files", 2015-10-30) and to
whitelist-common.inc on commit 695b67f43 ("handle
~/.config/user-dirs.dirs", 2015-11-17).
