### PR TITLE
disable-common.inc: add more ro editor/browser paths

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -327,6 +327,7 @@ read-only ${HOME}/.ssh/config.d
 # Initialization files that allow arbitrary command execution
 read-only ${HOME}/.caffrc
 read-only ${HOME}/.cargo/env
+read-only ${HOME}/.config/nano
 read-only ${HOME}/.config/nvim
 read-only ${HOME}/.config/pkcs11
 read-only ${HOME}/.dotfiles

--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -330,6 +330,7 @@ read-only ${HOME}/.cargo/env
 read-only ${HOME}/.config/nvim
 read-only ${HOME}/.config/pkcs11
 read-only ${HOME}/.dotfiles
+read-only ${HOME}/.elinks
 read-only ${HOME}/.emacs
 read-only ${HOME}/.emacs.d
 read-only ${HOME}/.exrc
@@ -345,6 +346,7 @@ read-only ${HOME}/.msmtprc
 read-only ${HOME}/.mutt/muttrc
 read-only ${HOME}/.muttrc
 read-only ${HOME}/.nano
+read-only ${HOME}/.nanorc
 read-only ${HOME}/.npmrc
 read-only ${HOME}/.pythonrc.py
 read-only ${HOME}/.reportbugrc
@@ -352,6 +354,7 @@ read-only ${HOME}/.tmux.conf
 read-only ${HOME}/.vim
 read-only ${HOME}/.viminfo
 read-only ${HOME}/.vimrc
+read-only ${HOME}/.w3m
 read-only ${HOME}/.xmonad
 read-only ${HOME}/.xscreensaver
 read-only ${HOME}/.yarnrc

--- a/etc/profile-a-l/elinks.profile
+++ b/etc/profile-a-l/elinks.profile
@@ -17,5 +17,7 @@ whitelist ${HOME}/.elinks
 
 private-bin elinks
 
+read-write ${HOME}/.elinks
+
 # Redirect
 include links-common.profile

--- a/etc/profile-m-z/mutt.profile
+++ b/etc/profile-m-z/mutt.profile
@@ -133,8 +133,5 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
-read-only ${HOME}/.elinks
-read-only ${HOME}/.nanorc
 read-only ${HOME}/.signature
-read-only ${HOME}/.w3m
 restrict-namespaces

--- a/etc/profile-m-z/nano.profile
+++ b/etc/profile-m-z/nano.profile
@@ -56,5 +56,6 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+read-write ${HOME}/.config/nano
 read-write ${HOME}/.nanorc
 restrict-namespaces

--- a/etc/profile-m-z/nano.profile
+++ b/etc/profile-m-z/nano.profile
@@ -56,4 +56,5 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+read-write ${HOME}/.nanorc
 restrict-namespaces

--- a/etc/profile-m-z/neomutt.profile
+++ b/etc/profile-m-z/neomutt.profile
@@ -125,8 +125,5 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
-read-only ${HOME}/.elinks
-read-only ${HOME}/.nanorc
 read-only ${HOME}/.signature
-read-only ${HOME}/.w3m
 restrict-namespaces

--- a/etc/profile-m-z/w3m.profile
+++ b/etc/profile-m-z/w3m.profile
@@ -68,4 +68,5 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+read-write ${HOME}/.w3m
 restrict-namespaces


### PR DESCRIPTION
Move some paths from mutt.profile and neomutt.profile.

Added on commit 6b9bfad ("Fix python; add read-only to editors/cli
browsers;re-add cache directory", 2020-12-29) / PR #3849.

And also make ~/.config/nano read-only.

Misc: This is a follow-up to #5626.
