### PR TITLE
ephemeral: use newly introduced private-etc @groups syntax

### DIFF
--- a/etc/profile-a-l/ephemeral.profile
+++ b/etc/profile-a-l/ephemeral.profile
@@ -55,7 +55,7 @@ disable-mnt
 private-cache
 ?BROWSER_DISABLE_U2F: private-dev
 # private-etc below works fine on most distributions. There are some problems on CentOS.
-#private-etc alternatives,asound.conf,ca-certificates,crypto-policies,dconf,fonts,group,gtk-2.0,gtk-3.0,hostname,hosts,ld.so.cache,localtime,login.defs,machine-id,mailcap,mime.types,nsswitch.conf,os-release,pango,passwd,pki,pulse,resolv.conf,selinux,ssl,X11,xdg
+#private-etc @tls-ca,@x11,mailcap,mime.types,os-release
 private-tmp
 
 # breaks preferences


### PR DESCRIPTION
Only changed the syntax to adhere to the @groups work and kept private-etc disabled.

Relates to #5610.
See the [commit comment](https://github.com/netblue30/firejail/commit/0f996ea4de584dc061faf21853d61a600da1a1d8#commitcomment-99461328).