### PR TITLE
fix: do not show apparmor CLI options in usage if app armor is not supported

### DIFF
--- a/README
+++ b/README
@@ -26,7 +26,7 @@ $ cd firejail
 $ ./configure && make && sudo make install-strip
 
 On Debian/Ubuntu you will need to install git and gcc compiler. AppArmor
-development libraries and pkg-config are required when using --apparmor
+development libraries and pkg-config are required when using --enable-apparmor
 ./configure option:
 
 $ sudo apt-get install git build-essential libapparmor-dev pkg-config gawk

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ $ cd firejail
 $ ./configure && make && sudo make install-strip
 `````
 On Debian/Ubuntu you will need to install git and gcc compiler. AppArmor
-development libraries and pkg-config are required when using `--apparmor`
+development libraries and pkg-config are required when using `--enable-apparmor`
 ./configure option:
 `````
 $ sudo apt-get install git build-essential libapparmor-dev pkg-config gawk

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -30,10 +30,12 @@ static char *usage_str =
 	"    -- - signal the end of options and disables further option processing.\n"
 	"    --allow-debuggers - allow tools such as strace and gdb inside the sandbox.\n"
 	"    --allusers - all user home directories are visible inside the sandbox.\n"
+#ifdef HAVE_APPARMOR
 	"    --apparmor - enable AppArmor confinement with the default profile.\n"
 	"    --apparmor=profile_name - enable AppArmor confinement with a\n"
 	"\tcustom profile.\n"
 	"    --apparmor.print=name|pid - print apparmor status.\n"
+#endif
 	"    --appimage - sandbox an AppImage application.\n"
 #ifdef HAVE_NETWORK
 	"    --bandwidth=name|pid - set bandwidth limits.\n"


### PR DESCRIPTION
- If app armor is not supported do not show the apparmor CLI options in the usage info, needed because if any --apparmor* flag is used but apparmor is unsupported an invalid command line option error will be returned:
```
# (AppArmor support is disabled)
firejail --apparmor firefox
Error: invalid --apparmor command line option
```
- updated readme with the correct apparmor enable flag to be used with ./configure

