### PR TITLE
build: only install ids.config when --enable-ids is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,11 @@ endif
 	# profiles and settings
 	install -m 0755 -d $(DESTDIR)$(sysconfdir)/firejail
 	install -m 0644 -t $(DESTDIR)$(sysconfdir)/firejail src/firecfg/firecfg.config
-	install -m 0644 -t $(DESTDIR)$(sysconfdir)/firejail etc/profile-a-l/*.profile etc/profile-m-z/*.profile etc/inc/*.inc etc/net/*.net etc/firejail.config etc/ids.config
+	install -m 0644 -t $(DESTDIR)$(sysconfdir)/firejail etc/profile-a-l/*.profile etc/profile-m-z/*.profile etc/inc/*.inc etc/net/*.net etc/firejail.config
 	sh -c "if [ ! -f $(DESTDIR)/$(sysconfdir)/firejail/login.users ]; then install -c -m 0644 etc/login.users $(DESTDIR)/$(sysconfdir)/firejail/.; fi;"
+ifeq ($(HAVE_IDS),-DHAVE_IDS)
+	install -m 0644 -t $(DESTDIR)$(sysconfdir)/firejail etc/ids.config
+endif
 ifeq ($(BUSYBOX_WORKAROUND),yes)
 	./mketc.sh $(DESTDIR)$(sysconfdir)/firejail/disable-common.inc
 endif


### PR DESCRIPTION
This PR ensures ids.config only gets installed when --enable-ids is set during configure. Fixes #5356.