### PR TITLE
add timezone access to make libical functional

### DIFF
--- a/etc/profile-a-l/email-common.profile
+++ b/etc/profile-a-l/email-common.profile
@@ -69,7 +69,7 @@ tracelog
 # disable-mnt
 private-cache
 private-dev
-private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gcrypt,gnupg,groups,gtk-2.0,gtk-3.0,hostname,hosts,hosts.conf,ld.so.cache,ld.so.preload,localtime,machine-id,mailname,nsswitch.conf,passwd,pki,resolv.conf,selinux,ssl,xdg
+private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gcrypt,gnupg,groups,gtk-2.0,gtk-3.0,hostname,hosts,hosts.conf,ld.so.cache,ld.so.preload,localtime,machine-id,mailname,nsswitch.conf,passwd,pki,resolv.conf,selinux,ssl,timezone,xdg
 private-tmp
 # encrypting and signing email
 writable-run-user


### PR DESCRIPTION
claws-mail vcalendar-plugin uses libical to get current timezone. Libical needs access to file `/etc/timezone` to work properly.

See (already closed but not yet completely solved) bug report: https://github.com/netblue30/firejail/issues/5448