### PR TITLE
firefox-common.profile: Add DRM support when using psd

### DIFF
--- a/etc/profile-a-l/firefox-common.profile
+++ b/etc/profile-a-l/firefox-common.profile
@@ -8,6 +8,8 @@ include firefox-common.local
 
 # noexec ${HOME} breaks DRM binaries.
 ?BROWSER_ALLOW_DRM: ignore noexec ${HOME}
+# noexec ${RUNUSER} breaks DRM binaries when using profile-sync-daemon.
+?BROWSER_ALLOW_DRM: ignore noexec ${RUNUSER}
 
 # Add the next line to your firefox-common.local to allow access to common programs/addons/plugins.
 #include firefox-common-addons.profile


### PR DESCRIPTION
We already added profile-sync-daemon (psd) support in firefox.profile with:
noblacklist ${RUNUSER}/psd/*firefox*
whitelist ${RUNUSER}/psd/*firefox*
This PR fixes DRM usage when using psd by ignoring noexec ${RUNUSER}.