### PR TITLE
test/fs: enable private-lib in firejail.config

### DIFF
--- a/test/fs/fs.sh
+++ b/test/fs/fs.sh
@@ -46,8 +46,12 @@ echo "TESTING: read/write /var/tmp (test/fs/fs_var_tmp.exp)"
 rm -f /var/tmp/_firejail_test_file
 
 if [ "$(uname -m)" = "x86_64" ]; then
+    fjconfig=/etc/firejail/firejail.config
+    printf 'private-lib yes\n' | sudo tee -a "$fjconfig" >/dev/null
     echo "TESTING: private-lib (test/fs/private-lib.exp)"
     ./private-lib.exp
+    printf '%s\n' "$(sed '/^private-lib yes$/d' "$fjconfig")" |
+      sudo tee "$fjconfig" >/dev/null
 else
     echo "TESTING SKIP: private-lib test implemented only for x86_64."
 fi


### PR DESCRIPTION
Before running test/fs/private-lib.exp.

Inspired by the configuration changes that are done on
test/root/checkcfg.exp.

Reason: Since commit 9741d0b60 ("fix disabled private-lib in
/etc/firejail/firejail.config", 2022-06-23), the "build_and_test" job
fails with the following error[1]:

    TESTING: private-lib (test/fs/private-lib.exp)
    spawn /bin/bash
    firejail --private-lib --private-bin=sh,bash,dash,ps,grep,ls,find,echo,stty
    runner@fv-az489-993:~/work/firejail/firejail/test/fs$
    <private-bin=sh,bash,dash,ps,grep,ls,find,echo,stty
    Error: private-lib feature is disabled in Firejail configuration file
    runner@fv-az489-993:~/work/firejail/firejail/test/fs$ TESTING ERROR 1

This fixes CI.

Fixes #5214.

Relates to #5190.

[1] https://github.com/netblue30/firejail/runs/7030862406
