### PR TITLE
docs: Add gist note to bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -81,6 +81,9 @@ output goes here
 <details>
 <summary>Output of <code>LC_ALL=C firejail --debug /path/to/program</code></summary>
 <p>
+  
+<!-- If the output is too long to embed it into the comment,
+     create a secret gist at https://gist.github.com/ and link it here. -->
 
 ```
 output goes here


### PR DESCRIPTION
We had some comments saying that the output exceeds the allowed length of a github comment (65534 characters IIRC).

This commit adds a comment to instruct users to create a secret gist in that case.
