### PR TITLE
Add support for Qt6

### DIFF
--- a/etc/inc/whitelist-usr-share-common.inc
+++ b/etc/inc/whitelist-usr-share-common.inc
@@ -55,6 +55,7 @@ whitelist /usr/share/qt
 whitelist /usr/share/qt4
 whitelist /usr/share/qt5
 whitelist /usr/share/qt5ct
+whitelist /usr/share/qt6
 whitelist /usr/share/qt6ct
 whitelist /usr/share/sounds
 whitelist /usr/share/tcl8.6

--- a/etc/profile-m-z/qbittorrent.profile
+++ b/etc/profile-m-z/qbittorrent.profile
@@ -1,5 +1,5 @@
 # Firejail profile for qbittorrent
-# Description: BitTorrent client based on libtorrent-rasterbar with a Qt5 GUI
+# Description: An advanced BitTorrent client programmed in C++, based on Qt toolkit and libtorrent-rasterbar
 # This file is overwritten after every install/update
 # Persistent local customizations
 include qbittorrent.local


### PR DESCRIPTION
For now it looks as if only [qbittorrent](https://archlinux.org/packages/community/x86_64/qbittorrent/) uses Qt6 (on Arch Linux). I've checked and cantata, otter-browser and qutebrowser still use Qt5 so those profiles are fine as they are.