### PR TITLE
profiles: allow perl/exiftool on the relevant profiles

### DIFF
--- a/etc/profile-a-l/darktable.profile
+++ b/etc/profile-a-l/darktable.profile
@@ -10,7 +10,11 @@ noblacklist ${HOME}/.cache/darktable
 noblacklist ${HOME}/.config/darktable
 noblacklist ${PICTURES}
 
+# Allow lua (blacklisted by disable-interpreters.inc)
 include allow-lua.inc
+
+# Allow perl (blacklisted by disable-interpreters.inc)
+include allow-perl.inc
 
 include disable-common.inc
 include disable-devel.inc
@@ -33,7 +37,7 @@ novideo
 protocol unix,inet,inet6
 seccomp
 
-#private-bin darktable
+#private-bin darktable,exiftool,perl
 private-dev
 private-tmp
 

--- a/etc/profile-a-l/digikam.profile
+++ b/etc/profile-a-l/digikam.profile
@@ -13,6 +13,9 @@ noblacklist ${HOME}/.kde4/share/apps/digikam
 noblacklist ${HOME}/.local/share/kxmlgui5/digikam
 noblacklist ${PICTURES}
 
+# Allow perl (blacklisted by disable-interpreters.inc)
+include allow-perl.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/profile-a-l/geeqie.profile
+++ b/etc/profile-a-l/geeqie.profile
@@ -10,6 +10,9 @@ noblacklist ${HOME}/.cache/geeqie
 noblacklist ${HOME}/.config/geeqie
 noblacklist ${HOME}/.local/share/geeqie
 
+# Allow perl (blacklisted by disable-interpreters.inc)
+include allow-perl.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc

--- a/etc/profile-a-l/hugin.profile
+++ b/etc/profile-a-l/hugin.profile
@@ -13,6 +13,9 @@ noblacklist ${PICTURES}
 # Allow /bin/sh (blacklisted by disable-shell.inc)
 include allow-bin-sh.inc
 
+# Allow perl (blacklisted by disable-interpreters.inc)
+include allow-perl.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
@@ -35,7 +38,7 @@ novideo
 protocol unix
 seccomp
 
-private-bin align_image_stack,autooptimiser,calibrate_lens_gui,celeste_standalone,checkpto,cpclean,cpfind,deghosting_mask,enblend,fulla,geocpset,hugin,hugin_executor,hugin_hdrmerge,hugin_lensdb,hugin_stitch_project,icpfind,linefind,nona,pano_modify,pano_trafo,PTBatcherGUI,pto_gen,pto_lensstack,pto_mask,pto_merge,pto_move,pto_template,pto_var,sh,tca_correct,uname,verdandi,vig_optimize
+private-bin align_image_stack,autooptimiser,calibrate_lens_gui,celeste_standalone,checkpto,cpclean,cpfind,deghosting_mask,enblend,exiftool,fulla,geocpset,hugin,hugin_executor,hugin_hdrmerge,hugin_lensdb,hugin_stitch_project,icpfind,linefind,nona,pano_modify,pano_trafo,perl,PTBatcherGUI,pto_gen,pto_lensstack,pto_mask,pto_merge,pto_move,pto_template,pto_var,sh,tca_correct,uname,verdandi,vig_optimize
 private-cache
 private-dev
 private-tmp


### PR DESCRIPTION
Programs that seem to support exiftool:

    $ LC_ALL=C pacman -Sii perl-image-exiftool |
      grep -e '^Version' -e '^Required' -e '^Optional For' | head -n 3
    Version         : 12.42-1
    Required By     : digikam  geotag  gitlab-workhorse  mat2  rapid-photo-downloader
    Optional For    : darktable  geeqie  gpsprune  hugin  jpeg-archive  ranger  recoll  shutter

Environment: Artix Linux.

Note for hugin.profile: Does not currently work with private-bin on
Arch/Artix; see the private-bin comment on
etc/profile-a-l/exiftool.profile.

Relates to #5365.