### PR TITLE
Remove shell none from profiles

### DIFF
--- a/etc/profile-a-l/0ad.profile
+++ b/etc/profile-a-l/0ad.profile
@@ -44,7 +44,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/2048-qt.profile
+++ b/etc/profile-a-l/2048-qt.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 private-dev

--- a/etc/profile-a-l/Cryptocat.profile
+++ b/etc/profile-a-l/Cryptocat.profile
@@ -24,7 +24,6 @@ notv
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 private-cache
 private-dev

--- a/etc/profile-a-l/Fritzing.profile
+++ b/etc/profile-a-l/Fritzing.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-dev
 private-tmp

--- a/etc/profile-a-l/JDownloader.profile
+++ b/etc/profile-a-l/JDownloader.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-cache
 private-dev

--- a/etc/profile-a-l/abiword.profile
+++ b/etc/profile-a-l/abiword.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin abiword

--- a/etc/profile-a-l/agetpkg.profile
+++ b/etc/profile-a-l/agetpkg.profile
@@ -44,7 +44,6 @@ nou2f
 novideo
 protocol inet,inet6
 seccomp
-shell none
 tracelog
 
 private-bin agetpkg,python3

--- a/etc/profile-a-l/akregator.profile
+++ b/etc/profile-a-l/akregator.profile
@@ -42,7 +42,6 @@ novideo
 protocol unix,inet,inet6,netlink
 # chroot syscalls are needed for setting up the built-in sandbox
 seccomp !chroot
-shell none
 
 disable-mnt
 private-bin akregator,akregatorstorageexporter,dbus-launch,kdeinit4,kdeinit4_shutdown,kdeinit4_wrapper,kdeinit5,kdeinit5_shutdown,kdeinit5_wrapper,kshell4,kshell5

--- a/etc/profile-a-l/alacarte.profile
+++ b/etc/profile-a-l/alacarte.profile
@@ -46,7 +46,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/alienarena.profile
+++ b/etc/profile-a-l/alienarena.profile
@@ -37,7 +37,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/alpine.profile
+++ b/etc/profile-a-l/alpine.profile
@@ -84,7 +84,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/amarok.profile
+++ b/etc/profile-a-l/amarok.profile
@@ -27,7 +27,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 # seccomp
-shell none
 
 # private-bin amarok
 private-dev

--- a/etc/profile-a-l/amule.profile
+++ b/etc/profile-a-l/amule.profile
@@ -35,7 +35,6 @@ novideo
 # Add netlink protocol to use UPnP
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-bin amule
 private-dev

--- a/etc/profile-a-l/android-studio.profile
+++ b/etc/profile-a-l/android-studio.profile
@@ -34,7 +34,6 @@ notv
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-cache
 # private-tmp

--- a/etc/profile-a-l/anki.profile
+++ b/etc/profile-a-l/anki.profile
@@ -44,7 +44,6 @@ novideo
 protocol unix,inet,inet6
 # QtWebengine needs chroot to set up its own sandbox
 seccomp !chroot
-shell none
 
 disable-mnt
 private-bin anki,python*

--- a/etc/profile-a-l/anydesk.profile
+++ b/etc/profile-a-l/anydesk.profile
@@ -28,7 +28,6 @@ notv
 nou2f
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-bin anydesk

--- a/etc/profile-a-l/aosp.profile
+++ b/etc/profile-a-l/aosp.profile
@@ -38,6 +38,5 @@ notv
 novideo
 protocol unix,inet,inet6
 #seccomp
-shell none
 
 private-tmp

--- a/etc/profile-a-l/apktool.profile
+++ b/etc/profile-a-l/apktool.profile
@@ -28,7 +28,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-bin apktool,basename,bash,dirname,expr,java,sh
 private-cache

--- a/etc/profile-a-l/apostrophe.profile
+++ b/etc/profile-a-l/apostrophe.profile
@@ -56,7 +56,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/arch-audit.profile
+++ b/etc/profile-a-l/arch-audit.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private

--- a/etc/profile-a-l/archaudit-report.profile
+++ b/etc/profile-a-l/archaudit-report.profile
@@ -28,7 +28,6 @@ notv
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private

--- a/etc/profile-a-l/archiver-common.profile
+++ b/etc/profile-a-l/archiver-common.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-a-l/ardour5.profile
+++ b/etc/profile-a-l/ardour5.profile
@@ -31,7 +31,6 @@ notv
 nou2f
 protocol unix
 seccomp
-shell none
 
 #private-bin ardour4,ardour5,ardour5-copy-mixer,ardour5-export,ardour5-fix_bbtppq,grep,ldd,nm,sed,sh
 private-cache

--- a/etc/profile-a-l/arduino.profile
+++ b/etc/profile-a-l/arduino.profile
@@ -32,7 +32,6 @@ notv
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-cache
 private-tmp

--- a/etc/profile-a-l/aria2c.profile
+++ b/etc/profile-a-l/aria2c.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 # disable-mnt
 # Add your custom event hook commands to 'private-bin' in your aria2c.local.

--- a/etc/profile-a-l/ark.profile
+++ b/etc/profile-a-l/ark.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-bin 7z,ark,bash,lrzip,lsar,lz4,lzop,p7zip,rar,sh,tclsh,unar,unrar,unzip,zip,zipinfo
 #private-etc alternatives,drirc,fonts,group,kde5rc,mtab,passwd,samba,smb.conf,xdg

--- a/etc/profile-a-l/arm.profile
+++ b/etc/profile-a-l/arm.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/artha.profile
+++ b/etc/profile-a-l/artha.profile
@@ -48,7 +48,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/assogiate.profile
+++ b/etc/profile-a-l/assogiate.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/asunder.profile
+++ b/etc/profile-a-l/asunder.profile
@@ -35,7 +35,6 @@ notv
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-cache
 private-dev

--- a/etc/profile-a-l/atril.profile
+++ b/etc/profile-a-l/atril.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin 7z,7za,7zr,atril,atril-previewer,atril-thumbnailer,sh,tar,unrar,unzip,zipnote

--- a/etc/profile-a-l/audacious.profile
+++ b/etc/profile-a-l/audacious.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 # private-bin audacious

--- a/etc/profile-a-l/audacity.profile
+++ b/etc/profile-a-l/audacity.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix,inet
 seccomp
-shell none
 tracelog
 
 private-bin audacity

--- a/etc/profile-a-l/audio-recorder.profile
+++ b/etc/profile-a-l/audio-recorder.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/authenticator-rs.profile
+++ b/etc/profile-a-l/authenticator-rs.profile
@@ -40,7 +40,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/authenticator.profile
+++ b/etc/profile-a-l/authenticator.profile
@@ -34,7 +34,6 @@ nou2f
 # novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 # private-bin authenticator,python*

--- a/etc/profile-a-l/autokey-common.profile
+++ b/etc/profile-a-l/autokey-common.profile
@@ -32,7 +32,6 @@ noroot
 nou2f
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-a-l/avidemux.profile
+++ b/etc/profile-a-l/avidemux.profile
@@ -42,7 +42,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin avidemux3_cli,avidemux3_jobs_qt5,avidemux3_qt5

--- a/etc/profile-a-l/aweather.profile
+++ b/etc/profile-a-l/aweather.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 private-bin aweather

--- a/etc/profile-a-l/ballbuster.profile
+++ b/etc/profile-a-l/ballbuster.profile
@@ -38,7 +38,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/baloo_file.profile
+++ b/etc/profile-a-l/baloo_file.profile
@@ -46,7 +46,6 @@ novideo
 protocol unix
 # blacklisting of ioprio_set system calls breaks baloo_file
 seccomp !ioprio_set
-shell none
 # x11 xorg
 
 private-bin baloo_file,baloo_file_extractor,baloo_filemetadata_temp_extractor,kbuildsycoca4

--- a/etc/profile-a-l/balsa.profile
+++ b/etc/profile-a-l/balsa.profile
@@ -57,7 +57,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 # disable-mnt

--- a/etc/profile-a-l/baobab.profile
+++ b/etc/profile-a-l/baobab.profile
@@ -31,7 +31,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin baobab

--- a/etc/profile-a-l/barrier.profile
+++ b/etc/profile-a-l/barrier.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/bcompare.profile
+++ b/etc/profile-a-l/bcompare.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-a-l/bibletime.profile
+++ b/etc/profile-a-l/bibletime.profile
@@ -46,7 +46,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp !chroot
-shell none
 
 disable-mnt
 # private-bin bibletime

--- a/etc/profile-a-l/bijiben.profile
+++ b/etc/profile-a-l/bijiben.profile
@@ -44,7 +44,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/bitcoin-qt.profile
+++ b/etc/profile-a-l/bitcoin-qt.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 private-bin bitcoin-qt

--- a/etc/profile-a-l/bleachbit.profile
+++ b/etc/profile-a-l/bleachbit.profile
@@ -31,7 +31,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-dev
 # private-tmp

--- a/etc/profile-a-l/blender.profile
+++ b/etc/profile-a-l/blender.profile
@@ -35,6 +35,5 @@ nou2f
 protocol unix,inet,inet6,netlink
 # numpy, used by many add-ons, requires the mbind syscall
 seccomp !mbind
-shell none
 
 private-dev

--- a/etc/profile-a-l/bless.profile
+++ b/etc/profile-a-l/bless.profile
@@ -30,7 +30,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 # private-bin bash,bless,mono,sh
 private-cache

--- a/etc/profile-a-l/blobby.profile
+++ b/etc/profile-a-l/blobby.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/blobwars.profile
+++ b/etc/profile-a-l/blobwars.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/bluefish.profile
+++ b/etc/profile-a-l/bluefish.profile
@@ -29,7 +29,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin bluefish

--- a/etc/profile-a-l/brackets.profile
+++ b/etc/profile-a-l/brackets.profile
@@ -28,7 +28,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp !chroot,!ioperm
-shell none
 
 private-cache
 private-dev

--- a/etc/profile-a-l/brasero.profile
+++ b/etc/profile-a-l/brasero.profile
@@ -27,7 +27,6 @@ notv
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 # private-bin brasero

--- a/etc/profile-a-l/build-systems-common.profile
+++ b/etc/profile-a-l/build-systems-common.profile
@@ -54,7 +54,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/bzflag.profile
+++ b/etc/profile-a-l/bzflag.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/calibre.profile
+++ b/etc/profile-a-l/calibre.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp !chroot
-shell none
 
 private-dev
 private-tmp

--- a/etc/profile-a-l/calligra.profile
+++ b/etc/profile-a-l/calligra.profile
@@ -28,7 +28,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 
 private-bin calligra,calligraauthor,calligraconverter,calligraflow,calligragemini,calligraplan,calligraplanwork,calligrasheets,calligrastage,calligrawords,dbus-launch,kbuildsycoca4,kdeinit4
 private-dev

--- a/etc/profile-a-l/cameramonitor.profile
+++ b/etc/profile-a-l/cameramonitor.profile
@@ -40,7 +40,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/cantata.profile
+++ b/etc/profile-a-l/cantata.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 # private-etc drirc,fonts,gcrypt,hosts,kde5rc,mpd.conf,passwd,samba,ssl,xdg
 private-bin cantata,mpd,perl

--- a/etc/profile-a-l/catfish.profile
+++ b/etc/profile-a-l/catfish.profile
@@ -36,7 +36,6 @@ notv
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 # These options work but are disabled in case

--- a/etc/profile-a-l/cawbird.profile
+++ b/etc/profile-a-l/cawbird.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/celluloid.profile
+++ b/etc/profile-a-l/celluloid.profile
@@ -48,7 +48,6 @@ nou2f
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin celluloid,env,gnome-mpv,python*,youtube-dl

--- a/etc/profile-a-l/checkbashisms.profile
+++ b/etc/profile-a-l/checkbashisms.profile
@@ -41,7 +41,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 x11 none
 
 private-cache

--- a/etc/profile-a-l/cheese.profile
+++ b/etc/profile-a-l/cheese.profile
@@ -45,7 +45,6 @@ nou2f
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/cherrytree.profile
+++ b/etc/profile-a-l/cherrytree.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-a-l/chromium-common.profile
+++ b/etc/profile-a-l/chromium-common.profile
@@ -48,7 +48,6 @@ nogroups
 noinput
 notv
 ?BROWSER_DISABLE_U2F: nou2f
