### PR TITLE
Grant KeePassXC access to the Wayland socket

### DIFF
--- a/etc/profile-a-l/keepassxc.profile
+++ b/etc/profile-a-l/keepassxc.profile
@@ -62,6 +62,7 @@ include disable-xdg.inc
 #whitelist ${HOME}/.config/KeePassXCrc
 #include whitelist-common.inc
 
+whitelist ${RUNUSER}/wayland-*
 whitelist /usr/share/keepassxc
 include whitelist-run-common.inc
 include whitelist-usr-share-common.inc


### PR DESCRIPTION
KeePassXC is a graphical application, and won't start without this set.