### PR TITLE
Prevent empty /usr/share in google-chrome profiles

### DIFF
--- a/etc/profile-a-l/google-chrome-beta.profile
+++ b/etc/profile-a-l/google-chrome-beta.profile
@@ -5,12 +5,6 @@ include google-chrome-beta.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
-ignore whitelist /usr/share/mozilla/extensions
-ignore whitelist /usr/share/webext
-ignore include whitelist-runuser-common.inc
-ignore include whitelist-usr-share-common.inc
-
 noblacklist ${HOME}/.cache/google-chrome-beta
 noblacklist ${HOME}/.config/google-chrome-beta
 

--- a/etc/profile-a-l/google-chrome-unstable.profile
+++ b/etc/profile-a-l/google-chrome-unstable.profile
@@ -5,12 +5,6 @@ include google-chrome-unstable.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
-ignore whitelist /usr/share/mozilla/extensions
-ignore whitelist /usr/share/webext
-ignore include whitelist-runuser-common.inc
-ignore include whitelist-usr-share-common.inc
-
 noblacklist ${HOME}/.cache/google-chrome-unstable
 noblacklist ${HOME}/.config/google-chrome-unstable
 

--- a/etc/profile-a-l/google-chrome.profile
+++ b/etc/profile-a-l/google-chrome.profile
@@ -5,12 +5,6 @@ include google-chrome.local
 # Persistent global definitions
 include globals.local
 
-# Disable for now, see https://github.com/netblue30/firejail/pull/3688#issuecomment-718711565
-ignore whitelist /usr/share/mozilla/extensions
-ignore whitelist /usr/share/webext
-ignore include whitelist-runuser-common.inc
-ignore include whitelist-usr-share-common.inc
-
 noblacklist ${HOME}/.cache/google-chrome
 noblacklist ${HOME}/.config/google-chrome
 


### PR DESCRIPTION
Without whitelist-usr-share-common, /usr/share becomes empty.
Adding whitelist-runuser-common didn't break google chrome.

Whitelisting /usr/share/mozilla/extensions and /usr/share/webext shouldn't break google chrome, either.

I tested google-chrome.profile only, but I think later versions should not be different.

It fixes https://github.com/netblue30/firejail/issues/5125