### PR TITLE
kcalc.profile: fix mkfile without mkdir & comment legacy paths

### DIFF
--- a/etc/profile-a-l/kcalc.profile
+++ b/etc/profile-a-l/kcalc.profile
@@ -16,6 +16,8 @@ include disable-programs.inc
 include disable-shell.inc
 include disable-xdg.inc
 
+mkdir ${HOME}/.kde/share/config
+mkdir ${HOME}/.kde4/share/config
 mkdir ${HOME}/.local/share/kxmlgui5/kcalc
 mkfile ${HOME}/.config/kcalcrc
 mkfile ${HOME}/.kde/share/config/kcalcrc

--- a/etc/profile-a-l/kcalc.profile
+++ b/etc/profile-a-l/kcalc.profile
@@ -16,12 +16,14 @@ include disable-programs.inc
 include disable-shell.inc
 include disable-xdg.inc
 
-mkdir ${HOME}/.kde/share/config
-mkdir ${HOME}/.kde4/share/config
+# Legacy paths
+#mkdir ${HOME}/.kde/share/config
+#mkdir ${HOME}/.kde4/share/config
+#mkfile ${HOME}/.kde/share/config/kcalcrc
+#mkfile ${HOME}/.kde4/share/config/kcalcrc
+
 mkdir ${HOME}/.local/share/kxmlgui5/kcalc
 mkfile ${HOME}/.config/kcalcrc
-mkfile ${HOME}/.kde/share/config/kcalcrc
-mkfile ${HOME}/.kde4/share/config/kcalcrc
 whitelist ${HOME}/.config/kcalcrc
 whitelist ${HOME}/.kde/share/config/kcalcrc
 whitelist ${HOME}/.kde4/share/config/kcalcrc


### PR DESCRIPTION
kcalc.profile: fix mkfile without mkdir

firejail may fail to create the following files:

* ~/.kde/share/config/kcalcrc
* ~/.kde4/share/config/kcalcrc

Because it does not create the preceding directories beforehand:

* ~/.kde/share/config
* ~/.kde4/share/config

---

kcalc.profile: stop creating legacy KDE paths

Leave them commented.

With this commit, there are no more profiles creating paths in ~/.kde
nor in ~/.kde4:

    $ git grep -e '^mkdir .*\.kde' -e '^mkfile .*\.kde' -- etc
    $

Relates to #5415.