### PR TITLE
add restrict-namespaces to (almost) all profiles

### DIFF
--- a/etc/profile-a-l/0ad.profile
+++ b/etc/profile-a-l/0ad.profile
@@ -54,3 +54,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/2048-qt.profile
+++ b/etc/profile-a-l/2048-qt.profile
@@ -40,3 +40,5 @@ seccomp
 disable-mnt
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/Cryptocat.profile
+++ b/etc/profile-a-l/Cryptocat.profile
@@ -28,3 +28,5 @@ seccomp
 private-cache
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/Fritzing.profile
+++ b/etc/profile-a-l/Fritzing.profile
@@ -36,3 +36,4 @@ seccomp
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/JDownloader.profile
+++ b/etc/profile-a-l/JDownloader.profile
@@ -45,3 +45,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/abiword.profile
+++ b/etc/profile-a-l/abiword.profile
@@ -46,3 +46,5 @@ private-tmp
 
 # dbus-user none
 # dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/agetpkg.profile
+++ b/etc/profile-a-l/agetpkg.profile
@@ -56,3 +56,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/akonadi_control.profile
+++ b/etc/profile-a-l/akonadi_control.profile
@@ -55,3 +55,4 @@ tracelog
 private-dev
 # private-tmp - breaks programs that depend on akonadi
 
+# restrict-namespaces

--- a/etc/profile-a-l/akregator.profile
+++ b/etc/profile-a-l/akregator.profile
@@ -49,3 +49,4 @@ private-dev
 private-tmp
 
 deterministic-shutdown
+# restrict-namespaces

--- a/etc/profile-a-l/alacarte.profile
+++ b/etc/profile-a-l/alacarte.profile
@@ -62,3 +62,4 @@ read-write ${HOME}/.config/menus
 read-write ${HOME}/.gnome/apps
 read-write ${HOME}/.local/share/applications
 read-write ${HOME}/.local/share/flatpak/exports
+restrict-namespaces

--- a/etc/profile-a-l/alienarena.profile
+++ b/etc/profile-a-l/alienarena.profile
@@ -48,3 +48,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/alpine.profile
+++ b/etc/profile-a-l/alpine.profile
@@ -100,3 +100,4 @@ dbus-system none
 
 memory-deny-write-execute
 read-only ${HOME}/.signature
+restrict-namespaces

--- a/etc/profile-a-l/amarok.profile
+++ b/etc/profile-a-l/amarok.profile
@@ -44,3 +44,5 @@ dbus-user.talk org.freedesktop.Notifications
 #dbus-user.own org.kde.klauncher
 #dbus-user.talk org.kde.knotify
 dbus-system none
+
+# restrict-namespaces

--- a/etc/profile-a-l/amule.profile
+++ b/etc/profile-a-l/amule.profile
@@ -40,3 +40,4 @@ private-bin amule
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/android-studio.profile
+++ b/etc/profile-a-l/android-studio.profile
@@ -40,3 +40,4 @@ private-cache
 
 # noexec /tmp breaks 'Android Profiler'
 #noexec /tmp
+restrict-namespaces

--- a/etc/profile-a-l/anki.profile
+++ b/etc/profile-a-l/anki.profile
@@ -54,3 +54,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+# restrict-namespaces

--- a/etc/profile-a-l/anydesk.profile
+++ b/etc/profile-a-l/anydesk.profile
@@ -33,3 +33,5 @@ disable-mnt
 private-bin anydesk
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/aosp.profile
+++ b/etc/profile-a-l/aosp.profile
@@ -40,3 +40,5 @@ protocol unix,inet,inet6
 #seccomp
 
 private-tmp
+
+#restrict-namespaces

--- a/etc/profile-a-l/apktool.profile
+++ b/etc/profile-a-l/apktool.profile
@@ -35,3 +35,5 @@ private-dev
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/apostrophe.profile
+++ b/etc/profile-a-l/apostrophe.profile
@@ -69,3 +69,5 @@ dbus-user filter
 dbus-user.own org.gnome.gitlab.somas.Apostrophe
 dbus-user.talk ca.desrt.dconf
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/arch-audit.profile
+++ b/etc/profile-a-l/arch-audit.profile
@@ -49,3 +49,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/archaudit-report.profile
+++ b/etc/profile-a-l/archaudit-report.profile
@@ -36,3 +36,4 @@ private-bin arch-audit,archaudit-report,bash,cat,comm,cut,date,fold,grep,pacman,
 private-tmp
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/archiver-common.profile
+++ b/etc/profile-a-l/archiver-common.profile
@@ -49,3 +49,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/ardour5.profile
+++ b/etc/profile-a-l/ardour5.profile
@@ -40,3 +40,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/arduino.profile
+++ b/etc/profile-a-l/arduino.profile
@@ -33,3 +33,4 @@ seccomp
 private-cache
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/aria2c.profile
+++ b/etc/profile-a-l/aria2c.profile
@@ -53,3 +53,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/ark.profile
+++ b/etc/profile-a-l/ark.profile
@@ -44,3 +44,5 @@ private-tmp
 
 # dbus-user none
 # dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/arm.profile
+++ b/etc/profile-a-l/arm.profile
@@ -45,3 +45,4 @@ private-dev
 private-etc alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.preload,passwd,pki,ssl,tor
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/artha.profile
+++ b/etc/profile-a-l/artha.profile
@@ -65,3 +65,4 @@ dbus-user.talk org.freedesktop.Notifications
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/assogiate.profile
+++ b/etc/profile-a-l/assogiate.profile
@@ -51,3 +51,4 @@ dbus-system none
 
 memory-deny-write-execute
 read-write ${HOME}/.local/share/mime
+restrict-namespaces

--- a/etc/profile-a-l/asunder.profile
+++ b/etc/profile-a-l/asunder.profile
@@ -45,3 +45,4 @@ dbus-system none
 
 # mdwe is disabled due to breaking hardware accelerated decoding
 # memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/atril.profile
+++ b/etc/profile-a-l/atril.profile
@@ -49,3 +49,4 @@ private-tmp
 
 # webkit gtk killed by memory-deny-write-execute
 #memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/audacious.profile
+++ b/etc/profile-a-l/audacious.profile
@@ -42,3 +42,5 @@ private-tmp
 # dbus needed for MPRIS
 # dbus-user none
 # dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/audacity.profile
+++ b/etc/profile-a-l/audacity.profile
@@ -44,3 +44,5 @@ private-tmp
 # problems on Fedora 27
 # dbus-user none
 # dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/audio-recorder.profile
+++ b/etc/profile-a-l/audio-recorder.profile
@@ -51,3 +51,4 @@ dbus-user.talk ca.desrt.dconf
 dbus-system none
 
 # memory-deny-write-execute - breaks on Arch
+restrict-namespaces

--- a/etc/profile-a-l/authenticator-rs.profile
+++ b/etc/profile-a-l/authenticator-rs.profile
@@ -52,3 +52,5 @@ private-tmp
 dbus-user filter
 dbus-user.talk ca.desrt.dconf
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/authenticator.profile
+++ b/etc/profile-a-l/authenticator.profile
@@ -46,3 +46,4 @@ private-tmp
 # dbus-system none
 
 #memory-deny-write-execute - breaks on Arch (see issue #1803)
+restrict-namespaces

--- a/etc/profile-a-l/autokey-common.profile
+++ b/etc/profile-a-l/autokey-common.profile
@@ -39,3 +39,4 @@ private-dev
 private-tmp
 
 #memory-deny-write-execute - breaks on Arch (see issue #1803)
+restrict-namespaces

--- a/etc/profile-a-l/avidemux.profile
+++ b/etc/profile-a-l/avidemux.profile
@@ -55,3 +55,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/aweather.profile
+++ b/etc/profile-a-l/aweather.profile
@@ -37,3 +37,5 @@ tracelog
 private-bin aweather
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/awesome.profile
+++ b/etc/profile-a-l/awesome.profile
@@ -17,3 +17,4 @@ protocol unix,inet,inet6
 seccomp
 
 read-only ${HOME}/.config/awesome/autorun.sh
+restrict-namespaces

--- a/etc/profile-a-l/ballbuster.profile
+++ b/etc/profile-a-l/ballbuster.profile
@@ -49,3 +49,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/baloo_file.profile
+++ b/etc/profile-a-l/baloo_file.profile
@@ -52,3 +52,5 @@ private-bin baloo_file,baloo_file_extractor,baloo_filemetadata_temp_extractor,kb
 private-cache
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/balsa.profile
+++ b/etc/profile-a-l/balsa.profile
@@ -79,3 +79,4 @@ dbus-user.talk org.gnome.keyring.SystemPrompter
 dbus-system none
 
 read-only ${HOME}/.mozilla/firefox/profiles.ini
+restrict-namespaces

--- a/etc/profile-a-l/baobab.profile
+++ b/etc/profile-a-l/baobab.profile
@@ -41,3 +41,4 @@ private-tmp
 # dbus-system none
 
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-a-l/barrier.profile
+++ b/etc/profile-a-l/barrier.profile
@@ -42,3 +42,4 @@ private-cache
 private-tmp
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/basilisk.profile
+++ b/etc/profile-a-l/basilisk.profile
@@ -22,5 +22,8 @@ ignore seccomp
 #private-etc basilisk
 #private-opt basilisk
 
+restrict-namespaces
+ignore restrict-namespaces
+
 # Redirect
 include firefox-common.profile

--- a/etc/profile-a-l/bcompare.profile
+++ b/etc/profile-a-l/bcompare.profile
@@ -44,3 +44,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/bibletime.profile
+++ b/etc/profile-a-l/bibletime.profile
@@ -56,3 +56,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+# restrict-namespaces

--- a/etc/profile-a-l/bijiben.profile
+++ b/etc/profile-a-l/bijiben.profile
@@ -60,3 +60,4 @@ dbus-user.talk org.freedesktop.Tracker1
 dbus-system none
 
 env WEBKIT_FORCE_SANDBOX=0
+restrict-namespaces

--- a/etc/profile-a-l/bitcoin-qt.profile
+++ b/etc/profile-a-l/bitcoin-qt.profile
@@ -47,3 +47,4 @@ private-dev
 private-tmp
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/bitlbee.profile
+++ b/etc/profile-a-l/bitlbee.profile
@@ -38,3 +38,4 @@ private-dev
 private-tmp
 
 read-write /var/lib/bitlbee
+restrict-namespaces

--- a/etc/profile-a-l/blackbox.profile
+++ b/etc/profile-a-l/blackbox.profile
@@ -16,3 +16,4 @@ noroot
 protocol unix,inet,inet6
 seccomp
 
+restrict-namespaces

--- a/etc/profile-a-l/bleachbit.profile
+++ b/etc/profile-a-l/bleachbit.profile
@@ -40,3 +40,4 @@ dbus-system none
 
 # memory-deny-write-execute breaks some systems, see issue #1850
 # memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/blender.profile
+++ b/etc/profile-a-l/blender.profile
@@ -37,3 +37,5 @@ protocol unix,inet,inet6,netlink
 seccomp !mbind
 
 private-dev
+
+restrict-namespaces

--- a/etc/profile-a-l/bless.profile
+++ b/etc/profile-a-l/bless.profile
@@ -39,3 +39,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/blobby.profile
+++ b/etc/profile-a-l/blobby.profile
@@ -48,3 +48,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/blobwars.profile
+++ b/etc/profile-a-l/blobwars.profile
@@ -47,3 +47,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/bluefish.profile
+++ b/etc/profile-a-l/bluefish.profile
@@ -37,3 +37,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/brackets.profile
+++ b/etc/profile-a-l/brackets.profile
@@ -31,3 +31,5 @@ seccomp !chroot,!ioperm
 
 private-cache
 private-dev
+
+# restrict-namespaces

--- a/etc/profile-a-l/brasero.profile
+++ b/etc/profile-a-l/brasero.profile
@@ -33,3 +33,5 @@ tracelog
 private-cache
 # private-dev
 # private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/build-systems-common.profile
+++ b/etc/profile-a-l/build-systems-common.profile
@@ -63,3 +63,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/bzflag.profile
+++ b/etc/profile-a-l/bzflag.profile
@@ -44,3 +44,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/calibre.profile
+++ b/etc/profile-a-l/calibre.profile
@@ -35,3 +35,5 @@ seccomp !chroot
 
 private-dev
 private-tmp
+
+# restrict-namespaces

--- a/etc/profile-a-l/calligra.profile
+++ b/etc/profile-a-l/calligra.profile
@@ -37,3 +37,4 @@ private-dev
 
 # noexec ${HOME}
 noexec /tmp
+restrict-namespaces

--- a/etc/profile-a-l/cameramonitor.profile
+++ b/etc/profile-a-l/cameramonitor.profile
@@ -52,3 +52,4 @@ private-tmp
 # dbus-system none
 
 # memory-deny-write-execute - breaks on Arch
+restrict-namespaces

--- a/etc/profile-a-l/cantata.profile
+++ b/etc/profile-a-l/cantata.profile
@@ -37,3 +37,5 @@ seccomp
 # private-etc alternatives,drirc,fonts,gcrypt,hosts,kde5rc,mpd.conf,passwd,samba,ssl,xdg
 private-bin cantata,mpd,perl
 private-dev
+
+restrict-namespaces

--- a/etc/profile-a-l/catfish.profile
+++ b/etc/profile-a-l/catfish.profile
@@ -46,3 +46,5 @@ tracelog
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/cawbird.profile
+++ b/etc/profile-a-l/cawbird.profile
@@ -43,3 +43,5 @@ private-tmp
 
 # dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/celluloid.profile
+++ b/etc/profile-a-l/celluloid.profile
@@ -64,3 +64,4 @@ dbus-system none
 
 read-only ${HOME}
 read-write ${HOME}/.config/celluloid
+restrict-namespaces

--- a/etc/profile-a-l/chafa.profile
+++ b/etc/profile-a-l/chafa.profile
@@ -53,3 +53,4 @@ dbus-user none
 dbus-system none
 
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-a-l/checkbashisms.profile
+++ b/etc/profile-a-l/checkbashisms.profile
@@ -52,3 +52,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/cheese.profile
+++ b/etc/profile-a-l/cheese.profile
@@ -58,3 +58,5 @@ dbus-user filter
 dbus-user.own org.gnome.Cheese
 dbus-user.talk ca.desrt.dconf
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/cherrytree.profile
+++ b/etc/profile-a-l/cherrytree.profile
@@ -40,3 +40,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/chromium-common-hardened.inc.profile
+++ b/etc/profile-a-l/chromium-common-hardened.inc.profile
@@ -7,3 +7,5 @@ nonewprivs
 noroot
 protocol unix,inet,inet6,netlink
 seccomp !chroot
+
+#restrict-namespaces

--- a/etc/profile-a-l/cin.profile
+++ b/etc/profile-a-l/cin.profile
@@ -34,3 +34,5 @@ private-dev
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/clamav.profile
+++ b/etc/profile-a-l/clamav.profile
@@ -37,3 +37,4 @@ dbus-system none
 read-only ${HOME}
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/clamtk.profile
+++ b/etc/profile-a-l/clamtk.profile
@@ -27,3 +27,5 @@ private-dev
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/clawsker.profile
+++ b/etc/profile-a-l/clawsker.profile
@@ -51,3 +51,4 @@ dbus-user none
 dbus-system none
 
 #memory-deny-write-execute - breaks on Arch (see issue #1803)
