### PR TITLE
fzenity: fix dead store

### DIFF
--- a/src/fzenity/main.c
+++ b/src/fzenity/main.c
@@ -74,7 +74,7 @@ char *print_line(char *in, int col) {
 	if (*ptr == '\n') {
 		*ptr++ = '\0';
 		printf("%s\n", in);
-		return ptr++;
+		return ptr;
 	}
 	else if (i == col) {
 		while (*ptr != ' ' && ptr != in)


### PR DESCRIPTION
As caught by the Clang Static Analyzer:

    $ make clean && NO_EXTRA_CFLAGS="yes" scan-build --status-bugs make -C src/fzenity
    [...]
    main.c:77:10: warning: Value stored to 'ptr' is never read [deadcode.DeadStores]
                    return ptr++;
                           ^~~~~
    1 warning generated.
    [...]
    scan-build: Analysis run complete.
    scan-build: 1 bug found.

The above increment is a no-op, as it is equivalent to
`return ptr; ptr++;`.

For it to make any difference, the prefix increment operator would have
to be used in place of the postfix one:

    return ++ptr;

Which would be equivalent to `++ptr; return ptr;`.

But in order to fix the warning (and CI) while avoiding to change the
current behavior, just remove the operator instead.

Added on commit 1cdfa6f95 ("more on firecfg --guide: fzenity",
2022-04-25).
