### PR TITLE
Allow Firefox to own `org.mozilla.firefox_esr.*`

### DIFF
--- a/etc/profile-a-l/firefox.profile
+++ b/etc/profile-a-l/firefox.profile
@@ -51,6 +51,7 @@ include whitelist-usr-share-common.inc
 dbus-user filter
 dbus-user.own org.mozilla.Firefox.*
 dbus-user.own org.mozilla.firefox.*
+dbus-user.own org.mozilla.firefox_esr.*
 dbus-user.own org.mpris.MediaPlayer2.firefox.*
 # Add the next line to your firefox.local to enable native notifications.
 #dbus-user.talk org.freedesktop.Notifications


### PR DESCRIPTION
Firefox ESR 102 needs access to session DBus names matching `org.mozilla.firefox_esr.*` to open a new tab/window when Firefox is already running.

Closes #5379.