### PR TITLE
Revert "Makefile.in: stop running distclean on dist"

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -207,6 +207,11 @@ DISTFILES = "src etc m4 platform contrib configure configure.ac Makefile.in inst
 DISTFILES_TEST = "test/Makefile.in test/apps test/apps-x11 test/apps-x11-xorg test/root test/private-lib test/fnetfilter test/fcopy test/environment test/profiles test/utils test/compile test/filters test/network test/fs test/sysutils test/chroot"
 
 dist:
+	mv config.status config.status.old
+	mv mkdeb.sh mkdeb.sh.old
+	make distclean
+	mv mkdeb.sh.old mkdeb.sh
+	mv config.status.old config.status
 	rm -fr $(NAME)-$(VERSION) $(NAME)-$(VERSION).tar.xz
 	mkdir -p $(NAME)-$(VERSION)/test
 	cp -a "$(DISTFILES)" $(NAME)-$(VERSION)


### PR DESCRIPTION
This reverts commit 1fb814e51149d105233f1edc1abb0de202f71b4d.

If distclean is not executed before copying the files on dist, then the
generated files inside src/ are included in the dist archive:

    $ ./configure >/dev/null && make distclean >/dev/null &&
      ./configure >/dev/null && make dist | grep 'Makefile$' | wc -l
    26

This happens because src/ is copied wholesale on dist (see DISTFILES).
Revert the commit to ensure that only the input files (such as the
"Makefile.in" files) are archived.

Related discussion:
https://github.com/netblue30/firejail/pull/5154#pullrequestreview-980810845

Relates to #5142.
