### PR TITLE
modif: Stop forwarding own double-dash to the shell

### DIFF
--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -580,8 +580,6 @@ void start_application(int no_sandbox, int fd, char *set_sandbox_status) {
 			if (arg_debug)
 				printf("Running %s command through %s\n", cfg.command_line, cfg.usershell);
 			arg[index++] = "-c";
-			if (arg_doubledash)
-				arg[index++] = "--";
 			arg[index++] = cfg.command_line;
 		}
 		else if (login_shell) {


### PR DESCRIPTION
Currently, if double-dash ("--") is passed to firejail, it is forwarded
to the user shell:

    $ firejail --debug --noprofile -- echo test 2>&1 |
      grep -e execvp -e test
    Building quoted command line: 'echo' 'test'
    Building quoted command line: 'echo' 'test'
    Running 'echo' 'test'  command through /bin/bash
    execvp argument 0: /bin/bash
    execvp argument 1: -c
    execvp argument 2: --
    execvp argument 3: 'echo' 'test'
    test

This causes issues when the user shell does not accept "--" / is not
POSIX-compatible:

    $ /bin/bash -c -- 'echo test'
    test
    $ /bin/fish -c -- 'echo test'
    fish: Unknown command: --
    fish:
    --
    ^

Fixes #5599.

Relates to #3434.

Reported-by: @iltep64
Reported-by: @ferreum