### PR TITLE
Allow resolution of .local names with avahi-daemon in the apparmor profile.

### DIFF
--- a/etc/apparmor/firejail-default
+++ b/etc/apparmor/firejail-default
@@ -67,6 +67,9 @@ owner /{,var/}run/media/** w,
 # Allow access to cups printing socket.
 /{,var/}run/cups/cups.sock w,
 
+# Allow access to avahi-daemon socket.
+/{,var/}run/avahi-daemon/socket w,
+
 # Allow access to pcscd socket (smartcards)
 /{,var/}run/pcscd/pcscd.comm w,
 


### PR DESCRIPTION
Without this change here is what I see in syslog when running for example `firejail --profile=ssh /usr/bin/ssh test.local`:

```
Apr  2 14:59:29 kek kernel: [  177.596180] audit: type=1400 audit(1648900769.222:29): apparmor="DENIED" operation="connect" profile="firejail-default" name="/run/avahi-daemon/socket" pid=2562 comm="ssh" requested_mask="w" denied_mask="w" fsuid=1000 ouid=0
```

So it can't access the socket hence can't resolve the name.