### PR TITLE
Revert "remove make deb and use make deb-apparmor to build packages"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,9 @@ dist: config.mk
 asc: config.mk
 	./mkasc.sh $(VERSION)
 
+deb: dist config.sh
+	./mkdeb.sh
+
 deb-apparmor: dist config.sh
 	./mkdeb.sh -apparmor --enable-apparmor
 


### PR DESCRIPTION
This reverts commit 82299440533f54bd45bd5ec69136233c04028c15.

The idea is to later enable building the .deb package with AppArmor by
default with `make deb` and to then remove `make deb-apparmor` (though
note that some ci changes might also be needed in tandem[1]).  This
could potentially allow building a .deb package for all firejail
versions (including past and future ones) with just `make deb`.

Also, note that other options can be added/removed to the default `deb`
target (besides AppArmor-related ones), so ideally there would be only a
single `deb` target with all the desired options applied.

So instead of releasing a version without `make deb` and then
potentially adding it back and removing `make deb-apparmor`, just leave
the targets as is (considering the current release, 0.9.70) for now.

[1] https://github.com/netblue30/firejail/pull/5176#issuecomment-1146855467