+restrict-namespaces

--- a/etc/profile-a-l/clementine.profile
+++ b/etc/profile-a-l/clementine.profile
@@ -38,3 +38,5 @@ private-tmp
 
 dbus-system none
 # dbus-user none
+
+restrict-namespaces

--- a/etc/profile-a-l/clion.profile
+++ b/etc/profile-a-l/clion.profile
@@ -40,3 +40,4 @@ private-dev
 # private-tmp
 
 noexec /tmp
+restrict-namespaces

--- a/etc/profile-a-l/clipgrab.profile
+++ b/etc/profile-a-l/clipgrab.profile
@@ -48,3 +48,5 @@ private-tmp
 # 'dbus-user none' breaks tray menu - add 'dbus-user none' to your clipgrab.local if you don't need it.
 # dbus-user none
 # dbus-system none
+
+# restrict-namespaces

--- a/etc/profile-a-l/clipit.profile
+++ b/etc/profile-a-l/clipit.profile
@@ -59,5 +59,5 @@ dbus-user none
 dbus-system none
 
 #memory-deny-write-execute
-restrict-namespaces
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-a-l/cmus.profile
+++ b/etc/profile-a-l/cmus.profile
@@ -27,3 +27,5 @@ seccomp
 
 private-bin cmus
 private-etc alternatives,asound.conf,ca-certificates,crypto-policies,group,ld.so.cache,ld.so.preload,machine-id,pki,pulse,resolv.conf,ssl
+
+restrict-namespaces

--- a/etc/profile-a-l/cointop.profile
+++ b/etc/profile-a-l/cointop.profile
@@ -60,3 +60,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/colorful.profile
+++ b/etc/profile-a-l/colorful.profile
@@ -49,3 +49,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/com.github.bleakgrey.tootle.profile
+++ b/etc/profile-a-l/com.github.bleakgrey.tootle.profile
@@ -52,3 +52,5 @@ private-tmp
 # dbus-user.own com.github.bleakgrey.tootle
 # dbus-user.talk ca.desrt.dconf
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/com.github.dahenson.agenda.profile
+++ b/etc/profile-a-l/com.github.dahenson.agenda.profile
@@ -63,3 +63,4 @@ read-only ${HOME}
 read-write ${HOME}/.cache/agenda
 read-write ${HOME}/.config/agenda
 read-write ${HOME}/.local/share/agenda
+restrict-namespaces

--- a/etc/profile-a-l/com.github.johnfactotum.Foliate.profile
+++ b/etc/profile-a-l/com.github.johnfactotum.Foliate.profile
@@ -60,3 +60,4 @@ private-tmp
 read-only ${HOME}
 read-write ${HOME}/.cache/com.github.johnfactotum.Foliate
 read-write ${HOME}/.local/share/com.github.johnfactotum.Foliate
+restrict-namespaces

--- a/etc/profile-a-l/com.github.phase1geo.minder.profile
+++ b/etc/profile-a-l/com.github.phase1geo.minder.profile
@@ -58,3 +58,5 @@ dbus-user filter
 dbus-user.own com.github.phase1geo.minder
 dbus-user.talk ca.desrt.dconf
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/com.github.tchx84.Flatseal.profile
+++ b/etc/profile-a-l/com.github.tchx84.Flatseal.profile
@@ -62,3 +62,4 @@ dbus-user.talk org.gnome.Software
 dbus-system none
 
 read-write ${HOME}/.local/share/flatpak/overrides
+restrict-namespaces

--- a/etc/profile-a-l/conkeror.profile
+++ b/etc/profile-a-l/conkeror.profile
@@ -34,3 +34,5 @@ protocol unix,inet,inet6
 seccomp
 
 disable-mnt
+
+restrict-namespaces

--- a/etc/profile-a-l/conky.profile
+++ b/etc/profile-a-l/conky.profile
@@ -43,3 +43,4 @@ private-dev
 private-tmp
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/corebird.profile
+++ b/etc/profile-a-l/corebird.profile
@@ -35,3 +35,4 @@ private-bin corebird
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/cower.profile
+++ b/etc/profile-a-l/cower.profile
@@ -46,3 +46,4 @@ private-tmp
 
 memory-deny-write-execute
 read-only ${HOME}/.config/cower/config
+restrict-namespaces

--- a/etc/profile-a-l/coyim.profile
+++ b/etc/profile-a-l/coyim.profile
@@ -46,3 +46,4 @@ dbus-user none
 dbus-system none
 
 #memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/crawl.profile
+++ b/etc/profile-a-l/crawl.profile
@@ -44,3 +44,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/crow.profile
+++ b/etc/profile-a-l/crow.profile
@@ -43,3 +43,4 @@ private-opt none
 private-tmp
 private-srv none
 
+restrict-namespaces

--- a/etc/profile-a-l/curl.profile
+++ b/etc/profile-a-l/curl.profile
@@ -58,3 +58,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/d-feet.profile
+++ b/etc/profile-a-l/d-feet.profile
@@ -53,3 +53,4 @@ private-etc alternatives,dbus-1,fonts,ld.so.cache,ld.so.preload,machine-id
 private-tmp
 
 #memory-deny-write-execute - breaks on Arch (see issue #1803)
+restrict-namespaces

--- a/etc/profile-a-l/darktable.profile
+++ b/etc/profile-a-l/darktable.profile
@@ -41,3 +41,4 @@ seccomp
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/dbus-send.profile
+++ b/etc/profile-a-l/dbus-send.profile
@@ -56,3 +56,4 @@ private-tmp
 
 memory-deny-write-execute
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-a-l/dconf-editor.profile
+++ b/etc/profile-a-l/dconf-editor.profile
@@ -50,3 +50,5 @@ dbus-user filter
 dbus-user.own ca.desrt.dconf-editor
 dbus-user.talk ca.desrt.dconf
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/dconf.profile
+++ b/etc/profile-a-l/dconf.profile
@@ -50,3 +50,4 @@ private-lib
 private-tmp
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/ddgtk.profile
+++ b/etc/profile-a-l/ddgtk.profile
@@ -51,3 +51,4 @@ dbus-user none
 dbus-system none
 
 # memory-deny-write-execute - breaks on Arch
+restrict-namespaces

--- a/etc/profile-a-l/deadbeef.profile
+++ b/etc/profile-a-l/deadbeef.profile
@@ -32,3 +32,4 @@ seccomp
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/default.profile
+++ b/etc/profile-a-l/default.profile
@@ -60,4 +60,4 @@ seccomp
 # deterministic-shutdown
 # memory-deny-write-execute
 # read-only ${HOME}
-# restrict-namespaces
+restrict-namespaces

--- a/etc/profile-a-l/deluge.profile
+++ b/etc/profile-a-l/deluge.profile
@@ -43,3 +43,5 @@ seccomp
 private-bin deluge,deluge-console,deluge-gtk,deluge-web,deluged,python*,sh,uname
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/desktopeditors.profile
+++ b/etc/profile-a-l/desktopeditors.profile
@@ -42,3 +42,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/devhelp.profile
+++ b/etc/profile-a-l/devhelp.profile
@@ -50,3 +50,4 @@ private-tmp
 
 #memory-deny-write-execute - breaks on Arch (see issue #1803)
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-a-l/devilspie.profile
+++ b/etc/profile-a-l/devilspie.profile
@@ -56,3 +56,4 @@ dbus-system none
 
 memory-deny-write-execute
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-a-l/dex2jar.profile
+++ b/etc/profile-a-l/dex2jar.profile
@@ -39,3 +39,5 @@ private-dev
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/dia.profile
+++ b/etc/profile-a-l/dia.profile
@@ -54,3 +54,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/dig.profile
+++ b/etc/profile-a-l/dig.profile
@@ -56,3 +56,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/digikam.profile
+++ b/etc/profile-a-l/digikam.profile
@@ -43,3 +43,5 @@ private-tmp
 
 # dbus-user none
 # dbus-system none
+
+# restrict-namespaces

--- a/etc/profile-a-l/dillo.profile
+++ b/etc/profile-a-l/dillo.profile
@@ -37,3 +37,4 @@ private-dev
 private-tmp
 
 deterministic-shutdown
+restrict-namespaces

--- a/etc/profile-a-l/dino.profile
+++ b/etc/profile-a-l/dino.profile
@@ -53,3 +53,5 @@ dbus-user.talk org.freedesktop.Notifications
 dbus-system filter
 # Integration with systemd-logind or elogind
 dbus-system.talk org.freedesktop.login1
+
+restrict-namespaces

--- a/etc/profile-a-l/display.profile
+++ b/etc/profile-a-l/display.profile
@@ -45,3 +45,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/dnscrypt-proxy.profile
+++ b/etc/profile-a-l/dnscrypt-proxy.profile
@@ -51,3 +51,4 @@ dbus-system none
 
 # mdwe can break modules/plugins
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/dnsmasq.profile
+++ b/etc/profile-a-l/dnsmasq.profile
@@ -40,3 +40,5 @@ private
 private-dev
 private-tmp
 writable-var
+
+restrict-namespaces

--- a/etc/profile-a-l/dolphin-emu.profile
+++ b/etc/profile-a-l/dolphin-emu.profile
@@ -60,3 +60,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/dooble.profile
+++ b/etc/profile-a-l/dooble.profile
@@ -38,3 +38,4 @@ disable-mnt
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/dosbox.profile
+++ b/etc/profile-a-l/dosbox.profile
@@ -41,3 +41,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/dragon.profile
+++ b/etc/profile-a-l/dragon.profile
@@ -39,3 +39,4 @@ private-bin dragon
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/drawio.profile
+++ b/etc/profile-a-l/drawio.profile
@@ -51,3 +51,4 @@ dbus-user none
 dbus-system none
 
 # memory-deny-write-execute - breaks on Arch
+# restrict-namespaces

--- a/etc/profile-a-l/drill.profile
+++ b/etc/profile-a-l/drill.profile
@@ -52,3 +52,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/dropbox.profile
+++ b/etc/profile-a-l/dropbox.profile
@@ -46,3 +46,4 @@ private-dev
 private-tmp
 
 noexec /tmp
+restrict-namespaces

--- a/etc/profile-a-l/easystroke.profile
+++ b/etc/profile-a-l/easystroke.profile
@@ -53,3 +53,4 @@ private-tmp
 # dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/electrum.profile
+++ b/etc/profile-a-l/electrum.profile
@@ -51,3 +51,5 @@ private-tmp
 
 # dbus-user none
 # dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/emacs.profile
+++ b/etc/profile-a-l/emacs.profile
@@ -30,3 +30,4 @@ seccomp
 
 read-write ${HOME}/.emacs
 read-write ${HOME}/.emacs.d
+restrict-namespaces

--- a/etc/profile-a-l/email-common.profile
+++ b/etc/profile-a-l/email-common.profile
@@ -81,3 +81,4 @@ dbus-system none
 
 read-only ${HOME}/.mozilla/firefox/profiles.ini
 read-only ${HOME}/.signature
+restrict-namespaces

--- a/etc/profile-a-l/empathy.profile
+++ b/etc/profile-a-l/empathy.profile
@@ -24,3 +24,5 @@ seccomp
 
 private-cache
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/enchant.profile
+++ b/etc/profile-a-l/enchant.profile
@@ -55,3 +55,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/engrampa.profile
+++ b/etc/profile-a-l/engrampa.profile
@@ -38,3 +38,5 @@ private-dev
 dbus-user filter
 dbus-user.talk ca.desrt.dconf
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/enpass.profile
+++ b/etc/profile-a-l/enpass.profile
@@ -59,3 +59,4 @@ private-opt Enpass
 private-tmp
 
 #memory-deny-write-execute - breaks on Arch (see issue #1803)
+restrict-namespaces

--- a/etc/profile-a-l/eo-common.profile
+++ b/etc/profile-a-l/eo-common.profile
@@ -49,3 +49,5 @@ private-dev
 private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.preload
 private-lib eog,eom,gdk-pixbuf-2.*,gio,girepository-1.*,gvfs,libgconf-2.so.*
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/ephemeral.profile
+++ b/etc/profile-a-l/ephemeral.profile
@@ -61,3 +61,5 @@ private-tmp
 # breaks preferences
 # dbus-user none
 # dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/epiphany.profile
+++ b/etc/profile-a-l/epiphany.profile
@@ -34,3 +34,5 @@ nonewprivs
 notv
 protocol unix,inet,inet6
 seccomp
+
+restrict-namespaces

--- a/etc/profile-a-l/equalx.profile
+++ b/etc/profile-a-l/equalx.profile
@@ -60,3 +60,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/etr.profile
+++ b/etc/profile-a-l/etr.profile
@@ -53,3 +53,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/evince.profile
+++ b/etc/profile-a-l/evince.profile
@@ -64,3 +64,5 @@ dbus-user.talk ca.desrt.dconf
 dbus-user.talk org.gtk.vfs.Daemon
 dbus-user.talk org.gtk.vfs.Metadata
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/evolution.profile
+++ b/etc/profile-a-l/evolution.profile
@@ -43,3 +43,5 @@ seccomp
 private-dev
 private-tmp
 writable-var
+
+restrict-namespaces

--- a/etc/profile-a-l/exiftool.profile
+++ b/etc/profile-a-l/exiftool.profile
@@ -54,3 +54,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/falkon.profile
+++ b/etc/profile-a-l/falkon.profile
@@ -53,3 +53,5 @@ private-tmp
 # dbus-user filter
 # dbus-user.own org.kde.Falkon
 dbus-system none
+
+# restrict-namespaces

--- a/etc/profile-a-l/fbreader.profile
+++ b/etc/profile-a-l/fbreader.profile
@@ -36,3 +36,5 @@ seccomp
 private-bin fbreader,FBReader
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/fdns.profile
+++ b/etc/profile-a-l/fdns.profile
@@ -47,3 +47,4 @@ private-etc alternatives,ca-certificates,crypto-policies,fdns,ld.so.cache,ld.so.
 private-tmp
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/feedreader.profile
+++ b/etc/profile-a-l/feedreader.profile
@@ -56,3 +56,5 @@ dbus-user.talk org.freedesktop.secrets
 #dbus-user.talk org.freedesktop.Notifications
 #dbus-user.talk org.gnome.OnlineAccounts
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/feh.profile
+++ b/etc/profile-a-l/feh.profile
@@ -40,3 +40,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/ferdi.profile
+++ b/etc/profile-a-l/ferdi.profile
@@ -44,3 +44,5 @@ seccomp !chroot
 disable-mnt
 private-dev
 private-tmp
+
+# restrict-namespaces

--- a/etc/profile-a-l/fetchmail.profile
+++ b/etc/profile-a-l/fetchmail.profile
@@ -31,3 +31,5 @@ seccomp
 
 #private-bin bash,chmod,fetchmail,procmail
 private-dev
+
+restrict-namespaces

--- a/etc/profile-a-l/ffmpeg.profile
+++ b/etc/profile-a-l/ffmpeg.profile
@@ -54,3 +54,4 @@ dbus-user none
 dbus-system none
 
 # memory-deny-write-execute - it breaks old versions of ffmpeg
+restrict-namespaces

