### PR TITLE
teams: drop doubled option

### DIFF
--- a/etc/profile-m-z/teams.profile
+++ b/etc/profile-m-z/teams.profile
@@ -13,8 +13,6 @@ ignore include whitelist-usr-share-common.inc
 ignore novideo
 ignore private-tmp
 
-ignore novideo
-
 # see #3404
 ignore apparmor
 ignore dbus-user none


### PR DESCRIPTION
First time I looked at teams.profile in reference to #5086. The double `ignore novideo` is reduced to a single occurence now.