### PR TITLE
arduino.profile: allow devel paths

### DIFF
--- a/etc/profile-a-l/arduino.profile
+++ b/etc/profile-a-l/arduino.profile
@@ -10,13 +10,10 @@ noblacklist ${HOME}/.arduino15
 noblacklist ${HOME}/Arduino
 noblacklist ${DOCUMENTS}
 
-# Allow java (blacklisted by disable-devel.inc)
-include allow-java.inc
+# Allows files commonly used by IDEs
+include allow-common-devel.inc
 
 include disable-common.inc
-include disable-devel.inc
-include disable-exec.inc
-include disable-interpreters.inc
 include disable-programs.inc
 include disable-xdg.inc
 


### PR DESCRIPTION
As mentioned in its description, this profile is intended for an IDE, so
allow paths used for development and stop including the following
profiles:

* disable-devel.inc
* disable-exec.inc
* disable-interpreters.inc

Fixes #5292.