### PR TITLE
steam.profile: fix breakage with newer Proton-GE (process_vm_readv)

### DIFF
--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -156,7 +156,10 @@ protocol unix,inet,inet6,netlink
 # seccomp sometimes causes issues (see #2951, #3267).
 # Add 'ignore seccomp' to your steam.local if you experience this.
 # mount, name_to_handle_at, pivot_root and umount2 are used by Proton >= 5.13
+# (see #4366).
 seccomp !chroot,!mount,!name_to_handle_at,!pivot_root,!ptrace,!umount2
+# process_vm_readv is used by Proton > 7.2 (see #5185).
+seccomp.32 !process_vm_readv
 # tracelog breaks integrated browser
 #tracelog
 


### PR DESCRIPTION
As reported by @rsramkis on #5185, upgrading from Proton-7.2-GE-2[1]
(released on 2022-02-14) to GE-Proton7-18[2] (released on 2022-05-19)
breaks logging in on World of Tanks Blitz unless the `process_vm_ready`
32-bit syscall is allowed[3], so allow it.

Fixes #5185.

[1] https://github.com/GloriousEggroll/proton-ge-custom/releases/tag/7.2-GE-2
[2] https://github.com/GloriousEggroll/proton-ge-custom/releases/tag/GE-Proton7-18
[3] https://github.com/netblue30/firejail/issues/5185#issuecomment-1152350336
