### PR TITLE
qutebrowser.profile: Add more files to private-etc

### DIFF
--- a/etc/profile-m-z/qutebrowser.profile
+++ b/etc/profile-m-z/qutebrowser.profile
@@ -56,7 +56,7 @@ seccomp !chroot,!name_to_handle_at
 disable-mnt
 private-cache
 private-dev
-private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,localtime,machine-id,pki,pulse,resolv.conf,ssl
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,localtime,machine-id,passwd,pki,pulse,resolv.conf,ssl
 private-tmp
 
 dbus-user filter


### PR DESCRIPTION
Without those files in private-etc, qutebrowser cannot launch terminal emulators.

I personally think we shouldn't add individual files to private-etc. There should be file groups that we give to private-etc.

Like

```
private-etc @common,@3d,@audio,@dbus,@gui,@gtk,@kde,@networking,@qt
```