### PR TITLE
Stop warning on safe supplementary group clean

### DIFF
--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -173,11 +173,17 @@ static void clean_supplementary_groups(gid_t gid) {
 	assert(cfg.username);
 	gid_t groups[MAX_GROUPS];
 	int ngroups = MAX_GROUPS;
+
+	if (arg_nogroups && check_can_drop_all_groups()) {
+		if (setgroups(0, NULL) < 0)
+			errExit("setgroups");
+		if (arg_debug)
+			printf("No supplementary groups\n");
+		return;
+	}
+
 	int rv = getgrouplist(cfg.username, gid, groups, &ngroups);
 	if (rv == -1)
-		goto clean_all;
-
-	if (arg_nogroups && check_can_drop_all_groups())
 		goto clean_all;
 
 	// clean supplementary group list


### PR DESCRIPTION
When nogroups is used, the following warning may be issued (potentially
multiple times, as drop_privs may be called more than once):

    Warning: cleaning all supplementary groups

But the warning is being shown even when it seems that all supplementary
groups can be safely dropped (and are thus dropped), which is likely a
common scenario.  This commit prevents the warning from being printed in
that case, making it so that it is only shown in the non-happy paths (as
was the case on firejail 0.9.66).

Misc: The added code was copied from drop_privs.

This amends commit 7abce0b4c ("Fix keeping certain groups with
nogroups", 2021-11-30) / PR #4732.

Kind of relates to #4930.
