### PR TITLE
Update transmission profile for DBus notifications

### DIFF
--- a/etc/profile-m-z/transmission-common.profile
+++ b/etc/profile-m-z/transmission-common.profile
@@ -48,7 +48,9 @@ private-dev
 private-lib
 private-tmp
 
-dbus-user none
+dbus-user filter
+dbus-user.own com.transmissionbt.Transmission.*
+dbus-user.talk org.freedesktop.Notifications
 dbus-system none
 
 memory-deny-write-execute


### PR DESCRIPTION
While investigating why transmission-gtk seems slow when launched through firejail, I noticed the current profile blocks access to org.freedesktop.Notifications.

This profile PR fixes that, although transmission-gtk still seems to take ages to load when firejail'ed