### PR TITLE
Add new (redirect) profile: dirmngr

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Stats:
 ### New profiles:
 
 onionshare, onionshare-cli, opera-developer, songrec, gdu, makedeb, lbry-viewer, tuir,
-cinelerra-gg, tesseract, avidemux3_cli, avidemux3_jobs_qt5, avidemux3_qt5, 
+cinelerra-gg, tesseract, avidemux3_cli, avidemux3_jobs_qt5, avidemux3_qt5, dirmngr, 
 
 
 

--- a/etc/profile-a-l/dirmngr.profile
+++ b/etc/profile-a-l/dirmngr.profile
@@ -1,0 +1,14 @@
+# Firejail profile for dirmngr
+# Description: GNU privacy guard - network access daemon
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include dirmngr.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+# private-bin dirmngr
+
+# Redirect
+include gpg-agent.profile


### PR DESCRIPTION
Add support for dirmngr - GnuPG's network access daemon. Implemented as redirect to gpg-agent.profile.