--- a/etc/profile-a-l/file-manager-common.profile
+++ b/etc/profile-a-l/file-manager-common.profile
@@ -49,3 +49,5 @@ private-dev
 
 #dbus-user none
 #dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/file-roller.profile
+++ b/etc/profile-a-l/file-roller.profile
@@ -46,3 +46,5 @@ private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.preload,xdg
 # private-tmp
 
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/file.profile
+++ b/etc/profile-a-l/file.profile
@@ -44,3 +44,4 @@ dbus-system none
 
 memory-deny-write-execute
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-a-l/filezilla.profile
+++ b/etc/profile-a-l/filezilla.profile
@@ -41,3 +41,5 @@ seccomp
 private-bin bash,filezilla,fzputtygen,fzsftp,lsb_release,python*,sh,uname,zsh
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/firefox-common.profile
+++ b/etc/profile-a-l/firefox-common.profile
@@ -68,3 +68,5 @@ blacklist ${PATH}/wget2
 # Gnome connector, KDE connect and power management on KDE Plasma.
 dbus-user none
 dbus-system none
+
+#restrict-namespaces

--- a/etc/profile-a-l/flameshot.profile
+++ b/etc/profile-a-l/flameshot.profile
@@ -65,3 +65,5 @@ dbus-user.talk org.kde.KWin
 ?ALLOW_TRAY: dbus-user.talk org.kde.StatusNotifierWatcher
 ?ALLOW_TRAY: dbus-user.own org.kde.*
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/flowblade.profile
+++ b/etc/profile-a-l/flowblade.profile
@@ -35,3 +35,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/fluxbox.profile
+++ b/etc/profile-a-l/fluxbox.profile
@@ -16,3 +16,4 @@ noroot
 protocol unix,inet,inet6
 seccomp
 
+restrict-namespaces

--- a/etc/profile-a-l/font-manager.profile
+++ b/etc/profile-a-l/font-manager.profile
@@ -54,3 +54,4 @@ private-dev
 private-tmp
 
 #memory-deny-write-execute - breaks on Arch (see issue #1803)
+restrict-namespaces

--- a/etc/profile-a-l/fontforge.profile
+++ b/etc/profile-a-l/fontforge.profile
@@ -38,3 +38,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/fractal.profile
+++ b/etc/profile-a-l/fractal.profile
@@ -55,3 +55,5 @@ dbus-user.talk ca.desrt.dconf
 dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.freedesktop.secrets
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/franz.profile
+++ b/etc/profile-a-l/franz.profile
@@ -44,3 +44,5 @@ seccomp !chroot
 disable-mnt
 private-dev
 private-tmp
+
+# restrict-namespaces

--- a/etc/profile-a-l/freecad.profile
+++ b/etc/profile-a-l/freecad.profile
@@ -42,3 +42,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/freeciv.profile
+++ b/etc/profile-a-l/freeciv.profile
@@ -44,3 +44,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/freecol.profile
+++ b/etc/profile-a-l/freecol.profile
@@ -55,3 +55,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/freemind.profile
+++ b/etc/profile-a-l/freemind.profile
@@ -50,3 +50,5 @@ private-srv none
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/freshclam.profile
+++ b/etc/profile-a-l/freshclam.profile
@@ -33,3 +33,4 @@ writable-var
 writable-var-log
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/frogatto.profile
+++ b/etc/profile-a-l/frogatto.profile
@@ -49,3 +49,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/frozen-bubble.profile
+++ b/etc/profile-a-l/frozen-bubble.profile
@@ -46,3 +46,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/ftp.profile
+++ b/etc/profile-a-l/ftp.profile
@@ -51,3 +51,4 @@ dbus-system none
 
 memory-deny-write-execute
 noexec ${HOME}
+restrict-namespaces

--- a/etc/profile-a-l/funnyboat.profile
+++ b/etc/profile-a-l/funnyboat.profile
@@ -52,3 +52,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/gajim.profile
+++ b/etc/profile-a-l/gajim.profile
@@ -75,4 +75,5 @@ dbus-system.talk org.freedesktop.login1
 # Add the next line to your gajim.local to enable location plugin support.
 #dbus-system.talk org.freedesktop.GeoClue2
 
+restrict-namespaces
 join-or-start gajim

--- a/etc/profile-a-l/galculator.profile
+++ b/etc/profile-a-l/galculator.profile
@@ -50,3 +50,4 @@ dbus-user none
 dbus-system none
 
 #memory-deny-write-execute - breaks on Arch (see issue #1803)
+restrict-namespaces

--- a/etc/profile-a-l/gapplication.profile
+++ b/etc/profile-a-l/gapplication.profile
@@ -70,3 +70,4 @@ dbus-system none
 
 memory-deny-write-execute
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-a-l/gcloud.profile
+++ b/etc/profile-a-l/gcloud.profile
@@ -40,3 +40,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/gconf.profile
+++ b/etc/profile-a-l/gconf.profile
@@ -58,3 +58,4 @@ private-lib GConf,libpython*,python2*
 private-tmp
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/gdu.profile
+++ b/etc/profile-a-l/gdu.profile
@@ -37,6 +37,7 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces
 
 # gdu has built-in delete (d), empty (e) dir/file support and shell spawning (b) features.
 # Depending on workflow and use case the sandbox can be hardened by adding the

--- a/etc/profile-a-l/geany.profile
+++ b/etc/profile-a-l/geany.profile
@@ -32,3 +32,5 @@ seccomp
 private-cache
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/geary.profile
+++ b/etc/profile-a-l/geary.profile
@@ -91,3 +91,4 @@ dbus-user.talk org.gnome.evolution.dataserver.Sources5
 dbus-system none
 
 read-only ${HOME}/.mozilla/firefox/profiles.ini
+restrict-namespaces

--- a/etc/profile-a-l/gedit.profile
+++ b/etc/profile-a-l/gedit.profile
@@ -49,3 +49,5 @@ private-tmp
 # makes settings immutable
 # dbus-user none
 # dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/geekbench.profile
+++ b/etc/profile-a-l/geekbench.profile
@@ -55,3 +55,4 @@ dbus-system none
 
 read-only ${HOME}
 read-write ${HOME}/.geekbench5
+restrict-namespaces

--- a/etc/profile-a-l/geeqie.profile
+++ b/etc/profile-a-l/geeqie.profile
@@ -34,3 +34,5 @@ seccomp
 
 # private-bin geeqie
 private-dev
+
+restrict-namespaces

--- a/etc/profile-a-l/gfeeds.profile
+++ b/etc/profile-a-l/gfeeds.profile
@@ -67,3 +67,5 @@ dbus-user filter
 dbus-user.own org.gabmus.gfeeds
 dbus-user.talk ca.desrt.dconf
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/gget.profile
+++ b/etc/profile-a-l/gget.profile
@@ -56,3 +56,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/ghostwriter.profile
+++ b/etc/profile-a-l/ghostwriter.profile
@@ -56,3 +56,5 @@ private-tmp
 
 dbus-user filter
 dbus-system none
+
+#restrict-namespaces

--- a/etc/profile-a-l/gimp.profile
+++ b/etc/profile-a-l/gimp.profile
@@ -63,3 +63,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/gist.profile
+++ b/etc/profile-a-l/gist.profile
@@ -58,3 +58,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/git-cola.profile
+++ b/etc/profile-a-l/git-cola.profile
@@ -84,3 +84,5 @@ read-only ${HOME}/.git-credentials
 
 # Add 'ignore read-only ${HOME}/.ssh' to your git-cola.local if you need to allow hosts.
 read-only ${HOME}/.ssh
+
+restrict-namespaces

--- a/etc/profile-a-l/git.profile
+++ b/etc/profile-a-l/git.profile
@@ -65,3 +65,4 @@ private-cache
 private-dev
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/gitg.profile
+++ b/etc/profile-a-l/gitg.profile
@@ -61,3 +61,5 @@ dbus-user.talk ca.desrt.dconf
 # Add the next line to your gitg.local if you need keyring access.
 #dbus-user.talk org.freedesktop.secrets
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/gitter.profile
+++ b/etc/profile-a-l/gitter.profile
@@ -41,3 +41,4 @@ private-opt Gitter
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/gjs.profile
+++ b/etc/profile-a-l/gjs.profile
@@ -42,3 +42,5 @@ tracelog
 private-dev
 # private-etc alternatives,ca-certificates,crypto-policies,fonts,pki,ssl
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/gl-117.profile
+++ b/etc/profile-a-l/gl-117.profile
@@ -48,3 +48,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/glaxium.profile
+++ b/etc/profile-a-l/glaxium.profile
@@ -48,3 +48,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/globaltime.profile
+++ b/etc/profile-a-l/globaltime.profile
@@ -34,3 +34,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/gmpc.profile
+++ b/etc/profile-a-l/gmpc.profile
@@ -51,3 +51,4 @@ writable-run-user
 # dbus-system none
 
 # memory-deny-write-execute - breaks on Arch
+restrict-namespaces

--- a/etc/profile-a-l/gnome-books.profile
+++ b/etc/profile-a-l/gnome-books.profile
@@ -43,3 +43,4 @@ tracelog
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/gnome-builder.profile
+++ b/etc/profile-a-l/gnome-builder.profile
@@ -37,3 +37,4 @@ seccomp
 private-dev
 
 read-write ${HOME}/.bash_history
+restrict-namespaces

--- a/etc/profile-a-l/gnome-calculator.profile
+++ b/etc/profile-a-l/gnome-calculator.profile
@@ -52,3 +52,5 @@ dbus-user filter
 dbus-user.own org.gnome.Calculator
 dbus-user.talk ca.desrt.dconf
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/gnome-calendar.profile
+++ b/etc/profile-a-l/gnome-calendar.profile
@@ -60,3 +60,4 @@ dbus-system filter
 #dbus-system.talk org.freedesktop.GeoClue2
 
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-a-l/gnome-characters.profile
+++ b/etc/profile-a-l/gnome-characters.profile
@@ -56,3 +56,4 @@ private-tmp
 # dbus-system none
 
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-a-l/gnome-chess.profile
+++ b/etc/profile-a-l/gnome-chess.profile
@@ -51,3 +51,5 @@ private-cache
 private-dev
 private-etc alternatives,dconf,fonts,gnome-chess,gtk-3.0,ld.so.cache,ld.so.preload
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/gnome-clocks.profile
+++ b/etc/profile-a-l/gnome-clocks.profile
@@ -44,3 +44,4 @@ private-dev
 private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gtk-3.0,hosts,ld.so.cache,ld.so.preload,localtime,machine-id,pkcs11,pki,ssl
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/gnome-contacts.profile
+++ b/etc/profile-a-l/gnome-contacts.profile
@@ -38,3 +38,4 @@ disable-mnt
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/gnome-documents.profile
+++ b/etc/profile-a-l/gnome-documents.profile
@@ -41,3 +41,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/gnome-font-viewer.profile
+++ b/etc/profile-a-l/gnome-font-viewer.profile
@@ -35,3 +35,4 @@ disable-mnt
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/gnome-hexgl.profile
+++ b/etc/profile-a-l/gnome-hexgl.profile
@@ -49,3 +49,4 @@ dbus-system none
 
 read-only ${HOME}
 read-write ${HOME}/.cache/mesa_shader_cache
+restrict-namespaces

--- a/etc/profile-a-l/gnome-keyring.profile
+++ b/etc/profile-a-l/gnome-keyring.profile
@@ -59,3 +59,4 @@ private-tmp
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/gnome-latex.profile
+++ b/etc/profile-a-l/gnome-latex.profile
@@ -50,3 +50,5 @@ private-dev
 private-etc alternatives,dconf,fonts,gtk-3.0,latexmk.conf,ld.so.cache,ld.so.preload,login.defs,passwd,texlive
 
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/gnome-logs.profile
+++ b/etc/profile-a-l/gnome-logs.profile
@@ -51,3 +51,4 @@ dbus-system none
 
 # Add 'ignore read-only ${HOME}' to your gnome-logs.local if you export logs to a file under your ${HOME}.
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-a-l/gnome-maps.profile
+++ b/etc/profile-a-l/gnome-maps.profile
@@ -73,3 +73,5 @@ dbus-user.own org.gnome.Maps
 dbus-system filter
 #dbus-system.talk org.freedesktop.NetworkManager
 dbus-system.talk org.freedesktop.GeoClue2
+
+restrict-namespaces

--- a/etc/profile-a-l/gnome-mplayer.profile
+++ b/etc/profile-a-l/gnome-mplayer.profile
@@ -31,3 +31,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/gnome-music.profile
+++ b/etc/profile-a-l/gnome-music.profile
@@ -44,3 +44,4 @@ private-dev
 private-etc alternatives,asound.conf,dconf,fonts,fonts,gtk-3.0,ld.so.cache,ld.so.preload,machine-id,pulse,selinux,xdg
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/gnome-nettool.profile
+++ b/etc/profile-a-l/gnome-nettool.profile
@@ -46,3 +46,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+#restrict-namespaces

--- a/etc/profile-a-l/gnome-passwordsafe.profile
+++ b/etc/profile-a-l/gnome-passwordsafe.profile
@@ -59,3 +59,5 @@ dbus-user filter
 dbus-user.own org.gnome.PasswordSafe
 dbus-user.talk ca.desrt.dconf
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/gnome-photos.profile
+++ b/etc/profile-a-l/gnome-photos.profile
@@ -40,3 +40,4 @@ tracelog
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/gnome-pie.profile
+++ b/etc/profile-a-l/gnome-pie.profile
@@ -38,3 +38,4 @@ private-lib gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libgconf-2.so.*,librsvg-2.s
 private-tmp
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/gnome-pomodoro.profile
+++ b/etc/profile-a-l/gnome-pomodoro.profile
@@ -56,3 +56,4 @@ dbus-system none
 
 read-only ${HOME}
 read-write ${HOME}/.local/share/gnome-pomodoro
+restrict-namespaces

--- a/etc/profile-a-l/gnome-recipes.profile
+++ b/etc/profile-a-l/gnome-recipes.profile
@@ -50,3 +50,4 @@ private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so
 private-lib gdk-pixbuf-2.0,gio,gvfs/libgvfscommon.so,libgconf-2.so.*,libgnutls.so.*,libjpeg.so.*,libp11-kit.so.*,libproxy.so.*,librsvg-2.so.*
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/gnome-ring.profile
+++ b/etc/profile-a-l/gnome-ring.profile
@@ -30,3 +30,4 @@ disable-mnt
 # private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/gnome-schedule.profile
+++ b/etc/profile-a-l/gnome-schedule.profile
@@ -61,4 +61,3 @@ disable-mnt
 private-cache
 private-dev
 writable-var
-

