### PR TITLE
RELNOTES: add build items (plus commands)

### DIFF
--- a/RELNOTES
+++ b/RELNOTES
@@ -1,5 +1,8 @@
 firejail (0.9.71) baseline; urgency=low
   * work in progress
+  * build: deduplicate configure-time vars into new config files (#5140)
+  * build: fix file mode of shell scripts (644 -> 755) (#5206)
+  * build: reduce autoconf input files from 32 to 2 (#5219)
  -- netblue30 <netblue30@yahoo.com>  Sat, 11 Jun 2022 09:00:00 -0500
 
 firejail (0.9.70) baseline; urgency=low


### PR DESCRIPTION
The following leverages the fact that when using a normal merge (as
opposed to "rebase and merge" or "squash and merge") on GitHub, the pull
request number is put in the commit message title and the title of the
PR is added to the commit message body.

Commands used to find and print the items for the RELNOTES:

    $ git log --grep='^build:' --merges --reverse --pretty='%s %b' 0.9.70.. |
      sed -E -n 's/Merge pull request (#[0-9]+) from [^ ]+ (.*)/  * \2 (\1)/p'
      * build: deduplicate configure-time vars into new config files (#5140)
      * build: fix file mode of shell scripts (644 -> 755) (#5206)
      * build: reduce autoconf input files from 32 to 2 (#5219)

Commands used to generate the message below:

    $ git log --grep='^build:' --merges --reverse --pretty='%s %b' 0.9.70.. |
      sed -E -n 's/Merge pull request (#[0-9]+).*/\1/p' | sort | tr '\n' ' ' |
      sed -E 's/^(.*) /Relates to \1./'
    Relates to #5140 #5206 #5219.

Relates to #5140 #5206 #5219.
