### PR TITLE
profiles: move blacklist of /etc/profile.d & blacklist /etc/profile

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -261,7 +261,6 @@ blacklist /etc/grub*
 blacklist /etc/kernel*
 blacklist /etc/logrotate*
 blacklist /etc/modules*
-blacklist /etc/profile.d
 blacklist /etc/rc.local
 # rc1.d, rc2.d, ...
 blacklist /etc/rc?.d

--- a/etc/inc/disable-shell.inc
+++ b/etc/inc/disable-shell.inc
@@ -13,4 +13,5 @@ blacklist ${PATH}/sh
 blacklist ${PATH}/tclsh
 blacklist ${PATH}/tcsh
 blacklist ${PATH}/zsh
+blacklist /etc/profile
 blacklist /etc/profile.d

--- a/etc/inc/disable-shell.inc
+++ b/etc/inc/disable-shell.inc
@@ -13,3 +13,4 @@ blacklist ${PATH}/sh
 blacklist ${PATH}/tclsh
 blacklist ${PATH}/tcsh
 blacklist ${PATH}/zsh
+blacklist /etc/profile.d

--- a/etc/profile-a-l/kate.profile
+++ b/etc/profile-a-l/kate.profile
@@ -25,6 +25,7 @@ noblacklist ${HOME}/.local/share/kxmlgui5/kateproject
 noblacklist ${HOME}/.local/share/kxmlgui5/katesearch
 noblacklist /etc/profile.d
 
+# Allows files commonly used by IDEs
 include allow-common-devel.inc
 
 include disable-common.inc

--- a/etc/profile-a-l/kate.profile
+++ b/etc/profile-a-l/kate.profile
@@ -23,7 +23,6 @@ noblacklist ${HOME}/.local/share/kxmlgui5/kateopenheaderplugin
 noblacklist ${HOME}/.local/share/kxmlgui5/katepart
 noblacklist ${HOME}/.local/share/kxmlgui5/kateproject
 noblacklist ${HOME}/.local/share/kxmlgui5/katesearch
-noblacklist /etc/profile.d
 
 # Allows files commonly used by IDEs
 include allow-common-devel.inc


### PR DESCRIPTION
disable-common.inc: move blacklist of /etc/profile.d

To disable-shell.inc.

Interactive shells can be executed from certain development-related
programs (such as IDEs) and the shells themselves are not blocked by
default, but this shell startup directory currently is.  To avoid
running a shell without access to potentially needed startup files, only
blacklist /etc/profile.d when interactive shells are also blocked.

Note that /etc/profile.d should only be of concern to interactive
shells, so a profile that includes both disable-shell.inc and
allow-bin-sh.inc (which likely means that it needs access to only
non-interactive shells) should not be affected by the blacklisting.

Relates to #3411 #5159.

Cc: @hknaack (from #5159).