### PR TITLE
Revert "mpv: whitelist mpv-mpris (#5386)"

### DIFF
--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -58,7 +58,6 @@ whitelist ${HOME}/.config/yt-dlp.conf
 whitelist ${HOME}/.netrc
 whitelist ${HOME}/yt-dlp.conf
 whitelist ${HOME}/yt-dlp.conf.txt
-whitelist /usr/lib/mpv-mpris
 whitelist /usr/share/lua
 whitelist /usr/share/lua*
 whitelist /usr/share/vulkan


### PR DESCRIPTION
This reverts commit 393c5beff2686d7732221dadb6730917f24835a0.

Which broke mpv:

    $ mpv --version
    Cannot start application: No such file or directory

Probably because mpv itself uses many libraries and it has plugins that
may depend on files in /usr/lib as well:

    $ pacman -Qlq mpv | grep /lib/ | grep -v '/$'
    /usr/lib/libmpv.so
    /usr/lib/libmpv.so.1
    /usr/lib/libmpv.so.1.109.0
    /usr/lib/pkgconfig/mpv.pc
    $ strings /usr/bin/mpv | grep '^lib.*\.so' | sort -u | wc -l
    53
    $ pacman -Qlq yt-dlp | grep /lib/ | grep -v '/$' |
      cut -f -4 -d / | sort -u
    /usr/lib/python3.10
    $ pacman -Q mpv yt-dlp
    mpv 1:0.34.1-5
    yt-dlp 2022.09.01-1

Environment: Artix Linux.

Also, private-lib is disabled by default in firejail.config (see #5190)
and mpv.profile does not use private-lib, so there should be no need to
whitelist anything in /usr/lib in the default profile.

Cc: @glitsj16 @rusty-snake @WhyNotHugo (from #5386)
