### PR TITLE
disable-common.inc: add gnome-console to disabled terminals

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -558,6 +558,7 @@ blacklist /tmp/tmux-*
 # disable terminals running as server resulting in sandbox escape
 blacklist ${PATH}/gnome-terminal
 blacklist ${PATH}/gnome-terminal.wrapper
+blacklist ${PATH}/kgx
 # blacklist ${PATH}/konsole
 # konsole doesn't seem to have this problem - last tested on Ubuntu 16.04
 blacklist ${PATH}/lilyterm


### PR DESCRIPTION
The 'new' gnome-terminal, [gnome-console](https://gitlab.gnome.org/GNOME/console) comes with the executable `kgx`.