### PR TITLE
RELNOTES: add new and removed profiles

### DIFF
--- a/RELNOTES
+++ b/RELNOTES
@@ -28,7 +28,8 @@ firejail (0.9.69) baseline; urgency=low
   * docs: mention that the protocol command accumulates (#5043)
   * docs: mention inconsistent homedir bug involving --private=dir (#5052)
   * docs: mention capabilities(7) on --caps (#5078)
-  * new profiles: onionshare, onionshare-cli, songrec
+  * new profiles: onionshare, onionshare-cli, opera-developer, songrec
+  * new profiles: node-gyp, npx, semver, ping-hardened
  -- netblue30 <netblue30@yahoo.com>  Mon, 7 Feb 2022 09:00:00 -0500
 
 firejail (0.9.68) baseline; urgency=low

--- a/RELNOTES
+++ b/RELNOTES
@@ -30,6 +30,7 @@ firejail (0.9.69) baseline; urgency=low
   * docs: mention capabilities(7) on --caps (#5078)
   * new profiles: onionshare, onionshare-cli, opera-developer, songrec
   * new profiles: node-gyp, npx, semver, ping-hardened
+  * removed profiles: nvm
  -- netblue30 <netblue30@yahoo.com>  Mon, 7 Feb 2022 09:00:00 -0500
 
 firejail (0.9.68) baseline; urgency=low


### PR DESCRIPTION
RELNOTES: add missing new profiles

Profiles: opera-developer, node-gyp, npx, semver, ping-hardened.

Commands used to find the profiles:

    $ git log --pretty= --graph --name-only \
      --diff-filter=AC 0.9.68..HEAD -- etc
    $ tig --diff-filter=AC 0.9.68..HEAD -- etc

Relates to #5001 #5058 #5061.

---

RELNOTES: add removed nvm profile

Commands used to find the profile:

    $ git log --pretty= --graph --name-only \
              --diff-filter=DBX 0.9.68..HEAD -- etc
    $ tig --diff-filter=DXB 0.9.68..HEAD -- etc

Relates to #5058.