### PR TITLE
Blacklist  google-drive-ocamlfuse config

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -116,6 +116,7 @@ blacklist ${HOME}/.cache/fossamail
 blacklist ${HOME}/.cache/fractal
 blacklist ${HOME}/.cache/freecol
 blacklist ${HOME}/.cache/gajim
+blacklist ${HOME}/.cache/gdfuse
 blacklist ${HOME}/.cache/geary
 blacklist ${HOME}/.cache/geeqie
 blacklist ${HOME}/.cache/gegl-0.4
@@ -899,6 +900,7 @@ blacklist ${HOME}/.local/share/feral-interactive
 blacklist ${HOME}/.local/share/five-or-more
 blacklist ${HOME}/.local/share/freecol
 blacklist ${HOME}/.local/share/gajim
+blacklist ${HOME}/.local/share/gdfuse
 blacklist ${HOME}/.local/share/geary
 blacklist ${HOME}/.local/share/geeqie
 blacklist ${HOME}/.local/share/ghostwriter

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -436,6 +436,7 @@ blacklist ${HOME}/.config/gajim
 blacklist ${HOME}/.config/galculator
 blacklist ${HOME}/.config/gallery-dl
 blacklist ${HOME}/.config/gconf
+blacklist ${HOME}/.config/gdfuse
 blacklist ${HOME}/.config/geany
 blacklist ${HOME}/.config/geary
 blacklist ${HOME}/.config/gedit
@@ -708,6 +709,7 @@ blacklist ${HOME}/.frozen-bubble
 blacklist ${HOME}/.funnyboat
 blacklist ${HOME}/.g8
 blacklist ${HOME}/.gallery-dl.conf
+blacklist ${HOME}/.gdfuse
 blacklist ${HOME}/.geekbench5
 blacklist ${HOME}/.gimp*
 blacklist ${HOME}/.gist


### PR DESCRIPTION
[google-drive-ocamlfuse](https://github.com/astrada/google-drive-ocamlfuse) is a _FUSE filesystem over Google Drive_. Its config stores sensitive access tokens, much like rclone's config. The latter is blacklisted in firejail by default, so let it be the same for the former.

According to the [docs](https://github.com/astrada/google-drive-ocamlfuse/blob/beta/doc/Configuration.md) there are two default pathes for the config: either `~/.gdfuse` or `~/.config/gdfuse`
