### PR TITLE
feature: add fireurl

### DIFF
--- a/etc/inc/whitelist-runuser-common.inc
+++ b/etc/inc/whitelist-runuser-common.inc
@@ -6,6 +6,7 @@ include whitelist-runuser-common.local
 
 whitelist ${RUNUSER}/bus
 whitelist ${RUNUSER}/dconf
+whitelist ${RUNUSER}/fireurl
 whitelist ${RUNUSER}/gdm/Xauthority
 whitelist ${RUNUSER}/ICEauthority
 whitelist ${RUNUSER}/.mutter-Xwaylandauth.*

--- a/etc/profile-a-l/balsa.profile
+++ b/etc/profile-a-l/balsa.profile
@@ -18,7 +18,7 @@ whitelist ${HOME}/mail
 whitelist /usr/share/balsa
 
 # Add "pinentry-curses,pinentry-emacs,pinentry-fltk,pinentry-gnome3,pinentry-gtk,pinentry-gtk2,pinentry-gtk-2,pinentry-qt,pinentry-qt4,pinentry-tty,pinentry-x2go,pinentry-kwallet" for gpg.
-#private-bin balsa,balsa-ab,gpg,gpg-agent,gpg2,gpgsm
+#private-bin balsa,balsa-ab,fireurl,gpg,gpg-agent,gpg2,gpgsm
 
 dbus-user.own org.desktop.Balsa
 

--- a/etc/profile-a-l/electron-mail.profile
+++ b/etc/profile-a-l/electron-mail.profile
@@ -11,20 +11,11 @@ ignore disable-mnt
 
 noblacklist ${HOME}/.config/electron-mail
 
-# sh is needed to allow Firefox to open links
-include allow-bin-sh.inc
-
 include disable-shell.inc
 
 mkdir ${HOME}/.config/electron-mail
 whitelist ${HOME}/.config/electron-mail
 whitelist /opt/ElectronMail
-
-# The lines below are needed to find the default Firefox profile name, to allow
-# opening links in an existing instance of Firefox (note that it still fails if
-# there isn't a Firefox instance running with the default profile; see #5352)
-noblacklist ${HOME}/.mozilla
-whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 machine-id
 nosound
@@ -35,8 +26,6 @@ dbus-user filter
 dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.freedesktop.secrets
 dbus-user.talk org.gnome.keyring.SystemPrompter
-# allow D-Bus communication with firefox for opening links
-dbus-user.talk org.mozilla.*
 
 # Redirect
 include electron-common.profile

--- a/etc/profile-a-l/email-common.profile
+++ b/etc/profile-a-l/email-common.profile
@@ -10,7 +10,6 @@ include email-common.local
 noblacklist ${HOME}/.bogofilter
 noblacklist ${HOME}/.bsfilter
 noblacklist ${HOME}/.gnupg
-noblacklist ${HOME}/.mozilla
 noblacklist ${HOME}/.signature
 # when storing mail outside the default ${HOME}/Mail path, 'noblacklist' the custom path in your email-common.local
 # and 'blacklist' it in your disable-common.local too so it is kept hidden from other applications
@@ -38,7 +37,6 @@ whitelist ${HOME}/.bogofilter
 whitelist ${HOME}/.bsfilter
 whitelist ${HOME}/.config/mimeapps.list
 whitelist ${HOME}/.gnupg
-whitelist ${HOME}/.mozilla/firefox/profiles.ini
 whitelist ${HOME}/.signature
 whitelist ${DOCUMENTS}
 whitelist ${DOWNLOADS}
@@ -48,7 +46,7 @@ whitelist ${RUNUSER}/gnupg
 whitelist /usr/share/bogofilter
 whitelist /usr/share/gnupg
 whitelist /usr/share/gnupg2
-whitelist /var/lib/clamav 
+whitelist /var/lib/clamav
 whitelist /var/mail
 whitelist /var/spool/mail
 include whitelist-common.inc
