### PR TITLE
nvim: add XDG_STATE_HOME path

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -22,6 +22,7 @@ blacklist-nolog ${HOME}/.local/share/fish/fish_history
 blacklist-nolog ${HOME}/.local/share/ibus-typing-booster
 blacklist-nolog ${HOME}/.local/share/klipper
 blacklist-nolog ${HOME}/.local/share/nvim
+blacklist-nolog ${HOME}/.local/state/nvim
 blacklist-nolog ${HOME}/.macromedia
 blacklist-nolog ${HOME}/.mupdf.history
 blacklist-nolog ${HOME}/.python-history
@@ -339,6 +340,7 @@ read-only ${HOME}/.iscreenrc
 read-only ${HOME}/.local/lib
 read-only ${HOME}/.local/share/cool-retro-term
 read-only ${HOME}/.local/share/nvim
+read-only ${HOME}/.local/state/nvim
 read-only ${HOME}/.mailcap
 read-only ${HOME}/.msmtprc
 read-only ${HOME}/.mutt/muttrc

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -959,7 +959,6 @@ blacklist ${HOME}/.local/share/newsboat
 blacklist ${HOME}/.local/share/nheko
 blacklist ${HOME}/.local/share/nomacs
 blacklist ${HOME}/.local/share/notes
-blacklist ${HOME}/.local/share/nvim
 blacklist ${HOME}/.local/share/ocenaudio
 blacklist ${HOME}/.local/share/okular
 blacklist ${HOME}/.local/share/onlyoffice

--- a/etc/profile-m-z/nvim.profile
+++ b/etc/profile-m-z/nvim.profile
@@ -11,6 +11,7 @@ noblacklist ${HOME}/.vimrc
 noblacklist ${HOME}/.cache/nvim
 noblacklist ${HOME}/.config/nvim
 noblacklist ${HOME}/.local/share/nvim
+noblacklist ${HOME}/.local/state/nvim
 
 include disable-common.inc
 include disable-devel.inc
@@ -48,5 +49,6 @@ dbus-system none
 read-only ${HOME}/.config
 read-write ${HOME}/.config/nvim
 read-write ${HOME}/.local/share/nvim
+read-write ${HOME}/.local/state/nvim
 read-write ${HOME}/.vim
 read-write ${HOME}/.vimrc


### PR DESCRIPTION
Default paths as of neovim 0.7.0:

* backupdir:  $XDG_DATA_HOME/nvim/backup//
* directory:  $XDG_DATA_HOME/nvim/swap//
* undodir:    $XDG_DATA_HOME/nvim/undo//
* viewdir:    $XDG_DATA_HOME/nvim/view//
* shada file: $XDG_DATA_HOME/nvim/shada/main.shada
* log dir:    $XDG_CACHE_HOME/nvim/log

Default paths as of [1]:

* backupdir:  $XDG_STATE_HOME/nvim/backup//
* directory:  $XDG_STATE_HOME/nvim/swap//
* undodir:    $XDG_STATE_HOME/nvim/undo//
* viewdir:    $XDG_STATE_HOME/nvim/view//
* shada file: $XDG_STATE_HOME/nvim/shada/main.shada
* log dir:    $XDG_STATE_HOME/nvim/log

[1] https://github.com/neovim/neovim/pull/15583