### PR TITLE
modif: Escape control characters of the command line

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -143,6 +143,7 @@ int pid_proc_cmdline_x11_xpra_xephyr(const pid_t pid);
 int pid_hidepid(void);
 char *do_replace_cntrl_chars(char *str, char c);
 char *replace_cntrl_chars(const char *str, char c);
+char *escape_cntrl_chars(const char *str);
 int has_cntrl_chars(const char *str);
 void reject_cntrl_chars(const char *fname);
 void reject_meta_chars(const char *fname, int globbing);

--- a/src/lib/common.c
+++ b/src/lib/common.c
@@ -404,6 +404,61 @@ char *replace_cntrl_chars(const char *str, char c) {
 	return rv;
 }
 
+char *escape_cntrl_chars(const char *str) {
+	if (str) {
+		unsigned int cntrl_chars = 0;
+		const char *c = str;
+		while (*c) {
+			switch (*c++) {
+				case '\b':
+				case '\a':
+				case '\e':
+				case '\f':
+				case '\n':
+				case '\r':
+				case '\t':
+				case '\v':
+				case '\"':
+				case '\'':
+				case '\?':
+				case '\\':
+					++cntrl_chars;
+				default: break;
+			}
+		}
+		char *rv = malloc(strlen(str) + cntrl_chars + 1);
+		char *ptr = rv;
+		if (!rv)
+			errExit("malloc");
+		c = str;
+		while (*c) {
+			if (iscntrl(*c)) {
+				*ptr++ = '\\';
+				switch (*c) {
+					case '\b': *ptr++ = 'b'; break;
+					case '\a': *ptr++ = 'a'; break;
+					case '\e': *ptr++ = 'e'; break;
+					case '\f': *ptr++ = 'f'; break;
+					case '\n': *ptr++ = 'n'; break;
+					case '\r': *ptr++ = 'r'; break;
+					case '\t': *ptr++ = 't'; break;
+					case '\v': *ptr++ = 'v'; break;
+					case '\"': *ptr++ = '\"'; break;
+					case '\'': *ptr++ = '\''; break;
+					case '\?': *ptr++ = '?'; break;
+					case '\\': *ptr++ = '\\'; break;
+				}
+			} else {
+				*ptr++ = *c;
+			}
+			c++;
+		}
+		*ptr = '\0';
+		return rv;
+	}
+	return NULL;
+}
+
 int has_cntrl_chars(const char *str) {
 	assert(str);
 

--- a/src/lib/common.c
+++ b/src/lib/common.c
@@ -404,59 +404,62 @@ char *replace_cntrl_chars(const char *str, char c) {
 	return rv;
 }
 
+// Replaces each control character in str with an escape sequence, such as by
+// replacing '\n' (0x0a) with "\\n" (0x5c6e).
 char *escape_cntrl_chars(const char *str) {
-	if (str) {
-		unsigned int cntrl_chars = 0;
-		const char *c = str;
-		while (*c) {
-			switch (*c++) {
-				case '\b':
-				case '\a':
-				case '\e':
-				case '\f':
-				case '\n':
-				case '\r':
-				case '\t':
-				case '\v':
-				case '\"':
-				case '\'':
-				case '\?':
-				case '\\':
-					++cntrl_chars;
-				default: break;
-			}
+	if (str == NULL)
+		return NULL;
+
+	unsigned int cntrl_chars = 0;
+	const char *c = str;
+	while (*c) {
+		switch (*c++) {
+		case '\b':
+		case '\a':
+		case '\e':
+		case '\f':
+		case '\n':
+		case '\r':
+		case '\t':
+		case '\v':
+		case '\"':
+		case '\'':
+		case '\?':
+		case '\\':
+			++cntrl_chars;
+		default:
+			break;
 		}
-		char *rv = malloc(strlen(str) + cntrl_chars + 1);
-		char *ptr = rv;
-		if (!rv)
-			errExit("malloc");
-		c = str;
-		while (*c) {
-			if (iscntrl(*c)) {
-				*ptr++ = '\\';
-				switch (*c) {
-					case '\b': *ptr++ = 'b'; break;
-					case '\a': *ptr++ = 'a'; break;
-					case '\e': *ptr++ = 'e'; break;
-					case '\f': *ptr++ = 'f'; break;
-					case '\n': *ptr++ = 'n'; break;
-					case '\r': *ptr++ = 'r'; break;
-					case '\t': *ptr++ = 't'; break;
-					case '\v': *ptr++ = 'v'; break;
-					case '\"': *ptr++ = '\"'; break;
-					case '\'': *ptr++ = '\''; break;
-					case '\?': *ptr++ = '?'; break;
-					case '\\': *ptr++ = '\\'; break;
-				}
-			} else {
-				*ptr++ = *c;
-			}
-			c++;
-		}
-		*ptr = '\0';
-		return rv;
 	}
-	return NULL;
+	char *ptr, *rv = malloc(strlen(str) + cntrl_chars + 1);
+	if (!rv)
+		errExit("malloc");
+	ptr = rv;
+	c = str;
+	while (*c) {
+		if (iscntrl(*c)) {
+			*ptr++ = '\\';
+			switch (*c) {
+			case '\b': *ptr++ = 'b'; break;
+			case '\a': *ptr++ = 'a'; break;
+			case '\e': *ptr++ = 'e'; break;
+			case '\f': *ptr++ = 'f'; break;
+			case '\n': *ptr++ = 'n'; break;
+			case '\r': *ptr++ = 'r'; break;
+			case '\t': *ptr++ = 't'; break;
+			case '\v': *ptr++ = 'v'; break;
+			case '\"': *ptr++ = '\"'; break;
+			case '\'': *ptr++ = '\''; break;
+			case '\?': *ptr++ = '?'; break;
+			case '\\': *ptr++ = '\\'; break;
+			}
+		} else {
+			*ptr++ = *c;
+		}
+		c++;
+	}
+	*ptr = '\0';
+	return rv;
 }
 
 int has_cntrl_chars(const char *str) {

--- a/src/lib/pid.c
+++ b/src/lib/pid.c
@@ -197,10 +197,10 @@ static void print_elem(unsigned index, int nowrap) {
 	char *user = pid_get_user_name(uid);
 	char *user_allocated = user;
 
-	char *cmd_escape = escape_cntrl_chars(cmd);
-	if (cmd_escape) {
+	char *cmd_escaped = escape_cntrl_chars(cmd);
+	if (cmd_escaped) {
 		free(cmd);
-		cmd = cmd_escape;
+		cmd = cmd_escaped;
 	}
 
 	// extract sandbox name - pid == index
@@ -230,11 +230,11 @@ static void print_elem(unsigned index, int nowrap) {
 	}
 	free(fname);
 
-	char *sandbox_name_escape = escape_cntrl_chars(sandbox_name);
-	if (sandbox_name_escape) {
+	char *sandbox_name_escaped = escape_cntrl_chars(sandbox_name);
+	if (sandbox_name_escaped) {
 		if (sandbox_name_allocated)
 			free(sandbox_name_allocated);
-		sandbox_name = sandbox_name_escape;
+		sandbox_name = sandbox_name_escaped;
 		sandbox_name_allocated = sandbox_name;
 	}
 

--- a/src/lib/pid.c
+++ b/src/lib/pid.c
@@ -197,6 +197,12 @@ static void print_elem(unsigned index, int nowrap) {
 	char *user = pid_get_user_name(uid);
 	char *user_allocated = user;
 
+	char *cmd_escape = escape_cntrl_chars(cmd);
+	if (cmd_escape) {
+		free(cmd);
+		cmd = cmd_escape;
+	}
+
 	// extract sandbox name - pid == index
 	char *sandbox_name = "";
 	char *sandbox_name_allocated = NULL;
@@ -224,7 +230,15 @@ static void print_elem(unsigned index, int nowrap) {
 	}
 	free(fname);
 
-	if (user ==NULL)
+	char *sandbox_name_escape = escape_cntrl_chars(sandbox_name);
+	if (sandbox_name_escape) {
+		if (sandbox_name_allocated)
+			free(sandbox_name_allocated);
+		sandbox_name = sandbox_name_escape;
+		sandbox_name_allocated = sandbox_name;
+	}
+
+	if (user == NULL)
 		user = "";
 	if (cmd) {
 		if (col < 4 || nowrap)


### PR DESCRIPTION
Names and commands can contain control characters:

```
firejail --name="$(echo -e '\e[31mRed\n\b\b\bText\e[0m')" sleep 10s
```
results in "Text" printed in red.

Prevent commands like `--tree` to control the terminal.

I've tested some control characters and I can't do worse than making jails disappear from `--tree` (by controlling the cursor) and possibly output anything to console (hijacking a console output). Reading various documentations and forums, I didn't find interesting control characters like "writing to file" or "execute command", that resulted in CVEs in the past.

* Which other functions should be fixed? `print_elem` is the one used in `--tree`.
* Which other control characters should be escaped?
* In `if (iscntrl(*c)) {`, if the `*c`character is not one in the `switch`, the character is discarded. Is this the behavior you want, or do you prefer to allow that character?

Before submitting this PR, I contacted @netblue30.