### PR TITLE
fix(audacity): !5281 sharedlib bug on Arch/Fedora

### DIFF
--- a/etc/profile-a-l/audacity.profile
+++ b/etc/profile-a-l/audacity.profile
@@ -20,7 +20,8 @@ include disable-xdg.inc
 
 include whitelist-var-common.inc
 
-apparmor
+## Enabling App Armor appears to break some Fedora / Arch installs
+#apparmor
 caps.drop all
 net none
 no3d
@@ -36,7 +37,7 @@ protocol unix,inet
 seccomp
 tracelog
 
-#private-bin audacity
+private-bin audacity
 private-dev
 private-tmp
 

--- a/etc/profile-a-l/audacity.profile
+++ b/etc/profile-a-l/audacity.profile
@@ -36,7 +36,7 @@ protocol unix,inet
 seccomp
 tracelog
 
-private-bin audacity
+#private-bin audacity
 private-dev
 private-tmp
 


### PR DESCRIPTION
removed `private-bin` line from audacity profile as it appears to block
access to shared libraries needed to start audacity on some
distributions.

Relates to github issue #5281