-shell none
 
 disable-mnt
 private-cache

--- a/etc/profile-a-l/cin.profile
+++ b/etc/profile-a-l/cin.profile
@@ -27,7 +27,6 @@ protocol unix
 
 # If a 1-1.2% gap per thread hurts you, add 'ignore seccomp' to your cin.local.
 seccomp
-shell none
 
 #private-bin cin,ffmpeg
 private-cache

--- a/etc/profile-a-l/clamav.profile
+++ b/etc/profile-a-l/clamav.profile
@@ -26,7 +26,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-a-l/clamtk.profile
+++ b/etc/profile-a-l/clamtk.profile
@@ -22,7 +22,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-dev
 

--- a/etc/profile-a-l/clawsker.profile
+++ b/etc/profile-a-l/clawsker.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 private-bin bash,clawsker,perl,sh,which

--- a/etc/profile-a-l/clion.profile
+++ b/etc/profile-a-l/clion.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-cache
 private-dev

--- a/etc/profile-a-l/clipgrab.profile
+++ b/etc/profile-a-l/clipgrab.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp !chroot
-shell none
 
 disable-mnt
 private-cache

--- a/etc/profile-a-l/clipit.profile
+++ b/etc/profile-a-l/clipit.profile
@@ -41,7 +41,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 private-cache

--- a/etc/profile-a-l/cmus.profile
+++ b/etc/profile-a-l/cmus.profile
@@ -24,7 +24,6 @@ notv
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-bin cmus
 private-etc alternatives,asound.conf,ca-certificates,crypto-policies,group,ld.so.cache,ld.so.preload,machine-id,pki,pulse,resolv.conf,ssl

--- a/etc/profile-a-l/cointop.profile
+++ b/etc/profile-a-l/cointop.profile
@@ -46,7 +46,6 @@ novideo
 protocol inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/colorful.profile
+++ b/etc/profile-a-l/colorful.profile
@@ -38,7 +38,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/com.github.bleakgrey.tootle.profile
+++ b/etc/profile-a-l/com.github.bleakgrey.tootle.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/com.github.dahenson.agenda.profile
+++ b/etc/profile-a-l/com.github.dahenson.agenda.profile
@@ -45,7 +45,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/com.github.johnfactotum.Foliate.profile
+++ b/etc/profile-a-l/com.github.johnfactotum.Foliate.profile
@@ -48,7 +48,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/com.github.phase1geo.minder.profile
+++ b/etc/profile-a-l/com.github.phase1geo.minder.profile
@@ -45,7 +45,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/com.github.tchx84.Flatseal.profile
+++ b/etc/profile-a-l/com.github.tchx84.Flatseal.profile
@@ -45,7 +45,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/conky.profile
+++ b/etc/profile-a-l/conky.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-cache

--- a/etc/profile-a-l/corebird.profile
+++ b/etc/profile-a-l/corebird.profile
@@ -30,7 +30,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-bin corebird
 private-dev

--- a/etc/profile-a-l/cower.profile
+++ b/etc/profile-a-l/cower.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-bin cower

--- a/etc/profile-a-l/coyim.profile
+++ b/etc/profile-a-l/coyim.profile
@@ -34,7 +34,6 @@ notv
 nou2f
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/crawl.profile
+++ b/etc/profile-a-l/crawl.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 private-bin crawl,crawl-tiles

--- a/etc/profile-a-l/crow.profile
+++ b/etc/profile-a-l/crow.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 disable-mnt
 private-bin crow

--- a/etc/profile-a-l/curl.profile
+++ b/etc/profile-a-l/curl.profile
@@ -48,7 +48,6 @@ nou2f
 novideo
 protocol inet,inet6
 seccomp
-shell none
 tracelog
 
 # private-bin curl

--- a/etc/profile-a-l/d-feet.profile
+++ b/etc/profile-a-l/d-feet.profile
@@ -44,7 +44,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 private-bin d-feet,python*

--- a/etc/profile-a-l/darktable.profile
+++ b/etc/profile-a-l/darktable.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 #private-bin darktable
 private-dev

--- a/etc/profile-a-l/dbus-send.profile
+++ b/etc/profile-a-l/dbus-send.profile
@@ -43,7 +43,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/dconf-editor.profile
+++ b/etc/profile-a-l/dconf-editor.profile
@@ -36,7 +36,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/dconf.profile
+++ b/etc/profile-a-l/dconf.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-a-l/ddgtk.profile
+++ b/etc/profile-a-l/ddgtk.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/deadbeef.profile
+++ b/etc/profile-a-l/deadbeef.profile
@@ -28,7 +28,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-dev
 private-tmp

--- a/etc/profile-a-l/deluge.profile
+++ b/etc/profile-a-l/deluge.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 # deluge is using python on Debian
 private-bin deluge,deluge-console,deluge-gtk,deluge-web,deluged,python*,sh,uname

--- a/etc/profile-a-l/desktopeditors.profile
+++ b/etc/profile-a-l/desktopeditors.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 private-bin desktopeditors,sh

--- a/etc/profile-a-l/devhelp.profile
+++ b/etc/profile-a-l/devhelp.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/devilspie.profile
+++ b/etc/profile-a-l/devilspie.profile
@@ -40,7 +40,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-a-l/dex2jar.profile
+++ b/etc/profile-a-l/dex2jar.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-bin bash,dex2jar,dirname,expr,grep,java,ls,sh,uname
 private-cache

--- a/etc/profile-a-l/dia.profile
+++ b/etc/profile-a-l/dia.profile
@@ -44,7 +44,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/dig.profile
+++ b/etc/profile-a-l/dig.profile
@@ -43,7 +43,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/digikam.profile
+++ b/etc/profile-a-l/digikam.profile
@@ -33,7 +33,6 @@ notv
 protocol unix,inet,inet6,netlink
 # QtWebengine needs chroot to set up its own sandbox
 seccomp !chroot
-shell none
 
 # private-dev - prevents libdc1394 loading; this lib is used to connect to a camera device
 # private-etc alternatives,ca-certificates,crypto-policies,pki,ssl

--- a/etc/profile-a-l/dino.profile
+++ b/etc/profile-a-l/dino.profile
@@ -35,7 +35,6 @@ nou2f
 protocol unix,inet,inet6,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/display.profile
+++ b/etc/profile-a-l/display.profile
@@ -34,7 +34,6 @@ notv
 nou2f
 protocol unix
 seccomp
-shell none
 # x11 xorg - problems on kubuntu 17.04
 
 private-bin display,python*

--- a/etc/profile-a-l/dnscrypt-proxy.profile
+++ b/etc/profile-a-l/dnscrypt-proxy.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol inet,inet6
 seccomp.drop _sysctl,acct,add_key,adjtimex,clock_adjtime,delete_module,fanotify_init,finit_module,get_mempolicy,init_module,io_cancel,io_destroy,io_getevents,io_setup,io_submit,ioperm,iopl,kcmp,kexec_file_load,kexec_load,keyctl,lookup_dcookie,mbind,migrate_pages,modify_ldt,mount,move_pages,open_by_handle_at,perf_event_open,perf_event_open,pivot_root,process_vm_readv,process_vm_writev,ptrace,remap_file_pages,request_key,set_mempolicy,swapoff,swapon,sysfs,syslog,umount2,uselib,vmsplice
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/dolphin-emu.profile
+++ b/etc/profile-a-l/dolphin-emu.profile
@@ -48,7 +48,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink,bluetooth
 seccomp
-shell none
 tracelog
 
 private-bin bash,dolphin-emu,dolphin-emu-x11,sh

--- a/etc/profile-a-l/dooble.profile
+++ b/etc/profile-a-l/dooble.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/dosbox.profile
+++ b/etc/profile-a-l/dosbox.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 private-bin dosbox

--- a/etc/profile-a-l/dragon.profile
+++ b/etc/profile-a-l/dragon.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-bin dragon
 private-dev

--- a/etc/profile-a-l/drawio.profile
+++ b/etc/profile-a-l/drawio.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix
 seccomp !chroot
-shell none
 # tracelog - breaks on Arch
 
 private-bin drawio

--- a/etc/profile-a-l/drill.profile
+++ b/etc/profile-a-l/drill.profile
@@ -40,7 +40,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/dropbox.profile
+++ b/etc/profile-a-l/dropbox.profile
@@ -41,7 +41,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-dev
 private-tmp

--- a/etc/profile-a-l/easystroke.profile
+++ b/etc/profile-a-l/easystroke.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/electron-mail.profile
+++ b/etc/profile-a-l/electron-mail.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp !chroot
-shell none
 # tracelog - breaks on Arch
 
 private-bin electron-mail

--- a/etc/profile-a-l/electron.profile
+++ b/etc/profile-a-l/electron.profile
@@ -34,7 +34,6 @@ noinput
 notv
 nou2f
 novideo
-shell none
 
 disable-mnt
 private-cache

--- a/etc/profile-a-l/electrum.profile
+++ b/etc/profile-a-l/electrum.profile
@@ -40,7 +40,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-bin electrum,python*

--- a/etc/profile-a-l/email-common.profile
+++ b/etc/profile-a-l/email-common.profile
@@ -60,7 +60,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 # disable-mnt

--- a/etc/profile-a-l/enchant.profile
+++ b/etc/profile-a-l/enchant.profile
@@ -41,7 +41,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-a-l/engrampa.profile
+++ b/etc/profile-a-l/engrampa.profile
@@ -29,7 +29,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 # private-bin engrampa

--- a/etc/profile-a-l/enpass.profile
+++ b/etc/profile-a-l/enpass.profile
@@ -50,7 +50,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 private-bin dirname,Enpass,importer_enpass,readlink,sh

--- a/etc/profile-a-l/eo-common.profile
+++ b/etc/profile-a-l/eo-common.profile
@@ -42,7 +42,6 @@ novideo
 protocol unix,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-a-l/ephemeral.profile
+++ b/etc/profile-a-l/ephemeral.profile
@@ -49,7 +49,6 @@ notv
 ?BROWSER_DISABLE_U2F: nou2f
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/equalx.profile
+++ b/etc/profile-a-l/equalx.profile
@@ -47,7 +47,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/etr.profile
+++ b/etc/profile-a-l/etr.profile
@@ -42,7 +42,6 @@ novideo
 protocol unix,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/evince.profile
+++ b/etc/profile-a-l/evince.profile
@@ -49,7 +49,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin evince,evince-previewer,evince-thumbnailer,sh

--- a/etc/profile-a-l/evolution.profile
+++ b/etc/profile-a-l/evolution.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-dev
 private-tmp

--- a/etc/profile-a-l/exiftool.profile
+++ b/etc/profile-a-l/exiftool.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-a-l/fbreader.profile
+++ b/etc/profile-a-l/fbreader.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-bin fbreader,FBReader
 private-dev

--- a/etc/profile-a-l/feedreader.profile
+++ b/etc/profile-a-l/feedreader.profile
@@ -41,7 +41,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/feh.profile
+++ b/etc/profile-a-l/feh.profile
@@ -31,7 +31,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-bin feh,jpegexiforient,jpegtran
 private-cache

--- a/etc/profile-a-l/ferdi.profile
+++ b/etc/profile-a-l/ferdi.profile
@@ -40,7 +40,6 @@ notv
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp !chroot
-shell none
 
 disable-mnt
 private-dev

--- a/etc/profile-a-l/fetchmail.profile
+++ b/etc/profile-a-l/fetchmail.profile
@@ -28,7 +28,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 #private-bin bash,chmod,fetchmail,procmail
 private-dev

--- a/etc/profile-a-l/ffmpeg.profile
+++ b/etc/profile-a-l/ffmpeg.profile
@@ -42,7 +42,6 @@ protocol inet,inet6
 # allow set_mempolicy, which is required to encode using libx265
 seccomp !set_mempolicy
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin ffmpeg

--- a/etc/profile-a-l/file-manager-common.profile
+++ b/etc/profile-a-l/file-manager-common.profile
@@ -43,7 +43,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 private-dev