@@ -90,7 +88,6 @@ dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.freedesktop.secrets
 dbus-user.talk org.gnome.keyring.*
 dbus-user.talk org.gnome.seahorse.*
-dbus-user.talk org.mozilla.*
 dbus-system none
 
 read-only ${HOME}/.signature

--- a/etc/profile-a-l/fluffychat.profile
+++ b/etc/profile-a-l/fluffychat.profile
@@ -20,13 +20,6 @@ include disable-programs.inc
 include disable-shell.inc
 include disable-xdg.inc
 
-# The lines below are needed to find the default Firefox profile name, to allow
-# opening links in an existing instance of Firefox (note that it still fails if
-# there isn't a Firefox instance running with the default profile; see #5352)
-noblacklist ${HOME}/.mozilla
-whitelist ${HOME}/.mozilla/firefox/profiles.ini
-read-only ${HOME}/.mozilla/firefox/profiles.ini
-
 mkdir ${HOME}/.local/share/fluffychat
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.local/share/fluffychat
@@ -57,7 +50,7 @@ seccomp.block-secondary
 tracelog
 
 disable-mnt
-private-bin firefox,fluffychat,sh,which,zenity
+private-bin fireurl,fluffychat,sh,which,zenity
 private-cache
 private-dev
 private-etc X11,alsa,alternatives,asound.conf,ca-certificates,crypto-policies,dconf,fonts,gconf,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,pango,pki,protocols,pulse,resolv.conf,rpc,services,ssl,xdg
@@ -65,8 +58,6 @@ private-tmp
 
 dbus-user filter
 dbus-user.talk org.freedesktop.secrets
-# allow D-Bus communication with firefox for opening links
-dbus-user.talk org.mozilla.*
 dbus-system filter
 dbus-system.talk org.freedesktop.NetworkManager
 

--- a/etc/profile-a-l/geary.profile
+++ b/etc/profile-a-l/geary.profile
@@ -14,7 +14,6 @@ noblacklist ${HOME}/.config/geary
 noblacklist ${HOME}/.local/share/evolution
 noblacklist ${HOME}/.local/share/geary
 noblacklist ${HOME}/.local/share/pki
-noblacklist ${HOME}/.mozilla
 noblacklist ${HOME}/.pki
 
 include allow-bin-sh.inc
@@ -43,7 +42,6 @@ whitelist ${HOME}/.config/geary
 whitelist ${HOME}/.local/share/evolution
 whitelist ${HOME}/.local/share/geary
 whitelist ${HOME}/.local/share/pki
-whitelist ${HOME}/.mozilla/firefox/profiles.ini
 whitelist ${HOME}/.pki
 whitelist /usr/share/geary
 include whitelist-common.inc
@@ -72,7 +70,7 @@ seccomp.block-secondary
 tracelog
 
 #disable-mnt
-#private-bin geary,sh
+#private-bin fireurl,geary,sh
 private-cache
 private-dev
 private-etc @tls-ca,@x11,mailcap,mime.types
@@ -88,7 +86,6 @@ dbus-user.talk org.gnome.OnlineAccounts
 dbus-user.talk org.gnome.evolution.dataserver.AddressBook10
 dbus-user.talk org.gnome.evolution.dataserver.Sources5
 ?ALLOW_TRAY: dbus-user.talk org.kde.StatusNotifierWatcher
-dbus-user.talk org.mozilla.*
 dbus-system none
 
 restrict-namespaces

--- a/etc/profile-a-l/gtk-youtube-viewers-common.profile
+++ b/etc/profile-a-l/gtk-youtube-viewers-common.profile
@@ -9,14 +9,6 @@ include gtk-youtube-viewers-common.local
 
 ignore quiet
 
-# The lines below are needed to find the default Firefox profile name, to allow
-# opening links in an existing instance of Firefox (note that it still fails if
-# there isn't a Firefox instance running with the default profile; see #5352)
-noblacklist ${HOME}/.mozilla
-whitelist ${HOME}/.mozilla/firefox/profiles.ini
-
-private-bin firefox,xterm
+private-bin fireurl,xterm
 
 dbus-user filter
