### PR TITLE
ci: sort and ignore more paths

### DIFF
--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -6,6 +6,8 @@ on:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - 'etc/**'
+      - 'contrib/vim/**'
+      - 'src/man/*.txt'
       - .git-blame-ignore-revs
       - .github/dependabot.yml
       - .github/pull_request_template.md
@@ -24,6 +26,8 @@ on:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - 'etc/**'
+      - 'contrib/vim/**'
+      - 'src/man/*.txt'
       - .git-blame-ignore-revs
       - .github/dependabot.yml
       - .github/pull_request_template.md

--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [ master ]
     paths-ignore:
+      - '.github/ISSUE_TEMPLATE/*'
+      - 'etc/**'
       - .git-blame-ignore-revs
+      - .github/pull_request_template.md
       - .gitignore
       - CONTRIBUTING.md
       - COPYING
@@ -12,14 +15,14 @@ on:
       - README.md
       - RELNOTES
       - SECURITY.md
-      - 'etc/**'
-      - 'src/firecfg/firecfg.config'
-      - '.github/ISSUE_TEMPLATE/*'
-      - '.github/pull_request_template.md'
+      - src/firecfg/firecfg.config
   pull_request:
     branches: [ master ]
     paths-ignore:
+      - '.github/ISSUE_TEMPLATE/*'
+      - 'etc/**'
       - .git-blame-ignore-revs
+      - .github/pull_request_template.md
       - .gitignore
       - CONTRIBUTING.md
       - COPYING
@@ -27,10 +30,7 @@ on:
       - README.md
       - RELNOTES
       - SECURITY.md
-      - 'etc/**'
-      - 'src/firecfg/firecfg.config'
-      - '.github/ISSUE_TEMPLATE/*'
-      - '.github/pull_request_template.md'
+      - src/firecfg/firecfg.config
 
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -9,6 +9,7 @@ on:
       - .git-blame-ignore-revs
       - .github/dependabot.yml
       - .github/pull_request_template.md
+      - .github/workflows/codeql-analysis.yml
       - .gitignore
       - .gitlab-ci.yml
       - CONTRIBUTING.md
@@ -26,6 +27,7 @@ on:
       - .git-blame-ignore-revs
       - .github/dependabot.yml
       - .github/pull_request_template.md
+      - .github/workflows/codeql-analysis.yml
       - .gitignore
       - .gitlab-ci.yml
       - CONTRIBUTING.md

--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -7,8 +7,10 @@ on:
       - '.github/ISSUE_TEMPLATE/*'
       - 'etc/**'
       - .git-blame-ignore-revs
+      - .github/dependabot.yml
       - .github/pull_request_template.md
       - .gitignore
+      - .gitlab-ci.yml
       - CONTRIBUTING.md
       - COPYING
       - README
@@ -22,8 +24,10 @@ on:
       - '.github/ISSUE_TEMPLATE/*'
       - 'etc/**'
       - .git-blame-ignore-revs
+      - .github/dependabot.yml
       - .github/pull_request_template.md
       - .gitignore
+      - .gitlab-ci.yml
       - CONTRIBUTING.md
       - COPYING
       - README

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
       - .git-blame-ignore-revs
       - .github/dependabot.yml
       - .github/pull_request_template.md
+      - .github/workflows/codeql-analysis.yml
       - .gitignore
       - .gitlab-ci.yml
       - CONTRIBUTING.md
@@ -23,6 +24,7 @@ on:
       - .git-blame-ignore-revs
       - .github/dependabot.yml
       - .github/pull_request_template.md
+      - .github/workflows/codeql-analysis.yml
       - .gitignore
       - .gitlab-ci.yml
       - CONTRIBUTING.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [ master ]
     paths-ignore:
+      - '.github/ISSUE_TEMPLATE/*'
       - .git-blame-ignore-revs
+      - .github/pull_request_template.md
       - .gitignore
       - CONTRIBUTING.md
       - COPYING
@@ -15,7 +17,9 @@ on:
   pull_request:
     branches: [ master ]
     paths-ignore:
+      - '.github/ISSUE_TEMPLATE/*'
       - .git-blame-ignore-revs
+      - .github/pull_request_template.md
       - .gitignore
       - CONTRIBUTING.md
       - COPYING

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,10 @@ on:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - .git-blame-ignore-revs
+      - .github/dependabot.yml
       - .github/pull_request_template.md
       - .gitignore
+      - .gitlab-ci.yml
       - CONTRIBUTING.md
       - COPYING
       - README
