### PR TITLE
build: add dist build directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .directory
 *.man
 .vscode
+/firejail-*/
 autom4te.cache/
 config.log
 config.mk


### PR DESCRIPTION
Ignore it only on the repository root path, as a directory that matches
`firejail-*` could eventually be added.

Note that the dist archive is already ignored since commit da6b131c3
("chore(.gitignore) ignore built packages", 2018-01-15) / PR #1733.

Example paths:

* build dir: firejail-0.9.71/
* archive:   firejail-0.9.71.tar.xz

See `$(NAME)-$(VERSION)` and `$(NAME)-$(VERSION).tar.xz` in the "dist"
target on the root Makefile.
