### PR TITLE
appimage: blacklist and make ~/Applications dir read-only 

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -370,6 +370,9 @@ read-only ${HOME}/.nvm
 read-only ${HOME}/.rustup
 read-only ${HOME}/bin
 
+# Write-protection for portable apps
+read-only ${HOME}/Applications # used for storing AppImages
+
 # Write-protection for desktop entries
 read-only ${HOME}/.config/menus
 read-only ${HOME}/.gnome/apps

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -1144,6 +1144,7 @@ blacklist ${HOME}/.yarn-config
 blacklist ${HOME}/.yarncache
 blacklist ${HOME}/.yarnrc
 blacklist ${HOME}/.zoom
+blacklist ${HOME}/Applications # used for storing AppImages
 blacklist ${HOME}/Arduino
 blacklist ${HOME}/Monero/wallets
 blacklist ${HOME}/Nextcloud


### PR DESCRIPTION
This directory is monitored by both appimaged[1] and
AppImageLauncher[2].  Also, when opening an AppImage with
AppImageLauncher, it may prompt the user to move the AppImage to
~/Applications.

Note that even when blacklisting a directory, it is possible to execute
an AppImage from it.  For example, the following works:

    firejail --noprofile --blacklist='${HOME}/Applications' --appimage \
      ~/Applications/foo.AppImage

While the resulting process does not appear to have access to the
blacklisted directory.

[1] https://github.com/AppImage/appimaged/blob/2323f1825ed6abe19f2d3791d81307449692be03/README.md#monitored-directories
[2] https://github.com/TheAssassin/AppImageLauncher/wiki/Configuration
