### PR TITLE
ids.config: add missing global shell paths

### DIFF
--- a/etc/ids.config
+++ b/etc/ids.config
@@ -67,6 +67,7 @@ ${HOME}/.zshrc
 /etc/shells
 /etc/skel
 # bash
+/etc/bash
 /etc/bash_completion*
 /etc/bash.bashrc
 /etc/bashrc
@@ -74,6 +75,7 @@ ${HOME}/.zshrc
 /etc/fish
 # ksh
 /etc/ksh.kshrc
+/etc/suid_profile
 # tcsh
 /etc/complete.tcsh
 /etc/csh.cshrc
@@ -83,6 +85,7 @@ ${HOME}/.zshrc
 /etc/zlogin
 /etc/zlogout
 /etc/zprofile
+/etc/zsh
 /etc/zshenv
 /etc/zshrc
 


### PR DESCRIPTION
Add missing paths for bash, ksh and zsh.

Environment: Artix Linux