--- a/etc/profile-a-l/file-roller.profile
+++ b/etc/profile-a-l/file-roller.profile
@@ -37,7 +37,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin 7z,7za,7zr,ar,arj,atool,bash,brotli,bsdtar,bzip2,compress,cp,cpio,dpkg-deb,file-roller,gtar,gzip,isoinfo,lha,lrzip,lsar,lz4,lzip,lzma,lzop,mv,p7zip,rar,rm,rzip,sh,tar,unace,unalz,unar,uncompress,unrar,unsquashfs,unstuff,unzip,unzstd,xz,xzdec,zip,zoo,zstd

--- a/etc/profile-a-l/file.profile
+++ b/etc/profile-a-l/file.profile
@@ -30,7 +30,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-a-l/filezilla.profile
+++ b/etc/profile-a-l/filezilla.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 # private-bin breaks --join if the user has zsh set as $SHELL - adding zsh on private-bin
 private-bin bash,filezilla,fzputtygen,fzsftp,lsb_release,python*,sh,uname,zsh

--- a/etc/profile-a-l/firefox-common.profile
+++ b/etc/profile-a-l/firefox-common.profile
@@ -48,7 +48,6 @@ notv
 protocol unix,inet,inet6,netlink
 # The below seccomp configuration still permits chroot syscall. See https://github.com/netblue30/firejail/issues/2506 for possible workarounds.
 seccomp !chroot
-shell none
 # Disable tracelog, it breaks or causes major issues with many firefox based browsers, see https://github.com/netblue30/firejail/issues/1930.
 #tracelog
 

--- a/etc/profile-a-l/flameshot.profile
+++ b/etc/profile-a-l/flameshot.profile
@@ -46,7 +46,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/flowblade.profile
+++ b/etc/profile-a-l/flowblade.profile
@@ -30,7 +30,6 @@ notv
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 private-cache
 private-dev

--- a/etc/profile-a-l/font-manager.profile
+++ b/etc/profile-a-l/font-manager.profile
@@ -46,7 +46,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/fontforge.profile
+++ b/etc/profile-a-l/fontforge.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-cache
 private-dev

--- a/etc/profile-a-l/fractal.profile
+++ b/etc/profile-a-l/fractal.profile
@@ -40,7 +40,6 @@ notv
 nou2f
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/franz.profile
+++ b/etc/profile-a-l/franz.profile
@@ -40,7 +40,6 @@ notv
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp !chroot
-shell none
 
 disable-mnt
 private-dev

--- a/etc/profile-a-l/freecad.profile
+++ b/etc/profile-a-l/freecad.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-bin freecad,freecadcmd,python*
 private-cache

--- a/etc/profile-a-l/freeciv.profile
+++ b/etc/profile-a-l/freeciv.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/freecol.profile
+++ b/etc/profile-a-l/freecol.profile
@@ -46,7 +46,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/freemind.profile
+++ b/etc/profile-a-l/freemind.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/freshclam.profile
+++ b/etc/profile-a-l/freshclam.profile
@@ -22,7 +22,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/frogatto.profile
+++ b/etc/profile-a-l/frogatto.profile
@@ -38,7 +38,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/frozen-bubble.profile
+++ b/etc/profile-a-l/frozen-bubble.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/ftp.profile
+++ b/etc/profile-a-l/ftp.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol inet,inet6
 seccomp
-shell none
 tracelog
 
 #disable-mnt

--- a/etc/profile-a-l/funnyboat.profile
+++ b/etc/profile-a-l/funnyboat.profile
@@ -41,7 +41,6 @@ notv
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 # tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gajim.profile
+++ b/etc/profile-a-l/gajim.profile
@@ -52,7 +52,6 @@ notv
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/galculator.profile
+++ b/etc/profile-a-l/galculator.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin galculator

--- a/etc/profile-a-l/gapplication.profile
+++ b/etc/profile-a-l/gapplication.profile
@@ -40,7 +40,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-a-l/gcloud.profile
+++ b/etc/profile-a-l/gcloud.profile
@@ -31,7 +31,6 @@ notv
 nou2f
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gconf.profile
+++ b/etc/profile-a-l/gconf.profile
@@ -46,7 +46,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-a-l/geany.profile
+++ b/etc/profile-a-l/geany.profile
@@ -28,7 +28,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-cache
 private-dev

--- a/etc/profile-a-l/geary.profile
+++ b/etc/profile-a-l/geary.profile
@@ -69,7 +69,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 # disable-mnt

--- a/etc/profile-a-l/gedit.profile
+++ b/etc/profile-a-l/gedit.profile
@@ -38,7 +38,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 # private-bin gedit

--- a/etc/profile-a-l/geekbench.profile
+++ b/etc/profile-a-l/geekbench.profile
@@ -41,7 +41,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/geeqie.profile
+++ b/etc/profile-a-l/geeqie.profile
@@ -28,7 +28,6 @@ novideo
 # remove inet,inet6 to disable network access
 protocol unix,inet,inet6
 seccomp
-shell none
 
 # private-bin geeqie
 private-dev

--- a/etc/profile-a-l/gfeeds.profile
+++ b/etc/profile-a-l/gfeeds.profile
@@ -54,7 +54,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gget.profile
+++ b/etc/profile-a-l/gget.profile
@@ -42,7 +42,6 @@ novideo
 protocol inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/ghostwriter.profile
+++ b/etc/profile-a-l/ghostwriter.profile
@@ -45,7 +45,6 @@ novideo
 protocol unix,inet,inet6,netlink
 seccomp !chroot
 seccomp.block-secondary
-shell none
 #tracelog -- breaks
 
 private-bin context,gettext,ghostwriter,latex,mktexfmt,pandoc,pdflatex,pdfroff,prince,weasyprint,wkhtmltopdf

--- a/etc/profile-a-l/gimp.profile
+++ b/etc/profile-a-l/gimp.profile
@@ -56,7 +56,6 @@ notv
 nou2f
 protocol unix
 seccomp !mbind
-shell none
 tracelog
 
 private-dev

--- a/etc/profile-a-l/gist.profile
+++ b/etc/profile-a-l/gist.profile
@@ -46,7 +46,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/git-cola.profile
+++ b/etc/profile-a-l/git-cola.profile
@@ -62,7 +62,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 # Add your own diff viewer,editor,pinentry program to private-bin in your git-cola.local.

--- a/etc/profile-a-l/git.profile
+++ b/etc/profile-a-l/git.profile
@@ -60,7 +60,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-cache
 private-dev

--- a/etc/profile-a-l/gitg.profile
+++ b/etc/profile-a-l/gitg.profile
@@ -48,7 +48,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin git,gitg,ssh

--- a/etc/profile-a-l/gitter.profile
+++ b/etc/profile-a-l/gitter.profile
@@ -33,7 +33,6 @@ notv
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 disable-mnt
 private-bin bash,env,gitter

--- a/etc/profile-a-l/gjs.profile
+++ b/etc/profile-a-l/gjs.profile
@@ -36,7 +36,6 @@ notv
 nou2f
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 # private-bin gjs,gnome-books,gnome-documents,gnome-maps,gnome-photos,gnome-weather

--- a/etc/profile-a-l/gl-117.profile
+++ b/etc/profile-a-l/gl-117.profile
@@ -37,7 +37,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/glaxium.profile
+++ b/etc/profile-a-l/glaxium.profile
@@ -37,7 +37,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/globaltime.profile
+++ b/etc/profile-a-l/globaltime.profile
@@ -28,7 +28,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-cache

--- a/etc/profile-a-l/gmpc.profile
+++ b/etc/profile-a-l/gmpc.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gnome-books.profile
+++ b/etc/profile-a-l/gnome-books.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 # private-bin gjs,gnome-books

--- a/etc/profile-a-l/gnome-builder.profile
+++ b/etc/profile-a-l/gnome-builder.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-dev
 

--- a/etc/profile-a-l/gnome-calculator.profile
+++ b/etc/profile-a-l/gnome-calculator.profile
@@ -39,7 +39,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gnome-calendar.profile
+++ b/etc/profile-a-l/gnome-calendar.profile
@@ -37,7 +37,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gnome-characters.profile
+++ b/etc/profile-a-l/gnome-characters.profile
@@ -40,7 +40,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gnome-chess.profile
+++ b/etc/profile-a-l/gnome-chess.profile
@@ -43,7 +43,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gnome-clocks.profile
+++ b/etc/profile-a-l/gnome-clocks.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gnome-documents.profile
+++ b/etc/profile-a-l/gnome-documents.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-a-l/gnome-hexgl.profile
+++ b/etc/profile-a-l/gnome-hexgl.profile
@@ -34,7 +34,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gnome-keyring.profile
+++ b/etc/profile-a-l/gnome-keyring.profile
@@ -46,7 +46,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gnome-latex.profile
+++ b/etc/profile-a-l/gnome-latex.profile
@@ -42,7 +42,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-a-l/gnome-logs.profile
+++ b/etc/profile-a-l/gnome-logs.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gnome-maps.profile
+++ b/etc/profile-a-l/gnome-maps.profile
@@ -57,7 +57,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gnome-mplayer.profile
+++ b/etc/profile-a-l/gnome-mplayer.profile
@@ -25,7 +25,6 @@ noroot
 nou2f
 protocol unix,inet,inet6
 seccomp
-shell none
 
 # private-bin gnome-mplayer,mplayer
 private-cache

--- a/etc/profile-a-l/gnome-music.profile
+++ b/etc/profile-a-l/gnome-music.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 # private-bin calls a file manager - whatever is installed!

--- a/etc/profile-a-l/gnome-passwordsafe.profile
+++ b/etc/profile-a-l/gnome-passwordsafe.profile
@@ -46,7 +46,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gnome-photos.profile
+++ b/etc/profile-a-l/gnome-photos.profile
@@ -34,7 +34,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 # private-bin gjs,gnome-photos

--- a/etc/profile-a-l/gnome-pie.profile
+++ b/etc/profile-a-l/gnome-pie.profile
@@ -29,7 +29,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 private-cache

--- a/etc/profile-a-l/gnome-pomodoro.profile
+++ b/etc/profile-a-l/gnome-pomodoro.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gnome-recipes.profile
+++ b/etc/profile-a-l/gnome-recipes.profile
@@ -42,7 +42,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-bin gnome-recipes,tar

--- a/etc/profile-a-l/gnome-ring.profile
+++ b/etc/profile-a-l/gnome-ring.profile
@@ -25,7 +25,6 @@ noroot
 notv
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 disable-mnt
 # private-dev

--- a/etc/profile-a-l/gnome-schedule.profile
+++ b/etc/profile-a-l/gnome-schedule.profile
@@ -55,7 +55,6 @@ nosound
 notv
 nou2f
 novideo
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gnome-screenshot.profile
+++ b/etc/profile-a-l/gnome-screenshot.profile
@@ -36,7 +36,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gnome-sound-recorder.profile
+++ b/etc/profile-a-l/gnome-sound-recorder.profile
@@ -34,7 +34,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gnome-system-log.profile
+++ b/etc/profile-a-l/gnome-system-log.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 private-bin gnome-system-log

--- a/etc/profile-a-l/gnome-todo.profile
+++ b/etc/profile-a-l/gnome-todo.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gnome-twitch.profile
+++ b/etc/profile-a-l/gnome-twitch.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-dev

--- a/etc/profile-a-l/gnome-weather.profile
+++ b/etc/profile-a-l/gnome-weather.profile
@@ -38,7 +38,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gnome_games-common.profile
+++ b/etc/profile-a-l/gnome_games-common.profile
@@ -35,7 +35,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gnote.profile
+++ b/etc/profile-a-l/gnote.profile
@@ -44,7 +44,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gnubik.profile
+++ b/etc/profile-a-l/gnubik.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/godot.profile
+++ b/etc/profile-a-l/godot.profile
@@ -31,7 +31,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 

--- a/etc/profile-a-l/goldendict.profile
+++ b/etc/profile-a-l/goldendict.profile
@@ -44,7 +44,6 @@ novideo
 protocol unix,inet,inet6,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/goobox.profile
+++ b/etc/profile-a-l/goobox.profile
@@ -26,7 +26,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 # private-bin goobox

--- a/etc/profile-a-l/google-earth.profile
+++ b/etc/profile-a-l/google-earth.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-bin bash,dirname,google-earth,grep,ls,sed,sh

--- a/etc/profile-a-l/google-play-music-desktop-player.profile
+++ b/etc/profile-a-l/google-play-music-desktop-player.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 disable-mnt
 private-dev

