### PR TITLE
microsoft-edge.profile rewritten for stable channel and moved microsoft-edge{,-beta,-dev} from private-opt to whitelist

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -155,6 +155,7 @@ blacklist ${HOME}/.cache/liferea
 blacklist ${HOME}/.cache/lutris
 blacklist ${HOME}/.cache/marker
 blacklist ${HOME}/.cache/matrix-mirage
+blacklist ${HOME}/.cache/microsoft-edge
 blacklist ${HOME}/.cache/microsoft-edge-beta
 blacklist ${HOME}/.cache/microsoft-edge-dev
 blacklist ${HOME}/.cache/midori
@@ -520,6 +521,7 @@ blacklist ${HOME}/.config/meld
 blacklist ${HOME}/.config/menulibre.cfg
 blacklist ${HOME}/.config/meteo-qt
 blacklist ${HOME}/.config/mfusion
+blacklist ${HOME}/.config/microsoft-edge
 blacklist ${HOME}/.config/microsoft-edge-beta
 blacklist ${HOME}/.config/microsoft-edge-dev
 blacklist ${HOME}/.config/midori

--- a/etc/profile-m-z/microsoft-edge-beta.profile
+++ b/etc/profile-m-z/microsoft-edge-beta.profile
@@ -14,7 +14,7 @@ mkdir ${HOME}/.config/microsoft-edge-beta
 whitelist ${HOME}/.cache/microsoft-edge-beta
 whitelist ${HOME}/.config/microsoft-edge-beta
 
-private-opt microsoft
+whitelist /opt/microsoft/msedge-beta
 
 # Redirect
 include chromium-common.profile

--- a/etc/profile-m-z/microsoft-edge-dev.profile
+++ b/etc/profile-m-z/microsoft-edge-dev.profile
@@ -14,7 +14,7 @@ mkdir ${HOME}/.config/microsoft-edge-dev
 whitelist ${HOME}/.cache/microsoft-edge-dev
 whitelist ${HOME}/.config/microsoft-edge-dev
 
-private-opt microsoft
+whitelist /opt/microsoft/msedge-dev
 
 # Redirect
 include chromium-common.profile

--- a/etc/profile-m-z/microsoft-edge.profile
+++ b/etc/profile-m-z/microsoft-edge.profile
@@ -1,11 +1,20 @@
 # Firejail profile for Microsoft Edge
-# Description: Web browser from Microsoft
+# Description: Web browser from Microsoft,stable channel
 # This file is overwritten after every install/update
 # Persistent local customizations
 include microsoft-edge.local
 # Persistent global definitions
-# added by included profile
-#include globals.local
+include globals.local
+
+noblacklist ${HOME}/.cache/microsoft-edge
+noblacklist ${HOME}/.config/microsoft-edge
+
+mkdir ${HOME}/.cache/microsoft-edge
+mkdir ${HOME}/.config/microsoft-edge
+whitelist ${HOME}/.cache/microsoft-edge
+whitelist ${HOME}/.config/microsoft-edge
+
+whitelist /opt/microsoft/msedge
 
 # Redirect
-include microsoft-edge-dev.profile
+include chromium-common.profile


### PR DESCRIPTION
I did rewrite microsoft-edge.profile from dev/beta for stable channel that is using only this name as executable binary unlike the other two.

About what we were discussing in #5307, I did replace private-opt by whitelist for stable, beta and dev profiles.
Tell me if this is not the way you would like it to be and I will follow your recommendations..