### PR TITLE
Whitelist for NixOS to resolve binary paths in user environment

### DIFF
--- a/etc/inc/whitelist-common.inc
+++ b/etc/inc/whitelist-common.inc
@@ -85,3 +85,7 @@ whitelist ${HOME}/.kde4/share/config/oxygenrc
 whitelist ${HOME}/.kde4/share/icons
 whitelist ${HOME}/.local/share/qt5ct
 whitelist ${HOME}/.local/share/qt6ct
+
+# NixOS specific to resolve binary paths in
+# user environment
+whitelist ${HOME}/.nix-profile


### PR DESCRIPTION
This PR fixes an issue on NixOS where you cannot use firejail like this:
```
firejail chromium
```
it fails with `Error: no suitable chromium executable found`.

This is because `chromium` is usually a symlink in `~/.nix-profile` to the binary in the NixOS store. After whitelisting `~/.nix-profile` running 
```
firejail chromium
```
works :)

Solves downstream issue https://github.com/NixOS/nixpkgs/issues/170784 