### PR TITLE
abiword: fix libEGL warning

### DIFF
--- a/etc/profile-a-l/abiword.profile
+++ b/etc/profile-a-l/abiword.profile
@@ -24,7 +24,6 @@ apparmor
 caps.drop all
 machine-id
 net none
-no3d
 nodvd
 nogroups
 noinput


### PR DESCRIPTION
Here's the warning:

> libEGL warning: wayland-egl: could not open /dev/dri/renderD129 (No such file or directory)

Abiword actually seems to work perfectly fine even with this warning, but I'm submitting this PR just as a heads-up and because it's only a one-line deletion. If this change is undesired, please close this PR.
