### PR TITLE
window manager profiles: fix browser/electron internal sandboxes

### DIFF
--- a/etc/profile-a-l/awesome.profile
+++ b/etc/profile-a-l/awesome.profile
@@ -14,7 +14,7 @@ caps.drop all
 netfilter
 noroot
 protocol unix,inet,inet6
-seccomp
+seccomp !chroot
 
 read-only ${HOME}/.config/awesome/autorun.sh
-restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-a-l/blackbox.profile
+++ b/etc/profile-a-l/blackbox.profile
@@ -14,6 +14,6 @@ caps.drop all
 netfilter
 noroot
 protocol unix,inet,inet6
-seccomp
+seccomp !chroot
 
-restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-a-l/fluxbox.profile
+++ b/etc/profile-a-l/fluxbox.profile
@@ -14,6 +14,6 @@ caps.drop all
 netfilter
 noroot
 protocol unix,inet,inet6
-seccomp
+seccomp !chroot
 
-restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-a-l/i3.profile
+++ b/etc/profile-a-l/i3.profile
@@ -14,6 +14,6 @@ caps.drop all
 netfilter
 noroot
 protocol unix,inet,inet6
-seccomp
+seccomp !chroot
 
-restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-m-z/openbox.profile
+++ b/etc/profile-m-z/openbox.profile
@@ -14,8 +14,8 @@ caps.drop all
 netfilter
 noroot
 protocol unix,inet,inet6
-seccomp
+seccomp !chroot
 
 read-only ${HOME}/.config/openbox/autostart
 read-only ${HOME}/.config/openbox/environment
-restrict-namespaces
+#restrict-namespaces


### PR DESCRIPTION
Assuming that users expect a working browser on their desktops.

Fix browsers and electron apps running inside a window manager sandbox, most of the time.