### PR TITLE
Add basic gtksourceview language-spec

### DIFF
--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - 'etc/**'
+      - 'contrib/gtksourceview-5/**'
       - 'contrib/vim/**'
       - 'src/man/*.txt'
       - .git-blame-ignore-revs
@@ -27,6 +28,7 @@ on:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - 'etc/**'
+      - 'contrib/gtksourceview-5/**'
       - 'contrib/vim/**'
       - 'src/man/*.txt'
       - .git-blame-ignore-revs

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,7 @@ on:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - 'etc/**'
+      - 'contrib/gtksourceview-5/**'
       - 'contrib/vim/**'
       - 'src/man/*.txt'
       - .git-blame-ignore-revs
@@ -32,6 +33,7 @@ on:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - 'etc/**'
+      - 'contrib/gtksourceview-5/**'
       - 'contrib/vim/**'
       - 'src/man/*.txt'
       - .git-blame-ignore-revs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ If you add a new command, here's the checklist:
  - [ ] Update manpages: firejail(1) and firejail-profile(5)
  - [ ] Update shell completions
  - [ ] Update vim syntax files
+ - [ ] Update gtksourceview language specs
  - [ ] Update --help
 
 # Editing the wiki

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,9 @@ ifeq ($(HAVE_CONTRIB_INSTALL),yes)
 	install -m 0755 -d $(DESTDIR)$(datarootdir)/vim/vimfiles/syntax
 	install -m 0644 contrib/vim/ftdetect/firejail.vim $(DESTDIR)$(datarootdir)/vim/vimfiles/ftdetect
 	install -m 0644 contrib/vim/syntax/firejail.vim $(DESTDIR)$(datarootdir)/vim/vimfiles/syntax
+	# gtksourceview-5 language-specs
+	install -m 0755 -d $(DESTDIR)$(datarootdir)/gtksourceview-5/language-specs
+	install -m 0644 contrib/gtksourceview-5/language-specs/firejail-profile.lang $(DESTDIR)$(datarootdir)/gtksourceview-5/language-specs
 endif
 	# documents
 	install -m 0755 -d $(DESTDIR)$(docdir)

--- a/contrib/gtksourceview-5/language-specs/firejail-profile.lang
+++ b/contrib/gtksourceview-5/language-specs/firejail-profile.lang
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- vim: set ts=2 sts=2 sw=2 et: -->
+<!--
+  https://gitlab.gnome.org/GNOME/gtksourceview/-/blob/master/docs/lang-tutorial.md
+  https://gitlab.gnome.org/GNOME/gtksourceview/-/blob/master/docs/lang-reference.md
+-->
+<language id="firejail-profile" name="Firejail Profile" version="2.0" _section="Other">
+  <metadata>
+    <property name="mimetypes">text/plain;text/x-firejail-profile</property>
+    <property name="globs">*.profile;*.local;*.inc</property>
+    <property name="line-comment-start">#</property>
+  </metadata>
+
+  <styles>
+    <style id="comment" name="Comment" map-to="def:comment"/>
+    <style id="condition" name="Condition" map-to="def:preprocessor"/>
+    <style id="command" name="Command" map-to="def:keyword"/>
+    <style id="invalid" name="Invalid" map-to="def:error"/>
+  </styles>
+
+  <definitions>
+    <define-regex id="commands-with-arguments" extended="true">
+      (apparmor|bind|blacklist-nolog|blacklist|caps.drop|caps.keep|cpu|dbus-system.broadcast|dbus-system.call|dbus-system.own|dbus-system.see|dbus-system.talk|dbus-system|dbus-user.broadcast|dbus-user.call|dbus-user.own|dbus-user.see|dbus-user.talk|dbus-user|defaultgw|dns|env|hostname|hosts-file|ignore|include|ip6|ip|iprange|join-or-start|keep-fd|mac|mkdir|mkfile|mtu|name|net|netfilter6|netfilter|netmask|netns|nice|noblacklist|noexec|nowhitelist|overlay-named|private-bin|private-cwd|private-etc|private-home|private-lib|private-opt|private-srv|private|protocol|read-only|read-write|restrict-namespaces|rlimit-as|rlimit-cpu|rlimit-fsize|rlimit-nofile|rlimit-nproc|rlimit-sigpending|rlimit|rmenv|seccomp-error-action|seccomp.32.drop|seccomp.32.keep|seccomp.32|seccomp.drop|seccomp.keep|seccomp|shell|timeout|tmpfs|veth-name|whitelist-ro|whitelist|x11|xephyr-screen)
+    </define-regex>
+
+    <define-regex id="commands-without-arguments" extended="true">
+      (allow-debuggers|allusers|apparmor|caps|deterministic-exit-code|deterministic-shutdown|disable-mnt|ipc-namespace|keep-config-pulse|keep-dev-shm|keep-fd|keep-var-tmp|machine-id|memory-deny-write-execute|netfilter|no3d|noautopulse|nodbus|nodvd|nogroups|noinput|nonewprivs|noprinters|noroot|nosound|notv|nou2f|novideo|overlay-tmpfs|overlay|private-cache|private-cwd|private-dev|private-lib|private-tmp|private|quiet|restrict-namespaces|seccomp.32|seccomp.block-secondary|seccomp|tab|tracelog|writable-etc|writable-run-user|writable-var-log|writable-var|x11)
+    </define-regex>
+
+    <define-regex id="conditions" extended="true">
+      (ALLOW_TRAY|BROWSER_ALLOW_DRM|BROWSER_DISABLE_U2F|HAS_APPIMAGE|HAS_NET|HAS_NODBUS|HAS_NOSOUND|HAS_X11)
+    </define-regex>
+
+    <context id="conditional-line">
+      <match>\?(?P&lt;condition&gt;\%{conditions}): </match>
+      <include>
+        <context sub-pattern="condition" style-ref="condition"/>
+      </include>
+    </context>
+
+    <context id="command-with-args">
+      <match>(?P&lt;command&gt;\%{commands-with-arguments}) (?P&lt;args&gt;.+)</match>
+      <include>
+        <context sub-pattern="command" style-ref="command"/>
+      </include>
+    </context>
+
+    <context id="command-without-args">
+      <match dupnames="true">(?P&lt;command&gt;\%{commands-without-arguments})</match>
+      <include>
+        <context sub-pattern="command" style-ref="command"/>
+      </include>
+    </context>
+
+    <context id="invalid" style-ref="invalid">
+      <match>.+</match>
+    </context>
+
+    <context id="firejail-profile" class="no-spell-check">
+      <include>
+        <context ref="def:shell-like-comment"/>
+        <context ref="conditional-line"/>
+        <context ref="command-with-args"/>
+        <context ref="command-without-args"/>
+        <context ref="invalid"/>
+      </include>
+    </context>
+  </definitions>
+</language>


### PR DESCRIPTION
Tested with org.gnome.TextEditor.

The gtksourceview language-spec hasn't changed between gtksourceview 3, 4 and 5 AFAIK so it should also work on older systems if you copy/link the file in the right places.
