### PR TITLE
email-common refactoring

### DIFF
--- a/etc/profile-a-l/balsa.profile
+++ b/etc/profile-a-l/balsa.profile
@@ -17,6 +17,7 @@ whitelist ${HOME}/.balsa
 whitelist ${HOME}/mail
 whitelist /usr/share/balsa
 
+# Add "pinentry-curses,pinentry-emacs,pinentry-fltk,pinentry-gnome3,pinentry-gtk,pinentry-gtk2,pinentry-gtk-2,pinentry-qt,pinentry-qt4,pinentry-tty,pinentry-x2go,pinentry-kwallet" for gpg.
 private-bin balsa,balsa-ab,gpg,gpg-agent,gpg2,gpgsm
 
 dbus-user.own org.desktop.Balsa

--- a/etc/profile-a-l/balsa.profile
+++ b/etc/profile-a-l/balsa.profile
@@ -18,7 +18,7 @@ whitelist ${HOME}/mail
 whitelist /usr/share/balsa
 
 # Add "pinentry-curses,pinentry-emacs,pinentry-fltk,pinentry-gnome3,pinentry-gtk,pinentry-gtk2,pinentry-gtk-2,pinentry-qt,pinentry-qt4,pinentry-tty,pinentry-x2go,pinentry-kwallet" for gpg.
-private-bin balsa,balsa-ab,gpg,gpg-agent,gpg2,gpgsm
+#private-bin balsa,balsa-ab,gpg,gpg-agent,gpg2,gpgsm
 
 dbus-user.own org.desktop.Balsa
 

--- a/etc/profile-a-l/balsa.profile
+++ b/etc/profile-a-l/balsa.profile
@@ -7,76 +7,19 @@ include balsa.local
 include globals.local
 
 noblacklist ${HOME}/.balsa
-noblacklist ${HOME}/.gnupg
-noblacklist ${HOME}/.mozilla
-noblacklist ${HOME}/.signature
 noblacklist ${HOME}/mail
-noblacklist /var/mail
-noblacklist /var/spool/mail
 
-include disable-common.inc
-include disable-devel.inc
-include disable-exec.inc
-include disable-interpreters.inc
-include disable-programs.inc
 include disable-shell.inc
-include disable-xdg.inc
 
 mkdir ${HOME}/.balsa
-mkdir ${HOME}/.gnupg
-mkfile ${HOME}/.signature
 mkdir ${HOME}/mail
 whitelist ${HOME}/.balsa
-whitelist ${HOME}/.gnupg
-whitelist ${HOME}/.mozilla/firefox/profiles.ini
-whitelist ${HOME}/.signature
 whitelist ${HOME}/mail
-whitelist ${RUNUSER}/gnupg
 whitelist /usr/share/balsa
-whitelist /usr/share/gnupg
-whitelist /usr/share/gnupg2
-whitelist /var/mail
-whitelist /var/spool/mail
-include whitelist-common.inc
-include whitelist-runuser-common.inc
-include whitelist-usr-share-common.inc
-include whitelist-var-common.inc
 
-apparmor
-caps.drop all
-netfilter
-no3d
-nodvd
-nogroups
-noinput
-nonewprivs
-noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix,inet,inet6
-seccomp
-tracelog
-
-# disable-mnt
-# Add "pinentry-curses,pinentry-emacs,pinentry-fltk,pinentry-gnome3,pinentry-gtk,pinentry-gtk2,pinentry-gtk-2,pinentry-qt,pinentry-qt4,pinentry-tty,pinentry-x2go,pinentry-kwallet" for gpg
-# Add "ignore private-bin" for hyperlinks or have a look at the private-bins in firefox.profile and firefox-common.profile.
 private-bin balsa,balsa-ab,gpg,gpg-agent,gpg2,gpgsm
-private-cache
-private-dev
-private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gcrypt,groups,gtk-2.0,gtk-3.0,hostname,hosts,ld.so.cache,ld.so.preload,mailname,passwd,pki,resolv.conf,selinux,ssl,xdg
-private-tmp
-writable-run-user
-writable-var
 
-dbus-user filter
 dbus-user.own org.desktop.Balsa
-dbus-user.talk ca.desrt.dconf
-dbus-user.talk org.freedesktop.Notifications
-dbus-user.talk org.freedesktop.secrets
-dbus-user.talk org.gnome.keyring.SystemPrompter
-dbus-system none
 
-read-only ${HOME}/.mozilla/firefox/profiles.ini
-restrict-namespaces
+# Redirect
+include email-common.profile

