### PR TITLE
NixOS fix OpenGL app support

### DIFF
--- a/etc/inc/whitelist-run-common.inc
+++ b/etc/inc/whitelist-run-common.inc
@@ -14,3 +14,4 @@ whitelist /run/systemd/journal/socket
 whitelist /run/systemd/resolve/resolv.conf
 whitelist /run/systemd/resolve/stub-resolv.conf
 whitelist /run/udev/data
+whitelist /run/opengl-driver	# NixOS


### PR DESCRIPTION
Fixes downstream issue on NixOS https://github.com/NixOS/nixpkgs/issues/55191

Firefox or similar browsers are unable to render WebGL unless directory `/run/opengl-driver` is whitelisted.