### PR TITLE
firefox-common.profile: allow semtimedop syscall

### DIFF
--- a/etc/profile-a-l/firefox-common.profile
+++ b/etc/profile-a-l/firefox-common.profile
@@ -47,7 +47,7 @@ notv
 ?BROWSER_DISABLE_U2F: nou2f
 protocol unix,inet,inet6,netlink
 # The below seccomp configuration still permits chroot syscall. See https://github.com/netblue30/firejail/issues/2506 for possible workarounds.
-seccomp !chroot
+seccomp !chroot,!semtimedop
 # Disable tracelog, it breaks or causes major issues with many firefox based browsers, see https://github.com/netblue30/firejail/issues/1930.
 #tracelog
 


### PR DESCRIPTION
To prevent the audit logs from being flooded with this:

    audit: type=1326 [...] exe="/usr/lib/librewolf/librewolf" sig=0 arch=c000003e syscall=220 compat=0 [...] code=0x50000