-# allow D-Bus communication with firefox for opening links
-dbus-user.talk org.mozilla.*

--- a/etc/profile-a-l/kube.profile
+++ b/etc/profile-a-l/kube.profile
@@ -60,7 +60,7 @@ seccomp
 tracelog
 
 #disable-mnt
-# Add "gpg,gpg2,gpg-agent,pinentry-curses,pinentry-emacs,pinentry-fltk,pinentry-gnome3,pinentry-gtk,pinentry-gtk2,pinentry-gtk-2,pinentry-qt,pinentry-qt4,pinentry-tty,pinentry-x2go,pinentry-kwallet" for gpg
+# Add "gpg,gpg2,gpg-agent,pinentry-curses,pinentry-emacs,pinentry-fltk,pinentry-gnome3,pinentry-gtk,pinentry-gtk2,pinentry-gtk-2,pinentry-qt,pinentry-qt4,pinentry-tty,pinentry-x2go,pinentry-kwallet" for gpg.
 private-bin fireurl,kube,sink_synchronizer
 private-cache
 private-dev

--- a/etc/profile-a-l/kube.profile
+++ b/etc/profile-a-l/kube.profile
@@ -21,12 +21,6 @@ include disable-programs.inc
 include disable-shell.inc
 include disable-xdg.inc
 
-# The lines below are needed to find the default Firefox profile name, to allow
-# opening links in an existing instance of Firefox (note that it still fails if
-# there isn't a Firefox instance running with the default profile; see #5352)
-noblacklist ${HOME}/.mozilla
-whitelist ${HOME}/.mozilla/firefox/profiles.ini
-
 mkdir ${HOME}/.cache/kube
 mkdir ${HOME}/.config/kube
 mkdir ${HOME}/.config/sink
@@ -67,7 +61,7 @@ tracelog
 
 #disable-mnt
 # Add "gpg,gpg2,gpg-agent,pinentry-curses,pinentry-emacs,pinentry-fltk,pinentry-gnome3,pinentry-gtk,pinentry-gtk2,pinentry-gtk-2,pinentry-qt,pinentry-qt4,pinentry-tty,pinentry-x2go,pinentry-kwallet" for gpg
-private-bin kube,sink_synchronizer
+private-bin fireurl,kube,sink_synchronizer
 private-cache
 private-dev
 private-etc @tls-ca,@x11
@@ -78,8 +72,6 @@ dbus-user filter
 dbus-user.talk ca.desrt.dconf
 dbus-user.talk org.freedesktop.secrets
 dbus-user.talk org.freedesktop.Notifications
-# allow D-Bus communication with firefox for opening links
-dbus-user.talk org.mozilla.*
 dbus-system none
 
 restrict-namespaces

--- a/etc/profile-a-l/lettura.profile
+++ b/etc/profile-a-l/lettura.profile
@@ -35,12 +35,6 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
-# The lines below are needed to find the default Firefox profile name, to allow
-# opening links in an existing instance of Firefox (note that it still fails if
-# there isn't a Firefox instance running with the default profile; see #5352)
-noblacklist ${HOME}/.mozilla
-whitelist ${HOME}/.mozilla/firefox/profiles.ini
-
 apparmor
 caps.drop all
 netfilter
@@ -60,7 +54,7 @@ seccomp.block-secondary
 tracelog
 
 disable-mnt
-private-bin lettura
+private-bin fireurl,lettura
 private-cache
 private-dev
 private-etc @network,@sound,@tls-ca,@x11,mime.types
@@ -69,8 +63,6 @@ private-tmp
 dbus-user filter
 dbus-user.talk org.freedesktop.Notifications
 ?ALLOW_TRAY: dbus-user.talk org.kde.StatusNotifierWatcher
-# allow D-Bus communication with firefox for opening links
-dbus-user.talk org.mozilla.*
 dbus-system none
 
 restrict-namespaces