--- a/etc/profile-a-l/gnome-screenshot.profile
+++ b/etc/profile-a-l/gnome-screenshot.profile
@@ -48,3 +48,5 @@ dbus-user filter
 dbus-user.own org.gnome.Screenshot
 dbus-user.talk org.gnome.Shell.Screenshot
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/gnome-sound-recorder.profile
+++ b/etc/profile-a-l/gnome-sound-recorder.profile
@@ -41,3 +41,5 @@ private-cache
 private-dev
 private-etc alsa,alternatives,asound.conf,dconf,fonts,gtk-2.0,gtk-3.0,ld.so.cache,ld.so.preload,machine-id,openal,pango,pulse,xdg
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/gnome-system-log.profile
+++ b/etc/profile-a-l/gnome-system-log.profile
@@ -53,3 +53,4 @@ writable-var-log
 memory-deny-write-execute
 # Add 'ignore read-only ${HOME}' to your gnome-system-log.local if you export logs to a file under your ${HOME}.
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-a-l/gnome-todo.profile
+++ b/etc/profile-a-l/gnome-todo.profile
@@ -61,3 +61,4 @@ dbus-system none
 #dbus-system.talk org.freedesktop.login1
 
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-a-l/gnome-twitch.profile
+++ b/etc/profile-a-l/gnome-twitch.profile
@@ -37,3 +37,4 @@ disable-mnt
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/gnome-weather.profile
+++ b/etc/profile-a-l/gnome-weather.profile
@@ -46,3 +46,4 @@ private-dev
 # private-etc alternatives,ca-certificates,crypto-policies,fonts,pki,ssl
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/gnome_games-common.profile
+++ b/etc/profile-a-l/gnome_games-common.profile
@@ -46,3 +46,5 @@ private-tmp
 dbus-user filter
 dbus-user.talk ca.desrt.dconf
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/gnote.profile
+++ b/etc/profile-a-l/gnote.profile
@@ -57,3 +57,5 @@ dbus-user filter
 dbus-user.own org.gnome.Gnote
 dbus-user.talk ca.desrt.dconf
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/gnubik.profile
+++ b/etc/profile-a-l/gnubik.profile
@@ -47,3 +47,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/godot.profile
+++ b/etc/profile-a-l/godot.profile
@@ -42,3 +42,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/goldendict.profile
+++ b/etc/profile-a-l/goldendict.profile
@@ -55,3 +55,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/goobox.profile
+++ b/etc/profile-a-l/goobox.profile
@@ -32,3 +32,5 @@ tracelog
 private-dev
 # private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,machine-id,pki,pulse,ssl
 # private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/google-earth.profile
+++ b/etc/profile-a-l/google-earth.profile
@@ -39,3 +39,4 @@ private-bin bash,dirname,google-earth,grep,ls,sed,sh
 private-dev
 private-opt google
 
+restrict-namespaces

--- a/etc/profile-a-l/google-play-music-desktop-player.profile
+++ b/etc/profile-a-l/google-play-music-desktop-player.profile
@@ -39,3 +39,5 @@ seccomp
 disable-mnt
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/googler-common.profile
+++ b/etc/profile-a-l/googler-common.profile
@@ -58,3 +58,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/gpa.profile
+++ b/etc/profile-a-l/gpa.profile
@@ -30,3 +30,5 @@ tracelog
 
 # private-bin gpa,gpg
 private-dev
+
+restrict-namespaces

--- a/etc/profile-a-l/gpg-agent.profile
+++ b/etc/profile-a-l/gpg-agent.profile
@@ -49,3 +49,5 @@ tracelog
 # private-bin gpg-agent,gpg
 private-cache
 private-dev
+
+restrict-namespaces

--- a/etc/profile-a-l/gpg.profile
+++ b/etc/profile-a-l/gpg.profile
@@ -51,3 +51,4 @@ private-dev
 # installing/upgrading archlinux-keyring extremely slow.
 read-write /etc/pacman.d/gnupg
 read-write /usr/share/pacman/keyrings
+restrict-namespaces

--- a/etc/profile-a-l/gpicview.profile
+++ b/etc/profile-a-l/gpicview.profile
@@ -48,3 +48,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/gpredict.profile
+++ b/etc/profile-a-l/gpredict.profile
@@ -38,3 +38,4 @@ private-dev
 private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,pki,resolv.conf,ssl
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/gradio.profile
+++ b/etc/profile-a-l/gradio.profile
@@ -52,3 +52,5 @@ dbus-user.own de.haeckerfelix.gradio
 dbus-user.own org.mpris.MediaPlayer2.gradio
 dbus-user.talk ca.desrt.dconf
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/gramps.profile
+++ b/etc/profile-a-l/gramps.profile
@@ -48,3 +48,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/gravity-beams-and-evaporating-stars.profile
+++ b/etc/profile-a-l/gravity-beams-and-evaporating-stars.profile
@@ -44,3 +44,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/gthumb.profile
+++ b/etc/profile-a-l/gthumb.profile
@@ -34,3 +34,5 @@ private-bin gthumb
 private-cache
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/gtk-update-icon-cache.profile
+++ b/etc/profile-a-l/gtk-update-icon-cache.profile
@@ -53,3 +53,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/guayadeque.profile
+++ b/etc/profile-a-l/guayadeque.profile
@@ -32,3 +32,4 @@ private-bin guayadeque
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/gucharmap.profile
+++ b/etc/profile-a-l/gucharmap.profile
@@ -51,3 +51,4 @@ private-tmp
 # dbus-system none
 
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-a-l/guvcview.profile
+++ b/etc/profile-a-l/guvcview.profile
@@ -52,3 +52,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/gwenview.profile
+++ b/etc/profile-a-l/gwenview.profile
@@ -52,3 +52,4 @@ private-etc alternatives,fonts,gimp,gtk-2.0,kde4rc,kde5rc,ld.so.cache,ld.so.prel
 # dbus-system none
 
 # memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/handbrake.profile
+++ b/etc/profile-a-l/handbrake.profile
@@ -36,3 +36,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/hashcat.profile
+++ b/etc/profile-a-l/hashcat.profile
@@ -43,3 +43,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/hasher-common.profile
+++ b/etc/profile-a-l/hasher-common.profile
@@ -56,3 +56,4 @@ dbus-system none
 
 memory-deny-write-execute
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-a-l/hedgewars.profile
+++ b/etc/profile-a-l/hedgewars.profile
@@ -35,3 +35,5 @@ tracelog
 disable-mnt
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/hexchat.profile
+++ b/etc/profile-a-l/hexchat.profile
@@ -55,3 +55,4 @@ private-dev
 private-tmp
 
 # memory-deny-write-execute - breaks python
+restrict-namespaces

--- a/etc/profile-a-l/highlight.profile
+++ b/etc/profile-a-l/highlight.profile
@@ -41,3 +41,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/homebank.profile
+++ b/etc/profile-a-l/homebank.profile
@@ -56,3 +56,4 @@ dbus-user none
 dbus-system none
 
 # memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/host.profile
+++ b/etc/profile-a-l/host.profile
@@ -49,3 +49,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/hugin.profile
+++ b/etc/profile-a-l/hugin.profile
@@ -45,3 +45,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/hyperrogue.profile
+++ b/etc/profile-a-l/hyperrogue.profile
@@ -48,3 +48,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/i2prouter.profile
+++ b/etc/profile-a-l/i2prouter.profile
@@ -69,3 +69,5 @@ private-cache
 private-dev
 private-etc alternatives,ca-certificates,crypto-policies,dconf,group,hostname,hosts,i2p,java-10-openjdk,java-11-openjdk,java-12-openjdk,java-13-openjdk,java-8-openjdk,java-9-openjdk,java-openjdk,ld.so.cache,ld.so.preload,localtime,machine-id,nsswitch.conf,passwd,pki,resolv.conf,ssl
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/i3.profile
+++ b/etc/profile-a-l/i3.profile
@@ -16,3 +16,4 @@ noroot
 protocol unix,inet,inet6
 seccomp
 
+restrict-namespaces

--- a/etc/profile-a-l/iagno.profile
+++ b/etc/profile-a-l/iagno.profile
@@ -37,3 +37,5 @@ private-tmp
 
 # dbus-user none
 # dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/idea.sh.profile
+++ b/etc/profile-a-l/idea.sh.profile
@@ -39,3 +39,4 @@ private-dev
 # private-tmp
 
 noexec /tmp
+restrict-namespaces

--- a/etc/profile-a-l/imagej.profile
+++ b/etc/profile-a-l/imagej.profile
@@ -38,3 +38,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/img2txt.profile
+++ b/etc/profile-a-l/img2txt.profile
@@ -50,3 +50,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/impressive.profile
+++ b/etc/profile-a-l/impressive.profile
@@ -54,3 +54,4 @@ dbus-system none
 
 read-only ${HOME}
 read-write ${HOME}/.cache/mesa_shader_cache
+restrict-namespaces

--- a/etc/profile-a-l/imv.profile
+++ b/etc/profile-a-l/imv.profile
@@ -54,3 +54,4 @@ dbus-user none
 dbus-system none
 
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-a-l/inkscape.profile
+++ b/etc/profile-a-l/inkscape.profile
@@ -60,3 +60,4 @@ dbus-user none
 dbus-system none
 
 # memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/io.github.lainsce.Notejot.profile
+++ b/etc/profile-a-l/io.github.lainsce.Notejot.profile
@@ -57,3 +57,5 @@ dbus-user filter
 dbus-user.own io.github.lainsce.Notejot
 dbus-user.talk ca.desrt.dconf
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/ipcalc.profile
+++ b/etc/profile-a-l/ipcalc.profile
@@ -59,3 +59,4 @@ dbus-system none
 
 # memory-deny-write-execute
 # read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-a-l/itch.profile
+++ b/etc/profile-a-l/itch.profile
@@ -39,3 +39,4 @@ private-dev
 private-tmp
 
 noexec /tmp
+restrict-namespaces

--- a/etc/profile-a-l/jami-gnome.profile
+++ b/etc/profile-a-l/jami-gnome.profile
@@ -39,3 +39,4 @@ private-dev
 private-tmp
 
 env QT_QPA_PLATFORM=xcb
+restrict-namespaces

--- a/etc/profile-a-l/jd-gui.profile
+++ b/etc/profile-a-l/jd-gui.profile
@@ -41,3 +41,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/jerry.profile
+++ b/etc/profile-a-l/jerry.profile
@@ -40,3 +40,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/jitsi.profile
+++ b/etc/profile-a-l/jitsi.profile
@@ -28,3 +28,5 @@ tracelog
 disable-mnt
 private-cache
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/jumpnbump.profile
+++ b/etc/profile-a-l/jumpnbump.profile
@@ -45,3 +45,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/k3b.profile
+++ b/etc/profile-a-l/k3b.profile
@@ -35,3 +35,5 @@ novideo
 
 private-dev
 # private-tmp
+
+# restrict-namespaces - breaks privileged helpers

--- a/etc/profile-a-l/kaffeine.profile
+++ b/etc/profile-a-l/kaffeine.profile
@@ -40,3 +40,4 @@ seccomp
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/kalgebra.profile
+++ b/etc/profile-a-l/kalgebra.profile
@@ -46,3 +46,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+# restrict-namespaces

--- a/etc/profile-a-l/kate.profile
+++ b/etc/profile-a-l/kate.profile
@@ -60,4 +60,5 @@ private-tmp
 # dbus-user none
 # dbus-system none
 
+restrict-namespaces
 join-or-start kate

--- a/etc/profile-a-l/kazam.profile
+++ b/etc/profile-a-l/kazam.profile
@@ -52,3 +52,5 @@ private-etc alsa,alternatives,asound.conf,dconf,fonts,gtk-2.0,gtk-3.0,ld.so.cach
 private-tmp
 
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/kcalc.profile
+++ b/etc/profile-a-l/kcalc.profile
@@ -67,3 +67,4 @@ dbus-user none
 dbus-system none
 
 #memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/kdeinit4.profile
+++ b/etc/profile-a-l/kdeinit4.profile
@@ -34,3 +34,4 @@ private-bin kbuildsycoca4,kded4,kdeinit4,knotify4
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/kdenlive.profile
+++ b/etc/profile-a-l/kdenlive.profile
@@ -38,3 +38,5 @@ private-dev
 
 # dbus-user none
 # dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/kdiff3.profile
+++ b/etc/profile-a-l/kdiff3.profile
@@ -55,3 +55,5 @@ private-dev
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/keepass.profile
+++ b/etc/profile-a-l/keepass.profile
@@ -43,3 +43,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/keepassx.profile
+++ b/etc/profile-a-l/keepassx.profile
@@ -47,3 +47,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/keepassxc.profile
+++ b/etc/profile-a-l/keepassxc.profile
@@ -106,5 +106,7 @@ dbus-user.talk org.xfce.ScreenSaver
 dbus-system filter
 dbus-system.talk org.freedesktop.login1
 
+restrict-namespaces
+
 # Mutex is stored in /tmp by default, which is broken by private-tmp.
 join-or-start keepassxc

--- a/etc/profile-a-l/kfind.profile
+++ b/etc/profile-a-l/kfind.profile
@@ -44,3 +44,5 @@ private-tmp
 
 # dbus-user none
 # dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/kget.profile
+++ b/etc/profile-a-l/kget.profile
@@ -41,3 +41,4 @@ private-dev
 private-tmp
 
 # memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/kid3.profile
+++ b/etc/profile-a-l/kid3.profile
@@ -45,3 +45,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/kino.profile
+++ b/etc/profile-a-l/kino.profile
@@ -34,3 +34,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/kiwix-desktop.profile
+++ b/etc/profile-a-l/kiwix-desktop.profile
@@ -48,3 +48,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+# restrict-namespaces

--- a/etc/profile-a-l/klatexformula.profile
+++ b/etc/profile-a-l/klatexformula.profile
@@ -42,3 +42,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/klavaro.profile
+++ b/etc/profile-a-l/klavaro.profile
@@ -51,3 +51,5 @@ private-srv none
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/kmail.profile
+++ b/etc/profile-a-l/kmail.profile
@@ -62,3 +62,5 @@ private-dev
 # private-tmp - interrupts connection to akonadi, breaks opening of email attachments
 # writable-run-user is needed for signing and encrypting emails
 writable-run-user
+
+# restrict-namespaces

--- a/etc/profile-a-l/kmplayer.profile
+++ b/etc/profile-a-l/kmplayer.profile
@@ -38,3 +38,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/kodi.profile
+++ b/etc/profile-a-l/kodi.profile
@@ -51,3 +51,5 @@ tracelog
 
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/konversation.profile
+++ b/etc/profile-a-l/konversation.profile
@@ -43,3 +43,4 @@ private-dev
 private-tmp
 
 # memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/kopete.profile
+++ b/etc/profile-a-l/kopete.profile
@@ -37,3 +37,4 @@ private-dev
 private-tmp
 writable-var
 
+restrict-namespaces

--- a/etc/profile-a-l/krita.profile
+++ b/etc/profile-a-l/krita.profile
@@ -48,3 +48,5 @@ private-tmp
 
 # dbus-user none
 # dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/krunner.profile
+++ b/etc/profile-a-l/krunner.profile
@@ -35,3 +35,5 @@ protocol unix,inet,inet6
 seccomp
 
 # private-cache
+
+restrict-namespaces

--- a/etc/profile-a-l/ktorrent.profile
+++ b/etc/profile-a-l/ktorrent.profile
@@ -67,3 +67,4 @@ private-tmp
 
 deterministic-shutdown
 # memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/ktouch.profile
+++ b/etc/profile-a-l/ktouch.profile
@@ -50,3 +50,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/kube.profile
+++ b/etc/profile-a-l/kube.profile
@@ -78,3 +78,4 @@ dbus-user.talk org.freedesktop.Notifications
 dbus-system none
 
 read-only ${HOME}/.mozilla/firefox/profiles.ini
+restrict-namespaces