--- a/etc/profile-a-l/googler-common.profile
+++ b/etc/profile-a-l/googler-common.profile
@@ -47,7 +47,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gpa.profile
+++ b/etc/profile-a-l/gpa.profile
@@ -26,7 +26,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 # private-bin gpa,gpg

--- a/etc/profile-a-l/gpg-agent.profile
+++ b/etc/profile-a-l/gpg-agent.profile
@@ -44,7 +44,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 # private-bin gpg-agent,gpg

--- a/etc/profile-a-l/gpg.profile
+++ b/etc/profile-a-l/gpg.profile
@@ -40,7 +40,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 # private-bin gpg,gpg-agent

--- a/etc/profile-a-l/gpicview.profile
+++ b/etc/profile-a-l/gpicview.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin gpicview

--- a/etc/profile-a-l/gpredict.profile
+++ b/etc/profile-a-l/gpredict.profile
@@ -31,7 +31,6 @@ notv
 nou2f
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 private-bin gpredict

--- a/etc/profile-a-l/gradio.profile
+++ b/etc/profile-a-l/gradio.profile
@@ -38,7 +38,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gramps.profile
+++ b/etc/profile-a-l/gramps.profile
@@ -40,7 +40,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-cache

--- a/etc/profile-a-l/gravity-beams-and-evaporating-stars.profile
+++ b/etc/profile-a-l/gravity-beams-and-evaporating-stars.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gthumb.profile
+++ b/etc/profile-a-l/gthumb.profile
@@ -28,7 +28,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin gthumb

--- a/etc/profile-a-l/gtk-update-icon-cache.profile
+++ b/etc/profile-a-l/gtk-update-icon-cache.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-a-l/guayadeque.profile
+++ b/etc/profile-a-l/guayadeque.profile
@@ -27,7 +27,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 private-bin guayadeque
 private-dev

--- a/etc/profile-a-l/gucharmap.profile
+++ b/etc/profile-a-l/gucharmap.profile
@@ -36,7 +36,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/guvcview.profile
+++ b/etc/profile-a-l/guvcview.profile
@@ -41,7 +41,6 @@ nou2f
 protocol unix,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/gwenview.profile
+++ b/etc/profile-a-l/gwenview.profile
@@ -42,7 +42,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 # tracelog
 
 private-bin gimp*,gwenview,kbuildsycoca4,kdeinit4

--- a/etc/profile-a-l/handbrake.profile
+++ b/etc/profile-a-l/handbrake.profile
@@ -30,7 +30,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 private-dev
 private-tmp

--- a/etc/profile-a-l/hashcat.profile
+++ b/etc/profile-a-l/hashcat.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 x11 none
 
 disable-mnt

--- a/etc/profile-a-l/hasher-common.profile
+++ b/etc/profile-a-l/hasher-common.profile
@@ -42,7 +42,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-a-l/hexchat.profile
+++ b/etc/profile-a-l/hexchat.profile
@@ -45,7 +45,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/highlight.profile
+++ b/etc/profile-a-l/highlight.profile
@@ -31,7 +31,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-a-l/homebank.profile
+++ b/etc/profile-a-l/homebank.profile
@@ -43,7 +43,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/host.profile
+++ b/etc/profile-a-l/host.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/hugin.profile
+++ b/etc/profile-a-l/hugin.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-bin align_image_stack,autooptimiser,calibrate_lens_gui,celeste_standalone,checkpto,cpclean,cpfind,deghosting_mask,enblend,fulla,geocpset,hugin,hugin_executor,hugin_hdrmerge,hugin_lensdb,hugin_stitch_project,icpfind,linefind,nona,pano_modify,pano_trafo,PTBatcherGUI,pto_gen,pto_lensstack,pto_mask,pto_merge,pto_move,pto_template,pto_var,sh,tca_correct,uname,verdandi,vig_optimize
 private-cache

--- a/etc/profile-a-l/hyperrogue.profile
+++ b/etc/profile-a-l/hyperrogue.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/i2prouter.profile
+++ b/etc/profile-a-l/i2prouter.profile
@@ -63,7 +63,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-cache

--- a/etc/profile-a-l/iagno.profile
+++ b/etc/profile-a-l/iagno.profile
@@ -28,7 +28,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 private

--- a/etc/profile-a-l/idea.sh.profile
+++ b/etc/profile-a-l/idea.sh.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-cache
 private-dev

--- a/etc/profile-a-l/imagej.profile
+++ b/etc/profile-a-l/imagej.profile
@@ -31,7 +31,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-bin awk,basename,bash,cut,free,grep,hostname,imagej,ln,ls,mkdir,rm,sort,tail,touch,tr,uname,update-java-alternatives,whoami,xprop
 private-dev

--- a/etc/profile-a-l/img2txt.profile
+++ b/etc/profile-a-l/img2txt.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-a-l/impressive.profile
+++ b/etc/profile-a-l/impressive.profile
@@ -43,7 +43,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-a-l/imv.profile
+++ b/etc/profile-a-l/imv.profile
@@ -43,7 +43,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin imv,imv-wayland,imv-x11,sh

--- a/etc/profile-a-l/inkscape.profile
+++ b/etc/profile-a-l/inkscape.profile
@@ -49,7 +49,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 # private-bin inkscape,potrace,python* - problems on Debian stretch

--- a/etc/profile-a-l/io.github.lainsce.Notejot.profile
+++ b/etc/profile-a-l/io.github.lainsce.Notejot.profile
@@ -44,7 +44,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/ipcalc.profile
+++ b/etc/profile-a-l/ipcalc.profile
@@ -41,7 +41,6 @@ nou2f
 novideo
 # protocol unix
 seccomp
-shell none
 # tracelog
 
 disable-mnt

--- a/etc/profile-a-l/itch.profile
+++ b/etc/profile-a-l/itch.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 private-dev
 private-tmp

--- a/etc/profile-a-l/jami-gnome.profile
+++ b/etc/profile-a-l/jami-gnome.profile
@@ -33,7 +33,6 @@ noroot
 notv
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 disable-mnt
 private-dev

--- a/etc/profile-a-l/jd-gui.profile
+++ b/etc/profile-a-l/jd-gui.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-bin bash,jd-gui,sh
 private-cache

--- a/etc/profile-a-l/jerry.profile
+++ b/etc/profile-a-l/jerry.profile
@@ -29,7 +29,6 @@ notv
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin bash,jerry,sh,stockfish

--- a/etc/profile-a-l/jitsi.profile
+++ b/etc/profile-a-l/jitsi.profile
@@ -23,7 +23,6 @@ noroot
 notv
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/jumpnbump.profile
+++ b/etc/profile-a-l/jumpnbump.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/k3b.profile
+++ b/etc/profile-a-l/k3b.profile
@@ -32,7 +32,6 @@ notv
 novideo
 # protocol unix - breaks privileged helpers
 # seccomp - breaks privileged helpers
-shell none
 
 private-dev
 # private-tmp

--- a/etc/profile-a-l/kaffeine.profile
+++ b/etc/profile-a-l/kaffeine.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 # private-bin kaffeine
 private-dev

--- a/etc/profile-a-l/kalgebra.profile
+++ b/etc/profile-a-l/kalgebra.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix,netlink
 seccomp !chroot
-shell none
 # tracelog
 
 disable-mnt

--- a/etc/profile-a-l/kate.profile
+++ b/etc/profile-a-l/kate.profile
@@ -51,7 +51,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 # private-bin kate,kbuildsycoca4,kdeinit4
 private-dev

--- a/etc/profile-a-l/kazam.profile
+++ b/etc/profile-a-l/kazam.profile
@@ -42,7 +42,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/kcalc.profile
+++ b/etc/profile-a-l/kcalc.profile
@@ -49,7 +49,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/kdeinit4.profile
+++ b/etc/profile-a-l/kdeinit4.profile
@@ -29,7 +29,6 @@ novideo
 notv
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 private-bin kbuildsycoca4,kded4,kdeinit4,knotify4
 private-dev

--- a/etc/profile-a-l/kdenlive.profile
+++ b/etc/profile-a-l/kdenlive.profile
@@ -31,7 +31,6 @@ notv
 nou2f
 protocol unix,netlink
 seccomp
-shell none
 
 private-bin dbus-launch,dvdauthor,ffmpeg,ffplay,ffprobe,genisoimage,kdeinit4,kdeinit4_shutdown,kdeinit4_wrapper,kdeinit5,kdeinit5_shutdown,kdeinit5_wrapper,kdenlive,kdenlive_render,kshell4,kshell5,melt,mlt-melt,vlc,xine
 private-dev

--- a/etc/profile-a-l/kdiff3.profile
+++ b/etc/profile-a-l/kdiff3.profile
@@ -46,7 +46,6 @@ nou2f
 novideo
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/keepass.profile
+++ b/etc/profile-a-l/keepass.profile
@@ -35,7 +35,6 @@ notv
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 private-cache
 # Note: private-dev prevents the program from seeing new devices (such as

--- a/etc/profile-a-l/keepassx.profile
+++ b/etc/profile-a-l/keepassx.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin keepassx,keepassx2

--- a/etc/profile-a-l/keepassxc.profile
+++ b/etc/profile-a-l/keepassxc.profile
@@ -82,7 +82,6 @@ novideo
 protocol unix
 seccomp !name_to_handle_at
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin keepassxc,keepassxc-cli,keepassxc-proxy

--- a/etc/profile-a-l/kfind.profile
+++ b/etc/profile-a-l/kfind.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 # private-bin kbuildsycoca4,kdeinit4,kfind
 private-dev

--- a/etc/profile-a-l/kid3.profile
+++ b/etc/profile-a-l/kid3.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-a-l/kino.profile
+++ b/etc/profile-a-l/kino.profile
@@ -29,7 +29,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-cache
 private-dev

--- a/etc/profile-a-l/kiwix-desktop.profile
+++ b/etc/profile-a-l/kiwix-desktop.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp !chroot
-shell none
 
 disable-mnt
 private-cache

--- a/etc/profile-a-l/klatexformula.profile
+++ b/etc/profile-a-l/klatexformula.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-a-l/klavaro.profile
+++ b/etc/profile-a-l/klavaro.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/kmplayer.profile
+++ b/etc/profile-a-l/kmplayer.profile
@@ -32,7 +32,6 @@ noroot
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 # private-bin kmplayer,mplayer
 private-cache

--- a/etc/profile-a-l/kodi.profile
+++ b/etc/profile-a-l/kodi.profile
@@ -47,7 +47,6 @@ noroot
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 private-dev

--- a/etc/profile-a-l/konversation.profile
+++ b/etc/profile-a-l/konversation.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 private-bin kbuildsycoca4,konversation

--- a/etc/profile-a-l/krita.profile
+++ b/etc/profile-a-l/krita.profile
@@ -41,7 +41,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-cache
 private-dev

--- a/etc/profile-a-l/ktorrent.profile
+++ b/etc/profile-a-l/ktorrent.profile
@@ -55,7 +55,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 private-bin kbuildsycoca4,kdeinit4,ktorrent
 private-dev

--- a/etc/profile-a-l/ktouch.profile
+++ b/etc/profile-a-l/ktouch.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/kube.profile
+++ b/etc/profile-a-l/kube.profile
@@ -59,7 +59,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 # disable-mnt

--- a/etc/profile-a-l/kwin_x11.profile
+++ b/etc/profile-a-l/kwin_x11.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/kwrite.profile
+++ b/etc/profile-a-l/kwrite.profile
@@ -42,7 +42,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin kbuildsycoca4,kdeinit4,kwrite

--- a/etc/profile-a-l/latex-common.profile
+++ b/etc/profile-a-l/latex-common.profile
@@ -30,7 +30,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-a-l/leafpad.profile
+++ b/etc/profile-a-l/leafpad.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-bin leafpad
 private-dev

--- a/etc/profile-a-l/less.profile
+++ b/etc/profile-a-l/less.profile
@@ -31,7 +31,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-a-l/librecad.profile
+++ b/etc/profile-a-l/librecad.profile
@@ -34,7 +34,6 @@ novideo
 protocol unix,inet,inet6
 netfilter
 seccomp
-shell none
 #tracelog
 
 #disable-mnt

