### PR TITLE
build: add autoconf auto-generation comment to input files

### DIFF
--- a/config.mk.in
+++ b/config.mk.in
@@ -1,3 +1,5 @@
+# @configure_input@
+#
 # Configure-time variable definitions and any other common definition that can
 # be safely included by all makefiles.
 #

--- a/config.sh.in
+++ b/config.sh.in
@@ -1,2 +1,3 @@
+# @configure_input@
 NAME=@PACKAGE_NAME@
 VERSION=@PACKAGE_VERSION@


### PR DESCRIPTION
To note on the output files that they are generated and to clarify how
they are generated.

From the manual of GNU Autoconf (version 2.69):

>  -- Variable: configure_input
>      A comment saying that the file was generated automatically by
>      'configure' and giving the name of the input file.  'AC_OUTPUT'
>      adds a comment line containing this variable to the top of every
>      makefile it creates.  For other files, you should reference this
>      variable in a comment at the top of each input file.  For
>      example, an input shell script should begin like this:
>
>           #!/bin/sh
>           # @configure_input@
>
>      The presence of that line also reminds people editing the file
>      that it needs to be processed by 'configure' in order to be used.

Resulting output on config.mk:

    # config.mk.  Generated from config.mk.in by configure.

Relates to #5140.
