### PR TITLE
ci: fix --version not printing compile-time features

### DIFF
--- a/src/firejail/checkcfg.c
+++ b/src/firejail/checkcfg.c
@@ -300,6 +300,12 @@ errout:
 	exit(1);
 }
 
+void print_version(void) {
+	printf("firejail version %s\n", VERSION);
+	printf("\n");
+	print_compiletime_support();
+	printf("\n");
+}
 
 void print_compiletime_support(void) {
 	printf("Compile time support:\n");

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -833,6 +833,7 @@ extern char *config_seccomp_filter_add;
 extern char **whitelist_reject_topdirs;
 
 int checkcfg(int val);
+void print_version(void);
 void print_compiletime_support(void);
 
 // appimage.c

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -356,10 +356,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 		exit(0);
 	}
 	else if (strcmp(argv[i], "--version") == 0) {
-		printf("firejail version %s\n", VERSION);
-		printf("\n");
-		print_compiletime_support();
-		printf("\n");
+		print_version();
 		exit(0);
 	}
 #ifdef HAVE_OVERLAYFS
@@ -1082,7 +1079,7 @@ int main(int argc, char **argv, char **envp) {
 		EUID_USER();
 		if (rv == 0) {
 			if (check_arg(argc, argv, "--version", 1)) {
-				printf("firejail version %s\n", VERSION);
+				print_version();
 				exit(0);
 			}
 


### PR DESCRIPTION
Currently, when running on CI, `firejail --version` only prints the
following line:

    firejail version 0.9.69

Add a new print_version() function that always prints both the above and
the compile-time options (like it is done outside of CI) and call it in
both of the places that handle --version on main.c.

Misc: The printing of compile-time features was added on commit
48dd1fbec ("apparmor", 2016-08-02).