--- a/etc/profile-a-l/kwin_x11.profile
+++ b/etc/profile-a-l/kwin_x11.profile
@@ -44,3 +44,5 @@ private-bin kwin_x11
 private-dev
 private-etc alternatives,drirc,fonts,kde5rc,ld.so.cache,ld.so.preload,machine-id,xdg
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-a-l/kwrite.profile
+++ b/etc/profile-a-l/kwrite.profile
@@ -52,4 +52,5 @@ private-tmp
 # dbus-user none
 # dbus-system none
 
+restrict-namespaces
 join-or-start kwrite

--- a/etc/profile-a-l/latex-common.profile
+++ b/etc/profile-a-l/latex-common.profile
@@ -38,3 +38,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/leafpad.profile
+++ b/etc/profile-a-l/leafpad.profile
@@ -38,3 +38,4 @@ private-dev
 private-lib
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/less.profile
+++ b/etc/profile-a-l/less.profile
@@ -48,3 +48,4 @@ dbus-system none
 memory-deny-write-execute
 read-only ${HOME}
 read-write ${HOME}/.lesshst
+restrict-namespaces

--- a/etc/profile-a-l/librecad.profile
+++ b/etc/profile-a-l/librecad.profile
@@ -47,3 +47,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/libreoffice.profile
+++ b/etc/profile-a-l/libreoffice.profile
@@ -54,4 +54,5 @@ private-tmp
 
 dbus-system none
 
+restrict-namespaces
 join-or-start libreoffice

--- a/etc/profile-a-l/lifeograph.profile
+++ b/etc/profile-a-l/lifeograph.profile
@@ -54,3 +54,5 @@ private-tmp
 dbus-user filter
 dbus-user.talk ca.desrt.dconf
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/liferea.profile
+++ b/etc/profile-a-l/liferea.profile
@@ -59,3 +59,5 @@ dbus-user.talk ca.desrt.dconf
 # Add the next line to your liferea.local if you use the 'Libsecret Support' plugin.
 #dbus-user.talk org.freedesktop.secrets
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/lincity-ng.profile
+++ b/etc/profile-a-l/lincity-ng.profile
@@ -45,3 +45,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/links-common.profile
+++ b/etc/profile-a-l/links-common.profile
@@ -59,3 +59,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/linphone.profile
+++ b/etc/profile-a-l/linphone.profile
@@ -47,3 +47,4 @@ disable-mnt
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/lmms.profile
+++ b/etc/profile-a-l/lmms.profile
@@ -37,3 +37,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/lollypop.profile
+++ b/etc/profile-a-l/lollypop.profile
@@ -39,3 +39,4 @@ private-dev
 private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,machine-id,pki,pulse,resolv.conf,ssl,xdg
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/lugaru.profile
+++ b/etc/profile-a-l/lugaru.profile
@@ -49,3 +49,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/luminance-hdr.profile
+++ b/etc/profile-a-l/luminance-hdr.profile
@@ -36,3 +36,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/lutris.profile
+++ b/etc/profile-a-l/lutris.profile
@@ -80,3 +80,5 @@ dbus-user filter
 dbus-user.own net.lutris.Lutris
 dbus-user.talk com.feralinteractive.GameMode
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-a-l/lximage-qt.profile
+++ b/etc/profile-a-l/lximage-qt.profile
@@ -35,3 +35,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/lxmusic.profile
+++ b/etc/profile-a-l/lxmusic.profile
@@ -37,3 +37,4 @@ seccomp
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-a-l/lynx.profile
+++ b/etc/profile-a-l/lynx.profile
@@ -39,3 +39,5 @@ private-cache
 private-dev
 # private-etc alternatives,ca-certificates,crypto-policies,pki,ssl
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/Maelstrom.profile
+++ b/etc/profile-m-z/Maelstrom.profile
@@ -43,3 +43,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+#restrict-namespaces

--- a/etc/profile-m-z/Mathematica.profile
+++ b/etc/profile-m-z/Mathematica.profile
@@ -27,3 +27,5 @@ nonewprivs
 noroot
 notv
 seccomp
+
+restrict-namespaces

--- a/etc/profile-m-z/PCSX2.profile
+++ b/etc/profile-m-z/PCSX2.profile
@@ -53,3 +53,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+#restrict-namespaces

--- a/etc/profile-m-z/QMediathekView.profile
+++ b/etc/profile-m-z/QMediathekView.profile
@@ -56,3 +56,4 @@ dbus-user none
 dbus-system none
 
 #memory-deny-write-execute - breaks on Arch (see issue #1803)
+restrict-namespaces

--- a/etc/profile-m-z/QOwnNotes.profile
+++ b/etc/profile-m-z/QOwnNotes.profile
@@ -52,3 +52,4 @@ private-dev
 private-etc alternatives,ca-certificates,crypto-policies,fonts,host.conf,hosts,ld.so.cache,ld.so.preload,machine-id,nsswitch.conf,pki,pulse,resolv.conf,ssl
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/Viber.profile
+++ b/etc/profile-m-z/Viber.profile
@@ -34,3 +34,5 @@ disable-mnt
 private-bin awk,bash,dig,sh,Viber
 private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,hosts,ld.so.cache,ld.so.preload,localtime,machine-id,mailcap,nsswitch.conf,pki,proxychains.conf,pulse,resolv.conf,ssl,X11
 private-tmp
+
+# restrict-namespaces

--- a/etc/profile-m-z/XMind.profile
+++ b/etc/profile-m-z/XMind.profile
@@ -35,3 +35,4 @@ private-bin cp,sh,XMind
 private-tmp
 private-dev
 
+restrict-namespaces

--- a/etc/profile-m-z/Xephyr.profile
+++ b/etc/profile-m-z/Xephyr.profile
@@ -40,3 +40,5 @@ private
 private-dev
 # private-etc alternatives,gai.conf,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,nsswitch.conf,resolv.conf
 #private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/Xvfb.profile
+++ b/etc/profile-m-z/Xvfb.profile
@@ -44,3 +44,5 @@ private
 private-dev
 private-etc alternatives,gai.conf,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.preload,nsswitch.conf,resolv.conf
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/ZeGrapher.profile
+++ b/etc/profile-m-z/ZeGrapher.profile
@@ -45,3 +45,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/macrofusion.profile
+++ b/etc/profile-m-z/macrofusion.profile
@@ -42,3 +42,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/magicor.profile
+++ b/etc/profile-m-z/magicor.profile
@@ -49,3 +49,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/makepkg.profile
+++ b/etc/profile-m-z/makepkg.profile
@@ -58,3 +58,4 @@ private-cache
 private-tmp
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/man.profile
+++ b/etc/profile-m-z/man.profile
@@ -65,3 +65,4 @@ dbus-system none
 memory-deny-write-execute
 read-only ${HOME}
 #read-only /tmp # breaks mandoc (see #4927)
+restrict-namespaces

--- a/etc/profile-m-z/manaplus.profile
+++ b/etc/profile-m-z/manaplus.profile
@@ -48,3 +48,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/marker.profile
+++ b/etc/profile-m-z/marker.profile
@@ -60,3 +60,5 @@ dbus-user filter
 dbus-user.own com.github.fabiocolacio.marker
 dbus-user.talk ca.desrt.dconf
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/masterpdfeditor.profile
+++ b/etc/profile-m-z/masterpdfeditor.profile
@@ -38,3 +38,4 @@ private-dev
 private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/mate-calc.profile
+++ b/etc/profile-m-z/mate-calc.profile
@@ -50,3 +50,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/mate-color-select.profile
+++ b/etc/profile-m-z/mate-color-select.profile
@@ -38,3 +38,4 @@ private-lib
 private-tmp
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/mate-dictionary.profile
+++ b/etc/profile-m-z/mate-dictionary.profile
@@ -42,3 +42,4 @@ private-dev
 private-tmp
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/mcabber.profile
+++ b/etc/profile-m-z/mcabber.profile
@@ -31,3 +31,5 @@ seccomp
 private-bin mcabber
 private-dev
 private-etc alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.preload,pki,ssl
+
+restrict-namespaces

--- a/etc/profile-m-z/mcomix.profile
+++ b/etc/profile-m-z/mcomix.profile
@@ -70,3 +70,4 @@ read-write ${HOME}/.local/share/mcomix
 read-write ${HOME}/.local/share
 # used by mcomix <= 1.2, tip, make a symbolic link to .cache/thumbnails
 read-write ${HOME}/.thumbnails
+restrict-namespaces

--- a/etc/profile-m-z/mdr.profile
+++ b/etc/profile-m-z/mdr.profile
@@ -52,3 +52,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/mediainfo.profile
+++ b/etc/profile-m-z/mediainfo.profile
@@ -49,3 +49,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/mediathekview.profile
+++ b/etc/profile-m-z/mediathekview.profile
@@ -51,3 +51,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/megaglest.profile
+++ b/etc/profile-m-z/megaglest.profile
@@ -53,3 +53,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/meld.profile
+++ b/etc/profile-m-z/meld.profile
@@ -78,3 +78,4 @@ private-dev
 private-tmp
 
 read-only ${HOME}/.ssh
+restrict-namespaces

--- a/etc/profile-m-z/mendeleydesktop.profile
+++ b/etc/profile-m-z/mendeleydesktop.profile
@@ -47,3 +47,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/menulibre.profile
+++ b/etc/profile-m-z/menulibre.profile
@@ -61,3 +61,4 @@ read-write ${HOME}/.config/menus
 read-write ${HOME}/.gnome/apps
 read-write ${HOME}/.local/share/applications
 read-write ${HOME}/.local/share/flatpak/exports
+restrict-namespaces

--- a/etc/profile-m-z/meteo-qt.profile
+++ b/etc/profile-m-z/meteo-qt.profile
@@ -51,3 +51,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/midori.profile
+++ b/etc/profile-m-z/midori.profile
@@ -62,3 +62,5 @@ tracelog
 
 disable-mnt
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/mindless.profile
+++ b/etc/profile-m-z/mindless.profile
@@ -48,3 +48,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/minecraft-launcher.profile
+++ b/etc/profile-m-z/minecraft-launcher.profile
@@ -56,3 +56,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/minetest.profile
+++ b/etc/profile-m-z/minetest.profile
@@ -61,3 +61,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/minitube.profile
+++ b/etc/profile-m-z/minitube.profile
@@ -58,3 +58,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/mirage.profile
+++ b/etc/profile-m-z/mirage.profile
@@ -58,3 +58,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/mirrormagic.profile
+++ b/etc/profile-m-z/mirrormagic.profile
@@ -48,3 +48,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/mocp.profile
+++ b/etc/profile-m-z/mocp.profile
@@ -50,3 +50,4 @@ dbus-system none
 memory-deny-write-execute
 read-only ${HOME}
 read-write ${HOME}/.moc
+restrict-namespaces

--- a/etc/profile-m-z/mousepad.profile
+++ b/etc/profile-m-z/mousepad.profile
@@ -37,3 +37,5 @@ private-bin mousepad
 private-dev
 private-lib
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/mp3splt-gtk.profile
+++ b/etc/profile-m-z/mp3splt-gtk.profile
@@ -41,3 +41,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/mp3splt.profile
+++ b/etc/profile-m-z/mp3splt.profile
@@ -46,7 +46,8 @@ private-dev
 private-etc alternatives,ld.so.cache,ld.so.preload
 private-tmp
 
-memory-deny-write-execute
-
 dbus-user none
 dbus-system none
+
+memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/mpDris2.profile
+++ b/etc/profile-m-z/mpDris2.profile
@@ -55,3 +55,4 @@ private-tmp
 #memory-deny-write-execute - breaks on Arch (see issue #1803)
 
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-m-z/mpd.profile
+++ b/etc/profile-m-z/mpd.profile
@@ -41,3 +41,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/mpg123.profile
+++ b/etc/profile-m-z/mpg123.profile
@@ -42,3 +42,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/mplayer.profile
+++ b/etc/profile-m-z/mplayer.profile
@@ -37,3 +37,5 @@ seccomp
 private-bin mplayer
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/mpsyt.profile
+++ b/etc/profile-m-z/mpsyt.profile
@@ -68,3 +68,4 @@ private-tmp
 
 dbus-user none
 dbus-system none
+restrict-namespaces

--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -86,3 +86,5 @@ private-dev
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/mrrescue.profile
+++ b/etc/profile-m-z/mrrescue.profile
@@ -56,3 +56,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/ms-office.profile
+++ b/etc/profile-m-z/ms-office.profile
@@ -40,3 +40,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/mtpaint.profile
+++ b/etc/profile-m-z/mtpaint.profile
@@ -46,3 +46,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/multimc5.profile
+++ b/etc/profile-m-z/multimc5.profile
@@ -49,3 +49,4 @@ disable-mnt
 private-dev
 private-tmp
 
+# restrict-namespaces

--- a/etc/profile-m-z/mumble.profile
+++ b/etc/profile-m-z/mumble.profile
@@ -42,3 +42,4 @@ private-bin mumble
 private-tmp
 
 #memory-deny-write-execute - breaks on Arch (see issue #1803)
+restrict-namespaces

--- a/etc/profile-m-z/mupdf.profile
+++ b/etc/profile-m-z/mupdf.profile
@@ -44,3 +44,4 @@ dbus-system none
 
 memory-deny-write-execute
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-m-z/mupen64plus.profile
+++ b/etc/profile-m-z/mupen64plus.profile
@@ -31,3 +31,5 @@ seccomp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/musescore.profile
+++ b/etc/profile-m-z/musescore.profile
@@ -39,3 +39,5 @@ tracelog
 
 # private-bin musescore,mscore
 private-tmp
+
+# restrict-namespaces

--- a/etc/profile-m-z/musictube.profile
+++ b/etc/profile-m-z/musictube.profile
@@ -54,3 +54,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/musixmatch.profile
+++ b/etc/profile-m-z/musixmatch.profile
@@ -35,3 +35,4 @@ disable-mnt
 private-dev
 private-etc alternatives,asound.conf,ca-certificates,crypto-policies,ld.so.cache,ld.so.preload,machine-id,pki,pulse,ssl
 
+# restrict-namespaces

--- a/etc/profile-m-z/mutt.profile
+++ b/etc/profile-m-z/mutt.profile
@@ -146,3 +146,4 @@ read-only ${HOME}/.elinks
 read-only ${HOME}/.nanorc
 read-only ${HOME}/.signature
 read-only ${HOME}/.w3m
+restrict-namespaces

--- a/etc/profile-m-z/mypaint.profile
+++ b/etc/profile-m-z/mypaint.profile
@@ -47,3 +47,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/nano.profile
+++ b/etc/profile-m-z/nano.profile
@@ -56,3 +56,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/natron.profile
+++ b/etc/profile-m-z/natron.profile
@@ -34,3 +34,5 @@ private-bin natron,Natron,NatronRenderer
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/ncdu.profile
+++ b/etc/profile-m-z/ncdu.profile
@@ -35,3 +35,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -62,3 +62,5 @@ dbus-user.talk org.freedesktop.Notifications
 ?ALLOW_TRAY: dbus-user.talk org.kde.StatusNotifierWatcher
 dbus-user.talk org.kde.kwalletd5
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/neomutt.profile
+++ b/etc/profile-m-z/neomutt.profile
@@ -129,3 +129,4 @@ read-only ${HOME}/.elinks
 read-only ${HOME}/.nanorc
 read-only ${HOME}/.signature
 read-only ${HOME}/.w3m