--- a/etc/profile-a-l/claws-mail.profile
+++ b/etc/profile-a-l/claws-mail.profile
@@ -20,17 +20,5 @@ whitelist /usr/share/doc/claws-mail
 
 # private-bin claws-mail,curl,gpg,gpg2,gpg-agent,gpgsm,gpgme-config,pinentry,pinentry-gtk-2
 
-dbus-user filter
-dbus-user.talk ca.desrt.dconf
-# Add the next line to your claws-mail.local if you use the notification plugin.
-# dbus-user.talk org.freedesktop.Notifications
-dbus-user.talk org.freedesktop.secrets
-dbus-user.talk org.gnome.keyring
-dbus-user.talk org.gnome.keyring.PrivatePrompter
-dbus-user.talk org.gnome.keyring.SystemPrompter
-dbus-user.talk org.gnome.seahorse
-dbus-user.talk org.gnome.seahorse.Application
-dbus-user.talk org.mozilla.*
-
 # Redirect
 include email-common.profile

--- a/etc/profile-a-l/email-common.profile
+++ b/etc/profile-a-l/email-common.profile
@@ -79,11 +79,8 @@ dbus-user filter
 dbus-user.talk ca.desrt.dconf
 dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.freedesktop.secrets
-dbus-user.talk org.gnome.keyring
-dbus-user.talk org.gnome.keyring.PrivatePrompter
-dbus-user.talk org.gnome.keyring.SystemPrompter
-dbus-user.talk org.gnome.seahorse
-dbus-user.talk org.gnome.seahorse.Application
+dbus-user.talk org.gnome.keyring.*
+dbus-user.talk org.gnome.seahorse.*
 dbus-user.talk org.mozilla.*
 dbus-system none
 

--- a/etc/profile-a-l/email-common.profile
+++ b/etc/profile-a-l/email-common.profile
@@ -1,5 +1,5 @@
 # Firejail profile for email-common
-# Description: Common profile for claws-mail and sylpheed email clients
+# Description: Common profile for GUI mail clients
 # This file is overwritten after every install/update
 # Persistent local customizations
 include email-common.local
@@ -14,6 +14,8 @@ noblacklist ${HOME}/.signature
 # when storing mail outside the default ${HOME}/Mail path, 'noblacklist' the custom path in your email-common.local
 # and 'blacklist' it in your disable-common.local too so it is kept hidden from other applications
 noblacklist ${HOME}/Mail
+noblacklist /var/mail
+noblacklist /var/spool/mail
 
 noblacklist ${DOCUMENTS}
 
@@ -38,6 +40,8 @@ whitelist ${HOME}/Mail
 whitelist ${RUNUSER}/gnupg
 whitelist /usr/share/gnupg
 whitelist /usr/share/gnupg2
+whitelist /var/mail
+whitelist /var/spool/mail
 include whitelist-common.inc
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
@@ -69,15 +73,19 @@ private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gcrypt,gnup
 private-tmp
 # encrypting and signing email
 writable-run-user
+writable-var
 
+dbus-user filter
+dbus-user.talk ca.desrt.dconf
+dbus-user.talk org.freedesktop.Notifications
+dbus-user.talk org.freedesktop.secrets
+dbus-user.talk org.gnome.keyring
+dbus-user.talk org.gnome.keyring.PrivatePrompter
+dbus-user.talk org.gnome.keyring.SystemPrompter
+dbus-user.talk org.gnome.seahorse
+dbus-user.talk org.gnome.seahorse.Application
+dbus-user.talk org.mozilla.*
 dbus-system none
-
-# If you want to read local mail stored in /var/mail, add the following to email-common.local:
-#noblacklist /var/mail
-#noblacklist /var/spool/mail
-#whitelist /var/mail
-#whitelist /var/spool/mail
-#writable-var
 
 read-only ${HOME}/.mozilla/firefox/profiles.ini
 read-only ${HOME}/.signature

--- a/etc/profile-m-z/sylpheed.profile
+++ b/etc/profile-m-z/sylpheed.profile
@@ -15,13 +15,5 @@ whitelist /usr/share/sylpheed
 
 # private-bin curl,gpg,gpg2,gpg-agent,gpgsm,pinentry,pinentry-gtk-2,sylpheed
 
-dbus-user filter
-dbus-user.talk ca.desrt.dconf
-# Add the next line to your sylpheed.local to enable notifications.
-# dbus-user.talk org.freedesktop.Notifications
-dbus-user.talk org.freedesktop.secrets
-dbus-user.talk org.gnome.keyring.SystemPrompter
-dbus-user.talk org.mozilla.*
-
 # Redirect
 include email-common.profile


### PR DESCRIPTION
Started work for https://github.com/netblue30/firejail/pull/5305. For now only balsa.profile is fully refactored for email-common.profile. claws-mail and sylpheed already were so those needed just some reshuffling.