### PR TITLE
Whitelist electron-flags.conf for all versions of electron

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -407,7 +407,7 @@ blacklist ${HOME}/.config/dolphin-emu
 blacklist ${HOME}/.config/dolphinrc
 blacklist ${HOME}/.config/dragonplayerrc
 blacklist ${HOME}/.config/draw.io
-blacklist ${HOME}/.config/electron-flag*.conf
+blacklist ${HOME}/.config/electron*([0-9])-flag*.conf
 blacklist ${HOME}/.config/electron-mail
 blacklist ${HOME}/.config/emaildefaults
 blacklist ${HOME}/.config/emailidentities

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -407,7 +407,7 @@ blacklist ${HOME}/.config/dolphin-emu
 blacklist ${HOME}/.config/dolphinrc
 blacklist ${HOME}/.config/dragonplayerrc
 blacklist ${HOME}/.config/draw.io
-blacklist ${HOME}/.config/electron*([0-9])-flag*.conf
+blacklist ${HOME}/.config/electron*-flag*.conf
 blacklist ${HOME}/.config/electron-mail
 blacklist ${HOME}/.config/emaildefaults
 blacklist ${HOME}/.config/emailidentities

--- a/etc/profile-a-l/atom.profile
+++ b/etc/profile-a-l/atom.profile
@@ -12,7 +12,7 @@ ignore include disable-interpreters.inc
 ignore include disable-xdg.inc
 ignore whitelist ${DOWNLOADS}
 ignore whitelist ${HOME}/.config/Electron
-ignore whitelist ${HOME}/.config/electron-flag*.conf
+ignore whitelist ${HOME}/.config/electron*([0-9])-flag*.conf
 ignore include whitelist-common.inc
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/atom.profile
+++ b/etc/profile-a-l/atom.profile
@@ -12,7 +12,7 @@ ignore include disable-interpreters.inc
 ignore include disable-xdg.inc
 ignore whitelist ${DOWNLOADS}
 ignore whitelist ${HOME}/.config/Electron
-ignore whitelist ${HOME}/.config/electron*([0-9])-flag*.conf
+ignore whitelist ${HOME}/.config/electron*-flag*.conf
 ignore include whitelist-common.inc
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/code.profile
+++ b/etc/profile-a-l/code.profile
@@ -12,7 +12,7 @@ ignore include disable-interpreters.inc
 ignore include disable-xdg.inc
 ignore whitelist ${DOWNLOADS}
 ignore whitelist ${HOME}/.config/Electron
-ignore whitelist ${HOME}/.config/electron-flag*.conf
+ignore whitelist ${HOME}/.config/electron*([0-9])-flag*.conf
 ignore include whitelist-common.inc
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/code.profile
+++ b/etc/profile-a-l/code.profile
@@ -12,7 +12,7 @@ ignore include disable-interpreters.inc
 ignore include disable-xdg.inc
 ignore whitelist ${DOWNLOADS}
 ignore whitelist ${HOME}/.config/Electron
-ignore whitelist ${HOME}/.config/electron*([0-9])-flag*.conf
+ignore whitelist ${HOME}/.config/electron*-flag*.conf
 ignore include whitelist-common.inc
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/electron.profile
+++ b/etc/profile-a-l/electron.profile
@@ -5,7 +5,7 @@
 include electron.local
 
 noblacklist ${HOME}/.config/Electron
-noblacklist ${HOME}/.config/electron-flag*.conf
+noblacklist ${HOME}/.config/electron*-flag*.conf
 
 include disable-common.inc
 include disable-devel.inc
@@ -16,7 +16,7 @@ include disable-xdg.inc
 
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.config/Electron
-whitelist ${HOME}/.config/electron-flag*.conf
+whitelist ${HOME}/.config/electron*-flag*.conf
 include whitelist-common.inc
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/electron.profile
+++ b/etc/profile-a-l/electron.profile
@@ -5,7 +5,7 @@
 include electron.local
 
 noblacklist ${HOME}/.config/Electron