+restrict-namespaces

--- a/etc/profile-m-z/netactview.profile
+++ b/etc/profile-m-z/netactview.profile
@@ -52,3 +52,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/nethack-vultures.profile
+++ b/etc/profile-m-z/nethack-vultures.profile
@@ -42,3 +42,5 @@ writable-var
 
 dbus-user none
 dbus-system none
+
+#restrict-namespaces

--- a/etc/profile-m-z/nethack.profile
+++ b/etc/profile-m-z/nethack.profile
@@ -44,3 +44,4 @@ dbus-user none
 dbus-system none
 
 #memory-deny-write-execute
+#restrict-namespaces

--- a/etc/profile-m-z/netsurf.profile
+++ b/etc/profile-m-z/netsurf.profile
@@ -32,3 +32,5 @@ seccomp
 tracelog
 
 disable-mnt
+
+restrict-namespaces

--- a/etc/profile-m-z/neverball.profile
+++ b/etc/profile-m-z/neverball.profile
@@ -48,3 +48,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/newsboat.profile
+++ b/etc/profile-m-z/newsboat.profile
@@ -59,3 +59,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/newsflash.profile
+++ b/etc/profile-m-z/newsflash.profile
@@ -57,3 +57,5 @@ dbus-user none
 #dbus-user.own com.gitlab.newsflash
 #dbus-user.talk org.freedesktop.Notifications
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/nextcloud.profile
+++ b/etc/profile-m-z/nextcloud.profile
@@ -69,3 +69,5 @@ dbus-user filter
 dbus-user.talk org.freedesktop.secrets
 ?ALLOW_TRAY: dbus-user.talk org.kde.StatusNotifierWatcher
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/nheko.profile
+++ b/etc/profile-m-z/nheko.profile
@@ -56,3 +56,5 @@ dbus-user.talk org.freedesktop.secrets
 # Add the next line to your nheko.local to enable notification support.
 #dbus-user.talk org.freedesktop.Notifications
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/nicotine.profile
+++ b/etc/profile-m-z/nicotine.profile
@@ -59,3 +59,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/nitroshare.profile
+++ b/etc/profile-m-z/nitroshare.profile
@@ -49,3 +49,4 @@ private-tmp
 # dbus-system none
 
 # memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/nodejs-common.profile
+++ b/etc/profile-m-z/nodejs-common.profile
@@ -100,3 +100,4 @@ dbus-system none
 
 # Add the next line to your nodejs-common.local if you prefer to disable gatsby telemetry.
 #env GATSBY_TELEMETRY_DISABLED=1
+restrict-namespaces

--- a/etc/profile-m-z/nomacs.profile
+++ b/etc/profile-m-z/nomacs.profile
@@ -42,3 +42,5 @@ private-cache
 private-dev
 private-etc alternatives,ca-certificates,crypto-policies,dconf,drirc,fonts,gtk-3.0,hosts,ld.so.cache,ld.so.preload,login.defs,machine-id,pki,resolv.conf,ssl
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/notify-send.profile
+++ b/etc/profile-m-z/notify-send.profile
@@ -57,3 +57,4 @@ dbus-system none
 
 memory-deny-write-execute
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-m-z/nslookup.profile
+++ b/etc/profile-m-z/nslookup.profile
@@ -52,3 +52,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/nvim.profile
+++ b/etc/profile-m-z/nvim.profile
@@ -51,3 +51,4 @@ read-write ${HOME}/.local/share/nvim
 read-write ${HOME}/.local/state/nvim
 read-write ${HOME}/.vim
 read-write ${HOME}/.vimrc
+restrict-namespaces

--- a/etc/profile-m-z/nylas.profile
+++ b/etc/profile-m-z/nylas.profile
@@ -35,3 +35,5 @@ protocol unix,inet,inet6,netlink
 seccomp
 
 private-dev
+
+restrict-namespaces

--- a/etc/profile-m-z/nyx.profile
+++ b/etc/profile-m-z/nyx.profile
@@ -51,3 +51,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/obs.profile
+++ b/etc/profile-m-z/obs.profile
@@ -40,3 +40,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/ocenaudio.profile
+++ b/etc/profile-m-z/ocenaudio.profile
@@ -59,3 +59,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/odt2txt.profile
+++ b/etc/profile-m-z/odt2txt.profile
@@ -44,3 +44,4 @@ dbus-user none
 dbus-system none
 
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-m-z/okular.profile
+++ b/etc/profile-m-z/okular.profile
@@ -69,4 +69,5 @@ private-etc alternatives,cups,fonts,kde4rc,kde5rc,ld.so.cache,ld.so.preload,mach
 
 # memory-deny-write-execute
 
+restrict-namespaces
 join-or-start okular

--- a/etc/profile-m-z/onboard.profile
+++ b/etc/profile-m-z/onboard.profile
@@ -53,3 +53,5 @@ private-etc alternatives,dbus-1,dconf,fonts,gtk-2.0,gtk-3.0,ld.so.cache,ld.so.pr
 private-tmp
 
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/onionshare-gui.profile
+++ b/etc/profile-m-z/onionshare-gui.profile
@@ -65,3 +65,4 @@ dbus-user.talk org.freedesktop.secrets
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/open-invaders.profile
+++ b/etc/profile-m-z/open-invaders.profile
@@ -39,3 +39,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/openarena.profile
+++ b/etc/profile-m-z/openarena.profile
@@ -47,3 +47,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/openbox.profile
+++ b/etc/profile-m-z/openbox.profile
@@ -18,3 +18,4 @@ seccomp
 
 read-only ${HOME}/.config/openbox/autostart
 read-only ${HOME}/.config/openbox/environment
+restrict-namespaces

--- a/etc/profile-m-z/opencity.profile
+++ b/etc/profile-m-z/opencity.profile
@@ -45,3 +45,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/openclonk.profile
+++ b/etc/profile-m-z/openclonk.profile
@@ -45,3 +45,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/openmw.profile
+++ b/etc/profile-m-z/openmw.profile
@@ -58,3 +58,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/openshot.profile
+++ b/etc/profile-m-z/openshot.profile
@@ -46,3 +46,5 @@ private-tmp
 
 dbus-user filter
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/openstego.profile
+++ b/etc/profile-m-z/openstego.profile
@@ -55,3 +55,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/openttd.profile
+++ b/etc/profile-m-z/openttd.profile
@@ -45,3 +45,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/orage.profile
+++ b/etc/profile-m-z/orage.profile
@@ -36,3 +36,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/ostrichriders.profile
+++ b/etc/profile-m-z/ostrichriders.profile
@@ -47,3 +47,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/otter-browser.profile
+++ b/etc/profile-m-z/otter-browser.profile
@@ -56,3 +56,5 @@ private-etc alternatives,asound.conf,ca-certificates,crypto-policies,dconf,fonts
 private-tmp
 
 dbus-system none
+
+# restrict-namespaces

--- a/etc/profile-m-z/palemoon.profile
+++ b/etc/profile-m-z/palemoon.profile
@@ -22,5 +22,8 @@ ignore seccomp
 #private-etc palemoon
 #private-opt palemoon
 
+restrict-namespaces
+ignore restrict-namespaces
+
 # Redirect
 include firefox-common.profile

--- a/etc/profile-m-z/pandoc.profile
+++ b/etc/profile-m-z/pandoc.profile
@@ -56,3 +56,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/parole.profile
+++ b/etc/profile-m-z/parole.profile
@@ -27,3 +27,5 @@ seccomp
 private-bin dbus-launch,parole
 private-cache
 private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,group,ld.so.cache,ld.so.preload,machine-id,passwd,pki,pulse,ssl
+
+restrict-namespaces

--- a/etc/profile-m-z/patch.profile
+++ b/etc/profile-m-z/patch.profile
@@ -48,3 +48,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/pavucontrol.profile
+++ b/etc/profile-m-z/pavucontrol.profile
@@ -53,3 +53,4 @@ dbus-system none
 
 # mdwe is broken under Wayland, but works under Xorg.
 #memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/pcsxr.profile
+++ b/etc/profile-m-z/pcsxr.profile
@@ -53,3 +53,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/pdfchain.profile
+++ b/etc/profile-m-z/pdfchain.profile
@@ -40,3 +40,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/pdfmod.profile
+++ b/etc/profile-m-z/pdfmod.profile
@@ -41,3 +41,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/pdfsam.profile
+++ b/etc/profile-m-z/pdfsam.profile
@@ -41,3 +41,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/pdftotext.profile
+++ b/etc/profile-m-z/pdftotext.profile
@@ -53,3 +53,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/peek.profile
+++ b/etc/profile-m-z/peek.profile
@@ -59,3 +59,4 @@ dbus-user.talk org.gnome.Shell.Screencast
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/penguin-command.profile
+++ b/etc/profile-m-z/penguin-command.profile
@@ -39,3 +39,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/photoflare.profile
+++ b/etc/profile-m-z/photoflare.profile
@@ -47,3 +47,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/picard.profile
+++ b/etc/profile-m-z/picard.profile
@@ -40,3 +40,4 @@ seccomp
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/pidgin.profile
+++ b/etc/profile-m-z/pidgin.profile
@@ -45,3 +45,5 @@ tracelog
 private-cache
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/pinball.profile
+++ b/etc/profile-m-z/pinball.profile
@@ -52,3 +52,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/ping-hardened.inc.profile
+++ b/etc/profile-m-z/ping-hardened.inc.profile
@@ -9,3 +9,4 @@ protocol unix,inet,inet6
 seccomp
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/ping.profile
+++ b/etc/profile-m-z/ping.profile
@@ -68,3 +68,4 @@ dbus-user none
 dbus-system none
 
 read-only ${HOME}
+#restrict-namespaces

--- a/etc/profile-m-z/pingus.profile
+++ b/etc/profile-m-z/pingus.profile
@@ -54,3 +54,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/pinta.profile
+++ b/etc/profile-m-z/pinta.profile
@@ -38,3 +38,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/pioneer.profile
+++ b/etc/profile-m-z/pioneer.profile
@@ -44,3 +44,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/pithos.profile
+++ b/etc/profile-m-z/pithos.profile
@@ -40,3 +40,4 @@ private-bin env,pithos,python*
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/pitivi.profile
+++ b/etc/profile-m-z/pitivi.profile
@@ -39,3 +39,4 @@ seccomp
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/pix.profile
+++ b/etc/profile-m-z/pix.profile
@@ -34,3 +34,5 @@ private-bin pix
 private-cache
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/pkglog.profile
+++ b/etc/profile-m-z/pkglog.profile
@@ -56,3 +56,4 @@ read-only ${HOME}
 read-only /var/log/apt/history.log
 read-only /var/log/dnf.rpm.log
 read-only /var/log/pacman.log
+restrict-namespaces

--- a/etc/profile-m-z/pluma.profile
+++ b/etc/profile-m-z/pluma.profile
@@ -48,4 +48,5 @@ private-tmp
 # dbus-user none
 # dbus-system none
 
+restrict-namespaces
 join-or-start pluma

--- a/etc/profile-m-z/plv.profile
+++ b/etc/profile-m-z/plv.profile
@@ -57,3 +57,4 @@ dbus-system none
 read-only ${HOME}
 read-write ${HOME}/.config/PacmanLogViewer
 read-only /var/log/pacman.log
+restrict-namespaces

--- a/etc/profile-m-z/pngquant.profile
+++ b/etc/profile-m-z/pngquant.profile
@@ -53,3 +53,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/polari.profile
+++ b/etc/profile-m-z/polari.profile
@@ -49,3 +49,4 @@ disable-mnt
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/ppsspp.profile
+++ b/etc/profile-m-z/ppsspp.profile
@@ -48,3 +48,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/pragha.profile
+++ b/etc/profile-m-z/pragha.profile
@@ -35,3 +35,4 @@ private-dev
 private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,machine-id,pki,pulse,resolv.conf,ssl,xdg
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/profanity.profile
+++ b/etc/profile-m-z/profanity.profile
@@ -50,3 +50,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/psi-plus.profile
+++ b/etc/profile-m-z/psi-plus.profile
@@ -42,3 +42,5 @@ seccomp !chroot
 disable-mnt
 private-dev
 private-tmp
+
+# restrict-namespaces

--- a/etc/profile-m-z/psi.profile
+++ b/etc/profile-m-z/psi.profile
@@ -75,3 +75,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+#restrict-namespaces

--- a/etc/profile-m-z/pybitmessage.profile
+++ b/etc/profile-m-z/pybitmessage.profile
@@ -43,3 +43,4 @@ private-dev
 private-etc alternatives,ca-certificates,crypto-policies,fonts,gtk-2.0,hosts,ld.so.cache,ld.so.preload,localtime,pki,pki,PyBitmessage,PyBitmessage.conf,resolv.conf,selinux,sni-qt.conf,ssl,system-fips,Trolltech.conf,xdg
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/qbittorrent.profile
+++ b/etc/profile-m-z/qbittorrent.profile
@@ -63,3 +63,4 @@ dbus-user none
 dbus-system none
 
 # memory-deny-write-execute - problems on Arch, see #1690 on GitHub repo
+restrict-namespaces

--- a/etc/profile-m-z/qcomicbook.profile
+++ b/etc/profile-m-z/qcomicbook.profile
@@ -64,3 +64,4 @@ read-write ${HOME}/.config/PawelStolowski
 read-write ${HOME}/.local/share/PawelStolowski
 #to allow ${HOME}/.local/share/recently-used.xbel
 read-write ${HOME}/.local/share
+restrict-namespaces

--- a/etc/profile-m-z/qemu-launcher.profile
+++ b/etc/profile-m-z/qemu-launcher.profile
@@ -25,3 +25,4 @@ private-cache
 private-tmp
 
 noexec /tmp
+restrict-namespaces

--- a/etc/profile-m-z/qemu-system-x86_64.profile
+++ b/etc/profile-m-z/qemu-system-x86_64.profile
@@ -24,3 +24,4 @@ private-cache
 private-tmp
 
 noexec /tmp
+restrict-namespaces

--- a/etc/profile-m-z/qgis.profile
+++ b/etc/profile-m-z/qgis.profile
@@ -56,3 +56,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/qlipper.profile
+++ b/etc/profile-m-z/qlipper.profile
@@ -35,3 +35,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/qmmp.profile
+++ b/etc/profile-m-z/qmmp.profile
@@ -36,3 +36,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/qnapi.profile
+++ b/etc/profile-m-z/qnapi.profile
@@ -52,3 +52,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/qpdfview.profile
+++ b/etc/profile-m-z/qpdfview.profile
@@ -43,3 +43,5 @@ private-tmp
 # needs D-Bus when started from a file manager
 # dbus-user none
 # dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/qrencode.profile
+++ b/etc/profile-m-z/qrencode.profile
@@ -54,3 +54,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/qtox.profile
+++ b/etc/profile-m-z/qtox.profile
@@ -49,3 +49,4 @@ dbus-user none
 dbus-system none
 
 #memory-deny-write-execute - breaks on Arch (see issue #1803)
+restrict-namespaces

--- a/etc/profile-m-z/quassel.profile
+++ b/etc/profile-m-z/quassel.profile
@@ -24,3 +24,5 @@ seccomp !chroot
 
 private-cache
 private-tmp
