### PR TITLE
private-etc: always reference 'alternatives'

### DIFF
--- a/etc/profile-a-l/cantata.profile
+++ b/etc/profile-a-l/cantata.profile
@@ -34,6 +34,6 @@ novideo
 protocol unix,inet,inet6,netlink
 seccomp
 
-# private-etc drirc,fonts,gcrypt,hosts,kde5rc,mpd.conf,passwd,samba,ssl,xdg
+# private-etc alternatives,drirc,fonts,gcrypt,hosts,kde5rc,mpd.conf,passwd,samba,ssl,xdg
 private-bin cantata,mpd,perl
 private-dev

--- a/etc/profile-a-l/librecad.profile
+++ b/etc/profile-a-l/librecad.profile
@@ -39,7 +39,7 @@ seccomp
 #disable-mnt
 private-bin librecad
 private-dev
-# private-etc cups,drirc,fonts,passwd,xdg
+#private-etc alternatives,cups,drirc,fonts,passwd,xdg
 #private-lib
 private-tmp
 

--- a/etc/profile-m-z/ping.profile
+++ b/etc/profile-m-z/ping.profile
@@ -57,7 +57,7 @@ private
 private-cache
 private-dev
 # /etc/hosts is required in private-etc; however, just adding it to the list doesn't solve the problem!
-#private-etc ca-certificates,crypto-policies,hosts,pki,resolv.conf,ssl
+#private-etc alternatives,ca-certificates,crypto-policies,hosts,pki,resolv.conf,ssl
 private-lib
 private-tmp
 

--- a/etc/profile-m-z/rpcs3.profile
+++ b/etc/profile-m-z/rpcs3.profile
@@ -54,7 +54,7 @@ tracelog
 
 disable-mnt
 #private-cache
-#private-etc ca-certificates,crypto-policies,machine-id,pki,resolv.conf,ssl # seems to need awk
+#private-etc alternatives,ca-certificates,crypto-policies,machine-id,pki,resolv.conf,ssl # seems to need awk
 private-tmp
 
 dbus-user none


### PR DESCRIPTION
CI does checks on `private-etc` to always have 'alternatives' for Debian and derivatives. This PR ensures it's there, even in comments.