### PR TITLE
Fix spacing & typo in Landlock section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,43 +272,43 @@ Work in progress, the interface described in the man page below could change.
               lock.execute=/usr
 
 LANDLOCK
-       Landlock is a Linux security module first introduced in the  5.13  ver‐
-       sion  of  Linux  kernel.  It  allows unprivileged processes to restrict
-       their access to the filesystem. Once imposed,  these  restrictions  can
-       never  be  removed,  and  all child processes created by a Landlock-re‐
-       stricted processes inherit these restrictions. Firejail supports  Land‐
+       Landlock is a Linux security module first introduced in the 5.13  ver‐
+       sion of  Linux kernel. It allows unprivileged processes to restrict
+       their access to the filesystem. Once imposed, these restrictions can
+       never be removed, and all child processes created by a Landlock-re‐
+       stricted processes inherit these restrictions. Firejail supports Land‐
        lock as an additional sandboxing feature. It can be used to ensure that
-       a sandboxed application can only access files and directories  that  it
-       was  explicitly  allowed  to  access.  Firejail supports populating the
-       ruleset with both basic set of rules and with custom set of rules.  Ba‐
-       sic  set  of  rules  allows read-only access to /bin, /dev, /etc, /lib,
-       /opt, /proc, /usr and /var, read-write access to  the  home  directory,
+       a sandboxed application can only access files and directories that it
+       was explicitly allowed to access. Firejail supports populating the
+       ruleset with both basic set of rules and with custom set of rules. Ba‐
+       sic set of rules allows read-only access to /bin, /dev, /etc, /lib,
+       /opt, /proc, /usr and /var, read-write access to the home directory,
        and allows execution of binaries located in /bin, /opt and /usr.
 
        Important notes:
 
               - A process can install a Landlock ruleset only if it has either
-              CAP_SYS_ADMIN in its effective capability set, or  the  "No  New
-              Privileges"  restriction  enabled. Because of this, enabling the
+              CAP_SYS_ADMIN in its effective capability set, or the "No  New
+              Privileges" restriction enabled. Because of this, enabling the
               Landlock feature will also cause Firejail to enable the "No  New
-              Privileges"  restriction,  regardless  of  the  profile  or  the
+              Privileges" restriction, regardless of the profile or the
               --no-new-privs command line option.
 
-              - Access to the /proc directory is managed through  the  --land‐
+              - Access to the /proc directory is managed through the --land‐
               lock.proc command line option.
 
-              -  Access  to  the  /etc  directory is automatically allowed. To
-              override this, use the --writable-etc command line  option.  You
-              can  also use the --private-etc option to restrict access to the
+              -  Access to the /etc directory is automatically allowed. To
+              override this, use the --writable-etc command line option. You
+              can also use the --private-etc option to restrict access to the
               /etc directory.
 
        To enable Landlock self-restriction on top of your current Firejail se‐
        curity features, pass --landlock flag to Firejail command line. You can
-       also  use  --landlock.read,  --landlock.write,  --landlock.special  and
-       --landlock.execute  options  together with --landlock or instead of it.
+       also use --landlock.read, --landlock.write, --landlock.special and
+       --landlock.execute options together with --landlock or instead of it.
        Example:
 
-              $ firejail --landlock --landlock.read=/media  --landlock.proc=ro
+              $ firejail --landlock --landlock.read=/media --landlock.proc=ro
               mc
 `````
 

--- a/README.md
+++ b/README.md
@@ -235,40 +235,40 @@ in 0.9.74, sometime early next year. For now, use --enable-landlock during softw
 `````
 $ ./configure --enable-landlock
 `````
-The functionality is segragated with ifdefs in the code, at times it might not even compile!
+The functionality is segregated with ifdefs in the code, at times it might not even compile!
 Work in progress, the interface described in the man page below could change.
 `````
        --landlock
-              Create a Landlock ruleset (if it doesn't already exist) and  add
+              Create a Landlock ruleset (if it doesn't already exist) and add
               basic access rules to it. See LANDLOCK section for more informa‐
               tion.
 
        --landlock.proc=no|ro|rw
-              Add an access rule for /proc directory (read-only if set  to  ro
+              Add an access rule for /proc directory (read-only if set to ro
               and read-write if set to rw). The access rule for /proc is added
-              after this directory is set up in the sandbox. Access rules  for
-              /proc  set  up  with other Landlock-related command-line options
+              after this directory is set up in the sandbox. Access rules for
+              /proc set up with other Landlock-related command-line options
               have no effect.
 
        --landlock.read=path
-              Create a Landlock ruleset (if it doesn't already exist) and  add
+              Create a Landlock ruleset (if it doesn't already exist) and add
               a read access rule for path.
 
        --landlock.write=path
-              Create  a Landlock ruleset (if it doesn't already exist) and add
+              Create a Landlock ruleset (if it doesn't already exist) and add
               a write access rule for path.
 
        --landlock.special=path
-              Create a Landlock ruleset (if it doesn't already exist) and  add
-              a  permission rule to create FIFO pipes, Unix domain sockets and
+              Create a Landlock ruleset (if it doesn't already exist) and add
+              a permission rule to create FIFO pipes, Unix domain sockets and
               block devices beneath given path.
 
        --landlock.execute=path
-              Create a Landlock ruleset (if it doesn't already exist) and  add
+              Create a Landlock ruleset (if it doesn't already exist) and add
               an execution permission rule for path.
 
               Example:
-              $   firejail  --landlock.read=/  --landlock.write=/home  --land‐
+              $ firejail --landlock.read=/ --landlock.write=/home --land‐
               lock.execute=/usr
 
 LANDLOCK

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ LANDLOCK
               Privileges" restriction enabled. Because of this, enabling the
               Landlock feature will also cause Firejail to enable the "No  New
               Privileges" restriction, regardless of the profile or the
-              --no-new-privs command line option.
+              --nonewprivs command line option.
 
               - Access to the /proc directory is managed through the --land‐
               lock.proc command line option.


### PR DESCRIPTION
Cosmetic fixes for the Landlock section of README.md, no functional changes.