### PR TITLE
mpv: whitelist mpv-mpris

### DIFF
--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -58,6 +58,7 @@ whitelist ${HOME}/.config/yt-dlp.conf
 whitelist ${HOME}/.netrc
 whitelist ${HOME}/yt-dlp.conf
 whitelist ${HOME}/yt-dlp.conf.txt
+whitelist /usr/lib/mpv-mpris
 whitelist /usr/share/lua
 whitelist /usr/share/lua*
 whitelist /usr/share/vulkan


### PR DESCRIPTION
This is an mpv plugin for MPRIS integration.

See: https://github.com/hoyon/mpv-mpris