--- a/etc/profile-a-l/libreoffice.profile
+++ b/etc/profile-a-l/libreoffice.profile
@@ -45,7 +45,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 #private-bin libreoffice,sh,uname,dirname,grep,sed,basename,ls

--- a/etc/profile-a-l/lifeograph.profile
+++ b/etc/profile-a-l/lifeograph.profile
@@ -42,7 +42,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/liferea.profile
+++ b/etc/profile-a-l/liferea.profile
@@ -45,7 +45,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/lincity-ng.profile
+++ b/etc/profile-a-l/lincity-ng.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/links-common.profile
+++ b/etc/profile-a-l/links-common.profile
@@ -43,7 +43,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/linphone.profile
+++ b/etc/profile-a-l/linphone.profile
@@ -42,7 +42,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-dev

--- a/etc/profile-a-l/lmms.profile
+++ b/etc/profile-a-l/lmms.profile
@@ -31,7 +31,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-dev
 private-tmp

--- a/etc/profile-a-l/lollypop.profile
+++ b/etc/profile-a-l/lollypop.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-dev
 private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,machine-id,pki,pulse,resolv.conf,ssl,xdg

--- a/etc/profile-a-l/lugaru.profile
+++ b/etc/profile-a-l/lugaru.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-a-l/luminance-hdr.profile
+++ b/etc/profile-a-l/luminance-hdr.profile
@@ -29,7 +29,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 #private-bin luminance-hdr,luminance-hdr-cli,align_image_stack

--- a/etc/profile-a-l/lutris.profile
+++ b/etc/profile-a-l/lutris.profile
@@ -70,7 +70,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 # Add the next line to your lutris.local if you do not need controller support.
 #private-dev

--- a/etc/profile-a-l/lximage-qt.profile
+++ b/etc/profile-a-l/lximage-qt.profile
@@ -30,7 +30,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-cache
 private-dev

--- a/etc/profile-a-l/lxmusic.profile
+++ b/etc/profile-a-l/lxmusic.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-dev
 private-tmp

--- a/etc/profile-a-l/lynx.profile
+++ b/etc/profile-a-l/lynx.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 # private-bin lynx

--- a/etc/profile-m-z/Maelstrom.profile
+++ b/etc/profile-m-z/Maelstrom.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 #protocol unix
 #seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/PCSX2.profile
+++ b/etc/profile-m-z/PCSX2.profile
@@ -41,7 +41,6 @@ nou2f
 novideo
 protocol unix,netlink
 #seccomp - breaks loading with no logs
-shell none
 #tracelog - 32/64 bit incompatibility
 
 private-bin PCSX2

--- a/etc/profile-m-z/QMediathekView.profile
+++ b/etc/profile-m-z/QMediathekView.profile
@@ -44,7 +44,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/QOwnNotes.profile
+++ b/etc/profile-m-z/QOwnNotes.profile
@@ -44,7 +44,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/Viber.profile
+++ b/etc/profile-m-z/Viber.profile
@@ -29,7 +29,6 @@ noroot
 notv
 protocol unix,inet,inet6
 seccomp !chroot
-shell none
 
 disable-mnt
 private-bin awk,bash,dig,sh,Viber

--- a/etc/profile-m-z/XMind.profile
+++ b/etc/profile-m-z/XMind.profile
@@ -29,7 +29,6 @@ notv
 nou2f
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-bin cp,sh,XMind

--- a/etc/profile-m-z/Xephyr.profile
+++ b/etc/profile-m-z/Xephyr.profile
@@ -31,7 +31,6 @@ notv
 nou2f
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 # using a private home directory

--- a/etc/profile-m-z/Xvfb.profile
+++ b/etc/profile-m-z/Xvfb.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 # using a private home directory

--- a/etc/profile-m-z/ZeGrapher.profile
+++ b/etc/profile-m-z/ZeGrapher.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/macrofusion.profile
+++ b/etc/profile-m-z/macrofusion.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-bin align_image_stack,enfuse,env,exiftool,macrofusion,python*
 private-cache

--- a/etc/profile-m-z/magicor.profile
+++ b/etc/profile-m-z/magicor.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/makepkg.profile
+++ b/etc/profile-m-z/makepkg.profile
@@ -50,7 +50,6 @@ notv
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/man.profile
+++ b/etc/profile-m-z/man.profile
@@ -49,7 +49,6 @@ novideo
 nou2f
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-m-z/manaplus.profile
+++ b/etc/profile-m-z/manaplus.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/marker.profile
+++ b/etc/profile-m-z/marker.profile
@@ -48,7 +48,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin marker,python3*

--- a/etc/profile-m-z/masterpdfeditor.profile
+++ b/etc/profile-m-z/masterpdfeditor.profile
@@ -31,7 +31,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-m-z/mate-calc.profile
+++ b/etc/profile-m-z/mate-calc.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 private-bin mate-calc,mate-calculator

--- a/etc/profile-m-z/mate-color-select.profile
+++ b/etc/profile-m-z/mate-color-select.profile
@@ -29,7 +29,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 private-bin mate-color-select

--- a/etc/profile-m-z/mate-dictionary.profile
+++ b/etc/profile-m-z/mate-dictionary.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-bin mate-dictionary

--- a/etc/profile-m-z/mcabber.profile
+++ b/etc/profile-m-z/mcabber.profile
@@ -27,7 +27,6 @@ nou2f
 novideo
 protocol inet,inet6
 seccomp
-shell none
 
 private-bin mcabber
 private-dev

--- a/etc/profile-m-z/mcomix.profile
+++ b/etc/profile-m-z/mcomix.profile
@@ -50,7 +50,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 # mcomix <= 1.2 uses python2

--- a/etc/profile-m-z/mdr.profile
+++ b/etc/profile-m-z/mdr.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-m-z/mediainfo.profile
+++ b/etc/profile-m-z/mediainfo.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-m-z/megaglest.profile
+++ b/etc/profile-m-z/megaglest.profile
@@ -43,7 +43,6 @@ novideo
 protocol unix,inet,inet6,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/meld.profile
+++ b/etc/profile-m-z/meld.profile
@@ -67,7 +67,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin bzr,cvs,git,hg,meld,python*,svn

--- a/etc/profile-m-z/mendeleydesktop.profile
+++ b/etc/profile-m-z/mendeleydesktop.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/menulibre.profile
+++ b/etc/profile-m-z/menulibre.profile
@@ -46,7 +46,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/meteo-qt.profile
+++ b/etc/profile-m-z/meteo-qt.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/mindless.profile
+++ b/etc/profile-m-z/mindless.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/minecraft-launcher.profile
+++ b/etc/profile-m-z/minecraft-launcher.profile
@@ -42,7 +42,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/minetest.profile
+++ b/etc/profile-m-z/minetest.profile
@@ -48,7 +48,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/minitube.profile
+++ b/etc/profile-m-z/minitube.profile
@@ -47,7 +47,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/mirage.profile
+++ b/etc/profile-m-z/mirage.profile
@@ -47,7 +47,6 @@ notv
 nou2f
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/mirrormagic.profile
+++ b/etc/profile-m-z/mirrormagic.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/mocp.profile
+++ b/etc/profile-m-z/mocp.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 private-bin mocp

--- a/etc/profile-m-z/mousepad.profile
+++ b/etc/profile-m-z/mousepad.profile
@@ -31,7 +31,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin mousepad

--- a/etc/profile-m-z/mp3splt-gtk.profile
+++ b/etc/profile-m-z/mp3splt-gtk.profile
@@ -31,7 +31,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin mp3splt-gtk

--- a/etc/profile-m-z/mp3splt.profile
+++ b/etc/profile-m-z/mp3splt.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-m-z/mpDris2.profile
+++ b/etc/profile-m-z/mpDris2.profile
@@ -44,7 +44,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-bin mpDris2,notify-send,python*
 private-cache

--- a/etc/profile-m-z/mpd.profile
+++ b/etc/profile-m-z/mpd.profile
@@ -35,7 +35,6 @@ protocol unix,inet,inet6
 # blacklisting of ioprio_set system calls breaks auto-updating of
 # MPD's database when files in music_directory are changed
 seccomp !ioprio_set
-shell none
 
 #private-bin bash,mpd
 private-cache

--- a/etc/profile-m-z/mpg123.profile
+++ b/etc/profile-m-z/mpg123.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 #private-bin mpg123*

--- a/etc/profile-m-z/mplayer.profile
+++ b/etc/profile-m-z/mplayer.profile
@@ -33,7 +33,6 @@ noroot
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 private-bin mplayer
 private-dev

--- a/etc/profile-m-z/mpsyt.profile
+++ b/etc/profile-m-z/mpsyt.profile
@@ -59,7 +59,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 private-bin env,ffmpeg,mplayer,mpsyt,mpv,python*,youtube-dl

--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -77,7 +77,6 @@ nou2f
 protocol unix,inet,inet6,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin env,mpv,python*,waf,youtube-dl,yt-dlp

--- a/etc/profile-m-z/mrrescue.profile
+++ b/etc/profile-m-z/mrrescue.profile
@@ -45,7 +45,6 @@ novideo
 protocol unix,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/ms-office.profile
+++ b/etc/profile-m-z/ms-office.profile
@@ -30,7 +30,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/mtpaint.profile
+++ b/etc/profile-m-z/mtpaint.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/multimc5.profile
+++ b/etc/profile-m-z/multimc5.profile
@@ -42,7 +42,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 # seccomp
-shell none
 
 disable-mnt
 # private-bin works, but causes weirdness

--- a/etc/profile-m-z/mumble.profile
+++ b/etc/profile-m-z/mumble.profile
@@ -35,7 +35,6 @@ noroot
 notv
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/mupdf.profile
+++ b/etc/profile-m-z/mupdf.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-dev

--- a/etc/profile-m-z/musescore.profile
+++ b/etc/profile-m-z/musescore.profile
@@ -35,7 +35,6 @@ novideo
 protocol unix,inet,inet6
 # QtWebengine needs chroot to set up its own sandbox
 seccomp !chroot
-shell none
 tracelog
 
 # private-bin musescore,mscore

--- a/etc/profile-m-z/musictube.profile
+++ b/etc/profile-m-z/musictube.profile
@@ -43,7 +43,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/mutt.profile
+++ b/etc/profile-m-z/mutt.profile
@@ -128,7 +128,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 # disable-mnt

--- a/etc/profile-m-z/mypaint.profile
+++ b/etc/profile-m-z/mypaint.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-m-z/nano.profile
+++ b/etc/profile-m-z/nano.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-m-z/natron.profile
+++ b/etc/profile-m-z/natron.profile
@@ -29,7 +29,6 @@ notv
 nou2f
 protocol unix
 seccomp
-shell none
 
 private-bin natron,Natron,NatronRenderer
 

--- a/etc/profile-m-z/ncdu.profile
+++ b/etc/profile-m-z/ncdu.profile
@@ -26,7 +26,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 x11 none
 
 private-dev

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -48,7 +48,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/neomutt.profile
+++ b/etc/profile-m-z/neomutt.profile
@@ -131,7 +131,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 # disable-mnt

--- a/etc/profile-m-z/netactview.profile
+++ b/etc/profile-m-z/netactview.profile
@@ -39,7 +39,6 @@ notv
 nou2f
 novideo
 seccomp
-shell none
 
 disable-mnt
 private-bin netactview,netactview_polkit

--- a/etc/profile-m-z/nethack-vultures.profile
+++ b/etc/profile-m-z/nethack-vultures.profile
@@ -32,7 +32,6 @@ notv
 novideo
 #protocol unix,netlink
 #seccomp
-shell none
 
 disable-mnt
 #private

--- a/etc/profile-m-z/nethack.profile
+++ b/etc/profile-m-z/nethack.profile
@@ -32,7 +32,6 @@ notv
 novideo
 #protocol unix,netlink
 #seccomp
-shell none
 
 disable-mnt
 #private

--- a/etc/profile-m-z/neverball.profile
+++ b/etc/profile-m-z/neverball.profile
@@ -37,7 +37,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/newsboat.profile
+++ b/etc/profile-m-z/newsboat.profile
@@ -47,7 +47,6 @@ nou2f
 novideo
 protocol inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-bin gzip,lynx,newsboat,sh,w3m

