### PR TITLE
modif: Prevent sandbox name from containing only digits

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -2161,9 +2161,22 @@ int main(int argc, char **argv, char **envp) {
 		// hostname, etc
 		//*************************************
 		else if (strncmp(argv[i], "--name=", 7) == 0) {
+			int only_numbers = 1;
 			cfg.name = argv[i] + 7;
 			if (strlen(cfg.name) == 0) {
 				fprintf(stderr, "Error: please provide a name for sandbox\n");
+				return 1;
+			}
+			const char *c = cfg.name;
+			while (*c) {
+				if (!isdigit(*c)) {
+					only_numbers = 0;
+					break;
+				}
+				++c;
+			}
+			if (only_numbers) {
+				fprintf(stderr, "Error: invalid sandbox name: it only contains digits\n");
 				return 1;
 			}
 		}

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -326,9 +326,22 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 	}
 	// sandbox name
 	else if (strncmp(ptr, "name ", 5) == 0) {
+		int only_numbers = 1;
 		cfg.name = ptr + 5;
 		if (strlen(cfg.name) == 0) {
 			fprintf(stderr, "Error: invalid sandbox name\n");
+			exit(1);
+		}
+		const char *c = cfg.name;
+		while (*c) {
+			if (!isdigit(*c)) {
+				only_numbers = 0;
+				break;
+			}
+			++c;
+		}
+		if (only_numbers) {
+			fprintf(stderr, "Error: invalid sandbox name: it only contains digits\n");
 			exit(1);
 		}
 		return 0;

--- a/src/man/firejail.txt
+++ b/src/man/firejail.txt
@@ -1330,6 +1330,7 @@ $ firejail \-\-net=eth0 \-\-mtu=1492
 \fB\-\-name=name
 Set sandbox name. Several options, such as \-\-join and \-\-shutdown, can use
 this name to identify a sandbox.
+The name cannot contain only digits, as that is treated as a PID in the other options, such as in \-\-join.
 
 In case the name supplied by the user is already in use by another sandbox, Firejail will assign a
 new name as "name-PID", where PID is the process ID of the sandbox. This functionality


### PR DESCRIPTION
If I use only numbers for a name,`firejail --ls=numbers /` fails. Is this an actual bug? If you forbid only numbers in jails, I will close this PR. I can rework it to delete the `if`'s around the lines I added. This commit seems to me like the fix that touches the fewest lines of code. I gave priority to `extract_pid` which should better find the jail if it exists, is it correct?