--- a/etc/profile-a-l/linuxqq.profile
+++ b/etc/profile-a-l/linuxqq.profile
@@ -15,7 +15,6 @@ include disable-shell.inc
 
 mkdir ${HOME}/.config/QQ
 whitelist ${HOME}/.config/QQ
-whitelist ${HOME}/.mozilla/firefox/profiles.ini
 whitelist ${DESKTOP}
 whitelist /opt/QQ
 
@@ -34,7 +33,6 @@ dbus-user.talk org.freedesktop.portal.IBus
 dbus-user.talk org.freedesktop.ScreenSaver
 dbus-user.talk org.gnome.Mutter.IdleMonitor
 ?ALLOW_TRAY: dbus-user.talk org.kde.StatusNotifierWatcher
-dbus-user.talk org.mozilla.*
 ignore dbus-user none
 
 # Redirect

--- a/etc/profile-m-z/signal-desktop.profile
+++ b/etc/profile-m-z/signal-desktop.profile
@@ -11,23 +11,13 @@ ignore noexec /tmp
 
 noblacklist ${HOME}/.config/Signal
 
-# The lines below are needed to find the default Firefox profile name, to allow
-# opening links in an existing instance of Firefox (note that it still fails if
-# there isn't a Firefox instance running with the default profile; see #5352)
-noblacklist ${HOME}/.mozilla
-whitelist ${HOME}/.mozilla/firefox/profiles.ini
-
 mkdir ${HOME}/.config/Signal
 whitelist ${HOME}/.config/Signal
 
 private-etc @tls-ca
 
 dbus-user filter
-# allow D-Bus notifications
 dbus-user.talk org.freedesktop.Notifications
-# allow D-Bus communication with firefox for opening links
-dbus-user.talk org.mozilla.*
-
 ignore dbus-user none
 
 # Redirect

--- a/etc/profile-m-z/thunderbird.profile
+++ b/etc/profile-m-z/thunderbird.profile
@@ -6,8 +6,6 @@ include thunderbird.local
 # Persistent global definitions
 include globals.local
 
-ignore include whitelist-runuser-common.inc
-
 # TB stopped supporting enigmail in 2020 (v78) - let's harden D-Bus
 # https://support.mozilla.org/en-US/kb/openpgp-thunderbird-howto-and-faq
 ignore dbus-user none
@@ -15,8 +13,6 @@ dbus-user filter
 dbus-user.own org.mozilla.thunderbird.*
 dbus-user.talk ca.desrt.dconf
 dbus-user.talk org.freedesktop.Notifications
-# allow D-Bus communication with firefox for opening links
-dbus-user.talk org.mozilla.*
 # e2ee email needs writable-run-user
 # https://support.mozilla.org/en-US/kb/introduction-to-e2e-encryption
 writable-run-user
@@ -28,10 +24,6 @@ writable-run-user
 #whitelist /var/mail
 #whitelist /var/spool/mail
 #writable-var
-
-# These lines are needed to allow Firefox to load your profile when clicking a link in an email
-noblacklist ${HOME}/.mozilla
-whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 noblacklist ${HOME}/.cache/thunderbird
 noblacklist ${HOME}/.gnupg

--- a/etc/profile-m-z/trojita.profile
+++ b/etc/profile-m-z/trojita.profile
@@ -18,12 +18,6 @@ include disable-programs.inc
 include disable-shell.inc
 include disable-xdg.inc
 
-# The lines below are needed to find the default Firefox profile name, to allow
-# opening links in an existing instance of Firefox (note that it still fails if
-# there isn't a Firefox instance running with the default profile; see #5352)
-noblacklist ${HOME}/.mozilla
-whitelist ${HOME}/.mozilla/firefox/profiles.ini
-
 mkdir ${HOME}/.abook
 mkdir ${HOME}/.cache/flaska.net/trojita
 mkdir ${HOME}/.config/flaska.net
@@ -53,7 +47,7 @@ seccomp
 tracelog
 
 #disable-mnt
-private-bin trojita
+private-bin fireurl,trojita
 private-cache
 private-dev
 private-etc @tls-ca,@x11
