### PR TITLE
ktorrent.profile: fix mkfile without mkdir & comment legacy paths

### DIFF
--- a/etc/profile-a-l/ktorrent.profile
+++ b/etc/profile-a-l/ktorrent.profile
@@ -22,7 +22,9 @@ include disable-programs.inc
 include disable-shell.inc
 
 mkdir ${HOME}/.kde/share/apps/ktorrent
+mkdir ${HOME}/.kde/share/config
 mkdir ${HOME}/.kde4/share/apps/ktorrent
+mkdir ${HOME}/.kde4/share/config
 mkdir ${HOME}/.local/share/ktorrent
 mkdir ${HOME}/.local/share/kxmlgui5/ktorrent
 mkfile ${HOME}/.config/ktorrentrc

--- a/etc/profile-a-l/ktorrent.profile
+++ b/etc/profile-a-l/ktorrent.profile
@@ -21,15 +21,17 @@ include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
 
-mkdir ${HOME}/.kde/share/apps/ktorrent
-mkdir ${HOME}/.kde/share/config
-mkdir ${HOME}/.kde4/share/apps/ktorrent
-mkdir ${HOME}/.kde4/share/config
+# Legacy paths
+#mkdir ${HOME}/.kde/share/apps/ktorrent
+#mkdir ${HOME}/.kde/share/config
+#mkdir ${HOME}/.kde4/share/apps/ktorrent
+#mkdir ${HOME}/.kde4/share/config
+#mkfile ${HOME}/.kde/share/config/ktorrentrc
+#mkfile ${HOME}/.kde4/share/config/ktorrentrc
+
 mkdir ${HOME}/.local/share/ktorrent
 mkdir ${HOME}/.local/share/kxmlgui5/ktorrent
 mkfile ${HOME}/.config/ktorrentrc
-mkfile ${HOME}/.kde/share/config/ktorrentrc
-mkfile ${HOME}/.kde4/share/config/ktorrentrc
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.config/ktorrentrc
 whitelist ${HOME}/.kde/share/apps/ktorrent

--- a/etc/profile-a-l/ktorrent.profile
+++ b/etc/profile-a-l/ktorrent.profile
@@ -60,7 +60,7 @@ novideo
 protocol unix,inet,inet6,netlink
 seccomp
 
-private-bin kbuildsycoca4,kdeinit4,ktorrent
+private-bin kbuildsycoca4,kdeinit4,ktmagnetdownloader,ktorrent,ktupnptest
 private-dev
 # private-lib - problems on Arch
 private-tmp


### PR DESCRIPTION
firejail fails to create the following files:

* ~/.kde/share/config/ktorrentrc
* ~/.kde4/share/config/ktorrentrc

Because it does not create the preceding directories beforehand:

* ~/.kde/share/config
* ~/.kde4/share/config

Relates to #5414.