### PR TITLE
Avidemux tools support

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -42,6 +42,7 @@ blacklist ${HOME}/.asunder_album_title
 blacklist ${HOME}/.atom
 blacklist ${HOME}/.attic
 blacklist ${HOME}/.audacity-data
+blacklist ${HOME}/.avidemux3
 blacklist ${HOME}/.avidemux6
 blacklist ${HOME}/.ballbuster.hs
 blacklist ${HOME}/.balsa

--- a/etc/profile-a-l/avidemux.profile
+++ b/etc/profile-a-l/avidemux.profile
@@ -1,5 +1,6 @@
 # Firejail profile for Avidemux
 # Description: Avidemux is a free video editor designed for simple cutting, filtering and encoding tasks.
+# This file is overwritten after every install/update
 # Persistent local customizations
 include avidemux.local
 # Persistent global definitions

--- a/etc/profile-a-l/avidemux.profile
+++ b/etc/profile-a-l/avidemux.profile
@@ -6,6 +6,7 @@ include avidemux.local
 # Persistent global definitions
 include globals.local
 
+noblacklist ${HOME}/.avidemux3
 noblacklist ${HOME}/.avidemux6
 noblacklist ${HOME}/.config/avidemux3_qt5rc
 noblacklist ${VIDEOS}
@@ -18,8 +19,10 @@ include disable-programs.inc
 include disable-shell.inc
 include disable-xdg.inc
 
+mkdir ${HOME}/.avidemux3
 mkdir ${HOME}/.avidemux6
 mkdir ${HOME}/.config/avidemux3_qt5rc
+whitelist ${HOME}/.avidemux3
 whitelist ${HOME}/.avidemux6
 whitelist ${HOME}/.config/avidemux3_qt5rc
 whitelist ${VIDEOS}

--- a/etc/profile-a-l/avidemux3_cli.profile
+++ b/etc/profile-a-l/avidemux3_cli.profile
@@ -1,0 +1,11 @@
+# Firejail profile for avidemux3_cli
+# Description: The command-line interface for Avidemux.
+# This file is overwritten after every install/update
+# Persistent local customizations
+include avidemux3_cli.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+# Redirect
+include avidemux.profile

--- a/etc/profile-a-l/avidemux3_jobs_qt5.profile
+++ b/etc/profile-a-l/avidemux3_jobs_qt5.profile
@@ -1,0 +1,18 @@
+# Firejail profile for avidemux3_jobs_qt5
+# Description: The Qt5 GUI to run Avidemux jobs.
+# This file is overwritten after every install/update
+# Persistent local customizations
+include avidemux3_jobs_qt5.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+# Provide a shell to spawn avidemux3_cli
+include allow-bin-sh.inc
+private-bin sh
+
+# Needs to bind to a socket on localhost
+protocol inet,inet6
+
+# Redirect
+include avidemux3_qt5.profile

--- a/etc/profile-a-l/avidemux3_qt5.profile
+++ b/etc/profile-a-l/avidemux3_qt5.profile
@@ -1,0 +1,15 @@
+# Firejail profile for avidemux3_qt5
+# Description: The Qt5 GUI for Avidemux.
+# This file is overwritten after every install/update
+# Persistent local customizations
+include avidemux3_qt5.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+# Allow translations
+whitelist /usr/share/avidemux3
+whitelist /usr/share/avidemux6
+
+# Redirect
+include avidemux.profile

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -74,6 +74,7 @@ autokey-gtk
 autokey-qt
 autokey-run
 autokey-shell
+avidemux3_cli
 avidemux3_qt5
 aweather
 ballbuster

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -75,6 +75,7 @@ autokey-qt
 autokey-run
 autokey-shell
 avidemux3_cli
+avidemux3_jobs_qt5
 avidemux3_qt5
 aweather
 ballbuster


### PR DESCRIPTION
A profile already exists for Avidemux, but when running the GUI avidemux3_qt5, the GUI job processor avidemux3_jobs_qt5 or the command line interface avidemux3_cli, only the default profile is used (on openSUSE Tumbleweed with avidemux3 installed from the Packman repository). Add profiles for each of the tools.
The Avidemux builds from Packman are also patched to store settings in directory ~/.avidemux3 instead of ~/.avidemux6.