### PR TITLE
docs: set vim filetype on man pages for syntax highlighting

### DIFF
--- a/src/man/firecfg.txt
+++ b/src/man/firecfg.txt
@@ -146,3 +146,4 @@ Homepage: https://firejail.wordpress.com
 .BR firejail-login (5),
 .BR firejail-users (5),
 .BR jailcheck (1)
+.\" vim: set filetype=groff :

--- a/src/man/firejail-login.txt
+++ b/src/man/firejail-login.txt
@@ -40,3 +40,4 @@ Homepage: https://firejail.wordpress.com
 .BR firejail-profile (5),
 .BR firejail-users (5),
 .BR jailcheck (1)
+.\" vim: set filetype=groff :

--- a/src/man/firejail-profile.txt
+++ b/src/man/firejail-profile.txt
@@ -1031,3 +1031,4 @@ Homepage: https://firejail.wordpress.com
 
 .UR https://github.com/netblue30/firejail/wiki/Creating-Profiles
 .UE
+.\" vim: set filetype=groff :

--- a/src/man/firejail-users.txt
+++ b/src/man/firejail-users.txt
@@ -60,3 +60,4 @@ Homepage: https://firejail.wordpress.com
 .BR firejail-profile (5),
 .BR firejail-login (5),
 .BR jailcheck (1)
+.\" vim: set filetype=groff :

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -3611,3 +3611,4 @@ Homepage: https://firejail.wordpress.com
 .UE ,
 .UR https://github.com/netblue30/firejail
 .UE
+.\" vim: set filetype=groff :


### PR DESCRIPTION
Since the man pages in src/man use a ".txt" file extension (rather than
".1" or ".5"), their filetype is detected by (neo)vim as "text".

So at the bottom of every man page, add a vim modeline in a comment and
set the filetype to "groff", to enable syntax highlighting.

Note: All of the generated ".man", ".1" and ".5" files are currently
being detected as "nroff".

Note2: Set the filetype to "groff" rather than "nroff" because at least
.UR and .UE are groff extensions.  These macros look the same with
either filetype, but there may be more extensions being used and the
nroff.vim syntax file (which is included by groff.vim) does things
differently based on which filetype is used.

Based on the following example from (neo)vim's filetype.txt:

    or add this modeline to the file:
            /* vim: set filetype=idl : */

See `:help groff.vim` and `:help filetype.txt` in (neo)vim.

See also groff_man(7) for the man page macros (including extensions).

Environment: neovim 0.7.2-3 on Artix Linux.

Misc: I noticed this on #5290.