--- a/etc/profile-m-z/newsflash.profile
+++ b/etc/profile-m-z/newsflash.profile
@@ -44,7 +44,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/nextcloud.profile
+++ b/etc/profile-m-z/nextcloud.profile
@@ -56,7 +56,6 @@ novideo
 protocol unix,inet,inet6,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/nheko.profile
+++ b/etc/profile-m-z/nheko.profile
@@ -41,7 +41,6 @@ noroot
 notv
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/nicotine.profile
+++ b/etc/profile-m-z/nicotine.profile
@@ -44,7 +44,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/nitroshare.profile
+++ b/etc/profile-m-z/nitroshare.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 disable-mnt
 private-bin awk,grep,nitroshare,nitroshare-cli,nitroshare-nmh,nitroshare-send,nitroshare-ui

--- a/etc/profile-m-z/nodejs-common.profile
+++ b/etc/profile-m-z/nodejs-common.profile
@@ -89,7 +89,6 @@ novideo
 protocol unix,inet,inet6,netlink
 seccomp
 seccomp.block-secondary
-shell none
 
 disable-mnt
 private-dev

--- a/etc/profile-m-z/nomacs.profile
+++ b/etc/profile-m-z/nomacs.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 #private-bin nomacs

--- a/etc/profile-m-z/notify-send.profile
+++ b/etc/profile-m-z/notify-send.profile
@@ -40,7 +40,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-m-z/nslookup.profile
+++ b/etc/profile-m-z/nslookup.profile
@@ -41,7 +41,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/nvim.profile
+++ b/etc/profile-m-z/nvim.profile
@@ -37,7 +37,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-m-z/nylas.profile
+++ b/etc/profile-m-z/nylas.profile
@@ -33,6 +33,5 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 private-dev

--- a/etc/profile-m-z/nyx.profile
+++ b/etc/profile-m-z/nyx.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-bin nyx,python*

--- a/etc/profile-m-z/obs.profile
+++ b/etc/profile-m-z/obs.profile
@@ -33,7 +33,6 @@ notv
 nou2f
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 private-bin bash,obs,obs-ffmpeg-mux,python*,sh

--- a/etc/profile-m-z/ocenaudio.profile
+++ b/etc/profile-m-z/ocenaudio.profile
@@ -48,7 +48,6 @@ novideo
 # Add `protocol unix\nignore protocol` to your ocenaudio.local to disable networking.
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 private-bin ocenaudio,ocenvst

--- a/etc/profile-m-z/odt2txt.profile
+++ b/etc/profile-m-z/odt2txt.profile
@@ -31,7 +31,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-m-z/okular.profile
+++ b/etc/profile-m-z/okular.profile
@@ -57,7 +57,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin kbuildsycoca4,kdeinit4,lpr,okular,unar,unrar

--- a/etc/profile-m-z/onboard.profile
+++ b/etc/profile-m-z/onboard.profile
@@ -43,7 +43,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/onionshare-gui.profile
+++ b/etc/profile-m-z/onionshare-gui.profile
@@ -48,7 +48,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 #tracelog - may cause issues, see #1930
 
 disable-mnt

--- a/etc/profile-m-z/open-invaders.profile
+++ b/etc/profile-m-z/open-invaders.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix,netlink
 seccomp
-shell none
 
 private-bin open-invaders
 private-dev

--- a/etc/profile-m-z/openarena.profile
+++ b/etc/profile-m-z/openarena.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/opencity.profile
+++ b/etc/profile-m-z/opencity.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/openclonk.profile
+++ b/etc/profile-m-z/openclonk.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/openmw.profile
+++ b/etc/profile-m-z/openmw.profile
@@ -47,7 +47,6 @@ novideo
 protocol unix,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin bsatool,esmtool,niftest,openmw,openmw-cs,openmw-essimporter,openmw-iniimporter,openmw-launcher,openmw-wizard

--- a/etc/profile-m-z/openshot.profile
+++ b/etc/profile-m-z/openshot.profile
@@ -37,7 +37,6 @@ nou2f
 protocol unix,inet,inet6,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin blender,inkscape,openshot,openshot-qt,python3*

--- a/etc/profile-m-z/openstego.profile
+++ b/etc/profile-m-z/openstego.profile
@@ -45,7 +45,6 @@ nou2f
 novideo
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/openttd.profile
+++ b/etc/profile-m-z/openttd.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/orage.profile
+++ b/etc/profile-m-z/orage.profile
@@ -30,7 +30,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 private-cache

--- a/etc/profile-m-z/ostrichriders.profile
+++ b/etc/profile-m-z/ostrichriders.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/otter-browser.profile
+++ b/etc/profile-m-z/otter-browser.profile
@@ -47,7 +47,6 @@ notv
 ?BROWSER_DISABLE_U2F: nou2f
 protocol unix,inet,inet6,netlink
 seccomp !chroot
-shell none
 
 disable-mnt
 private-bin bash,otter-browser,sh,which

--- a/etc/profile-m-z/pandoc.profile
+++ b/etc/profile-m-z/pandoc.profile
@@ -43,7 +43,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-m-z/parole.profile
+++ b/etc/profile-m-z/parole.profile
@@ -23,7 +23,6 @@ noroot
 notv
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-bin dbus-launch,parole
 private-cache

--- a/etc/profile-m-z/patch.profile
+++ b/etc/profile-m-z/patch.profile
@@ -37,7 +37,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-m-z/pavucontrol.profile
+++ b/etc/profile-m-z/pavucontrol.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/pcsxr.profile
+++ b/etc/profile-m-z/pcsxr.profile
@@ -41,7 +41,6 @@ nou2f
 novideo
 protocol unix,netlink
 seccomp
-shell none
 tracelog
 
 private-bin pcsxr

--- a/etc/profile-m-z/pdfchain.profile
+++ b/etc/profile-m-z/pdfchain.profile
@@ -30,7 +30,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-bin pdfchain,pdftk,sh
 private-dev

--- a/etc/profile-m-z/pdfmod.profile
+++ b/etc/profile-m-z/pdfmod.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-dev
 private-tmp

--- a/etc/profile-m-z/pdfsam.profile
+++ b/etc/profile-m-z/pdfsam.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-bin archlinux-java,awk,bash,dirname,expr,find,grep,java,java-config,ls,pdfsam,readlink,sh,sort,uname,which
 private-cache

--- a/etc/profile-m-z/pdftotext.profile
+++ b/etc/profile-m-z/pdftotext.profile
@@ -42,7 +42,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-m-z/peek.profile
+++ b/etc/profile-m-z/peek.profile
@@ -42,7 +42,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/penguin-command.profile
+++ b/etc/profile-m-z/penguin-command.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix,netlink
 seccomp
-shell none
 
 private-bin penguin-command
 private-dev

--- a/etc/profile-m-z/photoflare.profile
+++ b/etc/profile-m-z/photoflare.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/picard.profile
+++ b/etc/profile-m-z/picard.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-dev
 private-tmp

--- a/etc/profile-m-z/pinball.profile
+++ b/etc/profile-m-z/pinball.profile
@@ -41,7 +41,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/ping.profile
+++ b/etc/profile-m-z/ping.profile
@@ -49,7 +49,6 @@ novideo
 # protocol command is built using seccomp; nonewprivs will kill it
 #protocol unix,inet,inet6,netlink,packet
 #seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/pingus.profile
+++ b/etc/profile-m-z/pingus.profile
@@ -43,7 +43,6 @@ novideo
 protocol unix,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/pinta.profile
+++ b/etc/profile-m-z/pinta.profile
@@ -31,7 +31,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-dev
 private-cache

--- a/etc/profile-m-z/pioneer.profile
+++ b/etc/profile-m-z/pioneer.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/pithos.profile
+++ b/etc/profile-m-z/pithos.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-bin env,pithos,python*

--- a/etc/profile-m-z/pitivi.profile
+++ b/etc/profile-m-z/pitivi.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-dev
 private-tmp

--- a/etc/profile-m-z/pix.profile
+++ b/etc/profile-m-z/pix.profile
@@ -28,7 +28,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin pix

--- a/etc/profile-m-z/pkglog.profile
+++ b/etc/profile-m-z/pkglog.profile
@@ -36,7 +36,6 @@ notv
 nou2f
 novideo
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/pluma.profile
+++ b/etc/profile-m-z/pluma.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin pluma

--- a/etc/profile-m-z/plv.profile
+++ b/etc/profile-m-z/plv.profile
@@ -39,7 +39,6 @@ notv
 nou2f
 novideo
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/pngquant.profile
+++ b/etc/profile-m-z/pngquant.profile
@@ -40,7 +40,6 @@ nou2f
 novideo
 # block the socket syscall to simulate an be empty protocol line, see #639
 seccomp socket
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-m-z/polari.profile
+++ b/etc/profile-m-z/polari.profile
@@ -43,7 +43,6 @@ notv
 nou2f
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/ppsspp.profile
+++ b/etc/profile-m-z/ppsspp.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix,netlink
 seccomp
-shell none
 
 private-bin ppsspp,PPSSPP,PPSSPPQt,PPSSPPSDL
 # Add the next line to your ppsspp.local if you do not need controller support.

--- a/etc/profile-m-z/pragha.profile
+++ b/etc/profile-m-z/pragha.profile
@@ -30,7 +30,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-dev
 private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,machine-id,pki,pulse,resolv.conf,ssl,xdg

--- a/etc/profile-m-z/profanity.profile
+++ b/etc/profile-m-z/profanity.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-bin profanity
 private-cache

--- a/etc/profile-m-z/psi-plus.profile
+++ b/etc/profile-m-z/psi-plus.profile
@@ -38,7 +38,6 @@ novideo
 protocol unix,inet,inet6
 # QtWebengine needs chroot to set up its own sandbox
 seccomp !chroot
-shell none
 
 disable-mnt
 private-dev

--- a/etc/profile-m-z/psi.profile
+++ b/etc/profile-m-z/psi.profile
@@ -62,7 +62,6 @@ novideo
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp !chroot
-shell none
 #tracelog - breaks on Arch
 
 disable-mnt

--- a/etc/profile-m-z/pybitmessage.profile
+++ b/etc/profile-m-z/pybitmessage.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 disable-mnt
 private-bin bash,env,ldconfig,pybitmessage,python*,sh,stat

--- a/etc/profile-m-z/pycharm-community.profile
+++ b/etc/profile-m-z/pycharm-community.profile
@@ -26,7 +26,6 @@ nosound
 notv
 nou2f
 novideo
-shell none
 tracelog
 
 # private-etc alternatives,fonts,passwd - minimal required to run but will probably break

--- a/etc/profile-m-z/qbittorrent.profile
+++ b/etc/profile-m-z/qbittorrent.profile
@@ -52,7 +52,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 private-bin python*,qbittorrent
 private-dev

--- a/etc/profile-m-z/qcomicbook.profile
+++ b/etc/profile-m-z/qcomicbook.profile
@@ -47,7 +47,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin 7z,7zr,qcomicbook,rar,sh,tar,unace,unrar,unzip

--- a/etc/profile-m-z/qemu-launcher.profile
+++ b/etc/profile-m-z/qemu-launcher.profile
@@ -19,7 +19,6 @@ noroot
 notv
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-m-z/qemu-system-x86_64.profile
+++ b/etc/profile-m-z/qemu-system-x86_64.profile
@@ -18,7 +18,6 @@ noroot
 notv
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-m-z/qgis.profile
+++ b/etc/profile-m-z/qgis.profile
@@ -46,7 +46,6 @@ novideo
 # blacklisting of mbind system calls breaks old version
 seccomp !mbind
 protocol unix,inet,inet6,netlink
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/qlipper.profile
+++ b/etc/profile-m-z/qlipper.profile
@@ -29,7 +29,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 private-cache

--- a/etc/profile-m-z/qmmp.profile
+++ b/etc/profile-m-z/qmmp.profile
@@ -28,7 +28,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 private-bin bzip2,gzip,qmmp,tar,unzip

--- a/etc/profile-m-z/qnapi.profile
+++ b/etc/profile-m-z/qnapi.profile
@@ -41,7 +41,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 private-bin 7z,qnapi

--- a/etc/profile-m-z/qpdfview.profile
+++ b/etc/profile-m-z/qpdfview.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin qpdfview

