### PR TITLE
disable-common.inc: make ~/.config/pkcs11 read-only

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -328,6 +328,7 @@ read-only ${HOME}/.ssh/config.d
 read-only ${HOME}/.caffrc
 read-only ${HOME}/.cargo/env
 read-only ${HOME}/.config/nvim
+read-only ${HOME}/.config/pkcs11
 read-only ${HOME}/.dotfiles
 read-only ${HOME}/.emacs
 read-only ${HOME}/.emacs.d


### PR DESCRIPTION
It looks like it allows arbitrary command execution.  From
pkcs11.conf(5):

>     remote:
>         Instead of loading the PKCS#11 module locally, run the module
>         remotely.
>
>         Specify a command to run, prefixed with | a pipe. The command
>         must speak the p11-kit remoting protocol on its standard in
>         and standard out. For example:
>
>             remote: |ssh user@remote p11-kit remote /path/to/module.so
>
>         Other forms of remoting will appear in later p11-kit releases.

Environment: p11-kit 0.24.1-1 on Artix Linux.

Currently this entry only exists on whitelist-common.inc, added on
commit f74cfd07c ("add p11-kit support - #1646").

With this commit applied, all read-only entries on whitelist-commons.inc
are also part of disable-common.inc.

See also the discussion on #5069.
