### PR TITLE
remmina.profile: allow python3

### DIFF
--- a/etc/profile-m-z/remmina.profile
+++ b/etc/profile-m-z/remmina.profile
@@ -12,7 +12,8 @@ noblacklist ${HOME}/.local/share/remmina
 
 # Allow ssh (blacklisted by disable-common.inc)
 include allow-ssh.inc
-# Remmina needs to load some modules
+
+# Allow python (blacklisted by disable-interpreters.inc)
 include allow-python3.inc
 
 include disable-common.inc

--- a/etc/profile-m-z/remmina.profile
+++ b/etc/profile-m-z/remmina.profile
@@ -12,6 +12,8 @@ noblacklist ${HOME}/.local/share/remmina
 
 # Allow ssh (blacklisted by disable-common.inc)
 include allow-ssh.inc
+# Remmina needs to load some modules
+include allow-python3.inc
 
 include disable-common.inc
 include disable-devel.inc


### PR DESCRIPTION
Remmina failed to work after some update with this:

```
Reading profile /etc/firejail/remmina.profile
Reading profile /etc/firejail/allow-ssh.inc
Reading profile /etc/firejail/disable-common.inc
Reading profile /etc/firejail/disable-devel.inc
Reading profile /etc/firejail/disable-exec.inc
Reading profile /etc/firejail/disable-interpreters.inc
Reading profile /etc/firejail/disable-programs.inc
Reading profile /etc/firejail/disable-xdg.inc
Reading profile /etc/firejail/whitelist-runuser-common.inc
Reading profile /etc/firejail/whitelist-var-common.inc
Parent pid 373392, child pid 373393
Warning: /sbin directory link was not blacklisted
Warning: /usr/sbin directory link was not blacklisted
Child process initialized in 243.40 ms
remmina-Message: 20:38:05.572: Remmina does not log all output statements. Turn on more verbose output by using "G_MESSAGES_DEBUG=all" as an environment variable.
More info available on the Remmina wiki at:
https://gitlab.com/Remmina/Remmina/-/wikis/Usage/Remmina-debugging
Load modules from /usr/lib/remmina/plugins
Could not find platform independent libraries <prefix>
Could not find platform dependent libraries <exec_prefix>
Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
Python path configuration:
  PYTHONHOME = (not set)
  PYTHONPATH = (not set)
  program name = 'python3'
  isolated = 0
  environment = 1
  user site = 1
  import site = 1
  sys._base_executable = ''
  sys.base_prefix = '/usr'
  sys.base_exec_prefix = '/usr'
  sys.platlibdir = 'lib'
  sys.executable = ''
  sys.prefix = '/usr'
  sys.exec_prefix = '/usr'
  sys.path = [
    '/usr/lib/python310.zip',
    '/usr/lib/python3.10',
    '/usr/lib/lib-dynload',
  ]
Fatal Python error: init_fs_encoding: failed to get the Python codec of the filesystem encoding
Python runtime state: core initialized
ModuleNotFoundError: No module named 'encodings'

Current thread 0x00007f19479f2dc0 (most recent call first):
  <no Python frame>

Parent is shutting down, bye...
```

It requires python now or it will not start.