### PR TITLE
Update DBus wiki link

### DIFF
--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -214,7 +214,7 @@ include globals.local
 #  - In order to make dconf work (when used by the app) you need to allow
 #    'ca.desrt.dconf' even when not allowed by flatpak.
 # Notes and policies about addresses can be found at
-# <https://github.com/netblue30/firejail/wiki/Restrict-D-Bus>
+# <https://github.com/netblue30/firejail/wiki/Restrict-DBus>
 #dbus-user filter
 #dbus-user.own com.github.netblue30.firejail
 #dbus-user.talk ca.desrt.dconf


### PR DESCRIPTION
Updates the link to the "Restrict DBus" wiki page in the profile template, it currently links to https://github.com/netblue30/firejail/wiki/Restrict-D-Bus, but it seems like the title got changed to https://github.com/netblue30/firejail/wiki/Restrict-DBus.