### PR TITLE
profiles: nodejs-common: fix node-gyp failing to build canvas

### DIFF
--- a/etc/profile-m-z/nodejs-common.profile
+++ b/etc/profile-m-z/nodejs-common.profile
@@ -67,6 +67,7 @@ include disable-xdg.inc
 whitelist /usr/share/doc/node
 whitelist /usr/share/nvm
 whitelist /usr/share/systemtap/tapset/node.stp
+include build-systems-common.profile
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc


### PR DESCRIPTION
So there is a commonly use node (npm) package called "canvas", which uses node-gyp to bind to cairo (2D canvas drawing library). And I assume this is useful outside of this particular case. node-gyp (run by `yarn install` or `npm install`) needs access to `/usr/share/pkgconfig` otherwise it fails to buold the native extensions.

So it's either this proposed change, or it can be move to `yarn.profile` or `npm.profile`. I'm not sure it will work when moved to `node-gyp.profile` as that one is invoked as a subprocess.

It can also, instead of including `build-systems-common.profile` just whitelist `/usr/share/pkgconfig`.