+
+# restrict-namespaces

--- a/etc/profile-m-z/quaternion.profile
+++ b/etc/profile-m-z/quaternion.profile
@@ -51,3 +51,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/quiterss.profile
+++ b/etc/profile-m-z/quiterss.profile
@@ -52,3 +52,4 @@ private-bin quiterss
 private-dev
 # private-etc alternatives,ca-certificates,crypto-policies,pki,ssl,X11
 
+restrict-namespaces

--- a/etc/profile-m-z/quodlibet.profile
+++ b/etc/profile-m-z/quodlibet.profile
@@ -63,3 +63,5 @@ private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,dconf,
 private-tmp
 
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/qutebrowser.profile
+++ b/etc/profile-m-z/qutebrowser.profile
@@ -48,7 +48,7 @@ notv
 protocol unix,inet,inet6,netlink
 # blacklisting of chroot system calls breaks qt webengine
 seccomp !chroot,!name_to_handle_at
-# tracelog
+#tracelog
 
 disable-mnt
 private-cache
@@ -65,3 +65,5 @@ dbus-user.talk org.freedesktop.Notifications
 # with the above lines (might depend on the portal implementation).
 #ignore noroot
 dbus-system none
+
+#restrict-namespaces

--- a/etc/profile-m-z/raincat.profile
+++ b/etc/profile-m-z/raincat.profile
@@ -46,3 +46,4 @@ private-tmp
 dbus-user none
 dbus-system none
 
+restrict-namespaces

--- a/etc/profile-m-z/rambox.profile
+++ b/etc/profile-m-z/rambox.profile
@@ -35,4 +35,6 @@ protocol unix,inet,inet6,netlink
 # electron-based application, needing chroot
 #seccomp
 seccomp !chroot
-# tracelog
+#tracelog
+
+#restrict-namespaces

--- a/etc/profile-m-z/redeclipse.profile
+++ b/etc/profile-m-z/redeclipse.profile
@@ -45,3 +45,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/rednotebook.profile
+++ b/etc/profile-m-z/rednotebook.profile
@@ -63,3 +63,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/redshift.profile
+++ b/etc/profile-m-z/redshift.profile
@@ -50,3 +50,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/regextester.profile
+++ b/etc/profile-m-z/regextester.profile
@@ -52,3 +52,4 @@ dbus-system none
 
 # never write anything
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-m-z/remmina.profile
+++ b/etc/profile-m-z/remmina.profile
@@ -42,3 +42,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/retroarch.profile
+++ b/etc/profile-m-z/retroarch.profile
@@ -51,3 +51,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/rhythmbox.profile
+++ b/etc/profile-m-z/rhythmbox.profile
@@ -63,3 +63,5 @@ dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.gnome.SettingsDaemon.MediaKeys
 dbus-system filter
 dbus-system.talk org.freedesktop.Avahi
+
+restrict-namespaces

--- a/etc/profile-m-z/ricochet.profile
+++ b/etc/profile-m-z/ricochet.profile
@@ -39,3 +39,4 @@ private-bin ricochet,tor
 private-dev
 #private-etc alternatives,alternatives,ca-certificates,crypto-policies,fonts,pki,ssl,tor,X11
 
+restrict-namespaces

--- a/etc/profile-m-z/ripperx.profile
+++ b/etc/profile-m-z/ripperx.profile
@@ -40,3 +40,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/ristretto.profile
+++ b/etc/profile-m-z/ristretto.profile
@@ -39,3 +39,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/rpcs3.profile
+++ b/etc/profile-m-z/rpcs3.profile
@@ -59,3 +59,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/rsync-download_only.profile
+++ b/etc/profile-m-z/rsync-download_only.profile
@@ -55,3 +55,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/rtin.profile
+++ b/etc/profile-m-z/rtin.profile
@@ -5,4 +5,5 @@
 # Persistent local customizations
 include rtin.local
 
+# Redirect
 include tin.profile

--- a/etc/profile-m-z/rtorrent.profile
+++ b/etc/profile-m-z/rtorrent.profile
@@ -31,3 +31,5 @@ private-bin rtorrent
 private-cache
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/rtv.profile
+++ b/etc/profile-m-z/rtv.profile
@@ -62,3 +62,5 @@ private-etc alternatives,ca-certificates,crypto-policies,host.conf,hostname,host
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/sayonara.profile
+++ b/etc/profile-m-z/sayonara.profile
@@ -33,3 +33,4 @@ private-bin sayonara
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/scallion.profile
+++ b/etc/profile-m-z/scallion.profile
@@ -41,3 +41,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/scorched3d.profile
+++ b/etc/profile-m-z/scorched3d.profile
@@ -47,3 +47,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/scorchwentbonkers.profile
+++ b/etc/profile-m-z/scorchwentbonkers.profile
@@ -47,3 +47,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/scribus.profile
+++ b/etc/profile-m-z/scribus.profile
@@ -61,3 +61,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/sdat2img.profile
+++ b/etc/profile-m-z/sdat2img.profile
@@ -41,3 +41,5 @@ private-dev
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/seafile-applet.profile
+++ b/etc/profile-m-z/seafile-applet.profile
@@ -59,3 +59,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/seahorse-adventures.profile
+++ b/etc/profile-m-z/seahorse-adventures.profile
@@ -52,3 +52,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/seahorse.profile
+++ b/etc/profile-m-z/seahorse.profile
@@ -67,3 +67,5 @@ dbus-user.own org.gnome.seahorse
 dbus-user.own org.gnome.seahorse.Application
 dbus-user.talk org.freedesktop.secrets
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/seamonkey.profile
+++ b/etc/profile-m-z/seamonkey.profile
@@ -57,3 +57,5 @@ tracelog
 disable-mnt
 # private-etc adobe,alternatives,asound.conf,ca-certificates,crypto-policies,firefox,fonts,group,gtk-2.0,hostname,hosts,iceweasel,localtime,machine-id,mailcap,mime.types,nsswitch.conf,pango,passwd,pki,pulse,resolv.conf,ssl
 writable-run-user
+
+restrict-namespaces

--- a/etc/profile-m-z/server.profile
+++ b/etc/profile-m-z/server.profile
@@ -83,6 +83,9 @@ private-dev
 # private-lib
 # private-opt none
 private-tmp
+# writable-run-user
+# writable-var
+# writable-var-log
 
 dbus-user none
 # dbus-system none
@@ -90,7 +93,4 @@ dbus-user none
 # deterministic-shutdown
 # memory-deny-write-execute
 # read-only ${HOME}
-# restrict-namespaces
-# writable-run-user
-# writable-var
-# writable-var-log
+restrict-namespaces

--- a/etc/profile-m-z/servo.profile
+++ b/etc/profile-m-z/servo.profile
@@ -46,3 +46,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/shellcheck.profile
+++ b/etc/profile-m-z/shellcheck.profile
@@ -49,3 +49,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/shortwave.profile
+++ b/etc/profile-m-z/shortwave.profile
@@ -47,3 +47,5 @@ private-cache
 private-dev
 private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,dconf,fonts,gconf,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,pango,passwd,pki,pulse,resolv.conf,ssl,X11,xdg
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/shotcut.profile
+++ b/etc/profile-m-z/shotcut.profile
@@ -35,3 +35,5 @@ private-dev
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/shotwell.profile
+++ b/etc/profile-m-z/shotwell.profile
@@ -57,3 +57,5 @@ dbus-user.own org.gnome.Shotwell
 dbus-user.talk ca.desrt.dconf
 dbus-user.talk org.gtk.vfs.UDisks2VolumeMonitor
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/signal-cli.profile
+++ b/etc/profile-m-z/signal-cli.profile
@@ -48,3 +48,5 @@ private-dev
 # Does not work with all Java configurations. You will notice immediately, so you might want to give it a try
 #private-etc alternatives,ca-certificates,crypto-policies,dbus-1,host.conf,hostname,hosts,java-10-openjdk,java-7-openjdk,java-8-openjdk,java-9-openjdk,java.conf,machine-id,nsswitch.conf,passwd,pki,protocols,resolv.conf,rpc,services,ssl
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/silentarmy.profile
+++ b/etc/profile-m-z/silentarmy.profile
@@ -37,3 +37,4 @@ private-dev
 private-opt none
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/simple-scan.profile
+++ b/etc/profile-m-z/simple-scan.profile
@@ -38,3 +38,5 @@ tracelog
 # private-dev
 # private-etc alternatives,ca-certificates,crypto-policies,fonts,pki,ssl
 # private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/simplescreenrecorder.profile
+++ b/etc/profile-m-z/simplescreenrecorder.profile
@@ -36,3 +36,5 @@ tracelog
 private-cache
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/simutrans.profile
+++ b/etc/profile-m-z/simutrans.profile
@@ -39,3 +39,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/skanlite.profile
+++ b/etc/profile-m-z/skanlite.profile
@@ -33,3 +33,5 @@ seccomp !ioperm
 
 # dbus-user none
 # dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/slashem.profile
+++ b/etc/profile-m-z/slashem.profile
@@ -44,3 +44,4 @@ dbus-user none
 dbus-system none
 
 #memory-deny-write-execute
+#restrict-namespaces

--- a/etc/profile-m-z/smplayer.profile
+++ b/etc/profile-m-z/smplayer.profile
@@ -52,3 +52,5 @@ private-tmp
 # problems with KDE
 # dbus-user none
 # dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/smtube.profile
+++ b/etc/profile-m-z/smtube.profile
@@ -45,3 +45,4 @@ seccomp
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/smuxi-frontend-gnome.profile
+++ b/etc/profile-m-z/smuxi-frontend-gnome.profile
@@ -52,3 +52,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/softmaker-common.profile
+++ b/etc/profile-m-z/softmaker-common.profile
@@ -47,3 +47,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/sol.profile
+++ b/etc/profile-m-z/sol.profile
@@ -44,3 +44,4 @@ dbus-user none
 dbus-system none
 
 # memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/songrec.profile
+++ b/etc/profile-m-z/songrec.profile
@@ -51,3 +51,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/sound-juicer.profile
+++ b/etc/profile-m-z/sound-juicer.profile
@@ -40,3 +40,5 @@ private-tmp
 
 # dbus-user none
 # dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/soundconverter.profile
+++ b/etc/profile-m-z/soundconverter.profile
@@ -47,3 +47,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/spectacle.profile
+++ b/etc/profile-m-z/spectacle.profile
@@ -65,3 +65,5 @@ dbus-user.talk org.freedesktop.FileManager1
 #dbus-user.talk org.kde.JobViewServer
 #dbus-user.talk org.kde.kglobalaccel
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/spectral.profile
+++ b/etc/profile-m-z/spectral.profile
@@ -53,3 +53,5 @@ dbus-user filter
 # Add the next line to your spectral.local to enable notification support.
 #dbus-user.talk org.freedesktop.Notifications
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/spectre-meltdown-checker.profile
+++ b/etc/profile-m-z/spectre-meltdown-checker.profile
@@ -49,3 +49,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/spotify.profile
+++ b/etc/profile-m-z/spotify.profile
@@ -53,3 +53,5 @@ private-tmp
 # dbus needed for MPRIS
 # dbus-user none
 # dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/sqlitebrowser.profile
+++ b/etc/profile-m-z/sqlitebrowser.profile
@@ -49,3 +49,4 @@ private-tmp
 # dbus-system none
 
 #memory-deny-write-execute - breaks on Arch (see issue #1803)
+restrict-namespaces

--- a/etc/profile-m-z/ssh-agent.profile
+++ b/etc/profile-m-z/ssh-agent.profile
@@ -33,3 +33,5 @@ writable-run-user
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/ssh.profile
+++ b/etc/profile-m-z/ssh.profile
@@ -51,3 +51,4 @@ dbus-system none
 
 deterministic-shutdown
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/standardnotes-desktop.profile
+++ b/etc/profile-m-z/standardnotes-desktop.profile
@@ -42,3 +42,5 @@ private-etc alternatives,ca-certificates,crypto-policies,fonts,host.conf,hostnam
 
 dbus-user none
 dbus-system none
+
+# restrict-namespaces

--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -178,7 +178,8 @@ private-dev
 private-etc alsa,alternatives,asound.conf,bumblebee,ca-certificates,crypto-policies,dbus-1,drirc,fonts,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,lsb-release,machine-id,mime.types,nvidia,os-release,passwd,pki,pulse,resolv.conf,services,ssl,vulkan
 private-tmp
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 read-only ${HOME}/.config/MangoHud
+#restrict-namespaces

--- a/etc/profile-m-z/stellarium.profile
+++ b/etc/profile-m-z/stellarium.profile
@@ -43,3 +43,4 @@ private-bin stellarium
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/strawberry.profile
+++ b/etc/profile-m-z/strawberry.profile
@@ -46,3 +46,5 @@ private-etc alternatives,ca-certificates,crypto-policies,fonts,host.conf,hostnam
 private-tmp
 
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/strings.profile
+++ b/etc/profile-m-z/strings.profile
@@ -54,3 +54,4 @@ dbus-system none
 
 memory-deny-write-execute
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-m-z/subdownloader.profile
+++ b/etc/profile-m-z/subdownloader.profile
@@ -50,3 +50,4 @@ dbus-user none
 dbus-system none
 
 #memory-deny-write-execute - breaks on Arch (see issue #1803)
+restrict-namespaces

--- a/etc/profile-m-z/supertux2.profile
+++ b/etc/profile-m-z/supertux2.profile
@@ -49,3 +49,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/supertuxkart.profile
+++ b/etc/profile-m-z/supertuxkart.profile
@@ -60,3 +60,5 @@ private-srv none
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/surf.profile
+++ b/etc/profile-m-z/surf.profile
@@ -36,3 +36,4 @@ private-dev
 private-etc alternatives,ca-certificates,crypto-policies,fonts,group,hosts,ld.so.cache,ld.so.preload,machine-id,passwd,pki,resolv.conf,ssl
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/sushi.profile
+++ b/etc/profile-m-z/sushi.profile
@@ -45,3 +45,4 @@ read-only /media
 read-only /run/mount
 read-only /run/media
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-m-z/sway.profile
+++ b/etc/profile-m-z/sway.profile
@@ -17,3 +17,5 @@ netfilter
 noroot
 protocol unix,inet,inet6
 seccomp
+
+restrict-namespaces

--- a/etc/profile-m-z/synfigstudio.profile
+++ b/etc/profile-m-z/synfigstudio.profile
@@ -36,3 +36,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/sysprof.profile
+++ b/etc/profile-m-z/sysprof.profile
@@ -74,3 +74,4 @@ dbus-user.own org.gnome.Sysprof3
 dbus-user.talk ca.desrt.dconf
 
 # memory-deny-write-execute - breaks on Arch
+restrict-namespaces

--- a/etc/profile-m-z/tcpdump.profile
+++ b/etc/profile-m-z/tcpdump.profile
@@ -44,3 +44,4 @@ private-dev
 private-tmp
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/teamspeak3.profile
+++ b/etc/profile-m-z/teamspeak3.profile
@@ -39,3 +39,4 @@ disable-mnt
 private-dev
 private-tmp
 
+# restrict-namespaces

