### PR TITLE
aria2c.profile: allow access to ~/.cache/winetricks

### DIFF
--- a/etc/profile-a-l/aria2c.profile
+++ b/etc/profile-a-l/aria2c.profile
@@ -7,6 +7,7 @@ include aria2c.local
 include globals.local
 
 noblacklist ${HOME}/.aria2
+noblacklist ${HOME}/.cache/winetricks
 noblacklist ${HOME}/.config/aria2
 noblacklist ${HOME}/.netrc
 


### PR DESCRIPTION
Otherwise winetricks fails to download packages.