### PR TITLE
zoom.profile: whitelist ~/.config/zoom.conf

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -674,6 +674,7 @@ blacklist ${HOME}/.config/yt-dlp
 blacklist ${HOME}/.config/yt-dlp.conf
 blacklist ${HOME}/.config/zathura
 blacklist ${HOME}/.config/zim
+blacklist ${HOME}/.config/zoom.conf
 blacklist ${HOME}/.config/zoomus.conf
 blacklist ${HOME}/.conkeror.mozdev.org
 blacklist ${HOME}/.crawl

--- a/etc/profile-m-z/zoom.profile
+++ b/etc/profile-m-z/zoom.profile
@@ -22,9 +22,11 @@ noblacklist ${HOME}/.zoom
 nowhitelist ${DOWNLOADS}
 
 mkdir ${HOME}/.cache/zoom
+mkfile ${HOME}/.config/zoom.conf
 mkfile ${HOME}/.config/zoomus.conf
 mkdir ${HOME}/.zoom
 whitelist ${HOME}/.cache/zoom
+whitelist ${HOME}/.config/zoom.conf
 whitelist ${HOME}/.config/zoomus.conf
 whitelist ${HOME}/.zoom
 

--- a/etc/profile-m-z/zoom.profile
+++ b/etc/profile-m-z/zoom.profile
@@ -16,6 +16,7 @@ ignore dbus-system none
 # If you use such a system, add 'ignore nogroups' to your zoom.local.
 #ignore nogroups
 
+noblacklist ${HOME}/.config/zoom.conf
 noblacklist ${HOME}/.config/zoomus.conf
 noblacklist ${HOME}/.zoom
 


### PR DESCRIPTION
With Zoom version 5.12.6 Zoom changed how they handle encrypting the local database. This change resulted in the new file zoom.conf being used. As it was not allowed by the default profile this could lead to users losing their chat history if they cannot be retrieved from the cloud (e.g. when e2e encryption is used).
