### PR TITLE
docs: Make appimage examples consistent with --appimage option short description

### DIFF
--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -164,12 +164,12 @@ private-bin and private-lib are disabled by default when running appimages.
 .br
 Example:
 .br
-$ firejail --appimage --profile=krita krita-3.0-x86_64.appimage
+$ firejail --profile=krita --appimage krita-3.0-x86_64.appimage
 .br
-$ firejail --appimage --private --profile=krita krita-3.0-x86_64.appimage
+$ firejail --private --profile=krita --appimage krita-3.0-x86_64.appimage
 .br
 #ifdef HAVE_X11
-$ firejail --appimage --net=none --x11 --profile=krita krita-3.0-x86_64.appimage
+$ firejail --net=none --x11 --profile=krita --appimage krita-3.0-x86_64.appimage
 #endif
 .TP
 #ifdef HAVE_NETWORK


### PR DESCRIPTION
`--appimage` option is mentioned twice in the man page: first with a short description, next with usage examples. The short description is:

```
firejail [OPTIONS] --appimage [appimage-file and arguments]
```

While the examples are of form `firejail --appimage <some extra options> someapp.appimage`.

Even though the option parser recognizes such order, it is better to keep it the same way in both places in the man page.