### PR TITLE
mpv: whitelist mpv-mpris in lib64

### DIFF
--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -59,6 +59,7 @@ whitelist ${HOME}/.netrc
 whitelist ${HOME}/yt-dlp.conf
 whitelist ${HOME}/yt-dlp.conf.txt
 whitelist /usr/lib/mpv-mpris
+whitelist /usr/lib64/mpv-mpris
 whitelist /usr/share/lua
 whitelist /usr/share/lua*
 whitelist /usr/share/vulkan


### PR DESCRIPTION
Might be a thing in some distros?

See: https://github.com/netblue30/firejail/pull/5386#issuecomment-1264478380