--- a/etc/profile-m-z/qrencode.profile
+++ b/etc/profile-m-z/qrencode.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-m-z/qtox.profile
+++ b/etc/profile-m-z/qtox.profile
@@ -36,7 +36,6 @@ notv
 nou2f
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/quaternion.profile
+++ b/etc/profile-m-z/quaternion.profile
@@ -40,7 +40,6 @@ notv
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/quiterss.profile
+++ b/etc/profile-m-z/quiterss.profile
@@ -45,7 +45,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/quodlibet.profile
+++ b/etc/profile-m-z/quodlibet.profile
@@ -54,7 +54,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin exfalso,operon,python*,quodlibet,sh

--- a/etc/profile-m-z/raincat.profile
+++ b/etc/profile-m-z/raincat.profile
@@ -32,7 +32,6 @@ novideo
 protocol unix
 net none
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/redeclipse.profile
+++ b/etc/profile-m-z/redeclipse.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/rednotebook.profile
+++ b/etc/profile-m-z/rednotebook.profile
@@ -52,7 +52,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/redshift.profile
+++ b/etc/profile-m-z/redshift.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/regextester.profile
+++ b/etc/profile-m-z/regextester.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/remmina.profile
+++ b/etc/profile-m-z/remmina.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-cache
 private-dev

--- a/etc/profile-m-z/retroarch.profile
+++ b/etc/profile-m-z/retroarch.profile
@@ -41,7 +41,6 @@ novideo
 protocol unix,inet,inet6,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/rhythmbox.profile
+++ b/etc/profile-m-z/rhythmbox.profile
@@ -46,7 +46,6 @@ novideo
 protocol unix,inet,inet6,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin rhythmbox,rhythmbox-client

--- a/etc/profile-m-z/ricochet.profile
+++ b/etc/profile-m-z/ricochet.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-bin ricochet,tor

--- a/etc/profile-m-z/ripperx.profile
+++ b/etc/profile-m-z/ripperx.profile
@@ -32,7 +32,6 @@ notv
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-m-z/ristretto.profile
+++ b/etc/profile-m-z/ristretto.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-cache
 private-dev

--- a/etc/profile-m-z/rpcs3.profile
+++ b/etc/profile-m-z/rpcs3.profile
@@ -50,7 +50,6 @@ novideo
 protocol unix,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/rsync-download_only.profile
+++ b/etc/profile-m-z/rsync-download_only.profile
@@ -42,7 +42,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/rtorrent.profile
+++ b/etc/profile-m-z/rtorrent.profile
@@ -26,7 +26,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-bin rtorrent
 private-cache

--- a/etc/profile-m-z/rtv.profile
+++ b/etc/profile-m-z/rtv.profile
@@ -52,7 +52,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/sayonara.profile
+++ b/etc/profile-m-z/sayonara.profile
@@ -27,7 +27,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 private-bin sayonara

--- a/etc/profile-m-z/scallion.profile
+++ b/etc/profile-m-z/scallion.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 private

--- a/etc/profile-m-z/scorched3d.profile
+++ b/etc/profile-m-z/scorched3d.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/scorchwentbonkers.profile
+++ b/etc/profile-m-z/scorchwentbonkers.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/scribus.profile
+++ b/etc/profile-m-z/scribus.profile
@@ -53,7 +53,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 # private-bin gimp*,gs,scribus

--- a/etc/profile-m-z/sdat2img.profile
+++ b/etc/profile-m-z/sdat2img.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-bin env,python*,sdat2img
 private-cache

--- a/etc/profile-m-z/seafile-applet.profile
+++ b/etc/profile-m-z/seafile-applet.profile
@@ -47,7 +47,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/seahorse-adventures.profile
+++ b/etc/profile-m-z/seahorse-adventures.profile
@@ -40,7 +40,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/seahorse.profile
+++ b/etc/profile-m-z/seahorse.profile
@@ -54,7 +54,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/servo.profile
+++ b/etc/profile-m-z/servo.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/shellcheck.profile
+++ b/etc/profile-m-z/shellcheck.profile
@@ -40,7 +40,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-m-z/shortwave.profile
+++ b/etc/profile-m-z/shortwave.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/shotcut.profile
+++ b/etc/profile-m-z/shotcut.profile
@@ -27,7 +27,6 @@ notv
 nou2f
 protocol unix
 seccomp
-shell none
 tracelog
 
 #private-bin melt,nice,qmelt,shotcut

--- a/etc/profile-m-z/shotwell.profile
+++ b/etc/profile-m-z/shotwell.profile
@@ -43,7 +43,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin shotwell

--- a/etc/profile-m-z/signal-cli.profile
+++ b/etc/profile-m-z/signal-cli.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/silentarmy.profile
+++ b/etc/profile-m-z/silentarmy.profile
@@ -29,7 +29,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private

--- a/etc/profile-m-z/simple-scan.profile
+++ b/etc/profile-m-z/simple-scan.profile
@@ -32,7 +32,6 @@ notv
 protocol unix,inet,inet6,netlink
 # blacklisting of ioperm system calls breaks simple-scan
 seccomp !ioperm
-shell none
 tracelog
 
 # private-bin simple-scan

--- a/etc/profile-m-z/simplescreenrecorder.profile
+++ b/etc/profile-m-z/simplescreenrecorder.profile
@@ -31,7 +31,6 @@ notv
 nou2f
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-m-z/simutrans.profile
+++ b/etc/profile-m-z/simutrans.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 # private-bin simutrans
 private-dev

--- a/etc/profile-m-z/skanlite.profile
+++ b/etc/profile-m-z/skanlite.profile
@@ -26,7 +26,6 @@ notv
 protocol unix,inet,inet6,netlink
 # blacklisting of ioperm system calls breaks skanlite
 seccomp !ioperm
-shell none
 
 # private-bin kbuildsycoca4,kdeinit4,skanlite
 # private-dev

--- a/etc/profile-m-z/slashem.profile
+++ b/etc/profile-m-z/slashem.profile
@@ -32,7 +32,6 @@ notv
 novideo
 #protocol unix,netlink
 #seccomp
-shell none
 
 disable-mnt
 #private

--- a/etc/profile-m-z/smplayer.profile
+++ b/etc/profile-m-z/smplayer.profile
@@ -44,7 +44,6 @@ noroot
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 private-bin env,mplayer,mpv,python*,smplayer,smtube,waf,youtube-dl
 private-dev

--- a/etc/profile-m-z/smtube.profile
+++ b/etc/profile-m-z/smtube.profile
@@ -40,7 +40,6 @@ nonewprivs
 noroot
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 #no private-bin because users can add their own players to smtube and that would prevent that
 private-dev

--- a/etc/profile-m-z/smuxi-frontend-gnome.profile
+++ b/etc/profile-m-z/smuxi-frontend-gnome.profile
@@ -41,7 +41,6 @@ notv
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/softmaker-common.profile
+++ b/etc/profile-m-z/softmaker-common.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 private-bin freeoffice-planmaker,freeoffice-presentations,freeoffice-textmaker,planmaker18,planmaker18free,presentations18,presentations18free,sh,textmaker18,textmaker18free

--- a/etc/profile-m-z/sol.profile
+++ b/etc/profile-m-z/sol.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 private-bin sol

--- a/etc/profile-m-z/songrec.profile
+++ b/etc/profile-m-z/songrec.profile
@@ -42,7 +42,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 
 disable-mnt
 private-bin ffmpeg,songrec

--- a/etc/profile-m-z/sound-juicer.profile
+++ b/etc/profile-m-z/sound-juicer.profile
@@ -32,7 +32,6 @@ notv
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-m-z/soundconverter.profile
+++ b/etc/profile-m-z/soundconverter.profile
@@ -42,7 +42,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-cache
 private-dev

--- a/etc/profile-m-z/spectacle.profile
+++ b/etc/profile-m-z/spectacle.profile
@@ -49,7 +49,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/spectral.profile
+++ b/etc/profile-m-z/spectral.profile
@@ -39,7 +39,6 @@ notv
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/spectre-meltdown-checker.profile
+++ b/etc/profile-m-z/spectre-meltdown-checker.profile
@@ -37,7 +37,6 @@ notv
 novideo
 protocol unix
 seccomp.drop @clock,@cpu-emulation,@module,@obsolete,@reboot,@resources,@swap
-shell none
 x11 none
 
 disable-mnt

--- a/etc/profile-m-z/spotify.profile
+++ b/etc/profile-m-z/spotify.profile
@@ -37,7 +37,6 @@ notv
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/sqlitebrowser.profile
+++ b/etc/profile-m-z/sqlitebrowser.profile
@@ -37,7 +37,6 @@ novideo
 protocol unix,inet,inet6,netlink
 seccomp
 seccomp.block-secondary
-shell none
 
 private-bin sqlitebrowser
 private-cache

--- a/etc/profile-m-z/ssh-agent.profile
+++ b/etc/profile-m-z/ssh-agent.profile
@@ -27,7 +27,6 @@ notv
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 writable-run-user

--- a/etc/profile-m-z/ssh.profile
+++ b/etc/profile-m-z/ssh.profile
@@ -39,7 +39,6 @@ notv
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -151,7 +151,6 @@ protocol unix,inet,inet6,netlink
 # Add 'ignore seccomp' to your steam.local if you experience this.
 # mount, name_to_handle_at, pivot_root and umount2 are used by Proton >= 5.13
 seccomp !chroot,!mount,!name_to_handle_at,!pivot_root,!ptrace,!umount2
-shell none
 # tracelog breaks integrated browser
 #tracelog
 

--- a/etc/profile-m-z/stellarium.profile
+++ b/etc/profile-m-z/stellarium.profile
@@ -36,7 +36,6 @@ notv
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/strawberry.profile
+++ b/etc/profile-m-z/strawberry.profile
@@ -36,7 +36,6 @@ novideo
 protocol unix,inet,inet6,netlink
 # blacklisting of ioprio_set system calls breaks strawberry
 seccomp !ioprio_set
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/strings.profile
+++ b/etc/profile-m-z/strings.profile
@@ -38,7 +38,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-m-z/subdownloader.profile
+++ b/etc/profile-m-z/subdownloader.profile
@@ -39,7 +39,6 @@ notv
 nou2f
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-m-z/supertux2.profile
+++ b/etc/profile-m-z/supertux2.profile
@@ -38,7 +38,6 @@ novideo
 protocol unix,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/supertuxkart.profile
+++ b/etc/profile-m-z/supertuxkart.profile
@@ -46,7 +46,6 @@ novideo
 protocol unix,inet,inet6,netlink,bluetooth
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/surf.profile
+++ b/etc/profile-m-z/surf.profile
@@ -28,7 +28,6 @@ notv
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/sushi.profile
+++ b/etc/profile-m-z/sushi.profile
@@ -31,7 +31,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin gjs,sushi

--- a/etc/profile-m-z/synfigstudio.profile
+++ b/etc/profile-m-z/synfigstudio.profile
@@ -28,7 +28,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 #private-bin ffmpeg,synfig,synfigstudio
 private-cache

--- a/etc/profile-m-z/sysprof.profile
+++ b/etc/profile-m-z/sysprof.profile
@@ -56,7 +56,6 @@ nou2f
 novideo
 protocol unix,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/teamspeak3.profile
+++ b/etc/profile-m-z/teamspeak3.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp !chroot
-shell none
 
 disable-mnt
 private-dev

--- a/etc/profile-m-z/teeworlds.profile
+++ b/etc/profile-m-z/teeworlds.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/telegram.profile
+++ b/etc/profile-m-z/telegram.profile
@@ -41,7 +41,6 @@ notv
 protocol unix,inet,inet6,netlink
 seccomp
 seccomp.block-secondary
-shell none
 
 disable-mnt
 private-bin bash,sh,telegram,Telegram,telegram-desktop,xdg-open

--- a/etc/profile-m-z/telnet.profile
+++ b/etc/profile-m-z/telnet.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol inet,inet6
 seccomp
-shell none
 tracelog
 
 #disable-mnt

--- a/etc/profile-m-z/terasology.profile
+++ b/etc/profile-m-z/terasology.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-dev

--- a/etc/profile-m-z/tilp.profile
+++ b/etc/profile-m-z/tilp.profile
@@ -24,7 +24,6 @@ notv
 novideo
 protocol unix,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/tin.profile
