### PR TITLE
Makefile.in: stop running distclean on dist

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -207,11 +207,6 @@ DISTFILES = "src etc m4 platform contrib configure configure.ac Makefile.in inst
 DISTFILES_TEST = "test/Makefile.in test/apps test/apps-x11 test/apps-x11-xorg test/root test/private-lib test/fnetfilter test/fcopy test/environment test/profiles test/utils test/compile test/filters test/network test/fs test/sysutils test/chroot"
 
 dist:
-	mv config.status config.status.old
-	mv mkdeb.sh mkdeb.sh.old
-	make distclean
-	mv mkdeb.sh.old mkdeb.sh
-	mv config.status.old config.status
 	rm -fr $(NAME)-$(VERSION) $(NAME)-$(VERSION).tar.xz
 	mkdir -p $(NAME)-$(VERSION)/test
 	cp -a "$(DISTFILES)" $(NAME)-$(VERSION)


### PR DESCRIPTION
distclean erases user-made modifications to the files generated by the
configure script; it is not obvious that a non-"clean" target would ever
run it.

That is, instead of:

    ./configure --enable-foo && make distclean && make dist

It would probably be safer (and more maintainable) to do:

    make distclean && ./configure --enable-foo && make dist

So drop the distclean call and the file-moving hacks around it.

Added on commit 137985136 ("Baseline firejail 0.9.28", 2015-08-08).

Relates to commit 684919100 ("bug: preserve config.status during make
dist", 2016-09-19) and commit 31dc1218a ("fixups", 2020-07-19).
