### PR TITLE
build: fix formatting and misc in configure

### DIFF
--- a/configure
+++ b/configure
@@ -3670,7 +3670,7 @@ if test "x$enable_lts" = "xyes"; then :
 	HAVE_FILE_TRANSFER=""
 	HAVE_SUID="-DHAVE_SUID"
 	BUSYBOX_WORKAROUND="no"
-	HAVE_CONTRIB_INSTALL="no",
+	HAVE_CONTRIB_INSTALL="no"
 
 fi
 

--- a/configure
+++ b/configure
@@ -5288,7 +5288,7 @@ if test "$HAVE_LTS" = -DHAVE_LTS; then
 
 *********************************************************
 *    Warning: Long-term support (LTS) was enabled!      *
-*    Most compile-time options have bean rewritten!     *
+*    Most compile-time options have been rewritten!     *
 *********************************************************
 
 

--- a/configure
+++ b/configure
@@ -3056,7 +3056,8 @@ else
 fi
 
 if test "x$enable_sanitizer" != "xno" ; then :
-  as_CACHEVAR=`$as_echo "ax_cv_check_cflags__-fsanitize=$enable_sanitizer" | $as_tr_sh`
+
+	as_CACHEVAR=`$as_echo "ax_cv_check_cflags__-fsanitize=$enable_sanitizer" | $as_tr_sh`
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -fsanitize=$enable_sanitizer" >&5
 $as_echo_n "checking whether C compiler accepts -fsanitize=$enable_sanitizer... " >&6; }
 if eval \${$as_CACHEVAR+:} false; then :
@@ -3094,8 +3095,8 @@ if eval test \"x\$"$as_CACHEVAR"\" = x"yes"; then :
 
 else
   as_fn_error $? "sanitizer not supported: $enable_sanitizer" "$LINENO" 5
-
 fi
+
 
 fi
 

--- a/configure
+++ b/configure
@@ -3615,7 +3615,7 @@ fi
 
 if test "x$enable_contrib_install" = "xno"; then :
 
-       HAVE_CONTRIB_INSTALL="no"
+	HAVE_CONTRIB_INSTALL="no"
 
 fi
 
@@ -3641,7 +3641,7 @@ fi
 
 if test "x$enable_only_syscfg_profiles" = "xyes"; then :
 
-    HAVE_ONLY_SYSCFG_PROFILES="-DHAVE_ONLY_SYSCFG_PROFILES"
+	HAVE_ONLY_SYSCFG_PROFILES="-DHAVE_ONLY_SYSCFG_PROFILES"
 
 fi
 

--- a/configure
+++ b/configure
@@ -5282,13 +5282,10 @@ EOF
 
 if test "$HAVE_LTS" = -DHAVE_LTS; then
 	cat <<\EOF
-
-
 *********************************************************
 *    Warning: Long-term support (LTS) was enabled!      *
 *    Most compile-time options have been rewritten!     *
 *********************************************************
-
 
 EOF
 fi

--- a/configure
+++ b/configure
@@ -3345,7 +3345,6 @@ fi
 
 
 
-
 HAVE_DBUSPROXY=""
 
 # Check whether --enable-dbusproxy was given.
@@ -3590,7 +3589,6 @@ if test "x$enable_busybox_workaround" = "xyes"; then :
 	BUSYBOX_WORKAROUND="yes"
 
 fi
-
 
 HAVE_GCOV=""
 

--- a/configure
+++ b/configure
@@ -2914,7 +2914,9 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___mindirect_branch_thunk" >&5
 $as_echo "$ax_cv_check_cflags___mindirect_branch_thunk" >&6; }
 if test "x$ax_cv_check_cflags___mindirect_branch_thunk" = xyes; then :
-  HAVE_SPECTRE="yes" && EXTRA_CFLAGS="$EXTRA_CFLAGS -mindirect-branch=thunk"
+
+	HAVE_SPECTRE="yes"
+	EXTRA_CFLAGS="$EXTRA_CFLAGS -mindirect-branch=thunk"
 
 else
   :
