### PR TITLE
mkdeb.sh.in: stop enabling apparmor

### DIFF
--- a/README
+++ b/README
@@ -34,7 +34,7 @@ $ sudo apt-get install git build-essential libapparmor-dev pkg-config gawk
 For --selinux option, add libselinux1-dev (libselinux-devel for Fedora).
 
 We build our release firejail.tar.xz and firejail.deb packages using the following command:
-$ make distclean && ./configure && make deb
+$ make distclean && ./configure && make deb-apparmor
 
 
 Maintainer:

--- a/mkdeb.sh.in
+++ b/mkdeb.sh.in
@@ -28,7 +28,7 @@ echo "*****************************************"
 tar -xJvf "$CODE_ARCHIVE"
 #mkdir -p "$INSTALL_DIR"
 cd "$CODE_DIR"
-./configure --prefix=/usr --enable-apparmor "$@"
+./configure --prefix=/usr "$@"
 make -j2
 mkdir debian
 DESTDIR=debian make install-strip


### PR DESCRIPTION
Since `make deb-apparmor` already exists, use that for now instead of
changing what `make deb` does.

This fixes CI.

Added on commit 494b26d50 ("adding --enable-apparmor by default for make
deb - most Debian-based distros have apparmor enabled by default",
2022-06-03).

Kind of relates to #5154.
