### PR TITLE
Fix Firefox 'Profile not found' for psd (v6.45)

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -1172,6 +1172,7 @@ blacklist ${HOME}/yt-dlp.conf
 blacklist ${HOME}/yt-dlp.conf.txt
 blacklist ${RUNUSER}/*firefox*
 blacklist ${RUNUSER}/akonadi
+blacklist ${RUNUSER}/psd/*firefox*
 blacklist /tmp/.wine-*
 blacklist /tmp/akonadi-*
 blacklist /var/games/nethack

--- a/etc/profile-a-l/firefox.profile
+++ b/etc/profile-a-l/firefox.profile
@@ -25,7 +25,6 @@ mkdir ${HOME}/.cache/mozilla/firefox
 mkdir ${HOME}/.mozilla
 whitelist ${HOME}/.cache/mozilla/firefox
 whitelist ${HOME}/.mozilla
-whitelist ${RUNUSER}/psd/*firefox*
 
 # Add one of the following whitelist options to your firefox.local to enable KeePassXC Plugin support.
 # NOTE: start KeePassXC before Firefox and keep it open to allow communication between them.
@@ -39,6 +38,7 @@ whitelist /usr/share/gtk-doc/html
 whitelist /usr/share/mozilla
 whitelist /usr/share/webext
 whitelist ${RUNUSER}/*firefox*
+whitelist ${RUNUSER}/psd/*firefox*
 include whitelist-usr-share-common.inc
 
 # firefox requires a shell to launch on Arch - add the next line to your firefox.local to enable private-bin.

--- a/etc/profile-a-l/firefox.profile
+++ b/etc/profile-a-l/firefox.profile
@@ -17,6 +17,7 @@ include globals.local
 noblacklist ${HOME}/.cache/mozilla
 noblacklist ${HOME}/.mozilla
 noblacklist ${RUNUSER}/*firefox*
+noblacklist ${RUNUSER}/psd/*firefox*
 
 blacklist /usr/libexec
 

--- a/etc/profile-a-l/firefox.profile
+++ b/etc/profile-a-l/firefox.profile
@@ -25,6 +25,7 @@ mkdir ${HOME}/.cache/mozilla/firefox
 mkdir ${HOME}/.mozilla
 whitelist ${HOME}/.cache/mozilla/firefox
 whitelist ${HOME}/.mozilla
+whitelist ${RUNUSER}/psd/*firefox*
 
 # Add one of the following whitelist options to your firefox.local to enable KeePassXC Plugin support.
 # NOTE: start KeePassXC before Firefox and keep it open to allow communication between them.


### PR DESCRIPTION
code change: `whitelist ${RUNUSER}/psd/*firefox*`

fixes: #4568