@@ -19,8 +21,10 @@ on:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - .git-blame-ignore-revs
+      - .github/dependabot.yml
       - .github/pull_request_template.md
       - .gitignore
+      - .gitlab-ci.yml
       - CONTRIBUTING.md
       - COPYING
       - README

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches: [ master ]
     paths-ignore:
+      - 'etc/**'
       - .git-blame-ignore-revs
       - .gitignore
       - CONTRIBUTING.md
@@ -17,11 +18,11 @@ on:
       - README.md
       - RELNOTES
       - SECURITY.md
-      - 'etc/**'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
     paths-ignore:
+      - 'etc/**'
       - .git-blame-ignore-revs
       - .gitignore
       - CONTRIBUTING.md
@@ -30,7 +31,6 @@ on:
       - README.md
       - RELNOTES
       - SECURITY.md
-      - 'etc/**'
   schedule:
     - cron: '0 7 * * 2'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,8 +12,10 @@ on:
       - '.github/ISSUE_TEMPLATE/*'
       - 'etc/**'
       - .git-blame-ignore-revs
+      - .github/dependabot.yml
       - .github/pull_request_template.md
       - .gitignore
+      - .gitlab-ci.yml
       - CONTRIBUTING.md
       - COPYING
       - README
@@ -27,8 +29,10 @@ on:
       - '.github/ISSUE_TEMPLATE/*'
       - 'etc/**'
       - .git-blame-ignore-revs
+      - .github/dependabot.yml
       - .github/pull_request_template.md
       - .gitignore
+      - .gitlab-ci.yml
       - CONTRIBUTING.md
       - COPYING
       - README

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,7 @@ on:
       - README.md
       - RELNOTES
       - SECURITY.md
+      - src/firecfg/firecfg.config
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
@@ -39,6 +40,7 @@ on:
       - README.md
       - RELNOTES
       - SECURITY.md
+      - src/firecfg/firecfg.config
   schedule:
     - cron: '0 7 * * 2'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,8 @@ on:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - 'etc/**'
+      - 'contrib/vim/**'
+      - 'src/man/*.txt'
       - .git-blame-ignore-revs
       - .github/dependabot.yml
       - .github/pull_request_template.md
@@ -29,6 +31,8 @@ on:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - 'etc/**'
+      - 'contrib/vim/**'
+      - 'src/man/*.txt'
       - .git-blame-ignore-revs
       - .github/dependabot.yml
       - .github/pull_request_template.md

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,8 +9,10 @@ on:
   push:
     branches: [ master ]
     paths-ignore:
+      - '.github/ISSUE_TEMPLATE/*'
       - 'etc/**'
       - .git-blame-ignore-revs
+      - .github/pull_request_template.md
       - .gitignore
       - CONTRIBUTING.md
       - COPYING
@@ -22,8 +24,10 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ master ]
     paths-ignore:
+      - '.github/ISSUE_TEMPLATE/*'
       - 'etc/**'
       - .git-blame-ignore-revs
+      - .github/pull_request_template.md
       - .gitignore
       - CONTRIBUTING.md
       - COPYING

--- a/.github/workflows/profile-checks.yml
+++ b/.github/workflows/profile-checks.yml
@@ -4,17 +4,17 @@ on:
   push:
     branches: [ master ]
     paths:
-      - 'etc/**'
       - 'ci/check/profiles/**'
-      - 'src/firecfg/firecfg.config'
-      - 'contrib/sort.py'
+      - 'etc/**'
+      - contrib/sort.py
+      - src/firecfg/firecfg.config
   pull_request:
     branches: [ master ]
     paths:
-      - 'etc/**'
       - 'ci/check/profiles/**'
-      - 'src/firecfg/firecfg.config'
-      - 'contrib/sort.py'
+      - 'etc/**'
+      - contrib/sort.py
+      - src/firecfg/firecfg.config
 
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read


### PR DESCRIPTION
Commits:

```console
$ git log --reverse --pretty='* %s' master..
* ci: sort items on paths-ignore lists
* ci: ignore github markdown templates in all workflows
* ci: ignore dependabot and gitlab-ci in all workflows
* ci: ignore codeql workflow file in other workflows
* ci: ignore firecfg.config in the codeql workflow
* ci: ignore man/vim paths in build-extra/codeql workflows
```

Sort the paths and then ignore unnecessary files (mainly ignore workflow files
in other workflows).

Relates to #5249.

Kind of relates to #5289 #5296.
