### PR TITLE
Transmission fixes: drop private-lib

### DIFF
--- a/etc/profile-m-z/transmission-common.profile
+++ b/etc/profile-m-z/transmission-common.profile
@@ -44,7 +44,6 @@ tracelog
 
 private-cache
 private-dev
-private-lib
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/transmission-qt.profile
+++ b/etc/profile-m-z/transmission-qt.profile
@@ -9,9 +9,6 @@ include globals.local
 
 private-bin transmission-qt
 
-# private-lib - breaks on Arch
-ignore private-lib
-
 # If you need native notifications, add the next lines to your transmission-qt.local.
 #ignore dbus-user none
 #dbus-user filter

--- a/etc/profile-m-z/transmission-remote-gtk.profile
+++ b/etc/profile-m-z/transmission-remote-gtk.profile
@@ -13,8 +13,6 @@ mkdir ${HOME}/.config/transmission-remote-gtk
 whitelist ${HOME}/.config/transmission-remote-gtk
 
 private-etc alternatives,fonts,hostname,hosts,ld.so.cache,ld.so.preload,resolv.conf
-# Problems with private-lib (see issue #2889)
-ignore private-lib
 
 ignore memory-deny-write-execute
 


### PR DESCRIPTION
Too many issues with private-lib in Transmission. See #5211 for discussion and rationale for removing private-lib from relevant profiles as suggested by @reinerh.