### PR TITLE
Fix musl warnings

### DIFF
--- a/src/fnettrace/main.c
+++ b/src/fnettrace/main.c
@@ -19,6 +19,7 @@
 */
 #include "fnettrace.h"
 #include "radix.h"
+#include <limits.h>
 #include <sys/ioctl.h>
 #define MAX_BUF_SIZE (64 * 1024)
 
@@ -190,7 +191,6 @@ static char *print_bw(unsigned units) {
 	return bw_line[units];
 }
 
-#define LINE_MAX 200
 static inline void adjust_line(char *str, int len, int cols) {
 	if (len > LINE_MAX) // functions such as snprintf truncate the string, and return the length of the untruncated string
 		len = LINE_MAX;

--- a/src/libtrace/libtrace.c
+++ b/src/libtrace/libtrace.c
@@ -44,8 +44,6 @@
 // break recursivity on fopen call
 typedef FILE *(*orig_fopen_t)(const char *pathname, const char *mode);
 static orig_fopen_t orig_fopen = NULL;
-typedef FILE *(*orig_fopen64_t)(const char *pathname, const char *mode);
-static orig_fopen64_t orig_fopen64 = NULL;
 typedef int (*orig_access_t)(const char *pathname, int mode);
 static orig_access_t orig_access = NULL;
 
@@ -341,7 +339,9 @@ FILE *fopen(const char *pathname, const char *mode) {
 	return rv;
 }
 
-#ifdef __GLIBC__
+#ifndef fopen64
+typedef FILE *(*orig_fopen64_t)(const char *pathname, const char *mode);
+static orig_fopen64_t orig_fopen64 = NULL;
 FILE *fopen64(const char *pathname, const char *mode) {
 	if (!orig_fopen64)
 		orig_fopen64 = (orig_fopen_t)dlsym(RTLD_NEXT, "fopen64");
@@ -350,7 +350,7 @@ FILE *fopen64(const char *pathname, const char *mode) {
 	tprintf(ftty, "%u:%s:fopen64 %s:%p\n", mypid, myname, pathname, rv);
 	return rv;
 }
-#endif /* __GLIBC__ */
+#endif
 
 
 // freopen
@@ -365,7 +365,7 @@ FILE *freopen(const char *pathname, const char *mode, FILE *stream) {
 	return rv;
 }
 
-#ifdef __GLIBC__
+#ifndef freopen64
 typedef FILE *(*orig_freopen64_t)(const char *pathname, const char *mode, FILE *stream);
 static orig_freopen64_t orig_freopen64 = NULL;
 FILE *freopen64(const char *pathname, const char *mode, FILE *stream) {
@@ -376,7 +376,7 @@ FILE *freopen64(const char *pathname, const char *mode, FILE *stream) {
 	tprintf(ftty, "%u:%s:freopen64 %s:%p\n", mypid, myname, pathname, rv);
 	return rv;
 }
-#endif /* __GLIBC__ */
+#endif
 
 // unlink
 typedef int (*orig_unlink_t)(const char *pathname);
@@ -447,7 +447,7 @@ int stat(const char *pathname, struct stat *statbuf) {
 	return rv;
 }
 
-#ifdef __GLIBC__
+#ifndef stat64
 typedef int (*orig_stat64_t)(const char *pathname, struct stat64 *statbuf);
 static orig_stat64_t orig_stat64 = NULL;
 int stat64(const char *pathname, struct stat64 *statbuf) {
@@ -458,7 +458,7 @@ int stat64(const char *pathname, struct stat64 *statbuf) {
 	tprintf(ftty, "%u:%s:stat64 %s:%d\n", mypid, myname, pathname, rv);
 	return rv;
 }
-#endif /* __GLIBC__ */
+#endif
 
 // lstat
 typedef int (*orig_lstat_t)(const char *pathname, struct stat *statbuf);
@@ -472,7 +472,7 @@ int lstat(const char *pathname, struct stat *statbuf) {
 	return rv;
 }
 
-#ifdef __GLIBC__
+#ifndef lstat64
 typedef int (*orig_lstat64_t)(const char *pathname, struct stat64 *statbuf);
 static orig_lstat64_t orig_lstat64 = NULL;
 int lstat64(const char *pathname, struct stat64 *statbuf) {
@@ -483,7 +483,7 @@ int lstat64(const char *pathname, struct stat64 *statbuf) {
 	tprintf(ftty, "%u:%s:lstat64 %s:%d\n", mypid, myname, pathname, rv);
 	return rv;
 }
-#endif /* __GLIBC__ */
+#endif
 
 // opendir
 typedef DIR *(*orig_opendir_t)(const char *pathname);

--- a/src/libtracelog/libtracelog.c
+++ b/src/libtracelog/libtracelog.c
@@ -39,8 +39,6 @@
 // break recursivity on fopen call
 typedef FILE *(*orig_fopen_t)(const char *pathname, const char *mode);
 static orig_fopen_t orig_fopen = NULL;
-typedef FILE *(*orig_fopen64_t)(const char *pathname, const char *mode);
-static orig_fopen64_t orig_fopen64 = NULL;
 
 //
 // blacklist storage
@@ -405,7 +403,9 @@ FILE *fopen(const char *pathname, const char *mode) {
 	return rv;
 }
 
-#ifdef __GLIBC__
+#ifndef fopen64
+typedef FILE *(*orig_fopen64_t)(const char *pathname, const char *mode);
+static orig_fopen64_t orig_fopen64 = NULL;
 FILE *fopen64(const char *pathname, const char *mode) {
 #ifdef DEBUG
 	printf("%s %s\n", __FUNCTION__, pathname);
@@ -420,7 +420,7 @@ FILE *fopen64(const char *pathname, const char *mode) {
 	FILE *rv = orig_fopen64(pathname, mode);
 	return rv;
 }
-#endif /* __GLIBC__ */
+#endif
 
 
 // freopen
@@ -441,7 +441,7 @@ FILE *freopen(const char *pathname, const char *mode, FILE *stream) {
 	return rv;
 }
 
-#ifdef __GLIBC__
+#ifndef freopen64
 typedef FILE *(*orig_freopen64_t)(const char *pathname, const char *mode, FILE *stream);
 static orig_freopen64_t orig_freopen64 = NULL;
 FILE *freopen64(const char *pathname, const char *mode, FILE *stream) {
@@ -458,7 +458,7 @@ FILE *freopen64(const char *pathname, const char *mode, FILE *stream) {
 	FILE *rv = orig_freopen64(pathname, mode, stream);
 	return rv;
 }
-#endif /* __GLIBC__ */
+#endif
 
 // unlink
 typedef int (*orig_unlink_t)(const char *pathname);
@@ -565,7 +565,7 @@ int stat(const char *pathname, struct stat *buf) {
 	return rv;
 }
 
-#ifdef __GLIBC__
+#ifndef stat64
 typedef int (*orig_stat64_t)(const char *pathname, struct stat64 *buf);
 static orig_stat64_t orig_stat64 = NULL;
 int stat64(const char *pathname, struct stat64 *buf) {
@@ -582,7 +582,7 @@ int stat64(const char *pathname, struct stat64 *buf) {
 	int rv = orig_stat64(pathname, buf);
 	return rv;
 }
-#endif /* __GLIBC__ */
+#endif
 
 typedef int (*orig_lstat_t)(const char *pathname, struct stat *buf);
 static orig_lstat_t orig_lstat = NULL;
@@ -601,7 +601,7 @@ int lstat(const char *pathname, struct stat *buf) {
 	return rv;
 }
 
-#ifdef __GLIBC__
+#ifndef lstat64
 typedef int (*orig_lstat64_t)(const char *pathname, struct stat64 *buf);
 static orig_lstat64_t orig_lstat64 = NULL;
 int lstat64(const char *pathname, struct stat64 *buf) {
@@ -618,7 +618,7 @@ int lstat64(const char *pathname, struct stat64 *buf) {
 	int rv = orig_lstat64(pathname, buf);
 	return rv;
 }
-#endif /* __GLIBC__ */
+#endif
 
 // access
 typedef int (*orig_access_t)(const char *pathname, int mode);


### PR DESCRIPTION
Fixes two warnings when building firejail with musl libc.

Should fix #5421.