### PR TITLE
ci: ignore git-related paths and the project license

### DIFF
--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [ master ]
     paths-ignore:
+      - .git-blame-ignore-revs
+      - .gitignore
       - CONTRIBUTING.md
+      - COPYING
       - README
       - README.md
       - RELNOTES
@@ -16,7 +19,10 @@ on:
   pull_request:
     branches: [ master ]
     paths-ignore:
+      - .git-blame-ignore-revs
+      - .gitignore
       - CONTRIBUTING.md
+      - COPYING
       - README
       - README.md
       - RELNOTES

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [ master ]
     paths-ignore:
+      - .git-blame-ignore-revs
+      - .gitignore
       - CONTRIBUTING.md
+      - COPYING
       - README
       - README.md
       - RELNOTES
@@ -12,7 +15,10 @@ on:
   pull_request:
     branches: [ master ]
     paths-ignore:
+      - .git-blame-ignore-revs
+      - .gitignore
       - CONTRIBUTING.md
+      - COPYING
       - README
       - README.md
       - RELNOTES

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,10 @@ on:
   push:
     branches: [ master ]
     paths-ignore:
+      - .git-blame-ignore-revs
+      - .gitignore
       - CONTRIBUTING.md
+      - COPYING
       - README
       - README.md
       - RELNOTES
@@ -19,7 +22,10 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ master ]
     paths-ignore:
+      - .git-blame-ignore-revs
+      - .gitignore
       - CONTRIBUTING.md
+      - COPYING
       - README
       - README.md
       - RELNOTES


### PR DESCRIPTION
Add the following paths to the ignore lists:

- .git-blame-ignore-revs
- .gitignore
- COPYING

To avoid running CI unnecessarily.

Commands used to show only the root files:

    $ git ls-files | grep -v /

Misc: I noticed the missing paths on #5248.