@@ -2950,7 +2952,9 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___mretpoline" >&5
 $as_echo "$ax_cv_check_cflags___mretpoline" >&6; }
 if test "x$ax_cv_check_cflags___mretpoline" = xyes; then :
-  HAVE_SPECTRE="yes" && EXTRA_CFLAGS="$EXTRA_CFLAGS -mretpoline"
+
+	HAVE_SPECTRE="yes"
+	EXTRA_CFLAGS="$EXTRA_CFLAGS -mretpoline"
 
 else
   :
@@ -2986,7 +2990,9 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___fstack_clash_protection" >&5
 $as_echo "$ax_cv_check_cflags___fstack_clash_protection" >&6; }
 if test "x$ax_cv_check_cflags___fstack_clash_protection" = xyes; then :
-  HAVE_SPECTRE="yes" && EXTRA_CFLAGS="$EXTRA_CFLAGS -fstack-clash-protection"
+
+	HAVE_SPECTRE="yes"
+	EXTRA_CFLAGS="$EXTRA_CFLAGS -fstack-clash-protection"
 
 else
   :
@@ -3022,7 +3028,9 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___fstack_protector_strong" >&5
 $as_echo "$ax_cv_check_cflags___fstack_protector_strong" >&6; }
 if test "x$ax_cv_check_cflags___fstack_protector_strong" = xyes; then :
-  HAVE_SPECTRE="yes" && EXTRA_CFLAGS="$EXTRA_CFLAGS -fstack-protector-strong"
+
+	HAVE_SPECTRE="yes"
+	EXTRA_CFLAGS="$EXTRA_CFLAGS -fstack-protector-strong"
 
 else
   :
@@ -3323,7 +3331,10 @@ else
 	AA_LIBS=$pkg_cv_AA_LIBS
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-	EXTRA_CFLAGS="$EXTRA_CFLAGS $AA_CFLAGS" && EXTRA_LDFLAGS="$EXTRA_LDFLAGS $AA_LIBS"
+
+		EXTRA_CFLAGS="$EXTRA_CFLAGS $AA_CFLAGS"
+		EXTRA_LDFLAGS="$EXTRA_LDFLAGS $AA_LIBS"
+
 fi
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -328,7 +328,7 @@ if test "$HAVE_LTS" = -DHAVE_LTS; then
 
 *********************************************************
 *    Warning: Long-term support (LTS) was enabled!      *
-*    Most compile-time options have bean rewritten!     *
+*    Most compile-time options have been rewritten!     *
 *********************************************************
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -272,7 +272,7 @@ AS_IF([test "x$enable_lts" = "xyes"], [
 	HAVE_FILE_TRANSFER=""
 	HAVE_SUID="-DHAVE_SUID"
 	BUSYBOX_WORKAROUND="no"
-	HAVE_CONTRIB_INSTALL="no",
+	HAVE_CONTRIB_INSTALL="no"
 ])
 
 AC_CHECK_HEADER([linux/seccomp.h], [], AC_MSG_ERROR([*** SECCOMP support is not installed (/usr/include/linux/seccomp.h missing) ***]))

--- a/configure.ac
+++ b/configure.ac
@@ -322,13 +322,10 @@ EOF
 
 if test "$HAVE_LTS" = -DHAVE_LTS; then
 	cat <<\EOF
-
-
 *********************************************************
 *    Warning: Long-term support (LTS) was enabled!      *
 *    Most compile-time options have been rewritten!     *
 *********************************************************
