### PR TITLE
Kate fixes

### DIFF
--- a/etc/profile-a-l/kate.profile
+++ b/etc/profile-a-l/kate.profile
@@ -22,6 +22,7 @@ noblacklist ${HOME}/.local/share/kxmlgui5/kateopenheaderplugin
 noblacklist ${HOME}/.local/share/kxmlgui5/katepart
 noblacklist ${HOME}/.local/share/kxmlgui5/kateproject
 noblacklist ${HOME}/.local/share/kxmlgui5/katesearch
+noblacklist /etc/profile.d
 
 include allow-common-devel.inc
 

--- a/etc/profile-a-l/kate.profile
+++ b/etc/profile-a-l/kate.profile
@@ -23,6 +23,8 @@ noblacklist ${HOME}/.local/share/kxmlgui5/katepart
 noblacklist ${HOME}/.local/share/kxmlgui5/kateproject
 noblacklist ${HOME}/.local/share/kxmlgui5/katesearch
 
+include allow-common-devel.inc
+
 include disable-common.inc
 # include disable-devel.inc
 include disable-exec.inc

--- a/etc/profile-a-l/kate.profile
+++ b/etc/profile-a-l/kate.profile
@@ -52,7 +52,6 @@ novideo
 protocol unix
 seccomp
 shell none
-tracelog
 
 # private-bin kate,kbuildsycoca4,kdeinit4
 private-dev

--- a/etc/profile-a-l/kate.profile
+++ b/etc/profile-a-l/kate.profile
@@ -14,6 +14,7 @@ noblacklist ${HOME}/.config/katerc
 noblacklist ${HOME}/.config/kateschemarc
 noblacklist ${HOME}/.config/katesyntaxhighlightingrc
 noblacklist ${HOME}/.config/katevirc
+noblacklist ${HOME}/.config/kwinrc
 noblacklist ${HOME}/.local/share/kate
 noblacklist ${HOME}/.local/share/kxmlgui5/kate
 noblacklist ${HOME}/.local/share/kxmlgui5/katefiletree


### PR DESCRIPTION
Reduce restrictions, so that Kate can be used as intended by the developers:

- allow usage of Git
- permit Bash completion in built-in Konsole
- permit the requested access to kwinrc configuration