-noblacklist ${HOME}/.config/electron*-flag*.conf
+noblacklist ${HOME}/.config/electron[0-9]*-flag*.conf
 
 include disable-common.inc
 include disable-devel.inc
@@ -16,7 +16,7 @@ include disable-xdg.inc
 
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.config/Electron
-whitelist ${HOME}/.config/electron*-flag*.conf
+whitelist ${HOME}/.config/electron[0-9]*-flag*.conf
 include whitelist-common.inc
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/electron.profile
+++ b/etc/profile-a-l/electron.profile
@@ -5,7 +5,7 @@
 include electron.local
 
 noblacklist ${HOME}/.config/Electron
-noblacklist ${HOME}/.config/electron*([0-9])-flag*.conf
+noblacklist ${HOME}/.config/electron*-flag*.conf
 
 include disable-common.inc
 include disable-devel.inc
@@ -16,7 +16,7 @@ include disable-xdg.inc
 
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.config/Electron
-whitelist ${HOME}/.config/electron*([0-9])-flag*.conf
+whitelist ${HOME}/.config/electron*-flag*.conf
 include whitelist-common.inc
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/electron.profile
+++ b/etc/profile-a-l/electron.profile
@@ -5,7 +5,7 @@
 include electron.local
 
 noblacklist ${HOME}/.config/Electron
-noblacklist ${HOME}/.config/electron[0-9]*-flag*.conf
+noblacklist ${HOME}/.config/electron*([0-9])-flag*.conf
 
 include disable-common.inc
 include disable-devel.inc
@@ -16,7 +16,7 @@ include disable-xdg.inc
 
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.config/Electron
-whitelist ${HOME}/.config/electron[0-9]*-flag*.conf
+whitelist ${HOME}/.config/electron*([0-9])-flag*.conf
 include whitelist-common.inc
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/github-desktop.profile
+++ b/etc/profile-a-l/github-desktop.profile
@@ -15,7 +15,7 @@ include globals.local
 ignore include disable-xdg.inc
 ignore whitelist ${DOWNLOADS}
 ignore whitelist ${HOME}/.config/Electron
-ignore whitelist ${HOME}/.config/electron-flag*.conf
+ignore whitelist ${HOME}/.config/electron*([0-9])-flag*.conf
 ignore include whitelist-common.inc
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/github-desktop.profile
+++ b/etc/profile-a-l/github-desktop.profile
@@ -15,7 +15,7 @@ include globals.local
 ignore include disable-xdg.inc
 ignore whitelist ${DOWNLOADS}
 ignore whitelist ${HOME}/.config/Electron
-ignore whitelist ${HOME}/.config/electron*([0-9])-flag*.conf
+ignore whitelist ${HOME}/.config/electron*-flag*.conf
 ignore include whitelist-common.inc
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-m-z/notable.profile
+++ b/etc/profile-m-z/notable.profile
@@ -27,7 +27,7 @@ ignore dbus-user none
 # Notable keeps claiming it is started for the first time when whitelisting - see #4812.
 ignore whitelist ${DOWNLOADS}
 ignore whitelist ${HOME}/.config/Electron
-ignore whitelist ${HOME}/.config/electron-flag*.conf
+ignore ${HOME}/.config/electron*([0-9])-flag*.conf
 ignore include whitelist-common.inc
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc

--- a/etc/profile-m-z/notable.profile
+++ b/etc/profile-m-z/notable.profile
@@ -27,7 +27,7 @@ ignore dbus-user none
 # Notable keeps claiming it is started for the first time when whitelisting - see #4812.
 ignore whitelist ${DOWNLOADS}
 ignore whitelist ${HOME}/.config/Electron
-ignore ${HOME}/.config/electron*([0-9])-flag*.conf
+ignore whitelist ${HOME}/.config/electron*-flag*.conf
 ignore include whitelist-common.inc
 ignore include whitelist-runuser-common.inc
 ignore include whitelist-usr-share-common.inc


### PR DESCRIPTION
Different versions of electron load flags from different files.