### PR TITLE
viewnior.profile: allow accessing /usr/share/viewnior

### DIFF
--- a/etc/profile-m-z/viewnior.profile
+++ b/etc/profile-m-z/viewnior.profile
@@ -19,6 +19,7 @@ include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
 
+whitelist /usr/share/viewnior
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 


### PR DESCRIPTION
Wanted to crop an image in viewnior, noticed it did not work, checked stdout and sure enough it was missing a whitelisted path.