### PR TITLE
Make /etc/ssh/ssh_config.d visible for ssh

### DIFF
--- a/etc/inc/allow-ssh.inc
+++ b/etc/inc/allow-ssh.inc
@@ -5,6 +5,7 @@ include allow-ssh.local
 noblacklist ${HOME}/.ssh
 noblacklist /etc/ssh
 noblacklist /etc/ssh/ssh_config
+noblacklist /etc/ssh/ssh_config.d
 noblacklist ${PATH}/ssh
 noblacklist /tmp/ssh-*
 # Arch Linux and derivatives


### PR DESCRIPTION
Currently ssh client cant see anything under `/etc/ssh/ssh_config.d`. It is evidently a bug.