-
 
 EOF
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -45,8 +45,10 @@ AS_IF([test "x$enable_analyzer" = "xyes"], [
 ])
 
 AC_ARG_ENABLE([sanitizer],
-    [AS_HELP_STRING([--enable-sanitizer=@<:@address | memory | undefined@:>@], [enable a compiler-based sanitizer (debug)])],
-    [], [enable_sanitizer=no])
+    [AS_HELP_STRING([--enable-sanitizer=@<:@address | memory | undefined@:>@],
+        [enable a compiler-based sanitizer (debug)])],
+    [],
+    [enable_sanitizer=no])
 AS_IF([test "x$enable_sanitizer" != "xno" ],
 	[AX_CHECK_COMPILE_FLAG([-fsanitize=$enable_sanitizer], [
 		EXTRA_CFLAGS="$EXTRA_CFLAGS -fsanitize=$enable_sanitizer -fno-omit-frame-pointer"

--- a/configure.ac
+++ b/configure.ac
@@ -232,7 +232,7 @@ AC_SUBST([HAVE_CONTRIB_INSTALL])
 AC_ARG_ENABLE([contrib-install],
     [AS_HELP_STRING([--enable-contrib-install], [install contrib scripts])])
 AS_IF([test "x$enable_contrib_install" = "xno"], [
-       HAVE_CONTRIB_INSTALL="no"
+	HAVE_CONTRIB_INSTALL="no"
 ])
 
 HAVE_FORCE_NONEWPRIVS=""
@@ -248,7 +248,7 @@ AC_SUBST([HAVE_ONLY_SYSCFG_PROFILES])
 AC_ARG_ENABLE([only-syscfg-profiles],
     [AS_HELP_STRING([--enable-only-syscfg-profiles], [disable profiles in $HOME/.config/firejail])])
 AS_IF([test "x$enable_only_syscfg_profiles" = "xyes"], [
-    HAVE_ONLY_SYSCFG_PROFILES="-DHAVE_ONLY_SYSCFG_PROFILES"
+	HAVE_ONLY_SYSCFG_PROFILES="-DHAVE_ONLY_SYSCFG_PROFILES"
 ])
 
 HAVE_LTS=""

--- a/configure.ac
+++ b/configure.ac
@@ -277,7 +277,8 @@ AS_IF([test "x$enable_lts" = "xyes"], [
 	HAVE_CONTRIB_INSTALL="no"
 ])
 
-AC_CHECK_HEADER([linux/seccomp.h], [], AC_MSG_ERROR([*** SECCOMP support is not installed (/usr/include/linux/seccomp.h missing) ***]))
+AC_CHECK_HEADER([linux/seccomp.h], [],
+    [AC_MSG_ERROR([*** SECCOMP support is not installed (/usr/include/linux/seccomp.h missing) ***])])
 
 # set sysconfdir
 if test "$prefix" = /usr; then

--- a/configure.ac
+++ b/configure.ac
@@ -84,7 +84,6 @@ AS_IF([test "x$enable_selinux" = "xyes"], [
 AC_SUBST([EXTRA_CFLAGS])
 AC_SUBST([EXTRA_LDFLAGS])
 
-
 HAVE_DBUSPROXY=""
 AC_SUBST([HAVE_DBUSPROXY])
 AC_ARG_ENABLE([dbusproxy],
@@ -216,7 +215,6 @@ AC_ARG_ENABLE([busybox-workaround],
 AS_IF([test "x$enable_busybox_workaround" = "xyes"], [
 	BUSYBOX_WORKAROUND="yes"
 ])
-
 
 HAVE_GCOV=""
 AC_SUBST([HAVE_GCOV])

--- a/configure.ac
+++ b/configure.ac
@@ -21,22 +21,22 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
 
 HAVE_SPECTRE="no"
-AX_CHECK_COMPILE_FLAG(
-    [-mindirect-branch=thunk],
-    [HAVE_SPECTRE="yes" && EXTRA_CFLAGS="$EXTRA_CFLAGS -mindirect-branch=thunk"]
-)
-AX_CHECK_COMPILE_FLAG(
-    [-mretpoline],
-    [HAVE_SPECTRE="yes" && EXTRA_CFLAGS="$EXTRA_CFLAGS -mretpoline"]
-)
-AX_CHECK_COMPILE_FLAG(
-    [-fstack-clash-protection],
-    [HAVE_SPECTRE="yes" && EXTRA_CFLAGS="$EXTRA_CFLAGS -fstack-clash-protection"]
-)
-AX_CHECK_COMPILE_FLAG(
-    [-fstack-protector-strong],
-    [HAVE_SPECTRE="yes" && EXTRA_CFLAGS="$EXTRA_CFLAGS -fstack-protector-strong"]
-)
+AX_CHECK_COMPILE_FLAG([-mindirect-branch=thunk], [
+	HAVE_SPECTRE="yes"
+	EXTRA_CFLAGS="$EXTRA_CFLAGS -mindirect-branch=thunk"
+])
+AX_CHECK_COMPILE_FLAG([-mretpoline], [
+	HAVE_SPECTRE="yes"
+	EXTRA_CFLAGS="$EXTRA_CFLAGS -mretpoline"
+])
+AX_CHECK_COMPILE_FLAG([-fstack-clash-protection], [
+	HAVE_SPECTRE="yes"
+	EXTRA_CFLAGS="$EXTRA_CFLAGS -fstack-clash-protection"
+])
+AX_CHECK_COMPILE_FLAG([-fstack-protector-strong], [
+	HAVE_SPECTRE="yes"
+	EXTRA_CFLAGS="$EXTRA_CFLAGS -fstack-protector-strong"
+])
 
 AC_ARG_ENABLE([analyzer],
     [AS_HELP_STRING([--enable-analyzer], [enable GCC static analyzer])])
@@ -68,8 +68,10 @@ AC_ARG_ENABLE([apparmor],
     [AS_HELP_STRING([--enable-apparmor], [enable apparmor])])
 AS_IF([test "x$enable_apparmor" = "xyes"], [
 	HAVE_APPARMOR="-DHAVE_APPARMOR"
-	PKG_CHECK_MODULES([AA], [libapparmor],
-	    [EXTRA_CFLAGS="$EXTRA_CFLAGS $AA_CFLAGS" && EXTRA_LDFLAGS="$EXTRA_LDFLAGS $AA_LIBS"])
+	PKG_CHECK_MODULES([AA], [libapparmor], [
+		EXTRA_CFLAGS="$EXTRA_CFLAGS $AA_CFLAGS"
+		EXTRA_LDFLAGS="$EXTRA_LDFLAGS $AA_LIBS"
+	])
 ])
 
 HAVE_SELINUX=""

--- a/configure.ac
+++ b/configure.ac
@@ -49,12 +49,12 @@ AC_ARG_ENABLE([sanitizer],
         [enable a compiler-based sanitizer (debug)])],
     [],
     [enable_sanitizer=no])
-AS_IF([test "x$enable_sanitizer" != "xno" ],
-	[AX_CHECK_COMPILE_FLAG([-fsanitize=$enable_sanitizer], [
+AS_IF([test "x$enable_sanitizer" != "xno" ], [
+	AX_CHECK_COMPILE_FLAG([-fsanitize=$enable_sanitizer], [
 		EXTRA_CFLAGS="$EXTRA_CFLAGS -fsanitize=$enable_sanitizer -fno-omit-frame-pointer"
 		EXTRA_LDFLAGS="$EXTRA_LDFLAGS -fsanitize=$enable_sanitizer"
-	], [AC_MSG_ERROR([sanitizer not supported: $enable_sanitizer])]
-)])
+	], [AC_MSG_ERROR([sanitizer not supported: $enable_sanitizer])])
+])
 
 HAVE_IDS=""
 AC_SUBST([HAVE_IDS])


### PR DESCRIPTION
Commits:

```console
$ git log --reverse --pretty='* %s' master..
* configure*: fix typo of "been"
* configure*: fix trailing comma in HAVE_CONTRIB_INSTALL
* configure*: fix indentation
* configure*: remove extraneous blank lines
* configure*: remove extraneous blank lines (warning)
* configure*: wrap long shell command output lines
* configure*: wrap long AS_HELP_STRING line (sanitizer)
* configure*: fix quotes/parens alignment (sanitizer)
* configure*: quote and line-wrap AC_CHECK_HEADER line
```

Relates to #4712.
