### PR TITLE
disable-shell.inc: add global shell paths from ids.config

### DIFF
--- a/etc/ids.config
+++ b/etc/ids.config
@@ -58,6 +58,7 @@ ${HOME}/.zshenv
 ${HOME}/.zshprofile
 ${HOME}/.zshrc
 
+# Note: This list should be kept in sync with the one in inc/disable-shell.inc.
 ### shells global ###
 # all
 /etc/dircolors

--- a/etc/ids.config
+++ b/etc/ids.config
@@ -68,8 +68,8 @@ ${HOME}/.zshrc
 /etc/skel
 # bash
 /etc/bash
-/etc/bash_completion*
 /etc/bash.bashrc
+/etc/bash_completion*
 /etc/bashrc
 # fish
 /etc/fish

--- a/etc/inc/disable-shell.inc
+++ b/etc/inc/disable-shell.inc
@@ -13,5 +13,35 @@ blacklist ${PATH}/sh
 blacklist ${PATH}/tclsh
 blacklist ${PATH}/tcsh
 blacklist ${PATH}/zsh
+
+# Note: This list should be kept in sync with the one in ../ids.config.
+### shells global ###
+# all
+blacklist /etc/dircolors
+blacklist /etc/environment
 blacklist /etc/profile
 blacklist /etc/profile.d
+blacklist /etc/shells
+blacklist /etc/skel
+# bash
+blacklist /etc/bash
+blacklist /etc/bash.bashrc
+blacklist /etc/bash_completion*
+blacklist /etc/bashrc
+# fish
+blacklist /etc/fish
+# ksh
+blacklist /etc/ksh.kshrc
+blacklist /etc/suid_profile
+# tcsh
+blacklist /etc/complete.tcsh
+blacklist /etc/csh.cshrc
+blacklist /etc/csh.login
+blacklist /etc/csh.logout
+# zsh
+blacklist /etc/zlogin
+blacklist /etc/zlogout
+blacklist /etc/zprofile
+blacklist /etc/zsh
+blacklist /etc/zshenv
+blacklist /etc/zshrc


### PR DESCRIPTION
Since /etc/profile is present, add the other shell-related paths in /etc
that are listed on ids.config.

Suggestion by @rusty-snake[1].

Relates to #5167 #5170.

[1] https://github.com/netblue30/firejail/pull/5167#pullrequestreview-989621852