### PR TITLE
Fix an AppArmor profile denial issue with ptrace reading and signals

### DIFF
--- a/etc/apparmor/firejail-default
+++ b/etc/apparmor/firejail-default
@@ -33,6 +33,7 @@ owner /{,var/}run/firejail/dbus/[0-9]*/[0-9]*-user w,
 #ptrace,
 # Allow obtaining some process information, but not ptrace(2)
 ptrace (read,readby) peer=@{profile_name},
+ptrace (read,readby) peer=@{profile_name}//&unconfined,
 
 ##########
 # Allow read access to whole filesystem and control it from firejail.
@@ -123,6 +124,7 @@ network packet,
 ##########
 # There is no equivalent in Firejail for filtering signals.
 ##########
+signal (send) peer=@{profile_name}//&unconfined,
 signal (send) peer=@{profile_name},
 signal (receive),
 


### PR DESCRIPTION
Hello everyone!

Recently, a [pull request](https://github.com/netblue30/firejail/pull/5274) was merged that added support for custom AppArmor profiles. However, there was a use-case I haven't tested -- a case where an application confined by a default profile uses ptrace or sends signals. In the original profile, it was allowed only for apps with the same security label. However, I've missed that, while **firejail-default//&unconfined** and **firejail-default** have equal AppArmor permissions, ptrace reading and sending signals were previously allowed for peers only with the latter security label. I've fixed it in this PR by allowing both.

Fixes #5316 