+++ b/etc/profile-m-z/tin.profile
@@ -51,7 +51,6 @@ novideo
 protocol inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/tmux.profile
+++ b/etc/profile-m-z/tmux.profile
@@ -34,7 +34,6 @@ novideo
 protocol unix,inet,inet6,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 # private-cache

--- a/etc/profile-m-z/tor.profile
+++ b/etc/profile-m-z/tor.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 disable-mnt
 private

--- a/etc/profile-m-z/torbrowser-launcher.profile
+++ b/etc/profile-m-z/torbrowser-launcher.profile
@@ -52,7 +52,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp !chroot
-shell none
 #tracelog - may cause issues, see #1930
 
 disable-mnt

--- a/etc/profile-m-z/torcs.profile
+++ b/etc/profile-m-z/torcs.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/totem.profile
+++ b/etc/profile-m-z/totem.profile
@@ -45,7 +45,6 @@ noroot
 nou2f
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 private-bin totem

--- a/etc/profile-m-z/tracker.profile
+++ b/etc/profile-m-z/tracker.profile
@@ -31,7 +31,6 @@ notv
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 # private-bin tracker

--- a/etc/profile-m-z/transgui.profile
+++ b/etc/profile-m-z/transgui.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 private-bin geoiplookup,geoiplookup6,transgui

--- a/etc/profile-m-z/transmission-common.profile
+++ b/etc/profile-m-z/transmission-common.profile
@@ -40,7 +40,6 @@ novideo
 protocol unix,inet,inet6,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-m-z/tremulous.profile
+++ b/etc/profile-m-z/tremulous.profile
@@ -40,7 +40,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/trojita.profile
+++ b/etc/profile-m-z/trojita.profile
@@ -46,7 +46,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 # disable-mnt

--- a/etc/profile-m-z/truecraft.profile
+++ b/etc/profile-m-z/truecraft.profile
@@ -31,7 +31,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-dev

--- a/etc/profile-m-z/tvbrowser.profile
+++ b/etc/profile-m-z/tvbrowser.profile
@@ -41,7 +41,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/udiskie.profile
+++ b/etc/profile-m-z/udiskie.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix
 seccomp !request_key
-shell none
 tracelog
 
 private-bin awk,cut,dbus-send,egrep,file,grep,head,python*,readlink,sed,sh,udiskie,uname,which,xdg-mime,xdg-open,xprop

--- a/etc/profile-m-z/uefitool.profile
+++ b/etc/profile-m-z/uefitool.profile
@@ -29,7 +29,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-cache
 private-dev

--- a/etc/profile-m-z/uget-gtk.profile
+++ b/etc/profile-m-z/uget-gtk.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-bin uget-gtk
 private-dev

--- a/etc/profile-m-z/unf.profile
+++ b/etc/profile-m-z/unf.profile
@@ -40,7 +40,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-m-z/unknown-horizons.profile
+++ b/etc/profile-m-z/unknown-horizons.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 disable-mnt
 # private-bin unknown-horizons

--- a/etc/profile-m-z/utox.profile
+++ b/etc/profile-m-z/utox.profile
@@ -36,7 +36,6 @@ notv
 nou2f
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/uudeview.profile
+++ b/etc/profile-m-z/uudeview.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 x11 none
 

--- a/etc/profile-m-z/viewnior.profile
+++ b/etc/profile-m-z/viewnior.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin viewnior

--- a/etc/profile-m-z/viking.profile
+++ b/etc/profile-m-z/viking.profile
@@ -30,7 +30,6 @@ notv
 nou2f
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-dev
 private-tmp

--- a/etc/profile-m-z/virtualbox.profile
+++ b/etc/profile-m-z/virtualbox.profile
@@ -39,7 +39,6 @@ netfilter
 nodvd
 #nogroups
 notv
-shell none
 tracelog
 
 #disable-mnt

--- a/etc/profile-m-z/vlc.profile
+++ b/etc/profile-m-z/vlc.profile
@@ -41,7 +41,6 @@ noroot
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 
 private-bin cvlc,nvlc,qvlc,rvlc,svlc,vlc
 private-dev

--- a/etc/profile-m-z/vmware-view.profile
+++ b/etc/profile-m-z/vmware-view.profile
@@ -43,7 +43,6 @@ novideo
 protocol unix,inet,inet6
 seccomp !iopl
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/vmware.profile
+++ b/etc/profile-m-z/vmware.profile
@@ -33,7 +33,6 @@ caps.keep chown,net_raw,sys_nice
 netfilter
 nogroups
 notv
-shell none
 tracelog
 
 #disable-mnt

--- a/etc/profile-m-z/vym.profile
+++ b/etc/profile-m-z/vym.profile
@@ -28,7 +28,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 private-dev

--- a/etc/profile-m-z/w3m.profile
+++ b/etc/profile-m-z/w3m.profile
@@ -55,7 +55,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/warmux.profile
+++ b/etc/profile-m-z/warmux.profile
@@ -42,7 +42,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/warsow.profile
+++ b/etc/profile-m-z/warsow.profile
@@ -44,7 +44,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/warzone2100.profile
+++ b/etc/profile-m-z/warzone2100.profile
@@ -41,7 +41,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/webstorm.profile
+++ b/etc/profile-m-z/webstorm.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-cache
 private-dev

--- a/etc/profile-m-z/webui-aria2.profile
+++ b/etc/profile-m-z/webui-aria2.profile
@@ -29,7 +29,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-cache
 private-dev

--- a/etc/profile-m-z/wget.profile
+++ b/etc/profile-m-z/wget.profile
@@ -48,7 +48,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin wget

--- a/etc/profile-m-z/whois.profile
+++ b/etc/profile-m-z/whois.profile
@@ -39,7 +39,6 @@ novideo
 protocol unix,inet,inet6,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/widelands.profile
+++ b/etc/profile-m-z/widelands.profile
@@ -35,7 +35,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/wireshark.profile
+++ b/etc/profile-m-z/wireshark.profile
@@ -40,7 +40,6 @@ nou2f
 novideo
 # protocol unix,inet,inet6,netlink,packet,bluetooth - commented out in case they bring in new protocols
 #seccomp
-shell none
 tracelog
 
 # private-bin wireshark

--- a/etc/profile-m-z/wordwarvi.profile
+++ b/etc/profile-m-z/wordwarvi.profile
@@ -37,7 +37,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/wps.profile
+++ b/etc/profile-m-z/wps.profile
@@ -38,7 +38,6 @@ novideo
 protocol unix,inet,inet6
 # seccomp causes some minor issues. Add the next line to your wps.local if you can live with those.
 #seccomp
-shell none
 tracelog
 
 private-cache

--- a/etc/profile-m-z/x2goclient.profile
+++ b/etc/profile-m-z/x2goclient.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 #private-bin nxproxy,x2goclient

--- a/etc/profile-m-z/xbill.profile
+++ b/etc/profile-m-z/xbill.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/xcalc.profile
+++ b/etc/profile-m-z/xcalc.profile
@@ -30,7 +30,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 private

--- a/etc/profile-m-z/xed.profile
+++ b/etc/profile-m-z/xed.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin xed

--- a/etc/profile-m-z/xfburn.profile
+++ b/etc/profile-m-z/xfburn.profile
@@ -23,7 +23,6 @@ notv
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 # private-bin xfburn

--- a/etc/profile-m-z/xfce4-dict.profile
+++ b/etc/profile-m-z/xfce4-dict.profile
@@ -31,7 +31,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-cache

--- a/etc/profile-m-z/xfce4-mixer.profile
+++ b/etc/profile-m-z/xfce4-mixer.profile
@@ -40,7 +40,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 private-bin xfce4-mixer,xfconf-query

--- a/etc/profile-m-z/xfce4-notes.profile
+++ b/etc/profile-m-z/xfce4-notes.profile
@@ -33,7 +33,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 private-cache

--- a/etc/profile-m-z/xfce4-screenshooter.profile
+++ b/etc/profile-m-z/xfce4-screenshooter.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/xiphos.profile
+++ b/etc/profile-m-z/xiphos.profile
@@ -40,7 +40,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/xmms.profile
+++ b/etc/profile-m-z/xmms.profile
@@ -26,7 +26,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 private-bin xmms
 private-dev

--- a/etc/profile-m-z/xmr-stak.profile
+++ b/etc/profile-m-z/xmr-stak.profile
@@ -32,7 +32,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private ${HOME}/.xmr-stak

--- a/etc/profile-m-z/xonotic.profile
+++ b/etc/profile-m-z/xonotic.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/xournal.profile
+++ b/etc/profile-m-z/xournal.profile
@@ -37,7 +37,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin xournal

--- a/etc/profile-m-z/xpdf.profile
+++ b/etc/profile-m-z/xpdf.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 private-dev
 private-tmp

--- a/etc/profile-m-z/xplayer.profile
+++ b/etc/profile-m-z/xplayer.profile
@@ -37,7 +37,6 @@ noroot
 nou2f
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 private-bin xplayer,xplayer-audio-preview,xplayer-video-thumbnailer

--- a/etc/profile-m-z/xpra.profile
+++ b/etc/profile-m-z/xpra.profile
@@ -42,7 +42,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 
 disable-mnt
 # private home directory doesn't work on some distros, so we go for a regular home

--- a/etc/profile-m-z/xreader.profile
+++ b/etc/profile-m-z/xreader.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin xreader,xreader-previewer,xreader-thumbnailer

--- a/etc/profile-m-z/xviewer.profile
+++ b/etc/profile-m-z/xviewer.profile
@@ -34,7 +34,6 @@ nou2f
 novideo
 protocol unix
 seccomp
-shell none
 tracelog
 
 private-bin xviewer

--- a/etc/profile-m-z/yelp.profile
+++ b/etc/profile-m-z/yelp.profile
@@ -49,7 +49,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/youtube-dl-gui.profile
+++ b/etc/profile-m-z/youtube-dl-gui.profile
@@ -42,7 +42,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/youtube-dl.profile
+++ b/etc/profile-m-z/youtube-dl.profile
@@ -52,7 +52,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin env,ffmpeg,python*,youtube-dl

--- a/etc/profile-m-z/youtube-viewers-common.profile
+++ b/etc/profile-m-z/youtube-viewers-common.profile
@@ -46,7 +46,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/zaproxy.profile
+++ b/etc/profile-m-z/zaproxy.profile
@@ -39,7 +39,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-dev

--- a/etc/profile-m-z/zart.profile
+++ b/etc/profile-m-z/zart.profile
@@ -29,7 +29,6 @@ notv
 nou2f
 protocol unix
 seccomp
-shell none
 
 private-bin ffmpeg,ffplay,ffprobe,melt,zart
 private-dev

--- a/etc/profile-m-z/zathura.profile
+++ b/etc/profile-m-z/zathura.profile
@@ -43,7 +43,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 private-bin zathura

--- a/etc/profile-m-z/zeal.profile
+++ b/etc/profile-m-z/zeal.profile
@@ -54,7 +54,6 @@ novideo
 protocol unix,inet,inet6,netlink
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/zim.profile
+++ b/etc/profile-m-z/zim.profile
@@ -57,7 +57,6 @@ novideo
 protocol unix
 seccomp
 seccomp.block-secondary
-shell none
 tracelog
 
 disable-mnt

--- a/etc/profile-m-z/zulip.profile
+++ b/etc/profile-m-z/zulip.profile
@@ -38,7 +38,6 @@ nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-shell none
 
 disable-mnt
 private-bin locale,zulip


### PR DESCRIPTION
Command: `sed -i "/^shell none/d" etc/*/*`

TODO:

```
etc/profile-a-l/beaker.profile:ignore shell none
etc/profile-a-l/default.profile:# shell none
etc/profile-a-l/fdns.profile:#shell none
etc/profile-a-l/gnome-nettool.profile:#shell none
etc/profile-a-l/jitsi-meet-desktop.profile:ignore shell none
etc/profile-m-z/pidgin.profile:# shell none
etc/profile-m-z/rocketchat.profile:ignore shell none
etc/profile-m-z/server.profile:# shell none
etc/templates/profile.template:#   OPTIONS (caps*, net*, no*, protocol, seccomp*, shell none, tracelog)
etc/templates/profile.template:#shell none
```

- manpage
- RELNOTES
- fbuilder