### PR TITLE
makedeb profile creation

### DIFF
--- a/etc/profile-m-z/makedeb.profile
+++ b/etc/profile-m-z/makedeb.profile
@@ -1,0 +1,13 @@
+# Firejail profile for makedeb
+# Description: A utility to automate the building of Debian packages
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include makedeb.local
+# Persistent global definitions
+#include globals.local
+
+ignore noblacklist /var/lib/pacman
+
+# Redirect
+include makepkg.profile


### PR DESCRIPTION
makedeb is a makepkg fork for debian.

I didn't add it in firecfg because makepkg isn't there either.