--- a/etc/profile-m-z/teeworlds.profile
+++ b/etc/profile-m-z/teeworlds.profile
@@ -43,3 +43,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/telegram.profile
+++ b/etc/profile-m-z/telegram.profile
@@ -56,3 +56,5 @@ dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.gnome.Mutter.IdleMonitor
 dbus-user.talk org.freedesktop.ScreenSaver
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/telnet.profile
+++ b/etc/profile-m-z/telnet.profile
@@ -51,3 +51,4 @@ dbus-system none
 
 memory-deny-write-execute
 noexec ${HOME}
+restrict-namespaces

--- a/etc/profile-m-z/terasology.profile
+++ b/etc/profile-m-z/terasology.profile
@@ -45,3 +45,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/tilp.profile
+++ b/etc/profile-m-z/tilp.profile
@@ -32,3 +32,4 @@ private-cache
 private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/tin.profile
+++ b/etc/profile-m-z/tin.profile
@@ -65,3 +65,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/tmux.profile
+++ b/etc/profile-m-z/tmux.profile
@@ -42,3 +42,5 @@ private-dev
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/tor.profile
+++ b/etc/profile-m-z/tor.profile
@@ -48,3 +48,5 @@ private-dev
 private-etc alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.preload,passwd,pki,ssl,tor
 private-tmp
 writable-var
+
+restrict-namespaces

--- a/etc/profile-m-z/torbrowser-launcher.profile
+++ b/etc/profile-m-z/torbrowser-launcher.profile
@@ -63,3 +63,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+#restrict-namespaces

--- a/etc/profile-m-z/torcs.profile
+++ b/etc/profile-m-z/torcs.profile
@@ -45,3 +45,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/totem.profile
+++ b/etc/profile-m-z/totem.profile
@@ -57,3 +57,5 @@ private-tmp
 # makes settings immutable
 # dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/tracker.profile
+++ b/etc/profile-m-z/tracker.profile
@@ -36,3 +36,5 @@ tracelog
 # private-bin tracker
 # private-dev
 # private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/transgui.profile
+++ b/etc/profile-m-z/transgui.profile
@@ -52,3 +52,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/transmission-common.profile
+++ b/etc/profile-m-z/transmission-common.profile
@@ -50,3 +50,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/tremulous.profile
+++ b/etc/profile-m-z/tremulous.profile
@@ -50,3 +50,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/trojita.profile
+++ b/etc/profile-m-z/trojita.profile
@@ -61,3 +61,4 @@ dbus-user.talk org.freedesktop.secrets
 dbus-system none
 
 read-only ${HOME}/.mozilla/firefox/profiles.ini
+restrict-namespaces

--- a/etc/profile-m-z/truecraft.profile
+++ b/etc/profile-m-z/truecraft.profile
@@ -36,3 +36,4 @@ disable-mnt
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/tuxguitar.profile
+++ b/etc/profile-m-z/tuxguitar.profile
@@ -43,3 +43,5 @@ tracelog
 
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/tvbrowser.profile
+++ b/etc/profile-m-z/tvbrowser.profile
@@ -50,3 +50,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/udiskie.profile
+++ b/etc/profile-m-z/udiskie.profile
@@ -42,3 +42,5 @@ private-cache
 private-dev
 private-etc alternatives,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,mime.types,xdg
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/uefitool.profile
+++ b/etc/profile-m-z/uefitool.profile
@@ -36,3 +36,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/uget-gtk.profile
+++ b/etc/profile-m-z/uget-gtk.profile
@@ -36,3 +36,5 @@ seccomp
 private-bin uget-gtk
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/unbound.profile
+++ b/etc/profile-m-z/unbound.profile
@@ -52,3 +52,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/unf.profile
+++ b/etc/profile-m-z/unf.profile
@@ -56,3 +56,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/unknown-horizons.profile
+++ b/etc/profile-m-z/unknown-horizons.profile
@@ -41,3 +41,4 @@ private-tmp
 
 # doesn't work - maybe all Tcl/Tk programs have this problem
 # memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/utox.profile
+++ b/etc/profile-m-z/utox.profile
@@ -46,3 +46,4 @@ private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so
 private-tmp
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/uudeview.profile
+++ b/etc/profile-m-z/uudeview.profile
@@ -44,3 +44,5 @@ private-etc alternatives,ld.so.cache,ld.so.preload
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/uzbl-browser.profile
+++ b/etc/profile-m-z/uzbl-browser.profile
@@ -39,3 +39,5 @@ notv
 protocol unix,inet,inet6
 seccomp
 tracelog
+
+restrict-namespaces

--- a/etc/profile-m-z/viewnior.profile
+++ b/etc/profile-m-z/viewnior.profile
@@ -50,3 +50,4 @@ dbus-user none
 dbus-system none
 
 #memory-deny-write-execute - breaks on Arch (see issues #1803 and #1808)
+restrict-namespaces

--- a/etc/profile-m-z/viking.profile
+++ b/etc/profile-m-z/viking.profile
@@ -34,3 +34,4 @@ seccomp
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/vim.profile
+++ b/etc/profile-m-z/vim.profile
@@ -32,3 +32,5 @@ protocol unix,inet,inet6
 seccomp
 
 private-dev
+
+restrict-namespaces

--- a/etc/profile-m-z/vlc.profile
+++ b/etc/profile-m-z/vlc.profile
@@ -53,3 +53,5 @@ dbus-user.talk org.freedesktop.ScreenSaver
 ?ALLOW_TRAY: dbus-user.talk org.kde.StatusNotifierWatcher
 dbus-user.talk org.mpris.MediaPlayer2.Player
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/vmware-view.profile
+++ b/etc/profile-m-z/vmware-view.profile
@@ -54,3 +54,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/vym.profile
+++ b/etc/profile-m-z/vym.profile
@@ -33,3 +33,4 @@ disable-mnt
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/w3m.profile
+++ b/etc/profile-m-z/w3m.profile
@@ -68,3 +68,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/warmux.profile
+++ b/etc/profile-m-z/warmux.profile
@@ -53,3 +53,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/warsow.profile
+++ b/etc/profile-m-z/warsow.profile
@@ -54,3 +54,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/warzone2100.profile
+++ b/etc/profile-m-z/warzone2100.profile
@@ -47,3 +47,5 @@ disable-mnt
 private-bin bash,dash,sh,warzone2100,which
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/webstorm.profile
+++ b/etc/profile-m-z/webstorm.profile
@@ -42,3 +42,5 @@ seccomp
 private-cache
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/webui-aria2.profile
+++ b/etc/profile-m-z/webui-aria2.profile
@@ -36,3 +36,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/weechat.profile
+++ b/etc/profile-m-z/weechat.profile
@@ -28,3 +28,5 @@ seccomp
 # no private-bin support for various reasons:
 # Plugins loaded: alias, aspell, charset, exec, fifo, guile, irc,
 # logger, lua, perl, python, relay, ruby, script, tcl, trigger, xferloading plugins
+
+restrict-namespaces

--- a/etc/profile-m-z/wesnoth.profile
+++ b/etc/profile-m-z/wesnoth.profile
@@ -36,3 +36,5 @@ seccomp
 
 private-dev
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/wget.profile
+++ b/etc/profile-m-z/wget.profile
@@ -61,3 +61,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/whois.profile
+++ b/etc/profile-m-z/whois.profile
@@ -54,3 +54,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/widelands.profile
+++ b/etc/profile-m-z/widelands.profile
@@ -45,3 +45,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/wine.profile
+++ b/etc/profile-m-z/wine.profile
@@ -40,3 +40,5 @@ notv
 seccomp
 
 private-dev
+
+restrict-namespaces

--- a/etc/profile-m-z/wireshark.profile
+++ b/etc/profile-m-z/wireshark.profile
@@ -52,3 +52,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+#restrict-namespaces

--- a/etc/profile-m-z/wordwarvi.profile
+++ b/etc/profile-m-z/wordwarvi.profile
@@ -49,3 +49,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/wps.profile
+++ b/etc/profile-m-z/wps.profile
@@ -46,3 +46,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+#restrict-namespaces

--- a/etc/profile-m-z/x-terminal-emulator.profile
+++ b/etc/profile-m-z/x-terminal-emulator.profile
@@ -21,3 +21,4 @@ dbus-user none
 dbus-system none
 
 noexec /tmp
+restrict-namespaces

--- a/etc/profile-m-z/x2goclient.profile
+++ b/etc/profile-m-z/x2goclient.profile
@@ -48,3 +48,4 @@ dbus-user none
 dbus-system none
 
 #memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/xbill.profile
+++ b/etc/profile-m-z/xbill.profile
@@ -51,3 +51,4 @@ dbus-system none
 
 memory-deny-write-execute
 read-only ${HOME}
+restrict-namespaces

--- a/etc/profile-m-z/xcalc.profile
+++ b/etc/profile-m-z/xcalc.profile
@@ -40,3 +40,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/xchat.profile
+++ b/etc/profile-m-z/xchat.profile
@@ -21,3 +21,5 @@ protocol unix,inet,inet6
 seccomp
 
 # private-bin requires perl, python*, etc.
+
+restrict-namespaces

--- a/etc/profile-m-z/xed.profile
+++ b/etc/profile-m-z/xed.profile
@@ -51,3 +51,4 @@ private-tmp
 
 # xed uses python plugins, memory-deny-write-execute breaks python
 # memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/xfburn.profile
+++ b/etc/profile-m-z/xfburn.profile
@@ -28,3 +28,5 @@ tracelog
 # private-bin xfburn
 # private-dev
 # private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/xfce4-dict.profile
+++ b/etc/profile-m-z/xfce4-dict.profile
@@ -37,3 +37,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/xfce4-mixer.profile
+++ b/etc/profile-m-z/xfce4-mixer.profile
@@ -54,3 +54,4 @@ dbus-user.talk org.xfce.Xfconf
 dbus-system none
 
 # memory-deny-write-execute - breaks on Arch
+restrict-namespaces

--- a/etc/profile-m-z/xfce4-notes.profile
+++ b/etc/profile-m-z/xfce4-notes.profile
@@ -39,3 +39,4 @@ private-cache
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/xfce4-screenshooter.profile
+++ b/etc/profile-m-z/xfce4-screenshooter.profile
@@ -48,3 +48,4 @@ dbus-user none
 dbus-system none
 
 # memory-deny-write-execute -- see #3790
+restrict-namespaces

--- a/etc/profile-m-z/xiphos.profile
+++ b/etc/profile-m-z/xiphos.profile
@@ -48,3 +48,5 @@ private-cache
 private-dev
 private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,pki,resolv.conf,ssli,sword,sword.conf
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/xmms.profile
+++ b/etc/profile-m-z/xmms.profile
@@ -29,3 +29,5 @@ seccomp
 
 private-bin xmms
 private-dev
+
+restrict-namespaces

--- a/etc/profile-m-z/xmr-stak.profile
+++ b/etc/profile-m-z/xmr-stak.profile
@@ -43,3 +43,4 @@ private-opt cuda
 private-tmp
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/xonotic.profile
+++ b/etc/profile-m-z/xonotic.profile
@@ -53,3 +53,4 @@ dbus-system none
 
 read-only ${HOME}
 read-write ${HOME}/.xonotic
+restrict-namespaces

--- a/etc/profile-m-z/xournal.profile
+++ b/etc/profile-m-z/xournal.profile
@@ -48,3 +48,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/xpdf.profile
+++ b/etc/profile-m-z/xpdf.profile
@@ -42,3 +42,4 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/xplayer.profile
+++ b/etc/profile-m-z/xplayer.profile
@@ -47,3 +47,5 @@ private-tmp
 # makes settings immutable
 # dbus-user none
 # dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/xpra.profile
+++ b/etc/profile-m-z/xpra.profile
@@ -51,3 +51,5 @@ disable-mnt
 private-dev
 # private-etc alternatives,gai.conf,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,machine-id,nsswitch.conf,resolv.conf,X11,xpra
 private-tmp
+
+restrict-namespaces

--- a/etc/profile-m-z/xreader.profile
+++ b/etc/profile-m-z/xreader.profile
@@ -42,3 +42,4 @@ private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 private-tmp
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/xviewer.profile
+++ b/etc/profile-m-z/xviewer.profile
@@ -46,3 +46,4 @@ private-tmp
 # dbus-system none
 
 memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-m-z/yelp.profile
+++ b/etc/profile-m-z/yelp.profile
@@ -74,3 +74,5 @@ read-write ${HOME}/.cache
 # your yelp.local if you need PDF printing support.
 #noblacklist ${DOCUMENTS}
 #whitelist ${DOCUMENTS}
+
+restrict-namespaces

--- a/etc/profile-m-z/youtube-dl-gui.profile
+++ b/etc/profile-m-z/youtube-dl-gui.profile
@@ -53,3 +53,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/youtube-dl.profile
+++ b/etc/profile-m-z/youtube-dl.profile
@@ -64,3 +64,4 @@ dbus-user none
 dbus-system none
 
 #memory-deny-write-execute - breaks on Arch (see issue #1803)
+restrict-namespaces

--- a/etc/profile-m-z/youtube-viewers-common.profile
+++ b/etc/profile-m-z/youtube-viewers-common.profile
@@ -67,3 +67,5 @@ dbus-user filter
 dbus-user.talk org.mozilla.*
 
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/zaproxy.profile
+++ b/etc/profile-m-z/zaproxy.profile
@@ -44,3 +44,4 @@ disable-mnt
 private-dev
 private-tmp
 
+restrict-namespaces

--- a/etc/profile-m-z/zart.profile
+++ b/etc/profile-m-z/zart.profile
@@ -35,3 +35,5 @@ private-dev
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/zathura.profile
+++ b/etc/profile-m-z/zathura.profile
@@ -59,3 +59,4 @@ dbus-system none
 read-only ${HOME}
 read-write ${HOME}/.config/zathura
 read-write ${HOME}/.local/share/zathura
+restrict-namespaces

--- a/etc/profile-m-z/zeal.profile
+++ b/etc/profile-m-z/zeal.profile
@@ -69,3 +69,4 @@ dbus-user.talk org.mozilla.*
 dbus-system none
 
 # memory-deny-write-execute - breaks on Arch
+restrict-namespaces

--- a/etc/profile-m-z/zim.profile
+++ b/etc/profile-m-z/zim.profile
@@ -68,3 +68,5 @@ private-tmp
 
 dbus-user none
 dbus-system none
+
+restrict-namespaces

--- a/etc/profile-m-z/zulip.profile
+++ b/etc/profile-m-z/zulip.profile
@@ -45,3 +45,5 @@ private-cache
 private-dev
 private-etc alternatives,asound.conf,fonts,ld.so.cache,ld.so.preload,machine-id
 private-tmp
+
+restrict-namespaces


### PR DESCRIPTION
Closes #5440 

My algorithm was roughly as follows:

1. skip profiles with `# Redirect` tag
2. skip profiles without any `seccomp` directive
3. comment out `restrict-namespaces` if `seccomp` is commented out
4. comment out `restrict-namespaces` if there is a `seccomp !chroot` directive, indicating use of a new user namespace
5. add `restrict-namespaces` to all other profiles, including default.profile and server.profile

There are a few special cases, among them: basilisk.profile, palemoon.profile, fdns.profile, unbound.profile.

I didn't attempt for now to fit `restrict-namespaces` to common browsers.