### PR TITLE
ci: print version after install & fix apparmor support on build_apparmor

### DIFF
--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -35,6 +35,10 @@ jobs:
       run: CC=clang-11 ./configure --enable-fatal-warnings
     - name: make
       run: make
+    - name: make install
+      run: sudo make install
+    - name: print version
+      run: command -V firejail && firejail --version
   scan-build:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,5 +33,7 @@ jobs:
       run: make
     - name: make install
       run: sudo make install
+    - name: print version
+      run: command -V firejail && firejail --version
     - name: run tests
       run: SHELL=/bin/bash make test-github

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,6 +56,7 @@ build_apparmor:
         - DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential lintian libapparmor-dev pkg-config gawk
         - ./configure --prefix=/usr && make deb-apparmor && dpkg -i firejail*.deb
         - command -V firejail && firejail --version
+        - firejail --version | grep -F 'AppArmor support is enabled'
 
 debian_ci:
     image: registry.salsa.debian.org/salsa-ci-team/ci-image-git-buildpackage:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,7 @@ build_apparmor:
     script:
         - apt-get update -qq
         - DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential lintian libapparmor-dev pkg-config gawk
-        - ./configure --prefix=/usr && make deb-apparmor && dpkg -i firejail*.deb
+        - ./configure --prefix=/usr --enable-apparmor && make deb-apparmor && dpkg -i firejail*.deb
         - command -V firejail && firejail --version
         - firejail --version | grep -F 'AppArmor support is enabled'
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@ build_ubuntu_package:
         - apt-get update -qq
         - DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential lintian pkg-config python3 gawk
         - ./configure --prefix=/usr && make deb && dpkg -i firejail*.deb
+        - command -V firejail && firejail --version
         - python3 contrib/sort.py etc/profile-*/*.profile etc/inc/*.inc
 
 build_debian_package:
@@ -19,6 +20,7 @@ build_debian_package:
         - apt-get update -qq
         - apt-get install -y -qq build-essential lintian pkg-config gawk
         - ./configure --prefix=/usr && make deb && dpkg -i firejail*.deb
+        - command -V firejail && firejail --version
 
 build_redhat_package:
     image: almalinux:latest
@@ -26,6 +28,7 @@ build_redhat_package:
         - dnf update -y
         - dnf install -y rpm-build gcc make
         - ./configure --prefix=/usr && make rpms && rpm -i firejail*.rpm
+        - command -V firejail && firejail --version
 
 build_fedora_package:
     image: fedora:latest
@@ -33,6 +36,7 @@ build_fedora_package:
         - dnf update -y
         - dnf install -y rpm-build gcc make
         - ./configure --prefix=/usr && make rpms && rpm -i firejail*.rpm
+        - command -V firejail && firejail --version
         - python3 contrib/sort.py etc/profile-*/*.profile etc/inc/*.inc
 
 build_src_package:
@@ -42,6 +46,7 @@ build_src_package:
         - apk upgrade
         - apk add build-base linux-headers python3 gawk
         - ./configure --prefix=/usr && make && make install-strip
+        - command -V firejail && firejail --version
         # - python3 contrib/sort.py etc/*.{profile,inc}
 
 build_apparmor:
@@ -50,6 +55,7 @@ build_apparmor:
         - apt-get update -qq
         - DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential lintian libapparmor-dev pkg-config gawk
         - ./configure --prefix=/usr && make deb-apparmor && dpkg -i firejail*.deb
+        - command -V firejail && firejail --version
 
 debian_ci:
     image: registry.salsa.debian.org/salsa-ci-team/ci-image-git-buildpackage:latest


### PR DESCRIPTION
The "build_apparmor" job was added on commit 342e71cd8 ("Add
deb-apparmor build to Gitlab CI", 2019-01-26).  It would call
`./mkdeb-apparmor.sh`, which would run `./configure --enable-apparmor`
directly, adding `-lapparmor` to `EXTRA_LDFLAGS` and thus passing it to
the linker.

Later, commit 87e7b3139 ("Configure Debian package with AA and SELinux
options", 2020-05-13) / PR #3414 merged mkdeb.sh and mkdeb-apparmor.sh
into mkdeb.sh.in, which does not always pass `--enable-apparmor` to
./configure directly.  Instead, it adds `--enable-apparmor` depending on
whether the `$HAVE_APPARMOR` environment variable is set, which would be
done by a previous run of ./configure with `--enable-apparmor`.  Since
on "build_apparmor" ./configure is not run the first time with
`--enable-apparmor`, neither is it on the second time and thus
`-lapparmor` is never passed to the linker.  This commit adds
`--enable-apparmor` to the first ./configure run on the ci job, so that
it gets passed to the one being executed on mkdeb.sh as well.