### PR TITLE
lutris.profile: fix running League of Legends

### DIFF
--- a/etc/profile-a-l/lutris.profile
+++ b/etc/profile-a-l/lutris.profile
@@ -69,7 +69,8 @@ notv
 nou2f
 novideo
 protocol unix,inet,inet6,netlink
-seccomp
+seccomp !modify_ldt
+seccomp.32 !modify_ldt
 
 # Add the next line to your lutris.local if you do not need controller support.
 #private-dev


### PR DESCRIPTION
@Latrolage on Oct 20, 2022[1]:

> When I open the game the only error line which appears is this
> `modify_ldt: Operation not permitted`

So as suggested by @Latrolage[1] and @rusty-snake[2], allow the
`modify_ldt` syscall in seccomp.

Fixes #5430.

[1] https://github.com/netblue30/firejail/discussions/5430#discussion-4488996
[2] https://github.com/netblue30/firejail/discussions/5430#discussioncomment-3924098

Reported-by: @Latrolage