### PR TITLE
disable-common.inc: blacklist sudo/doas paths in /etc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -362,7 +362,7 @@ scan-build: clean
 
 .PHONY: codespell
 codespell: clean
-	codespell --ignore-regex "UE|creat|shotcut|ether" src test
+	codespell --ignore-regex "UE|creat|doas|shotcut|ether" src test
 
 .PHONY: print-env
 print-env:

--- a/etc/ids.config
+++ b/etc/ids.config
@@ -139,6 +139,7 @@ ${HOME}/.local/share/autostart
 /etc/security
 /etc/selinux
 /etc/shadow*
+/etc/sudo*.conf
 /etc/sudoers*
 /etc/tripwire
 ${HOME}/.config/firejail

--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -416,6 +416,7 @@ blacklist /tmp/ssh-*
 # top secret
 blacklist /.fscrypt
 blacklist /etc/davfs2/secrets
+blacklist /etc/doas.conf
 blacklist /etc/group+
 blacklist /etc/group-
 blacklist /etc/gshadow
@@ -428,6 +429,8 @@ blacklist /etc/shadow+
 blacklist /etc/shadow-
 blacklist /etc/ssh
 blacklist /etc/ssh/*
+blacklist /etc/sudo*.conf
+blacklist /etc/sudoers*
 blacklist /home/.ecryptfs
 blacklist /home/.fscrypt
 blacklist ${HOME}/*.kdb

--- a/src/jailcheck/main.c
+++ b/src/jailcheck/main.c
@@ -120,6 +120,7 @@ int main(int argc, char **argv) {
 	// basic sysfiles
 	sysfiles_setup("/etc/shadow");
 	sysfiles_setup("/etc/gshadow");
+	sysfiles_setup("/usr/bin/doas");
 	sysfiles_setup("/usr/bin/mount");
 	sysfiles_setup("/usr/bin/su");
 	sysfiles_setup("/usr/bin/ksu");


### PR DESCRIPTION

Commands used to find the relevant paths in /etc:

    $ pacman -Qo /etc/* 2>/dev/null | grep sudo | LC_ALL=C sort
    /etc/pam.d/ is owned by sudo 1.9.14.p1-1
    /etc/sudo.conf is owned by sudo 1.9.14.p1-1
    /etc/sudo_logsrvd.conf is owned by sudo 1.9.14.p1-1
    /etc/sudoers is owned by sudo 1.9.14.p1-1
    /etc/sudoers.d/ is owned by sudo 1.9.14.p1-1

Environment: Artix Linux.

Also, add missing paths sudo/doas to etc/ids.config and jailcheck.

See also commit dbebd71db ("disable-common.inc: blacklist doas binary",
2022-10-05).

Relates to #5385.

Reported-by: Dieter Plaetinck <dieter@plaetinck.be>