@@ -61,8 +55,6 @@ private-tmp
 
 dbus-user filter
 dbus-user.talk org.freedesktop.secrets
-# allow D-Bus communication with firefox for opening links
-dbus-user.talk org.mozilla.*
 dbus-system none
 
 restrict-namespaces

--- a/etc/profile-m-z/tutanota-desktop.profile
+++ b/etc/profile-m-z/tutanota-desktop.profile
@@ -13,9 +13,6 @@ ignore dbus-user none
 ignore disable-mnt
 ignore noexec /tmp
 
-# sh is needed to allow Firefox to open links
-include allow-bin-sh.inc
-
 include disable-shell.inc
 
 mkdir ${HOME}/.config/tuta_integration
@@ -23,12 +20,6 @@ mkdir ${HOME}/.config/tutanota-desktop
 whitelist ${HOME}/.config/tuta_integration
 whitelist ${HOME}/.config/tutanota-desktop
 whitelist /opt/tutanota-desktop
-
-# The lines below are needed to find the default Firefox profile name, to allow
-# opening links in an existing instance of Firefox (note that it still fails if
-# there isn't a Firefox instance running with the default profile; see #5352)
-noblacklist ${HOME}/.mozilla
-whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 machine-id
 nosound
@@ -40,8 +31,6 @@ dbus-user filter
 dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.freedesktop.secrets
 dbus-user.talk org.gnome.keyring.SystemPrompter
-# allow D-Bus communication with firefox for opening links
-dbus-user.talk org.mozilla.*
 
 # Redirect
 include electron-common.profile

--- a/etc/profile-m-z/youtube-viewers-common.profile
+++ b/etc/profile-m-z/youtube-viewers-common.profile
@@ -54,12 +54,13 @@ seccomp
 tracelog
 
 disable-mnt
-private-bin bash,ffmpeg,ffprobe,mpv,perl,python*,sh,smplayer,stty,wget,wget2,which,youtube-dl,yt-dlp
+private-bin bash,ffmpeg,ffprobe,fireurl,mpv,perl,python*,sh,smplayer,stty,wget,wget2,which,youtube-dl,yt-dlp
 private-cache
 private-dev
 private-etc @tls-ca,@x11,host.conf,mime.types
 private-tmp
 
+dbus-user none
 dbus-system none
 
 restrict-namespaces

--- a/etc/profile-m-z/zeal.profile
+++ b/etc/profile-m-z/zeal.profile
@@ -19,11 +19,6 @@ include disable-programs.inc
 include disable-shell.inc
 include disable-xdg.inc
 
-# Allow zeal to open links in Firefox browsers.
-# This also requires dbus-user filtering (see below).
-noblacklist ${HOME}/.mozilla
-whitelist ${HOME}/.mozilla/firefox/profiles.ini
-
 mkdir ${HOME}/.cache/Zeal
 mkdir ${HOME}/.config/Zeal
 mkdir ${HOME}/.local/share/Zeal
@@ -56,14 +51,13 @@ seccomp.block-secondary
 tracelog
 
 disable-mnt
-private-bin zeal
+private-bin fireurl,zeal
 private-cache
 private-dev
 private-etc @tls-ca,@x11,host.conf,mime.types,rpc,services
 private-tmp
 
 dbus-user filter
-dbus-user.talk org.mozilla.*
 ?ALLOW_TRAY: dbus-user.talk org.kde.StatusNotifierWatcher
 dbus-system none
 


### PR DESCRIPTION
[WIP] [POC] This PR is part of an attempt to integrate @rusty-snake's [fireurl](https://github.com/rusty-snake/fireurl) into Firejail and finally fix opening hyperlinks between sandboxes properly and elegantly.

IMO this offers a much needed (and much overdue) improvement to Firejail's (default) handling of inter-sandbox URL transport.
This PR takes care of cleaning up the 'level 1 hacks' from the affected profiles. Obviously there's more work to be done to bring in `fireurl`, but all in all surprisingly little.

Relates to:

* #6462