### PR TITLE
hostnames.c: fix mismatched dealloc (fclose -> pclose)

### DIFF
--- a/src/fnettrace/hostnames.c
+++ b/src/fnettrace/hostnames.c
@@ -50,7 +50,7 @@ char *retrieve_hostname(uint32_t ip) {
 				}
 			}
 		}
-		fclose(fp);
+		pclose(fp);
 		return rv;
 	}
 	else


### PR DESCRIPTION
Partial error log when building firejail-git (afee8603f) with
--enable-fatal-warnings:

    hostnames.c: In function ‘retrieve_hostname’:
    hostnames.c:53:17: error: ‘fclose’ called on pointer returned from a mismatched allocation function [-Werror=mismatched-dealloc]
       53 |                 fclose(fp);
          |                 ^~~~~~~~~~
    hostnames.c:38:20: note: returned from ‘popen’
       38 |         FILE *fp = popen(cmd, "r");
          |                    ^~~~~~~~~~~~~~~
    cc1: all warnings being treated as errors
    make[1]: *** [Makefile:7: hostnames.o] Error 1

Environment: gcc 11.2.0-4 on Artix Linux.

Added on commit 500a56efd ("more on nettrace", 2022-01-07).
