### PR TITLE
Revert "private-etc: big profile changes"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,6 @@ src/fcopy/fcopy
 src/fldd/fldd
 src/fbuilder/fbuilder
 src/profstats/profstats
-src/etc-cleanup/etc-cleanup
 src/bash_completion/firejail.bash_completion
 src/zsh_completion/_firejail
 src/jailcheck/jailcheck

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ src/fcopy/fcopy
 src/fldd/fldd
 src/fbuilder/fbuilder
 src/profstats/profstats
+src/etc-cleanup/etc-cleanup
 src/bash_completion/firejail.bash_completion
 src/zsh_completion/_firejail
 src/jailcheck/jailcheck

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 
 COMPLETIONDIRS = src/zsh_completion src/bash_completion
 
-APPS = src/firecfg/firecfg src/firejail/firejail src/firemon/firemon src/profstats/profstats src/jailcheck/jailcheck src/etc-cleanup/etc-cleanup
+APPS = src/firecfg/firecfg src/firejail/firejail src/firemon/firemon src/profstats/profstats src/jailcheck/jailcheck
 SBOX_APPS = src/fbuilder/fbuilder src/ftee/ftee src/fids/fids
 SBOX_APPS_NON_DUMPABLE = src/fcopy/fcopy src/fldd/fldd src/fnet/fnet src/fnetfilter/fnetfilter src/fzenity/fzenity
 SBOX_APPS_NON_DUMPABLE += src/fsec-optimize/fsec-optimize src/fsec-print/fsec-print src/fseccomp/fseccomp
@@ -200,7 +200,6 @@ endif
 	install -m 0644 -t $(DESTDIR)$(libdir)/firejail $(MYLIBS) $(SECCOMP_FILTERS)
 	install -m 0755 -t $(DESTDIR)$(libdir)/firejail $(SBOX_APPS)
 	install -m 0755 -t $(DESTDIR)$(libdir)/firejail src/profstats/profstats
-	install -m 0755 -t $(DESTDIR)$(libdir)/firejail src/etc-cleanup/etc-cleanup
 	# plugins w/o read permission (non-dumpable)
 	install -m 0711 -t $(DESTDIR)$(libdir)/firejail $(SBOX_APPS_NON_DUMPABLE)
 	install -m 0711 -t $(DESTDIR)$(libdir)/firejail src/fshaper/fshaper.sh

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 
 COMPLETIONDIRS = src/zsh_completion src/bash_completion
 
-APPS = src/firecfg/firecfg src/firejail/firejail src/firemon/firemon src/profstats/profstats src/jailcheck/jailcheck
+APPS = src/firecfg/firecfg src/firejail/firejail src/firemon/firemon src/profstats/profstats src/jailcheck/jailcheck src/etc-cleanup/etc-cleanup
 SBOX_APPS = src/fbuilder/fbuilder src/ftee/ftee src/fids/fids
 SBOX_APPS_NON_DUMPABLE = src/fcopy/fcopy src/fldd/fldd src/fnet/fnet src/fnetfilter/fnetfilter src/fzenity/fzenity
 SBOX_APPS_NON_DUMPABLE += src/fsec-optimize/fsec-optimize src/fsec-print/fsec-print src/fseccomp/fseccomp
@@ -200,6 +200,7 @@ endif
 	install -m 0644 -t $(DESTDIR)$(libdir)/firejail $(MYLIBS) $(SECCOMP_FILTERS)
 	install -m 0755 -t $(DESTDIR)$(libdir)/firejail $(SBOX_APPS)
 	install -m 0755 -t $(DESTDIR)$(libdir)/firejail src/profstats/profstats
+	install -m 0755 -t $(DESTDIR)$(libdir)/firejail src/etc-cleanup/etc-cleanup
 	# plugins w/o read permission (non-dumpable)
 	install -m 0711 -t $(DESTDIR)$(libdir)/firejail $(SBOX_APPS_NON_DUMPABLE)
 	install -m 0711 -t $(DESTDIR)$(libdir)/firejail src/fshaper/fshaper.sh

--- a/etc/profile-a-l/1password.profile
+++ b/etc/profile-a-l/1password.profile
@@ -11,7 +11,7 @@ noblacklist ${HOME}/.config/1Password
 mkdir ${HOME}/.config/1Password
 whitelist ${HOME}/.config/1Password
 
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,machine-id,nsswitch.conf,pki,resolv.conf,ssl
 
 # Needed for keychain things, talking to Firefox, possibly other things?  Not sure how to narrow down
 ignore dbus-user none

--- a/etc/profile-a-l/abiword.profile
+++ b/etc/profile-a-l/abiword.profile
@@ -41,7 +41,7 @@ tracelog
 private-bin abiword
 private-cache
 private-dev
-private-etc @x11
+private-etc alternatives,fonts,gtk-3.0,ld.so.cache,ld.so.preload,passwd
 private-tmp
 
 # dbus-user none

--- a/etc/profile-a-l/agetpkg.profile
+++ b/etc/profile-a-l/agetpkg.profile
@@ -49,7 +49,7 @@ tracelog
 private-bin agetpkg,python3
 private-cache
 private-dev
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.preload,pki,resolv.conf,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/alacarte.profile
+++ b/etc/profile-a-l/alacarte.profile
@@ -52,7 +52,7 @@ disable-mnt
 # private-bin alacarte,bash,python*,sh
 private-cache
 private-dev
-private-etc @tls-ca,@x11,mime.types
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.preload,locale.alias,locale.conf,login.defs,mime.types,nsswitch.conf,passwd,pki,X11,xdg
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/alienarena.profile
+++ b/etc/profile-a-l/alienarena.profile
@@ -43,7 +43,7 @@ disable-mnt
 private-bin alienarena
 private-cache
 private-dev
-private-etc @tls-ca,@x11,bumblebee,glvnd,host.conf,rpc,services
+private-etc alsa,alternatives,asound.conf,bumblebee,ca-certificates,crypto-policies,drirc,fonts,glvnd,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,nsswitch.conf,nvidia,pango,pki,protocols,pulse,resolv.conf,rpc,services,ssl,X11
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/alpine.profile
+++ b/etc/profile-a-l/alpine.profile
@@ -90,7 +90,7 @@ disable-mnt
 private-bin alpine
 private-cache
 private-dev
-private-etc @tls-ca,@x11,c-client.cf,host.conf,krb5.keytab,mailcap,mime.types,pine.conf,pinerc.fixed,rpc,services,terminfo
+private-etc alternatives,c-client.cf,ca-certificates,crypto-policies,host.conf,hostname,hosts,krb5.keytab,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,mailcap,mime.types,nsswitch.conf,passwd,pine.conf,pinerc.fixed,pki,protocols,resolv.conf,rpc,services,ssl,terminfo,xdg
 private-tmp
 writable-run-user
 writable-var

--- a/etc/profile-a-l/anki.profile
+++ b/etc/profile-a-l/anki.profile
@@ -49,7 +49,7 @@ disable-mnt
 private-bin anki,python*
 private-cache
 private-dev
-private-etc @tls-ca,@x11
+private-etc alternatives,ca-certificates,fonts,gtk-2.0,hostname,hosts,ld.so.cache,ld.so.preload,machine-id,pki,resolv.conf,ssl,Trolltech.conf
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/apostrophe.profile
+++ b/etc/profile-a-l/apostrophe.profile
@@ -62,7 +62,7 @@ disable-mnt
 private-bin apostrophe,fmtutil,kpsewhich,mktexfmt,pandoc,pdftex,perl,python3*,sh,xdvipdfmx,xelatex,xetex
 private-cache
 private-dev
-private-etc @x11,texlive
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,pango,texlive,X11
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/aria2c.profile
+++ b/etc/profile-a-l/aria2c.profile
@@ -45,7 +45,7 @@ private-bin aria2c,gzip
 # Add 'private-cache' to your aria2c.local if you don't use Lutris/winetricks (see issue #2772).
 #private-cache
 private-dev
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,groups,ld.so.cache,ld.so.preload,login.defs,machine-id,nsswitch.conf,passwd,pki,resolv.conf,ssl
 private-lib libreadline.so.*
 private-tmp
 

--- a/etc/profile-a-l/aria2c.profile
+++ b/etc/profile-a-l/aria2c.profile
@@ -45,7 +45,7 @@ private-bin aria2c,gzip
 # Add 'private-cache' to your aria2c.local if you don't use Lutris/winetricks (see issue #2772).
 #private-cache
 private-dev
-private-etc alternatives,ca-certificates,crypto-policies,groups,ld.so.cache,ld.so.preload,login.defs,machine-id,nsswitch.conf,passwd,pki,resolv.conf,ssl
+private-etc alternatives,ca-certificates,crypto-policies,group,ld.so.cache,ld.so.preload,login.defs,machine-id,nsswitch.conf,passwd,pki,resolv.conf,ssl
 private-lib libreadline.so.*
 private-tmp
 

--- a/etc/profile-a-l/arm.profile
+++ b/etc/profile-a-l/arm.profile
@@ -42,7 +42,7 @@ tracelog
 disable-mnt
 private-bin arm,bash,ldconfig,lsof,ps,python*,sh,tor
 private-dev
-private-etc @tls-ca,tor
+private-etc alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.preload,passwd,pki,resolv.conf,ssl,tor
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-a-l/artha.profile
+++ b/etc/profile-a-l/artha.profile
@@ -54,7 +54,7 @@ disable-mnt
 private-bin artha,enchant,notify-send
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,machine-id
 private-lib libnotify.so.*
 private-tmp
 

--- a/etc/profile-a-l/atool.profile
+++ b/etc/profile-a-l/atool.profile
@@ -13,7 +13,7 @@ include allow-perl.inc
 noroot
 
 # without login.defs atool complains and uses UID/GID 1000 by default
-private-etc
+private-etc alternatives,group,ld.so.cache,ld.so.preload,login.defs,passwd,resolv.conf
 private-tmp
 
 # Redirect

--- a/etc/profile-a-l/atril.profile
+++ b/etc/profile-a-l/atril.profile
@@ -41,7 +41,7 @@ tracelog
 
 private-bin 7z,7za,7zr,atril,atril-previewer,atril-thumbnailer,sh,tar,unrar,unzip,zipnote
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 # atril uses webkit gtk to display epub files
 # waiting for globbing support in private-lib; for now hardcoding it to webkit2gtk-4.0
 #private-lib webkit2gtk-4.0 - problems on Arch with the new version of WebKit

--- a/etc/profile-a-l/audio-recorder.profile
+++ b/etc/profile-a-l/audio-recorder.profile
@@ -43,7 +43,7 @@ tracelog
 disable-mnt
 # private-bin audio-recorder
 private-cache
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/authenticator-rs.profile
+++ b/etc/profile-a-l/authenticator-rs.profile
@@ -46,7 +46,7 @@ disable-mnt
 private-bin authenticator-rs
 private-cache
 private-dev
-private-etc @tls-ca,@x11
+private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gtk-2.0,gtk-3.0,ld.so.cache,ld.so.preload,pki,resolv.conf,ssl,xdg
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/authenticator.profile
+++ b/etc/profile-a-l/authenticator.profile
@@ -38,7 +38,7 @@ seccomp
 disable-mnt
 # private-bin authenticator,python*
 private-dev
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,pki,resolv.conf,ssl
 private-tmp
 
 # makes settings immutable

--- a/etc/profile-a-l/ballbuster.profile
+++ b/etc/profile-a-l/ballbuster.profile
@@ -44,7 +44,7 @@ disable-mnt
 private-bin ballbuster
 private-cache
 private-dev
-private-etc
+private-etc alsa,alternatives,asound.conf,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,machine-id,pulse
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/bibletime.profile
+++ b/etc/profile-a-l/bibletime.profile
@@ -51,7 +51,7 @@ disable-mnt
 # private-bin bibletime
 private-cache
 private-dev
-private-etc @tls-ca,sword,sword.conf
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,login.defs,machine-id,passwd,pki,resolv.conf,ssl,sword,sword.conf
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/bijiben.profile
+++ b/etc/profile-a-l/bijiben.profile
@@ -50,7 +50,7 @@ disable-mnt
 private-bin bijiben
 # private-cache -- access to .cache/tracker is required
 private-dev
-private-etc @x11
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/bitwarden.profile
+++ b/etc/profile-a-l/bitwarden.profile
@@ -23,7 +23,7 @@ no3d
 nosound
 
 ?HAS_APPIMAGE: ignore private-dev
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,hosts,ld.so.cache,ld.so.preload,nsswitch.conf,pki,resolv.conf,ssl
 private-opt Bitwarden
 
 # Redirect

--- a/etc/profile-a-l/bless.profile
+++ b/etc/profile-a-l/bless.profile
@@ -34,7 +34,7 @@ seccomp
 # private-bin bash,bless,mono,sh
 private-cache
 private-dev
-private-etc mono
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,mono
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/blobby.profile
+++ b/etc/profile-a-l/blobby.profile
@@ -40,7 +40,7 @@ tracelog
 disable-mnt
 private-bin blobby
 private-dev
-private-etc @x11
+private-etc alsa,alternatives,asound.conf,drirc,group,hosts,ld.so.cache,ld.so.preload,login.defs,machine-id,passwd,pulse
 private-lib
 private-tmp
 

--- a/etc/profile-a-l/blobwars.profile
+++ b/etc/profile-a-l/blobwars.profile
@@ -42,7 +42,7 @@ disable-mnt
 private-bin blobwars
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload,machine-id
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/bsdtar.profile
+++ b/etc/profile-a-l/bsdtar.profile
@@ -6,7 +6,7 @@ include bsdtar.local
 # Persistent global definitions
 include globals.local
 
-private-etc
+private-etc alternatives,group,ld.so.cache,ld.so.preload,localtime,passwd
 
 # Redirect
 include archiver-common.profile

--- a/etc/profile-a-l/cameramonitor.profile
+++ b/etc/profile-a-l/cameramonitor.profile
@@ -45,7 +45,7 @@ tracelog
 disable-mnt
 private-bin cameramonitor,python*
 private-cache
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 private-tmp
 
 # dbus-user none

--- a/etc/profile-a-l/cargo.profile
+++ b/etc/profile-a-l/cargo.profile
@@ -16,7 +16,7 @@ noblacklist ${HOME}/.cargo/credentials.toml
 #whitelist ${HOME}/.rustup
 
 #private-bin cargo,rustc
-private-etc @tls-ca,host.conf,magic,magic.mgc,rpc,services
+private-etc alternatives,ca-certificates,crypto-policies,group,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,magic,magic.mgc,nsswitch.conf,passwd,pki,protocols,resolv.conf,rpc,services,ssl
 
 memory-deny-write-execute
 

--- a/etc/profile-a-l/cawbird.profile
+++ b/etc/profile-a-l/cawbird.profile
@@ -38,7 +38,7 @@ disable-mnt
 private-bin cawbird
 private-cache
 private-dev
-private-etc @tls-ca,@x11,host.conf,mime.types
+private-etc alternatives,ca-certificates,crypto-policies,fonts,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,mime.types,nsswitch.conf,pki,resolv.conf,ssl,X11,xdg
 private-tmp
 
 # dbus-user none

--- a/etc/profile-a-l/celluloid.profile
+++ b/etc/profile-a-l/celluloid.profile
@@ -52,7 +52,7 @@ tracelog
 
 private-bin celluloid,env,gnome-mpv,python*,youtube-dl
 private-cache
-private-etc @tls-ca,@x11,libva.conf,pkcs11
+private-etc alternatives,ca-certificates,crypto-policies,dconf,drirc,fonts,gtk-3.0,hosts,ld.so.cache,ld.so.preload,libva.conf,localtime,machine-id,pkcs11,pki,resolv.conf,selinux,ssl,xdg
 private-dev
 private-tmp
 

--- a/etc/profile-a-l/chatterino.profile
+++ b/etc/profile-a-l/chatterino.profile
@@ -70,7 +70,7 @@ private-bin chatterino,cvlc,env,ffmpeg,mpv,nvlc,pgrep,python*,qvlc,rvlc,streamli
 # private-cache may cause issues with mpv (see #2838)
 private-cache
 private-dev
-private-etc @tls-ca,@x11,dbus-1,rpc,services
+private-etc alsa,alternatives,asound.conf,ca-certificates,dbus-1,fonts,hostname,hosts,kde4rc,kde5rc,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,nvidia,passwd,pulse,resolv.conf,rpc,services,ssl,Trolltech.conf,X11
 private-srv none
 private-tmp
 

--- a/etc/profile-a-l/cheese.profile
+++ b/etc/profile-a-l/cheese.profile
@@ -51,7 +51,7 @@ disable-mnt
 private-bin cheese
 private-cache
 private-dev
-private-etc @x11,clutter-1.0
+private-etc alternatives,clutter-1.0,dconf,drirc,fonts,gtk-3.0,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/clawsker.profile
+++ b/etc/profile-a-l/clawsker.profile
@@ -43,7 +43,7 @@ disable-mnt
 private-bin bash,clawsker,perl,sh,which
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 private-lib girepository-1.*,libdbus-glib-1.so.*,libetpan.so.*,libgirepository-1.*,libgtk-3.so.*,libgtk-x11-2.0.so.*,libstartup-notification-1.so.*,perl*
 private-tmp
 

--- a/etc/profile-a-l/cmus.profile
+++ b/etc/profile-a-l/cmus.profile
@@ -26,6 +26,6 @@ protocol unix,inet,inet6
 seccomp
 
 private-bin cmus
-private-etc @tls-ca
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,group,ld.so.cache,ld.so.preload,machine-id,pki,pulse,resolv.conf,ssl
 
 restrict-namespaces

--- a/etc/profile-a-l/cointop.profile
+++ b/etc/profile-a-l/cointop.profile
@@ -52,7 +52,7 @@ disable-mnt
 private-bin cointop
 private-cache
 private-dev
-private-etc @tls-ca,host.conf,rpc,services
+private-etc alternatives,ca-certificates,crypto-policies,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,nsswitch.conf,pki,protocols,resolv.conf,rpc,services,ssl
 private-lib
 private-tmp
 

--- a/etc/profile-a-l/colorful.profile
+++ b/etc/profile-a-l/colorful.profile
@@ -44,7 +44,7 @@ disable-mnt
 private-bin colorful
 private-cache
 private-dev
-private-etc
+private-etc alsa,alternatives,asound.conf,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,machine-id,pulse
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/com.github.bleakgrey.tootle.profile
+++ b/etc/profile-a-l/com.github.bleakgrey.tootle.profile
@@ -44,7 +44,7 @@ disable-mnt
 private-bin com.github.bleakgrey.tootle
 private-cache
 private-dev
-private-etc @tls-ca,@x11,host.conf,mime.types
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,dconf,fonts,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,machine-id mime.types,nsswitch.conf,pki,pulse,resolv.conf,ssl,X11,xdg
 private-tmp
 
 # Settings are immutable

--- a/etc/profile-a-l/com.github.dahenson.agenda.profile
+++ b/etc/profile-a-l/com.github.dahenson.agenda.profile
@@ -51,7 +51,7 @@ disable-mnt
 private-bin com.github.dahenson.agenda
 private-cache
 private-dev
-private-etc @x11
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/com.github.johnfactotum.Foliate.profile
+++ b/etc/profile-a-l/com.github.johnfactotum.Foliate.profile
@@ -54,7 +54,7 @@ disable-mnt
 private-bin com.github.johnfactotum.Foliate,gjs
 private-cache
 private-dev
-private-etc @x11,gconf
+private-etc alternatives,dconf,fonts,gconf,gtk-3.0,ld.so.cache,ld.so.preload
 private-tmp
 
 read-only ${HOME}

--- a/etc/profile-a-l/com.github.phase1geo.minder.profile
+++ b/etc/profile-a-l/com.github.phase1geo.minder.profile
@@ -51,7 +51,7 @@ disable-mnt
 private-bin com.github.phase1geo.minder
 private-cache
 private-dev
-private-etc @x11,mime.types
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,mime.types,pango,passwd,X11,xdg
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/com.github.tchx84.Flatseal.profile
+++ b/etc/profile-a-l/com.github.tchx84.Flatseal.profile
@@ -51,7 +51,7 @@ disable-mnt
 private-bin com.github.tchx84.Flatseal,gjs
 private-cache
 private-dev
-private-etc @x11
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/coyim.profile
+++ b/etc/profile-a-l/coyim.profile
@@ -39,7 +39,7 @@ tracelog
 disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,machine-id,pki,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/crow.profile
+++ b/etc/profile-a-l/crow.profile
@@ -38,7 +38,7 @@ seccomp
 disable-mnt
 private-bin crow
 private-dev
-private-etc @tls-ca,@x11
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,dconf,fonts,ld.so.cache,ld.so.preload,machine-id,nsswitch.conf,pki,pulse,resolv.conf,ssl
 private-opt none
 private-tmp
 private-srv none

--- a/etc/profile-a-l/d-feet.profile
+++ b/etc/profile-a-l/d-feet.profile
@@ -49,7 +49,7 @@ disable-mnt
 private-bin d-feet,python*
 private-cache
 private-dev
-private-etc dbus-1
+private-etc alternatives,dbus-1,fonts,ld.so.cache,ld.so.preload,machine-id
 private-tmp
 
 #memory-deny-write-execute - breaks on Arch (see issue #1803)

--- a/etc/profile-a-l/dbus-send.profile
+++ b/etc/profile-a-l/dbus-send.profile
@@ -50,7 +50,7 @@ private
 private-bin dbus-send
 private-cache
 private-dev
-private-etc dbus-1
+private-etc alternatives,dbus-1,ld.so.cache,ld.so.preload
 private-lib libpcre*
 private-tmp
 

--- a/etc/profile-a-l/dconf-editor.profile
+++ b/etc/profile-a-l/dconf-editor.profile
@@ -42,7 +42,7 @@ disable-mnt
 private-bin dconf-editor
 private-cache
 private-dev
-private-etc @x11
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.preload,machine-id
 private-lib
 private-tmp
 

--- a/etc/profile-a-l/dconf.profile
+++ b/etc/profile-a-l/dconf.profile
@@ -45,7 +45,7 @@ disable-mnt
 private-bin dconf,gsettings
 private-cache
 private-dev
-private-etc @x11
+private-etc alternatives,dconf,ld.so.cache,ld.so.preload
 private-lib
 private-tmp
 

--- a/etc/profile-a-l/ddgtk.profile
+++ b/etc/profile-a-l/ddgtk.profile
@@ -44,7 +44,7 @@ tracelog
 disable-mnt
 private-bin bash,dd,ddgtk,grep,lsblk,python*,sed,sh,tr
 private-cache
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/devhelp.profile
+++ b/etc/profile-a-l/devhelp.profile
@@ -41,7 +41,7 @@ disable-mnt
 private-bin devhelp
 private-cache
 private-dev
-private-etc @tls-ca,@x11
+private-etc alternatives,dconf,fonts,ld.so.cache,ld.so.preload,machine-id,ssl
 private-tmp
 
 # makes settings immutable

--- a/etc/profile-a-l/devilspie.profile
+++ b/etc/profile-a-l/devilspie.profile
@@ -47,7 +47,7 @@ disable-mnt
 private-bin devilspie
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 private-lib gconv
 private-tmp
 

--- a/etc/profile-a-l/dig.profile
+++ b/etc/profile-a-l/dig.profile
@@ -48,7 +48,7 @@ tracelog
 disable-mnt
 private-bin bash,dig,sh
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload,login.defs,passwd,resolv.conf
 # Add the next line to your dig.local on non Debian/Ubuntu OS (see issue #3038).
 #private-lib
 private-tmp

--- a/etc/profile-a-l/discord-common.profile
+++ b/etc/profile-a-l/discord-common.profile
@@ -24,7 +24,7 @@ whitelist ${HOME}/.config/BetterDiscord
 whitelist ${HOME}/.local/share/betterdiscordctl
 
 private-bin awk,bash,cut,echo,egrep,electron,electron[0-9],electron[0-9][0-9],fish,grep,head,sed,sh,tclsh,tr,which,xdg-mime,xdg-open,zsh
-private-etc alternatives,ca-certificates,crypto-policies,fonts,group,ld.so.cache,ld.so.preload,localtime,login.defs,machine-id,password,pki,pulse,resolv.conf,ssl
+private-etc alternatives,ca-certificates,crypto-policies,fonts,group,ld.so.cache,ld.so.preload,localtime,login.defs,machine-id,passwd,pki,pulse,resolv.conf,ssl
 
 join-or-start discord
 

--- a/etc/profile-a-l/discord-common.profile
+++ b/etc/profile-a-l/discord-common.profile
@@ -24,7 +24,7 @@ whitelist ${HOME}/.config/BetterDiscord
 whitelist ${HOME}/.local/share/betterdiscordctl
 
 private-bin awk,bash,cut,echo,egrep,electron,electron[0-9],electron[0-9][0-9],fish,grep,head,sed,sh,tclsh,tr,which,xdg-mime,xdg-open,zsh
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,group,ld.so.cache,ld.so.preload,localtime,login.defs,machine-id,password,pki,pulse,resolv.conf,ssl
 
 join-or-start discord
 

--- a/etc/profile-a-l/display.profile
+++ b/etc/profile-a-l/display.profile
@@ -39,7 +39,7 @@ seccomp
 private-bin display,python*
 private-dev
 # On Debian-based systems, display is a symlink in /etc/alternatives
-private-etc ImageMagick-6,ImageMagick-7
+private-etc alternatives,ImageMagick-6,ImageMagick-7,ld.so.cache,ld.so.preload
 private-lib gcc/*/*/libgcc_s.so.*,gcc/*/*/libgomp.so.*,ImageMagick*,libfreetype.so.*,libltdl.so.*,libMagickWand-*.so.*,libXext.so.*
 private-tmp
 

--- a/etc/profile-a-l/dolphin-emu.profile
+++ b/etc/profile-a-l/dolphin-emu.profile
@@ -54,7 +54,7 @@ private-bin bash,dolphin-emu,dolphin-emu-x11,sh
 private-cache
 # Add the next line to your dolphin-emu.local if you do not need controller support.
 #private-dev
-private-etc @tls-ca,@x11,bumblebee,gconf,glvnd,host.conf,mime.types,rpc,services
+private-etc alsa,alternatives,asound.conf,bumblebee,ca-certificates,crypto-policies,dconf,drirc,fonts,gconf,glvnd,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,kde4rc,kde5rc,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,nvidia,pango,pki,protocols,pulse,resolv.conf,rpc,services,ssl,Trolltech.conf,X11,xdg
 private-opt none
 private-tmp
 

--- a/etc/profile-a-l/drawio.profile
+++ b/etc/profile-a-l/drawio.profile
@@ -44,7 +44,7 @@ seccomp !chroot
 private-bin drawio
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/easystroke.profile
+++ b/etc/profile-a-l/easystroke.profile
@@ -44,7 +44,7 @@ disable-mnt
 #private-bin bash,easystroke,sh
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,group,ld.so.cache,ld.so.preload,passwd
 # breaks custom shell command functionality
 #private-lib gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libgconf-2.so.*,librsvg-2.so.*
 private-tmp

--- a/etc/profile-a-l/electron-mail.profile
+++ b/etc/profile-a-l/electron-mail.profile
@@ -29,7 +29,7 @@ read-only ${HOME}/.mozilla/firefox/profiles.ini
 machine-id
 nosound
 
-private-etc @tls-ca,@x11
+private-etc alternatives,ca-certificates,crypto-policies,fonts,gtk-2.0,gtk-3.0,ld.so.cache,ld.so.preload,nsswitch.conf,pki,resolv.conf,ssl
 private-opt ElectronMail
 
 dbus-user filter

--- a/etc/profile-a-l/electrum.profile
+++ b/etc/profile-a-l/electrum.profile
@@ -46,7 +46,7 @@ private-bin electrum,python*
 private-cache
 ?HAS_APPIMAGE: ignore private-dev
 private-dev
-private-etc @tls-ca,@x11
+private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,ld.so.cache,ld.so.preload,machine-id,pki,resolv.conf,ssl
 private-tmp
 
 # dbus-user none

--- a/etc/profile-a-l/email-common.profile
+++ b/etc/profile-a-l/email-common.profile
@@ -69,7 +69,7 @@ tracelog
 # disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca,@x11,gnupg,hosts.conf,mailname,timezone
+private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gcrypt,gnupg,groups,gtk-2.0,gtk-3.0,hostname,hosts,hosts.conf,ld.so.cache,ld.so.preload,localtime,machine-id,mailname,nsswitch.conf,passwd,pki,resolv.conf,selinux,ssl,timezone,xdg
 private-tmp
 # encrypting and signing email
 writable-run-user

--- a/etc/profile-a-l/email-common.profile
+++ b/etc/profile-a-l/email-common.profile
@@ -69,7 +69,7 @@ tracelog
 # disable-mnt
 private-cache
 private-dev
-private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gcrypt,gnupg,groups,gtk-2.0,gtk-3.0,hostname,hosts,hosts.conf,ld.so.cache,ld.so.preload,localtime,machine-id,mailname,nsswitch.conf,passwd,pki,resolv.conf,selinux,ssl,timezone,xdg
+private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gcrypt,gnupg,group,gtk-2.0,gtk-3.0,hostname,hosts,hosts.conf,ld.so.cache,ld.so.preload,localtime,machine-id,mailname,nsswitch.conf,passwd,pki,resolv.conf,selinux,ssl,timezone,xdg
 private-tmp
 # encrypting and signing email
 writable-run-user

--- a/etc/profile-a-l/enchant.profile
+++ b/etc/profile-a-l/enchant.profile
@@ -47,7 +47,7 @@ x11 none
 private-bin enchant,enchant-*
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 private-lib
 private-tmp
 

--- a/etc/profile-a-l/eo-common.profile
+++ b/etc/profile-a-l/eo-common.profile
@@ -46,7 +46,7 @@ tracelog
 
 private-cache
 private-dev
-private-etc @x11
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.preload
 private-lib eog,eom,gdk-pixbuf-2.*,gio,girepository-1.*,gvfs,libgconf-2.so.*
 private-tmp
 

--- a/etc/profile-a-l/ephemeral.profile
+++ b/etc/profile-a-l/ephemeral.profile
@@ -55,7 +55,7 @@ disable-mnt
 private-cache
 ?BROWSER_DISABLE_U2F: private-dev
 # private-etc below works fine on most distributions. There are some problems on CentOS.
-#private-etc @tls-ca,@x11,mailcap,mime.types,os-release
+#private-etc alternatives,asound.conf,ca-certificates,crypto-policies,dconf,fonts,group,gtk-2.0,gtk-3.0,hostname,hosts,ld.so.cache,localtime,login.defs,machine-id,mailcap,mime.types,nsswitch.conf,os-release,pango,passwd,pki,pulse,resolv.conf,selinux,ssl,X11,xdg
 private-tmp
 
 # breaks preferences

--- a/etc/profile-a-l/equalx.profile
+++ b/etc/profile-a-l/equalx.profile
@@ -53,7 +53,7 @@ disable-mnt
 private-bin equalx,gs,pdflatex,pdftocairo
 private-cache
 private-dev
-private-etc @x11,equalx,equalx.conf,latexmk.conf,papersize,texlive
+private-etc alternatives,equalx,equalx.conf,fonts,gtk-2.0,latexmk.conf,ld.so.cache,ld.so.preload,machine-id,papersize,passwd,texlive,Trolltech.conf
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/evince.profile
+++ b/etc/profile-a-l/evince.profile
@@ -54,7 +54,7 @@ tracelog
 private-bin evince,evince-previewer,evince-thumbnailer,sh
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,group,ld.so.cache,ld.so.preload,machine-id,passwd
 # private-lib might break two-page-view on some systems
 private-lib evince,gcc/*/*/libgcc_s.so.*,gcc/*/*/libstdc++.so.*,gconv,gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libarchive.so.*,libdjvulibre.so.*,libgconf-2.so.*,libgraphite2.so.*,libpoppler-glib.so.*,librsvg-2.so.*,libspectre.so.*
 private-tmp

--- a/etc/profile-a-l/exiftool.profile
+++ b/etc/profile-a-l/exiftool.profile
@@ -47,7 +47,7 @@ x11 none
 #private-bin exiftool,perl
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/falkon.profile
+++ b/etc/profile-a-l/falkon.profile
@@ -47,7 +47,7 @@ disable-mnt
 # private-bin falkon
 private-cache
 private-dev
-private-etc @tls-ca,@x11,adobe,mailcap,mime.types
+private-etc adobe,alternatives,asound.conf,ati,ca-certificates,crypto-policies,dconf,drirc,fonts,group,gtk-2.0,gtk-3.0,hostname,hosts,ld.so.cache,ld.so.preload,localtime,machine-id,mailcap,mime.types,nsswitch.conf,pango,passwd,pki,pulse,resolv.conf,selinux,ssl,xdg
 private-tmp
 
 # dbus-user filter

--- a/etc/profile-a-l/fdns.profile
+++ b/etc/profile-a-l/fdns.profile
@@ -42,7 +42,7 @@ private
 private-bin bash,fdns,sh
 private-cache
 #private-dev
-private-etc @tls-ca,fdns
+private-etc alternatives,ca-certificates,crypto-policies,fdns,ld.so.cache,ld.so.preload,localtime,nsswitch.conf,passwd,pki,ssl
 # private-lib
 private-tmp
 

--- a/etc/profile-a-l/feh-network.inc.profile
+++ b/etc/profile-a-l/feh-network.inc.profile
@@ -5,4 +5,4 @@ include feh-network.inc.local
 ignore net none
 netfilter
 protocol unix,inet,inet6
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,hosts,ld.so.cache,ld.so.preload,pki,resolv.conf,ssl

--- a/etc/profile-a-l/feh.profile
+++ b/etc/profile-a-l/feh.profile
@@ -35,7 +35,7 @@ seccomp
 private-bin feh,jpegexiforient,jpegtran
 private-cache
 private-dev
-private-etc feh
+private-etc alternatives,feh,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/ffmpeg.profile
+++ b/etc/profile-a-l/ffmpeg.profile
@@ -47,7 +47,7 @@ tracelog
 private-bin ffmpeg
 private-cache
 private-dev
-private-etc @tls-ca,pkcs11
+private-etc alternatives,ca-certificates,crypto-policies,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,nsswitch.conf,pkcs11,pki,resolv.conf,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/ffplay.profile
+++ b/etc/profile-a-l/ffplay.profile
@@ -14,7 +14,7 @@ ignore nogroups
 ignore nosound
 
 private-bin ffplay
-private-etc
+private-etc alsa,alternatives,asound.conf,group,ld.so.cache,ld.so.preload
 
 # Redirect
 include ffmpeg.profile

--- a/etc/profile-a-l/file-roller.profile
+++ b/etc/profile-a-l/file-roller.profile
@@ -42,7 +42,7 @@ tracelog
 private-bin 7z,7za,7zr,ar,arj,atool,bash,brotli,bsdtar,bzip2,compress,cp,cpio,dpkg-deb,file-roller,gtar,gzip,isoinfo,lha,lrzip,lsar,lz4,lzip,lzma,lzop,mv,p7zip,rar,rm,rzip,sh,tar,unace,unalz,unar,uncompress,unrar,unsquashfs,unstuff,unzip,unzstd,xz,xzdec,zip,zoo,zstd
 private-cache
 private-dev
-private-etc @x11
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.preload,xdg
 # private-tmp
 
 dbus-system none

--- a/etc/profile-a-l/firefox-common.profile
+++ b/etc/profile-a-l/firefox-common.profile
@@ -57,7 +57,9 @@ seccomp !chroot
 
 disable-mnt
 ?BROWSER_DISABLE_U2F: private-dev
-# private-etc below works fine on most distributions. There could be some problems on CentOS.
+# private-etc below works fine on most distributions. There are some problems on CentOS.
+# Add it to your firefox-common.local if you want to enable it.
+#private-etc alternatives,asound.conf,ca-certificates,crypto-policies,dconf,fonts,group,gtk-2.0,gtk-3.0,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,machine-id,mailcap,mime.types,nsswitch.conf,pango,passwd,pki,pulse,resolv.conf,selinux,ssl,X11,xdg
 private-etc @tls-ca,@x11,mailcap,mime.types,os-release
 private-tmp
 

--- a/etc/profile-a-l/flameshot.profile
+++ b/etc/profile-a-l/flameshot.profile
@@ -51,7 +51,7 @@ tracelog
 disable-mnt
 private-bin flameshot
 private-cache
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.conf,ld.so.preload,machine-id,pki,resolv.conf,ssl
 private-dev
 #private-tmp
 

--- a/etc/profile-a-l/fractal.profile
+++ b/etc/profile-a-l/fractal.profile
@@ -46,7 +46,7 @@ disable-mnt
 private-bin fractal
 private-cache
 private-dev
-private-etc @tls-ca,@x11,host.conf,mime.types
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,mime.types,nsswitch.conf,pki,pulse,resolv.conf,selinux,ssl,X11,xdg
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/freemind.profile
+++ b/etc/profile-a-l/freemind.profile
@@ -43,7 +43,7 @@ disable-mnt
 private-bin bash,cp,dirname,dpkg,echo,freemind,grep,java,lsb_release,mkdir,readlink,rpm,sed,sh,uname,which
 private-cache
 private-dev
-#private-etc alternatives,fonts,java
+#private-etc alternatives,fonts,java*
 private-tmp
 private-opt none
 private-srv none

--- a/etc/profile-a-l/freemind.profile
+++ b/etc/profile-a-l/freemind.profile
@@ -43,7 +43,7 @@ disable-mnt
 private-bin bash,cp,dirname,dpkg,echo,freemind,grep,java,lsb_release,mkdir,readlink,rpm,sed,sh,uname,which
 private-cache
 private-dev
-#private-etc alternatives,fonts,java*
+#private-etc alternatives,fonts,java
 private-tmp
 private-opt none
 private-srv none

--- a/etc/profile-a-l/freetube.profile
+++ b/etc/profile-a-l/freetube.profile
@@ -18,7 +18,7 @@ mkdir ${HOME}/.config/FreeTube
 whitelist ${HOME}/.config/FreeTube
 
 private-bin electron,electron[0-9],electron[0-9][0-9],freetube,sh
-private-etc @tls-ca,@x11,host.conf,mime.types
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,mime.types,nsswitch.conf,pki,pulse,resolv.conf,ssl,X11,xdg
 
 dbus-user filter
 dbus-user.own org.mpris.MediaPlayer2.chromium.*

--- a/etc/profile-a-l/frogatto.profile
+++ b/etc/profile-a-l/frogatto.profile
@@ -44,7 +44,7 @@ disable-mnt
 private-bin frogatto,sh
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload,machine-id
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/gajim.profile
+++ b/etc/profile-a-l/gajim.profile
@@ -58,7 +58,7 @@ disable-mnt
 private-bin bash,gajim,gajim-history-manager,gpg,gpg2,paplay,python*,sh,zsh
 private-cache
 private-dev
-private-etc @tls-ca,@x11
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,group,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.preload,localtime,machine-id,passwd,pki,pulse,resolv.conf,ssl,xdg
 private-tmp
 writable-run-user
 

--- a/etc/profile-a-l/galculator.profile
+++ b/etc/profile-a-l/galculator.profile
@@ -42,7 +42,7 @@ tracelog
 private-bin galculator
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 private-lib
 private-tmp
 

--- a/etc/profile-a-l/gallery-dl.profile
+++ b/etc/profile-a-l/gallery-dl.profile
@@ -12,7 +12,7 @@ noblacklist ${HOME}/.config/gallery-dl
 noblacklist ${HOME}/.gallery-dl.conf
 
 private-bin gallery-dl
-private-etc gallery-dl.conf
+private-etc alternatives,gallery-dl.conf,ld.so.cache,ld.so.preload
 
 # Redirect
 include youtube-dl.profile

--- a/etc/profile-a-l/gapplication.profile
+++ b/etc/profile-a-l/gapplication.profile
@@ -48,7 +48,7 @@ private
 private-bin gapplication
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 private-tmp
 
 # Add the next line to your gapplication.local to filter D-Bus names.

--- a/etc/profile-a-l/gcloud.profile
+++ b/etc/profile-a-l/gcloud.profile
@@ -35,7 +35,7 @@ tracelog
 
 disable-mnt
 private-dev
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,hosts,ld.so.cache,ld.so.preload,localtime,nsswitch.conf,pki,resolv.conf,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/gconf.profile
+++ b/etc/profile-a-l/gconf.profile
@@ -53,7 +53,7 @@ disable-mnt
 private-bin gconf-editor,gconf-merge-*,gconfpkg,gconftool-2,gsettings-*-convert,python2*
 private-cache
 private-dev
-private-etc gconf
+private-etc alternatives,fonts,gconf,ld.so.cache,ld.so.preload
 private-lib GConf,libpython*,python2*
 private-tmp
 

--- a/etc/profile-a-l/geary.profile
+++ b/etc/profile-a-l/geary.profile
@@ -75,7 +75,7 @@ tracelog
 #private-bin geary,sh
 private-cache
 private-dev
-private-etc @tls-ca,@x11,mailcap,mime.types
+private-etc alternatives,ca-certificates,crypto-policies,fonts,group,gtk-3.0,hostname,hosts,ld.so.cache,ld.so.preload,machine-id,mailcap,mime.types,nsswitch.conf,passwd,pki,resolv.conf,ssl,xdg
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/geekbench.profile
+++ b/etc/profile-a-l/geekbench.profile
@@ -47,7 +47,7 @@ disable-mnt
 #private-bin bash,geekbench*,sh -- #4576
 private-cache
 private-dev
-private-etc lsb-release
+private-etc alternatives,group,ld.so.cache,ld.so.preload,lsb-release,passwd
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/gfeeds.profile
+++ b/etc/profile-a-l/gfeeds.profile
@@ -60,7 +60,7 @@ disable-mnt
 private-bin gfeeds,python3*
 # private-cache -- feeds are stored in ~/.cache
 private-dev
-private-etc @tls-ca,@x11,dbus-1,gconf,host.conf,mime.types,rpc,services
+private-etc alternatives,ca-certificates,crypto-policies,dbus-1,dconf,fonts,gconf,group,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,pango,passwd,pki,protocols,resolv.conf,rpc,services,ssl,X11,xdg
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/gget.profile
+++ b/etc/profile-a-l/gget.profile
@@ -48,7 +48,7 @@ disable-mnt
 private-bin gget
 private-cache
 private-dev
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.preload,pki,resolv.conf,ssl
 private-lib
 private-tmp
 

--- a/etc/profile-a-l/ghostwriter.profile
+++ b/etc/profile-a-l/ghostwriter.profile
@@ -51,7 +51,7 @@ private-bin context,gettext,ghostwriter,latex,mktexfmt,pandoc,pdflatex,pdfroff,p
 private-cache
 private-dev
 # passwd,login.defs,firejail are a temporary workaround for #2877 and can be removed once it is fixed
-private-etc @tls-ca,@x11,dbus-1,firejail,gconf,host.conf,mime.types,rpc,services,texlive
+private-etc alternatives,ca-certificates,crypto-policies,dbus-1,dconf,firejail,fonts,gconf,groups,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,login.defs,machine-id,mime.types,nsswitch.conf,pango,passwd,pki,protocols,resolv.conf,rpc,services,ssl,texlive,Trolltech.conf,X11,xdg
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/ghostwriter.profile
+++ b/etc/profile-a-l/ghostwriter.profile
@@ -51,7 +51,7 @@ private-bin context,gettext,ghostwriter,latex,mktexfmt,pandoc,pdflatex,pdfroff,p
 private-cache
 private-dev
 # passwd,login.defs,firejail are a temporary workaround for #2877 and can be removed once it is fixed
-private-etc alternatives,ca-certificates,crypto-policies,dbus-1,dconf,firejail,fonts,gconf,groups,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,login.defs,machine-id,mime.types,nsswitch.conf,pango,passwd,pki,protocols,resolv.conf,rpc,services,ssl,texlive,Trolltech.conf,X11,xdg
+private-etc alternatives,ca-certificates,crypto-policies,dbus-1,dconf,firejail,fonts,gconf,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,login.defs,machine-id,mime.types,nsswitch.conf,pango,passwd,pki,protocols,resolv.conf,rpc,services,ssl,texlive,Trolltech.conf,X11,xdg
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/gimp.profile
+++ b/etc/profile-a-l/gimp.profile
@@ -59,7 +59,7 @@ seccomp !mbind
 tracelog
 
 private-dev
-private-etc @tls-ca,@x11,python*
+private-etc @x11,gcrypt,python*
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/gist.profile
+++ b/etc/profile-a-l/gist.profile
@@ -51,7 +51,7 @@ tracelog
 disable-mnt
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/git-cola.profile
+++ b/etc/profile-a-l/git-cola.profile
@@ -69,7 +69,7 @@ tracelog
 private-bin basename,bash,cola,envsubst,gettext,git,git-cola,git-dag,git-gui,gitk,gpg,gpg-agent,nano,ps,python*,sh,ssh,ssh-agent,tclsh,tr,wc,which,xed
 private-cache
 private-dev
-private-etc @tls-ca,@x11,gitconfig,host.conf,mime.types,ssh
+private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gcrypt,gitconfig,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,login.defs,machine-id,mime.types,nsswitch.conf,passwd,pki,resolv.conf,selinux,ssh,ssl,X11,xdg
 private-tmp
 writable-run-user
 

--- a/etc/profile-a-l/gitter.profile
+++ b/etc/profile-a-l/gitter.profile
@@ -36,7 +36,7 @@ seccomp
 
 disable-mnt
 private-bin bash,env,gitter
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,pki,pulse,resolv.conf,ssl
 private-opt Gitter
 private-dev
 private-tmp

--- a/etc/profile-a-l/gl-117.profile
+++ b/etc/profile-a-l/gl-117.profile
@@ -43,7 +43,7 @@ disable-mnt
 private-bin gl-117
 private-cache
 private-dev
-private-etc @x11,bumblebee,glvnd
+private-etc alsa,alternatives,asound.conf,bumblebee,drirc,glvnd,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,machine-id,nvidia,pulse
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/glaxium.profile
+++ b/etc/profile-a-l/glaxium.profile
@@ -43,7 +43,7 @@ disable-mnt
 private-bin glaxium
 private-cache
 private-dev
-private-etc @x11,bumblebee,glvnd
+private-etc alsa,alternatives,asound.conf,bumblebee,drirc,glvnd,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,machine-id,nvidia,pulse
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/gmpc.profile
+++ b/etc/profile-a-l/gmpc.profile
@@ -43,7 +43,7 @@ tracelog
 disable-mnt
 #private-bin gmpc
 private-cache
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,resolv.conf
 private-tmp
 writable-run-user
 

--- a/etc/profile-a-l/gnome-calendar.profile
+++ b/etc/profile-a-l/gnome-calendar.profile
@@ -44,7 +44,7 @@ private
 private-bin gnome-calendar
 private-cache
 private-dev
-private-etc @tls-ca,@x11
+private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.preload,localtime,nsswitch.conf,pki,resolv.conf,ssl
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/gnome-characters.profile
+++ b/etc/profile-a-l/gnome-characters.profile
@@ -48,7 +48,7 @@ disable-mnt
 private-bin gjs,gnome-characters
 private-cache
 private-dev
-private-etc @x11,gconf,mime.types
+private-etc alternatives,dconf,fonts,gconf,gtk-2.0,gtk-3.0,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,mime.types,pango,X11,xdg
 private-tmp
 
 # Add the next lines to your gnome-characters.local if you don't need access to recently used chars.

--- a/etc/profile-a-l/gnome-chess.profile
+++ b/etc/profile-a-l/gnome-chess.profile
@@ -49,7 +49,7 @@ disable-mnt
 private-bin fairymax,gnome-chess,gnuchess,hoichess
 private-cache
 private-dev
-private-etc @x11,gnome-chess
+private-etc alternatives,dconf,fonts,gnome-chess,gtk-3.0,ld.so.cache,ld.so.preload
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-a-l/gnome-clocks.profile
+++ b/etc/profile-a-l/gnome-clocks.profile
@@ -41,7 +41,7 @@ disable-mnt
 private-bin gnome-clocks,gsound-play
 private-cache
 private-dev
-private-etc @tls-ca,@x11,pkcs11
+private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gtk-3.0,hosts,ld.so.cache,ld.so.preload,localtime,machine-id,pkcs11,pki,resolv.conf,ssl
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-a-l/gnome-hexgl.profile
+++ b/etc/profile-a-l/gnome-hexgl.profile
@@ -41,7 +41,7 @@ private
 private-bin gnome-hexgl
 private-cache
 private-dev
-private-etc
+private-etc alsa,alternatives,asound.conf,ld.so.cache,ld.so.preload,machine-id,pulse
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/gnome-latex.profile
+++ b/etc/profile-a-l/gnome-latex.profile
@@ -47,7 +47,7 @@ tracelog
 private-cache
 private-dev
 # passwd,login.defs,firejail are a temporary workaround for #2877 and can be removed once it is fixed
-private-etc @x11,latexmk.conf,texlive
+private-etc alternatives,dconf,fonts,gtk-3.0,latexmk.conf,ld.so.cache,ld.so.preload,login.defs,passwd,texlive
 
 dbus-system none
 

--- a/etc/profile-a-l/gnome-logs.profile
+++ b/etc/profile-a-l/gnome-logs.profile
@@ -39,7 +39,7 @@ disable-mnt
 private-bin gnome-logs
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,localtime,machine-id
 private-lib gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libgconf-2.so.*,librsvg-2.so.*
 private-tmp
 writable-var-log

--- a/etc/profile-a-l/gnome-maps.profile
+++ b/etc/profile-a-l/gnome-maps.profile
@@ -63,7 +63,7 @@ disable-mnt
 private-bin gjs,gnome-maps
 # private-cache -- gnome-maps cache all maps/satelite-images
 private-dev
-private-etc @tls-ca,@x11,clutter-1.0,gconf,host.conf,mime.types,pkcs11,rpc,services
+private-etc alternatives,ca-certificates,clutter-1.0,crypto-policies,dconf,drirc,fonts,gconf,gcrypt,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,mime.types,nsswitch.conf,pango,pkcs11,pki,protocols,resolv.conf,rpc,services,ssl,X11,xdg
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/gnome-music.profile
+++ b/etc/profile-a-l/gnome-music.profile
@@ -41,7 +41,7 @@ tracelog
 # private-bin calls a file manager - whatever is installed!
 #private-bin env,gio-launch-desktop,gnome-music,python*,yelp
 private-dev
-private-etc @x11
+private-etc alternatives,asound.conf,dconf,fonts,fonts,gtk-3.0,ld.so.cache,ld.so.preload,machine-id,pulse,selinux,xdg
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-a-l/gnome-passwordsafe.profile
+++ b/etc/profile-a-l/gnome-passwordsafe.profile
@@ -52,7 +52,7 @@ disable-mnt
 private-bin gnome-passwordsafe,python3*
 private-cache
 private-dev
-private-etc @x11
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.preload,passwd
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/gnome-pie.profile
+++ b/etc/profile-a-l/gnome-pie.profile
@@ -33,7 +33,7 @@ seccomp
 disable-mnt
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,machine-id
 private-lib gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libgconf-2.so.*,librsvg-2.so.*
 private-tmp
 

--- a/etc/profile-a-l/gnome-pomodoro.profile
+++ b/etc/profile-a-l/gnome-pomodoro.profile
@@ -43,7 +43,7 @@ disable-mnt
 private-bin gnome-pomodoro
 private-cache
 private-dev
-private-etc @x11
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,machine-id
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/gnome-recipes.profile
+++ b/etc/profile-a-l/gnome-recipes.profile
@@ -46,7 +46,7 @@ seccomp
 disable-mnt
 private-bin gnome-recipes,tar
 private-dev
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,pki,ssl
 private-lib gdk-pixbuf-2.0,gio,gvfs/libgvfscommon.so,libgconf-2.so.*,libgnutls.so.*,libjpeg.so.*,libp11-kit.so.*,libproxy.so.*,librsvg-2.so.*
 private-tmp
 

--- a/etc/profile-a-l/gnome-screenshot.profile
+++ b/etc/profile-a-l/gnome-screenshot.profile
@@ -41,7 +41,7 @@ tracelog
 disable-mnt
 private-bin gnome-screenshot
 private-dev
-private-etc @x11
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.preload,localtime,machine-id
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/gnome-sound-recorder.profile
+++ b/etc/profile-a-l/gnome-sound-recorder.profile
@@ -39,7 +39,7 @@ tracelog
 disable-mnt
 private-cache
 private-dev
-private-etc @games,@x11
+private-etc alsa,alternatives,asound.conf,dconf,fonts,gtk-2.0,gtk-3.0,ld.so.cache,ld.so.preload,machine-id,openal,pango,pulse,xdg
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-a-l/gnome-system-log.profile
+++ b/etc/profile-a-l/gnome-system-log.profile
@@ -42,7 +42,7 @@ disable-mnt
 private-bin gnome-system-log
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,localtime,machine-id
 private-lib
 private-tmp
 writable-var-log

--- a/etc/profile-a-l/gnome-todo.profile
+++ b/etc/profile-a-l/gnome-todo.profile
@@ -45,7 +45,7 @@ disable-mnt
 private-bin gnome-todo
 private-cache
 private-dev
-private-etc @x11
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.preload,localtime,passwd,xdg
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/gnome_games-common.profile
+++ b/etc/profile-a-l/gnome_games-common.profile
@@ -40,7 +40,7 @@ tracelog
 disable-mnt
 private-cache
 private-dev
-private-etc @x11,gconf
+private-etc alternatives,dconf,fonts,gconf,gtk-2.0,gtk-3.0,ld.so.cache,ld.so.preload,machine-id,pango,passwd,X11
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/gnote.profile
+++ b/etc/profile-a-l/gnote.profile
@@ -50,7 +50,7 @@ disable-mnt
 private-bin gnote
 private-cache
 private-dev
-private-etc @x11
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.preload,pango,X11
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/gnubik.profile
+++ b/etc/profile-a-l/gnubik.profile
@@ -42,7 +42,7 @@ private
 private-bin gnubik
 private-cache
 private-dev
-private-etc @x11
+private-etc alternatives,drirc,fonts,gtk-2.0,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/godot.profile
+++ b/etc/profile-a-l/godot.profile
@@ -37,7 +37,7 @@ tracelog
 # private-bin godot
 private-cache
 private-dev
-private-etc @games,@tls-ca,@x11,mono
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,drirc,fonts,ld.so.cache,ld.so.preload,machine-id,mono,nsswitch.conf,openal,pki,pulse,resolv.conf,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/goldendict.profile
+++ b/etc/profile-a-l/goldendict.profile
@@ -50,7 +50,7 @@ disable-mnt
 private-bin goldendict
 private-cache
 private-dev
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,machine-id,nsswitch.conf,pki,resolv.conf,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/googler-common.profile
+++ b/etc/profile-a-l/googler-common.profile
@@ -53,7 +53,7 @@ disable-mnt
 private-bin env,python3*,sh,w3m
 private-cache
 private-dev
-private-etc @tls-ca,host.conf,rpc,services
+private-etc alternatives,ca-certificates,crypto-policies,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,nsswitch.conf,pki,protocols,resolv.conf,rpc,services,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/gpicview.profile
+++ b/etc/profile-a-l/gpicview.profile
@@ -40,7 +40,7 @@ tracelog
 private-bin gpicview
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,group,ld.so.cache,ld.so.preload,passwd
 private-lib
 private-tmp
 

--- a/etc/profile-a-l/gpredict.profile
+++ b/etc/profile-a-l/gpredict.profile
@@ -35,7 +35,7 @@ tracelog
 
 private-bin gpredict
 private-dev
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,pki,resolv.conf,ssl
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-a-l/gradio.profile
+++ b/etc/profile-a-l/gradio.profile
@@ -44,7 +44,7 @@ disable-mnt
 private-bin gradio
 private-cache
 private-dev
-private-etc @tls-ca,@x11,host.conf
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,machine-id,pki,pulse,resolv.conf,ssl,xdg
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/gravity-beams-and-evaporating-stars.profile
+++ b/etc/profile-a-l/gravity-beams-and-evaporating-stars.profile
@@ -39,7 +39,7 @@ private
 private-bin gravity-beams-and-evaporating-stars
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,machine-id
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/gtk-update-icon-cache.profile
+++ b/etc/profile-a-l/gtk-update-icon-cache.profile
@@ -45,7 +45,7 @@ disable-mnt
 private-bin gtk-update-icon-cache
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 private-lib
 private-tmp
 

--- a/etc/profile-a-l/gucharmap.profile
+++ b/etc/profile-a-l/gucharmap.profile
@@ -42,7 +42,7 @@ disable-mnt
 private-bin gnome-character-map,gucharmap
 private-cache
 private-dev
-private-etc @x11,dbus-1,gconf,mime.types
+private-etc alternatives,dbus-1,dconf,fonts,gconf,gtk-2.0,gtk-3.0,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,pango,X11,xdg
 private-lib
 private-tmp
 

--- a/etc/profile-a-l/guvcview.profile
+++ b/etc/profile-a-l/guvcview.profile
@@ -47,7 +47,7 @@ disable-mnt
 private-bin guvcview
 private-cache
 private-dev
-private-etc @x11,bumblebee,glvnd
+private-etc alsa,alternatives,asound.conf,bumblebee,dconf,drirc,fonts,glvnd,gtk-3.0,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,machine-id,nvidia,pango,pulse,X11
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/gwenview.profile
+++ b/etc/profile-a-l/gwenview.profile
@@ -46,7 +46,7 @@ seccomp
 
 private-bin gimp*,gwenview,kbuildsycoca4,kdeinit4
 private-dev
-private-etc @x11,gimp
+private-etc alternatives,fonts,gimp,gtk-2.0,kde4rc,kde5rc,ld.so.cache,ld.so.preload,machine-id,passwd,pulse,xdg
 
 # dbus-user none
 # dbus-system none

--- a/etc/profile-a-l/homebank.profile
+++ b/etc/profile-a-l/homebank.profile
@@ -49,7 +49,7 @@ disable-mnt
 private-bin homebank
 private-cache
 private-dev
-private-etc @tls-ca,@x11,mime.types
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,dconf,fonts,gtk-3.0,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,pki,pulse,resolv.conf,selinux,ssl,X11
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/host.profile
+++ b/etc/profile-a-l/host.profile
@@ -42,7 +42,7 @@ tracelog
 disable-mnt
 private
 private-bin bash,host,sh
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload,login.defs,passwd,resolv.conf
 private-dev
 private-tmp
 

--- a/etc/profile-a-l/hyperrogue.profile
+++ b/etc/profile-a-l/hyperrogue.profile
@@ -43,7 +43,7 @@ private-bin hyperrogue
 private-cache
 private-cwd
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,machine-id
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/i2prouter.profile
+++ b/etc/profile-a-l/i2prouter.profile
@@ -67,7 +67,7 @@ seccomp
 disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca,@x11,i2p,java*
+private-etc alternatives,ca-certificates,crypto-policies,dconf,group,hostname,hosts,i2p,java-10-openjdk,java-11-openjdk,java-12-openjdk,java-13-openjdk,java-8-openjdk,java-9-openjdk,java-openjdk,ld.so.cache,ld.so.preload,localtime,machine-id,nsswitch.conf,passwd,pki,resolv.conf,ssl
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-a-l/i2prouter.profile
+++ b/etc/profile-a-l/i2prouter.profile
@@ -67,7 +67,7 @@ seccomp
 disable-mnt
 private-cache
 private-dev
-private-etc alternatives,ca-certificates,crypto-policies,dconf,group,hostname,hosts,i2p,java-10-openjdk,java-11-openjdk,java-12-openjdk,java-13-openjdk,java-8-openjdk,java-9-openjdk,java-openjdk,ld.so.cache,ld.so.preload,localtime,machine-id,nsswitch.conf,passwd,pki,resolv.conf,ssl
+private-etc alternatives,ca-certificates,crypto-policies,dconf,group,hostname,hosts,i2p,java*,ld.so.cache,ld.so.preload,localtime,machine-id,nsswitch.conf,passwd,pki,resolv.conf,ssl
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-a-l/io.github.lainsce.Notejot.profile
+++ b/etc/profile-a-l/io.github.lainsce.Notejot.profile
@@ -50,7 +50,7 @@ disable-mnt
 private-bin io.github.lainsce.Notejot
 private-cache
 private-dev
-private-etc @x11
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,pango,X11
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/ipcalc.profile
+++ b/etc/profile-a-l/ipcalc.profile
@@ -49,7 +49,7 @@ private-bin bash,ipcalc,ipcalc-ng,perl,sh
 # private-cache
 private-dev
 # empty etc directory
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 private-lib
 private-opt none
 private-tmp

--- a/etc/profile-a-l/jerry.profile
+++ b/etc/profile-a-l/jerry.profile
@@ -33,7 +33,7 @@ tracelog
 
 private-bin bash,jerry,sh,stockfish
 private-dev
-private-etc @x11
+private-etc alternatives,fonts,gtk-2.0,gtk-3.0,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/jitsi-meet-desktop.profile
+++ b/etc/profile-a-l/jitsi-meet-desktop.profile
@@ -21,7 +21,7 @@ mkdir ${HOME}/.config/Jitsi Meet
 whitelist ${HOME}/.config/Jitsi Meet
 
 private-bin bash,electron,electron[0-9],electron[0-9][0-9],jitsi-meet-desktop,sh
-private-etc @tls-ca,@x11,bumblebee,glvnd,host.conf,mime.types,rpc,services
+private-etc alsa,alternatives,asound.conf,bumblebee,ca-certificates,crypto-policies,drirc,fonts,glvnd,group,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,nvidia,pango,passwd,pki,protocols,pulse,resolv.conf,rpc,services,ssl,X11,xdg
 
 # Redirect
 include electron.profile

--- a/etc/profile-a-l/jumpnbump.profile
+++ b/etc/profile-a-l/jumpnbump.profile
@@ -40,7 +40,7 @@ disable-mnt
 private-bin jumpnbump
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/kalgebra.profile
+++ b/etc/profile-a-l/kalgebra.profile
@@ -41,7 +41,7 @@ disable-mnt
 private-bin kalgebra,kalgebramobile
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,machine-id
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/kazam.profile
+++ b/etc/profile-a-l/kazam.profile
@@ -48,7 +48,7 @@ disable-mnt
 # private-bin kazam,python*
 private-cache
 private-dev
-private-etc @x11
+private-etc alsa,alternatives,asound.conf,dconf,fonts,gtk-2.0,gtk-3.0,ld.so.cache,ld.so.preload,machine-id,pulse,selinux,X11,xdg
 private-tmp
 
 dbus-system none

--- a/etc/profile-a-l/kcalc.profile
+++ b/etc/profile-a-l/kcalc.profile
@@ -59,7 +59,7 @@ disable-mnt
 private-bin kcalc
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,locale,locale.conf
 # private-lib - problems on Arch
 private-tmp
 

--- a/etc/profile-a-l/keepassx.profile
+++ b/etc/profile-a-l/keepassx.profile
@@ -40,7 +40,7 @@ tracelog
 
 private-bin keepassx,keepassx2
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,machine-id
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/keepassxc.profile
+++ b/etc/profile-a-l/keepassxc.profile
@@ -89,7 +89,7 @@ private-bin keepassxc,keepassxc-cli,keepassxc-proxy
 # hardware keys) on /dev after it has already started; add "ignore private-dev"
 # to keepassxc.local if this is an issue (see #4883).
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,machine-id
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/kid3.profile
+++ b/etc/profile-a-l/kid3.profile
@@ -36,7 +36,7 @@ tracelog
 
 private-cache
 private-dev
-private-etc @tls-ca,@x11
+private-etc alternatives,ca-certificates,crypto-policies,dconf,drirc,fonts,gtk-3.0,hostname,hosts,kde5rc,ld.so.cache,ld.so.preload,machine-id,pki,pulse,resolv.conf,ssl
 private-tmp
 private-opt none
 private-srv none

--- a/etc/profile-a-l/kiwix-desktop.profile
+++ b/etc/profile-a-l/kiwix-desktop.profile
@@ -43,7 +43,7 @@ seccomp !chroot
 disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,hostname,hosts,ld.so.cache,ld.so.preload,machine-id,pki,pulse,resolv.conf,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/klavaro.profile
+++ b/etc/profile-a-l/klavaro.profile
@@ -44,7 +44,7 @@ disable-mnt
 private-bin bash,klavaro,sh,tclsh,tclsh*
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 private-tmp
 private-opt none
 private-srv none

--- a/etc/profile-a-l/ktouch.profile
+++ b/etc/profile-a-l/ktouch.profile
@@ -45,7 +45,7 @@ disable-mnt
 private-bin ktouch
 private-cache
 private-dev
-private-etc @x11
+private-etc alternatives,fonts,kde5rc,ld.so.cache,ld.so.preload,machine-id
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/kube.profile
+++ b/etc/profile-a-l/kube.profile
@@ -67,7 +67,7 @@ tracelog
 private-bin kube,sink_synchronizer
 private-cache
 private-dev
-private-etc @tls-ca,@x11
+private-etc alternatives,ca-certificates,crypto-policies,fonts,gcrypt,gtk-2.0,gtk-3.0,hostname,hosts,ld.so.cache,ld.so.preload,pki,resolv.conf,selinux,ssl,xdg
 private-tmp
 writable-run-user
 

--- a/etc/profile-a-l/kwin_x11.profile
+++ b/etc/profile-a-l/kwin_x11.profile
@@ -42,7 +42,7 @@ tracelog
 disable-mnt
 private-bin kwin_x11
 private-dev
-private-etc @x11
+private-etc alternatives,drirc,fonts,kde5rc,ld.so.cache,ld.so.preload,machine-id,xdg
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-a-l/kwrite.profile
+++ b/etc/profile-a-l/kwrite.profile
@@ -46,7 +46,7 @@ tracelog
 
 private-bin kbuildsycoca4,kdeinit4,kwrite
 private-dev
-private-etc @x11
+private-etc alternatives,fonts,kde4rc,kde5rc,ld.so.cache,ld.so.preload,machine-id,pulse,xdg
 private-tmp
 
 # dbus-user none

--- a/etc/profile-a-l/lifeograph.profile
+++ b/etc/profile-a-l/lifeograph.profile
@@ -48,7 +48,7 @@ disable-mnt
 private-bin lifeograph
 private-cache
 private-dev
-private-etc @x11
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,pango,X11
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/links-common.profile
+++ b/etc/profile-a-l/links-common.profile
@@ -50,7 +50,7 @@ disable-mnt
 private-bin sh
 private-cache
 private-dev
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.preload,nsswitch.conf,pki,resolv.conf,ssl
 # Add the next line to your links-common.local to allow external media players.
 # private-etc alsa,asound.conf,machine-id,openal,pulse
 private-tmp

--- a/etc/profile-a-l/linuxqq.profile
+++ b/etc/profile-a-l/linuxqq.profile
@@ -23,7 +23,7 @@ noprinters
 
 # If you don't need/want to save anything to disk you can add `private` to your linuxqq.local.
 #private
-private-etc @tls-ca,@x11,host.conf,os-release
+private-etc alsa,alternatives,ca-certificates,crypto-policies,fonts,group,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,login.defs,machine-id,nsswitch.conf,os-release,passwd,pki,pulse,resolv.conf,ssl,xdg
 private-opt QQ
 
 dbus-user filter

--- a/etc/profile-a-l/lollypop.profile
+++ b/etc/profile-a-l/lollypop.profile
@@ -36,7 +36,7 @@ protocol unix,inet,inet6
 seccomp
 
 private-dev
-private-etc @tls-ca,@x11,host.conf
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,machine-id,pki,pulse,resolv.conf,ssl,xdg
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-a-l/lyx.profile
+++ b/etc/profile-a-l/lyx.profile
@@ -32,7 +32,7 @@ apparmor
 machine-id
 
 # private-bin atril,dvilualatex,env,latex,lua*,luatex,lyx,lyxclient,okular,pdf2latex,pdflatex,pdftex,perl*,python*,qpdf,qpdfview,sh,tex2lyx,texmf,xelatex
-private-etc @x11,lyx,mime.types,texmf
+private-etc alternatives,dconf,fonts,gtk-2.0,gtk-3.0,ld.so.cache,ld.so.preload,locale,locale.alias,locale.conf,lyx,machine-id,mime.types,passwd,texmf,X11,xdg
 
 # Redirect
 include latex-common.profile

--- a/etc/profile-m-z/PCSX2.profile
+++ b/etc/profile-m-z/PCSX2.profile
@@ -47,7 +47,7 @@ private-bin PCSX2
 private-cache
 # Add the next line to your PCSX2.local if you do not need controller support.
 #private-dev
-private-etc @tls-ca,@x11,bumblebee,gconf,glvnd,host.conf,mime.types,rpc,services
+private-etc alsa,alternatives,asound.conf,bumblebee,ca-certificates,crypto-policies,dconf,drirc,fonts,gconf,glvnd,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,nvidia,pango,pki,protocols,pulse,resolv.conf,rpc,services,ssl,X11,xdg
 private-opt none
 private-tmp
 

--- a/etc/profile-m-z/QMediathekView.profile
+++ b/etc/profile-m-z/QMediathekView.profile
@@ -71,7 +71,7 @@ disable-mnt
 private-bin mplayer,mpv,QMediathekView,smplayer,totem,vlc,xplayer
 private-cache
 private-dev
-private-etc @tls-ca
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,group,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,login.defs,nsswitch.conf,passwd,pki,pulse,resolv.conf,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/QOwnNotes.profile
+++ b/etc/profile-m-z/QOwnNotes.profile
@@ -49,7 +49,7 @@ tracelog
 disable-mnt
 private-bin gio,QOwnNotes
 private-dev
-private-etc @tls-ca,host.conf
+private-etc alternatives,ca-certificates,crypto-policies,fonts,host.conf,hosts,ld.so.cache,ld.so.preload,machine-id,nsswitch.conf,pki,pulse,resolv.conf,ssl
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/Viber.profile
+++ b/etc/profile-m-z/Viber.profile
@@ -32,7 +32,7 @@ seccomp !chroot
 
 disable-mnt
 private-bin awk,bash,dig,sh,Viber
-private-etc @tls-ca,@x11,mailcap,proxychains.conf
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,hosts,ld.so.cache,ld.so.preload,localtime,machine-id,mailcap,nsswitch.conf,pki,proxychains.conf,pulse,resolv.conf,ssl,X11
 private-tmp
 
 # restrict-namespaces

--- a/etc/profile-m-z/Xvfb.profile
+++ b/etc/profile-m-z/Xvfb.profile
@@ -42,7 +42,7 @@ private
 # private-bin sh,xkbcomp,Xvfb
 # private-bin bash,cat,ls,sh,strace,xkbcomp,Xvfb
 private-dev
-private-etc gai.conf,host.conf
+private-etc alternatives,gai.conf,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.preload,nsswitch.conf,resolv.conf
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/magicor.profile
+++ b/etc/profile-m-z/magicor.profile
@@ -44,7 +44,7 @@ disable-mnt
 private-bin magicor,python2*
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload,machine-id
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/man.profile
+++ b/etc/profile-m-z/man.profile
@@ -56,7 +56,7 @@ disable-mnt
 #private-bin apropos,bash,cat,catman,col,gpreconv,groff,grotty,gunzip,gzip,less,man,most,nroff,preconv,sed,sh,tbl,tr,troff,whatis,which,xtotroff,zcat,zsoelim
 private-cache
 private-dev
-private-etc @x11,groff,man_db.conf,manpath.config,sysless
+private-etc alternatives,fonts,groff,group,ld.so.cache,ld.so.preload,locale,locale.alias,locale.conf,login.defs,man_db.conf,manpath.config,passwd,selinux,sysless,xdg
 #private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/marker.profile
+++ b/etc/profile-m-z/marker.profile
@@ -53,7 +53,7 @@ tracelog
 private-bin marker,python3*
 private-cache
 private-dev
-private-etc @x11
+private-etc alternatives,dconfgtk-3.0,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,pango,X11
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/marker.profile
+++ b/etc/profile-m-z/marker.profile
@@ -53,7 +53,7 @@ tracelog
 private-bin marker,python3*
 private-cache
 private-dev
-private-etc alternatives,dconfgtk-3.0,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,pango,X11
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,pango,X11
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/masterpdfeditor.profile
+++ b/etc/profile-m-z/masterpdfeditor.profile
@@ -35,7 +35,7 @@ tracelog
 
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/mate-calc.profile
+++ b/etc/profile-m-z/mate-calc.profile
@@ -41,7 +41,7 @@ seccomp
 
 disable-mnt
 private-bin mate-calc,mate-calculator
-private-etc @x11
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.preload
 private-dev
 private-opt none
 private-tmp

--- a/etc/profile-m-z/mate-color-select.profile
+++ b/etc/profile-m-z/mate-color-select.profile
@@ -32,7 +32,7 @@ seccomp
 
 disable-mnt
 private-bin mate-color-select
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 private-dev
 private-lib
 private-tmp

--- a/etc/profile-m-z/mate-dictionary.profile
+++ b/etc/profile-m-z/mate-dictionary.profile
@@ -36,7 +36,7 @@ seccomp
 
 disable-mnt
 private-bin mate-dictionary
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,pki,resolv.conf,ssl
 private-opt mate-dictionary
 private-dev
 private-tmp

--- a/etc/profile-m-z/mattermost-desktop.profile
+++ b/etc/profile-m-z/mattermost-desktop.profile
@@ -17,7 +17,7 @@ include disable-shell.inc
 mkdir ${HOME}/.config/Mattermost
 whitelist ${HOME}/.config/Mattermost
 
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,machine-id,nsswitch.conf,pki,resolv.conf,ssl
 
 # Not tested
 #dbus-user filter

--- a/etc/profile-m-z/mcabber.profile
+++ b/etc/profile-m-z/mcabber.profile
@@ -30,6 +30,6 @@ seccomp
 
 private-bin mcabber
 private-dev
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.preload,pki,ssl
 
 restrict-namespaces

--- a/etc/profile-m-z/mcomix.profile
+++ b/etc/profile-m-z/mcomix.profile
@@ -57,7 +57,7 @@ private-bin 7z,lha,mcomix,mutool,python*,rar,sh,unrar,unzip
 private-cache
 private-dev
 # mcomix <= 1.2 uses gtk-2.0
-private-etc @x11,gconf,mime.types
+private-etc alternatives,dconf,fonts,gconf,gtk-2.0,gtk-3.0,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,pango,passwd,X11,xdg
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/mdr.profile
+++ b/etc/profile-m-z/mdr.profile
@@ -44,7 +44,7 @@ disable-mnt
 private-bin mdr
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 private-lib
 private-tmp
 

--- a/etc/profile-m-z/mediainfo.profile
+++ b/etc/profile-m-z/mediainfo.profile
@@ -42,7 +42,7 @@ x11 none
 private-bin mediainfo
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/menulibre.profile
+++ b/etc/profile-m-z/menulibre.profile
@@ -51,7 +51,7 @@ tracelog
 disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca,@x11,mime.types
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.preload,locale.alias,locale.conf,mime.types,nsswitch.conf,passwd,pki,selinux,X11,xdg
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/mindless.profile
+++ b/etc/profile-m-z/mindless.profile
@@ -41,7 +41,7 @@ private
 private-bin mindless
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/minecraft-launcher.profile
+++ b/etc/profile-m-z/minecraft-launcher.profile
@@ -50,7 +50,7 @@ private-cache
 private-dev
 # If multiplayer or realms break, add 'private-etc <your-own-java-folder-from-/etc>'
 # or 'ignore private-etc' to your minecraft-launcher.local.
-private-etc alternatives,asound.conf,ati,ca-certificates,crypto-policies,drirc,fonts,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,java-10-openjdk,java-11-openjdk,java-12-openjdk,java-13-openjdk,java-14-openjdk,java-7-openjdk,java-8-openjdk,java-9-openjdk,java-openjdk,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,login.defs,machine-id,mime.types,nvidia,passwd,pki,pulse,resolv.conf,selinux,services,ssl,timezone,X11,xdg
+private-etc alternatives,asound.conf,ati,ca-certificates,crypto-policies,drirc,fonts,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,java*,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,login.defs,machine-id,mime.types,nvidia,passwd,pki,pulse,resolv.conf,selinux,services,ssl,timezone,X11,xdg
 private-opt minecraft-launcher
 private-tmp
 

--- a/etc/profile-m-z/minecraft-launcher.profile
+++ b/etc/profile-m-z/minecraft-launcher.profile
@@ -50,7 +50,7 @@ private-cache
 private-dev
 # If multiplayer or realms break, add 'private-etc <your-own-java-folder-from-/etc>'
 # or 'ignore private-etc' to your minecraft-launcher.local.
-private-etc @tls-ca,@x11,host.conf,java*,mime.types,services,timezone
+private-etc alternatives,asound.conf,ati,ca-certificates,crypto-policies,drirc,fonts,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,java-10-openjdk,java-11-openjdk,java-12-openjdk,java-13-openjdk,java-14-openjdk,java-7-openjdk,java-8-openjdk,java-9-openjdk,java-openjdk,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,login.defs,machine-id,mime.types,nvidia,passwd,pki,pulse,resolv.conf,selinux,services,ssl,timezone,X11,xdg
 private-opt minecraft-launcher
 private-tmp
 

--- a/etc/profile-m-z/minitube.profile
+++ b/etc/profile-m-z/minitube.profile
@@ -53,7 +53,7 @@ disable-mnt
 private-bin minitube
 private-cache
 private-dev
-private-etc @tls-ca,@x11,host.conf,mime.types
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,drirc,fonts,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,mime.types,nsswitch.conf,pki,pulse,resolv.conf,selinux,ssl,X11,xdg
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/mirage.profile
+++ b/etc/profile-m-z/mirage.profile
@@ -53,7 +53,7 @@ disable-mnt
 private-bin ldconfig,mirage
 private-cache
 private-dev
-private-etc @tls-ca,@x11,host.conf,mime.types
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,mime.types,nsswitch.conf,pki,pulse,resolv.conf,selinux,ssl,X11,xdg
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/mirrormagic.profile
+++ b/etc/profile-m-z/mirrormagic.profile
@@ -43,7 +43,7 @@ private
 private-bin mirrormagic
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload,machine-id
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/mocp.profile
+++ b/etc/profile-m-z/mocp.profile
@@ -41,7 +41,7 @@ tracelog
 private-bin mocp
 private-cache
 private-dev
-private-etc @tls-ca
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,group,ld.so.cache,ld.so.preload,machine-id,pki,pulse,resolv.conf,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/mp3splt-gtk.profile
+++ b/etc/profile-m-z/mp3splt-gtk.profile
@@ -36,7 +36,7 @@ tracelog
 private-bin mp3splt-gtk
 private-cache
 private-dev
-private-etc @games,@x11
+private-etc alsa,alternatives,asound.conf,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.preload,machine-id,openal,pulse
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/mp3splt.profile
+++ b/etc/profile-m-z/mp3splt.profile
@@ -43,7 +43,7 @@ disable-mnt
 private-bin flacsplt,mp3splt,mp3wrap,oggsplt
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/mpDris2.profile
+++ b/etc/profile-m-z/mpDris2.profile
@@ -48,7 +48,7 @@ seccomp
 private-bin mpDris2,notify-send,python*
 private-cache
 private-dev
-private-etc
+private-etc alternatives,hosts,ld.so.cache,ld.so.preload,nsswitch.conf,resolv.conf
 private-lib libdbus-1.so.*,libdbus-glib-1.so.*,libgirepository-1.0.so.*,libnotify.so.*,libpython*,python2*,python3*
 private-tmp
 

--- a/etc/profile-m-z/mrrescue.profile
+++ b/etc/profile-m-z/mrrescue.profile
@@ -51,7 +51,7 @@ disable-mnt
 private-bin love,mrrescue,sh
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload,machine-id
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/ms-office.profile
+++ b/etc/profile-m-z/ms-office.profile
@@ -34,7 +34,7 @@ tracelog
 
 disable-mnt
 private-bin bash,env,fonts,jak,ms-office,python*,sh
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.preload,pki,resolv.conf,ssl
 private-dev
 private-tmp
 

--- a/etc/profile-m-z/mupdf-x11-curl.profile
+++ b/etc/profile-m-z/mupdf-x11-curl.profile
@@ -12,7 +12,7 @@ ignore net none
 netfilter
 protocol unix,inet,inet6
 
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,hosts,ld.so.cache,ld.so.preload,nsswitch.conf,pki,resolv.conf,ssl
 
 # Redirect
 include mupdf.profile

--- a/etc/profile-m-z/mupdf.profile
+++ b/etc/profile-m-z/mupdf.profile
@@ -36,7 +36,7 @@ seccomp
 tracelog
 
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/musictube.profile
+++ b/etc/profile-m-z/musictube.profile
@@ -49,7 +49,7 @@ disable-mnt
 private-bin musictube
 private-cache
 private-dev
-private-etc @tls-ca,@x11,host.conf,mime.types
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,drirc,fonts,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,machine-id,mime.types,nsswitch.conf,pki,pulse,resolv.conf,selinux,ssl,X11,xdg
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/musixmatch.profile
+++ b/etc/profile-m-z/musixmatch.profile
@@ -33,6 +33,6 @@ seccomp !chroot
 
 disable-mnt
 private-dev
-private-etc @tls-ca
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,ld.so.cache,ld.so.preload,machine-id,pki,pulse,ssl
 
 # restrict-namespaces

--- a/etc/profile-m-z/mutt.profile
+++ b/etc/profile-m-z/mutt.profile
@@ -124,7 +124,7 @@ tracelog
 # disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gai.conf,gnupg,gnutls,hosts.conf,mail,mailname,nntpserver,terminfo
+private-etc alternatives,ca-certificates,crypto-policies,fonts,gai.conf,gcrypt,gnupg,gnutls,hostname,hosts,hosts.conf,ld.so.cache,ld.so.preload,mail,mailname,Mutt,Muttrc,Muttrc.d,nntpserver,nsswitch.conf,passwd,pki,resolv.conf,ssl,terminfo,xdg
 private-tmp
 writable-run-user
 writable-var

--- a/etc/profile-m-z/mypaint.profile
+++ b/etc/profile-m-z/mypaint.profile
@@ -42,7 +42,7 @@ tracelog
 
 private-cache
 private-dev
-private-etc @x11
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/nano.profile
+++ b/etc/profile-m-z/nano.profile
@@ -48,7 +48,7 @@ private-dev
 # Add the next lines to your nano.local if you want to edit files in /etc directly.
 #ignore private-etc
 #writable-etc
-private-etc nanorc
+private-etc alternatives,ld.so.cache,ld.so.preload,nanorc
 # Add the next line to your nano.local if you want to edit files in /var directly.
 #writable-var
 

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -53,7 +53,7 @@ tracelog
 disable-mnt
 private-bin neochat
 private-dev
-private-etc @tls-ca,@x11,dbus-1,host.conf,mime.types,rpc,services
+private-etc alternatives,ca-certificates,crypto-policies,dbus-1,fonts,host.conf,hostname,hosts,kde4rc,kde5rc,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,pango,pki,protocols,resolv.conf,rpc,services,ssl,Trolltech.conf,X11,xdg
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/neomutt.profile
+++ b/etc/profile-m-z/neomutt.profile
@@ -116,7 +116,7 @@ tracelog
 # disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gnupg,hosts.conf,mail,mailname,neomuttrc,neomuttrc.d,nntpserver
+private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gcrypt,gnupg,hostname,hosts,hosts.conf,ld.so.cache,ld.so.preload,mail,mailname,Mutt,Muttrc,Muttrc.d,neomuttrc,neomuttrc.d,nntpserver,nsswitch.conf,passwd,pki,resolv.conf,ssl,xdg
 private-tmp
 writable-run-user
 writable-var

--- a/etc/profile-m-z/netactview.profile
+++ b/etc/profile-m-z/netactview.profile
@@ -44,7 +44,7 @@ disable-mnt
 private-bin netactview,netactview_polkit
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,resolv.conf
 private-lib
 private-tmp
 

--- a/etc/profile-m-z/neverball.profile
+++ b/etc/profile-m-z/neverball.profile
@@ -43,7 +43,7 @@ disable-mnt
 private-bin neverball
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,machine-id
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/newsboat.profile
+++ b/etc/profile-m-z/newsboat.profile
@@ -52,7 +52,7 @@ disable-mnt
 private-bin gzip,lynx,newsboat,sh,w3m
 private-cache
 private-dev
-private-etc @tls-ca,lynx.cfg,lynx.lss,terminfo
+private-etc alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.preload,lynx.cfg,lynx.lss,pki,resolv.conf,ssl,terminfo
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/newsflash.profile
+++ b/etc/profile-m-z/newsflash.profile
@@ -50,7 +50,7 @@ disable-mnt
 private-bin com.gitlab.newsflash,newsflash
 private-cache
 private-dev
-private-etc @tls-ca,@x11
+private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gtk-3.0,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,nsswitch.conf,pango,pki,resolv.conf,ssl,X11
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/nextcloud.profile
+++ b/etc/profile-m-z/nextcloud.profile
@@ -61,7 +61,7 @@ tracelog
 disable-mnt
 private-bin nextcloud,nextcloud-desktop
 private-cache
-private-etc @tls-ca,@x11,Nextcloud,host.conf,os-release
+private-etc alternatives,ca-certificates,crypto-policies,drirc,fonts,gcrypt,host.conf,hosts,ld.so.cache,ld.so.preload,machine-id,Nextcloud,nsswitch.conf,os-release,passwd,pki,pulse,resolv.conf,selinux,ssl,xdg
 private-dev
 private-tmp
 

--- a/etc/profile-m-z/nheko.profile
+++ b/etc/profile-m-z/nheko.profile
@@ -47,7 +47,7 @@ disable-mnt
 private-bin nheko
 private-cache
 private-dev
-private-etc @tls-ca,@x11,host.conf,mime.types
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,mime.types,nsswitch.conf,pki,pulse,resolv.conf,selinux,ssl,X11,xdg
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/nitroshare.profile
+++ b/etc/profile-m-z/nitroshare.profile
@@ -41,7 +41,7 @@ disable-mnt
 private-bin awk,grep,nitroshare,nitroshare-cli,nitroshare-nmh,nitroshare-send,nitroshare-ui
 private-cache
 private-dev
-private-etc @tls-ca,@x11
+private-etc alternatives,ca-certificates,dconf,fonts,hostname,hosts,ld.so.cache,ld.so.preload,machine-id,nsswitch.conf,ssl
 # private-lib libnitroshare.so.*,libqhttpengine.so.*,libqmdnsengine.so.*,nitroshare
 private-tmp
 

--- a/etc/profile-m-z/nodejs-common.profile
+++ b/etc/profile-m-z/nodejs-common.profile
@@ -92,7 +92,7 @@ seccomp.block-secondary
 
 disable-mnt
 private-dev
-private-etc @tls-ca,@x11,host.conf,mime.types,rpc,services
+private-etc alternatives,ca-certificates,crypto-policies,group,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,login.defs,mime.types,nsswitch.conf,passwd,pki,protocols,resolv.conf,rpc,services,ssl,xdg
 #private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/nomacs.profile
+++ b/etc/profile-m-z/nomacs.profile
@@ -40,7 +40,7 @@ tracelog
 #private-bin nomacs
 private-cache
 private-dev
-private-etc @tls-ca,@x11
+private-etc alternatives,ca-certificates,crypto-policies,dconf,drirc,fonts,gtk-3.0,hosts,ld.so.cache,ld.so.preload,login.defs,machine-id,pki,resolv.conf,ssl
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/notify-send.profile
+++ b/etc/profile-m-z/notify-send.profile
@@ -48,7 +48,7 @@ private
 private-bin notify-send
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/nslookup.profile
+++ b/etc/profile-m-z/nslookup.profile
@@ -45,7 +45,7 @@ tracelog
 
 disable-mnt
 private-bin bash,nslookup,sh
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload,login.defs,passwd,resolv.conf
 private-dev
 private-tmp
 

--- a/etc/profile-m-z/nuclear.profile
+++ b/etc/profile-m-z/nuclear.profile
@@ -18,7 +18,7 @@ whitelist ${HOME}/.config/nuclear
 no3d
 
 # private-bin nuclear
-private-etc @tls-ca,@x11,host.conf,mime.types
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,mime.types,nsswitch.conf,pki,pulse,resolv.conf,selinux,ssl,X11,xdg
 private-opt nuclear
 
 # Redirect

--- a/etc/profile-m-z/nyx.profile
+++ b/etc/profile-m-z/nyx.profile
@@ -44,7 +44,7 @@ disable-mnt
 private-bin nyx,python*
 private-cache
 private-dev
-private-etc tor
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,passwd,tor
 private-opt none
 private-srv none
 private-tmp

--- a/etc/profile-m-z/ocenaudio.profile
+++ b/etc/profile-m-z/ocenaudio.profile
@@ -53,7 +53,7 @@ tracelog
 private-bin ocenaudio,ocenvst
 private-cache
 private-dev
-private-etc @tls-ca,@x11,mime.types
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,dconf,fonts,group,gtk-2.0,gtk-3.0,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,mime.types,nsswitch.conf,pki,pulse,resolv.conf,ssl,X11,xdg
 private-opt ocenaudio
 private-tmp
 

--- a/etc/profile-m-z/odt2txt.profile
+++ b/etc/profile-m-z/odt2txt.profile
@@ -37,7 +37,7 @@ x11 none
 private-bin odt2txt
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/okular.profile
+++ b/etc/profile-m-z/okular.profile
@@ -61,7 +61,7 @@ tracelog
 
 private-bin kbuildsycoca4,kdeinit4,lpr,okular,unar,unrar
 private-dev
-private-etc @x11,cups
+private-etc alternatives,cups,fonts,kde4rc,kde5rc,ld.so.cache,ld.so.preload,machine-id,passwd,xdg
 # private-tmp - on KDE we need access to the real /tmp for data exchange with email clients
 
 # dbus-user none

--- a/etc/profile-m-z/onboard.profile
+++ b/etc/profile-m-z/onboard.profile
@@ -49,7 +49,7 @@ disable-mnt
 private-cache
 private-bin onboard,python*,tput
 private-dev
-private-etc @x11,dbus-1,mime.types
+private-etc alternatives,dbus-1,dconf,fonts,gtk-2.0,gtk-3.0,ld.so.cache,ld.so.preload,locale,locale.alias,locale.conf,mime.types,selinux,X11,xdg
 private-tmp
 
 dbus-system none

--- a/etc/profile-m-z/openarena.profile
+++ b/etc/profile-m-z/openarena.profile
@@ -42,7 +42,7 @@ disable-mnt
 private-bin bash,cut,glxinfo,grep,head,openarena,openarena_ded,quake3,zenity
 private-cache
 private-dev
-private-etc @games,@x11,udev
+private-etc alternatives,drirc,ld.so.cache,ld.so.preload,machine-id,openal,passwd,selinux,udev,xdg
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/openmw.profile
+++ b/etc/profile-m-z/openmw.profile
@@ -52,7 +52,7 @@ tracelog
 private-bin bsatool,esmtool,niftest,openmw,openmw-cs,openmw-essimporter,openmw-iniimporter,openmw-launcher,openmw-wizard
 private-cache
 private-dev
-private-etc @x11,bumblebee,glvnd,mime.types,openmw
+private-etc alsa,alternatives,asound.conf,bumblebee,drirc,fonts,glvnd,group,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nvidia,openmw,pango,passwd,pulse,Trolltech.conf,X11,xdg
 private-opt none
 private-tmp
 

--- a/etc/profile-m-z/otter-browser.profile
+++ b/etc/profile-m-z/otter-browser.profile
@@ -52,7 +52,7 @@ disable-mnt
 private-bin bash,otter-browser,sh,which
 private-cache
 ?BROWSER_DISABLE_U2F: private-dev
-private-etc @tls-ca,@x11,mailcap,mime.types
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,dconf,fonts,group,gtk-2.0,gtk-3.0,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,machine-id,mailcap,mime.types,nsswitch.conf,pango,passwd,pki,pulse,resolv.conf,selinux,ssl,X11,xdg
 private-tmp
 
 dbus-system none

--- a/etc/profile-m-z/pandoc.profile
+++ b/etc/profile-m-z/pandoc.profile
@@ -49,7 +49,7 @@ x11 none
 disable-mnt
 private-cache
 private-dev
-private-etc texlive,texmf
+private-etc alternatives,ld.so.cache,ld.so.preload,texlive,texmf
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/parole.profile
+++ b/etc/profile-m-z/parole.profile
@@ -26,6 +26,6 @@ seccomp
 
 private-bin dbus-launch,parole
 private-cache
-private-etc @tls-ca
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,group,ld.so.cache,ld.so.preload,machine-id,passwd,pki,pulse,ssl
 
 restrict-namespaces

--- a/etc/profile-m-z/pavucontrol.profile
+++ b/etc/profile-m-z/pavucontrol.profile
@@ -44,7 +44,7 @@ disable-mnt
 private-bin pavucontrol
 private-cache
 private-dev
-private-etc avahi
+private-etc alternatives,asound.conf,avahi,fonts,ld.so.cache,ld.so.preload,machine-id,pulse,resolv.conf
 private-lib
 private-tmp
 

--- a/etc/profile-m-z/pcsxr.profile
+++ b/etc/profile-m-z/pcsxr.profile
@@ -47,7 +47,7 @@ private-bin pcsxr
 private-cache
 # Add the next line to your pcsxr.local if you do not need controller support.
 #private-dev
-private-etc @tls-ca,@x11,bumblebee,gconf,glvnd,host.conf,mime.types,rpc,services
+private-etc alsa,alternatives,asound.conf,bumblebee,ca-certificates,crypto-policies,dconf,drirc,fonts,gconf,glvnd,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,nvidia,pango,pki,protocols,pulse,resolv.conf,rpc,services,ssl,X11,xdg
 private-opt none
 private-tmp
 

--- a/etc/profile-m-z/pdfchain.profile
+++ b/etc/profile-m-z/pdfchain.profile
@@ -33,7 +33,7 @@ seccomp
 
 private-bin pdfchain,pdftk,sh
 private-dev
-private-etc @x11
+private-etc alternatives,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.preload,xdg
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/pdftotext.profile
+++ b/etc/profile-m-z/pdftotext.profile
@@ -48,7 +48,7 @@ x11 none
 private-bin pdftotext
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/peek.profile
+++ b/etc/profile-m-z/peek.profile
@@ -47,7 +47,7 @@ tracelog
 disable-mnt
 private-bin bash,convert,ffmpeg,firejail,fish,peek,sh,which,zsh
 private-dev
-private-etc @x11,firejail
+private-etc alternatives,dconf,firejail,fonts,gtk-3.0,ld.so.cache,ld.so.preload,login.defs,pango,passwd,X11
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/photoflare.profile
+++ b/etc/profile-m-z/photoflare.profile
@@ -42,7 +42,7 @@ disable-mnt
 private-bin photoflare
 private-cache
 private-dev
-private-etc @x11,mime.types
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,locale,locale.alias,locale.conf,mime.types,X11
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/pinball.profile
+++ b/etc/profile-m-z/pinball.profile
@@ -47,7 +47,7 @@ disable-mnt
 private-bin pinball
 private-cache
 private-dev
-private-etc
+private-etc alsa,alternatives,asound.conf,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,machine-id,pulse
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/ping.profile
+++ b/etc/profile-m-z/ping.profile
@@ -56,7 +56,7 @@ private
 #private-bin ping - has mammoth problems with execvp: "No such file or directory"
 private-cache
 private-dev
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,hosts,ld.so.cache,ld.so.preload,login.defs,passwd,pki,resolv.conf,ssl
 private-lib
 private-tmp
 

--- a/etc/profile-m-z/pingus.profile
+++ b/etc/profile-m-z/pingus.profile
@@ -50,7 +50,7 @@ disable-mnt
 private-bin pingus,pingus.bin,sh
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload,machine-id
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/pkglog.profile
+++ b/etc/profile-m-z/pkglog.profile
@@ -43,7 +43,7 @@ private
 private-bin pkglog,python*
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 private-opt none
 private-tmp
 writable-var-log

--- a/etc/profile-m-z/plv.profile
+++ b/etc/profile-m-z/plv.profile
@@ -45,7 +45,7 @@ disable-mnt
 private-bin plv
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 private-opt none
 private-tmp
 writable-var-log

--- a/etc/profile-m-z/pngquant.profile
+++ b/etc/profile-m-z/pngquant.profile
@@ -46,7 +46,7 @@ x11 none
 private-bin pngquant
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/ppsspp.profile
+++ b/etc/profile-m-z/ppsspp.profile
@@ -42,7 +42,7 @@ seccomp
 private-bin ppsspp,PPSSPP,PPSSPPQt,PPSSPPSDL
 # Add the next line to your ppsspp.local if you do not need controller support.
 #private-dev
-private-etc @tls-ca,@x11,host.conf
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,drirc,fonts,group,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,machine-id,nsswitch.conf,passwd,pki,pulse,resolv.conf,ssl
 private-opt ppsspp
 private-tmp
 

--- a/etc/profile-m-z/pragha.profile
+++ b/etc/profile-m-z/pragha.profile
@@ -32,7 +32,7 @@ protocol unix,inet,inet6
 seccomp
 
 private-dev
-private-etc @tls-ca,@x11,host.conf
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,machine-id,pki,pulse,resolv.conf,ssl,xdg
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/profanity.profile
+++ b/etc/profile-m-z/profanity.profile
@@ -43,7 +43,7 @@ seccomp
 private-bin profanity
 private-cache
 private-dev
-private-etc @tls-ca,mime.types
+private-etc alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.preload,localtime,mime.types,nsswitch.conf,pki,resolv.conf,ssl
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/psi.profile
+++ b/etc/profile-m-z/psi.profile
@@ -70,7 +70,7 @@ disable-mnt
 private-bin getopt,psi
 private-cache
 private-dev
-private-etc @tls-ca,@x11
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,drirc,fonts,gcrypt,group,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.preload,machine-id,passwd,pki,pulse,resolv.conf,selinux,ssl,xdg
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/pybitmessage.profile
+++ b/etc/profile-m-z/pybitmessage.profile
@@ -40,7 +40,7 @@ seccomp
 disable-mnt
 private-bin bash,env,ldconfig,pybitmessage,python*,sh,stat
 private-dev
-private-etc @tls-ca,@x11,PyBitmessage,PyBitmessage.conf,sni-qt.conf,system-fips
+private-etc alternatives,ca-certificates,crypto-policies,fonts,gtk-2.0,hosts,ld.so.cache,ld.so.preload,localtime,pki,pki,PyBitmessage,PyBitmessage.conf,resolv.conf,selinux,sni-qt.conf,ssl,system-fips,Trolltech.conf,xdg
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/qcomicbook.profile
+++ b/etc/profile-m-z/qcomicbook.profile
@@ -52,7 +52,7 @@ tracelog
 private-bin 7z,7zr,qcomicbook,rar,sh,tar,unace,unrar,unzip
 private-cache
 private-dev
-private-etc @x11,mime.types
+private-etc alternatives,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,pango,passwd,Trolltech.conf,X11,xdg
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/qgis.profile
+++ b/etc/profile-m-z/qgis.profile
@@ -51,7 +51,7 @@ tracelog
 disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca,@x11,QGIS,QGIS.conf
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,machine-id,pki,QGIS,QGIS.conf,resolv.conf,ssl,Trolltech.conf
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/qnapi.profile
+++ b/etc/profile-m-z/qnapi.profile
@@ -46,7 +46,7 @@ tracelog
 private-bin 7z,qnapi
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,resolv.conf
 private-opt none
 private-tmp
 

--- a/etc/profile-m-z/qrencode.profile
+++ b/etc/profile-m-z/qrencode.profile
@@ -46,7 +46,7 @@ disable-mnt
 private-bin qrencode
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 private-lib libpcre*
 private-tmp
 

--- a/etc/profile-m-z/qtox.profile
+++ b/etc/profile-m-z/qtox.profile
@@ -42,7 +42,7 @@ disable-mnt
 private-bin qtox
 private-cache
 private-dev
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,localtime,machine-id,pki,pulse,resolv.conf,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/quaternion.profile
+++ b/etc/profile-m-z/quaternion.profile
@@ -46,7 +46,7 @@ disable-mnt
 private-bin quaternion
 private-cache
 private-dev
-private-etc @tls-ca,@x11,host.conf,mime.types
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,mime.types,nsswitch.conf,pki,pulse,resolv.conf,selinux,ssl,X11,xdg
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/quodlibet.profile
+++ b/etc/profile-m-z/quodlibet.profile
@@ -59,7 +59,7 @@ tracelog
 private-bin exfalso,operon,python*,quodlibet,sh
 private-cache
 private-dev
-private-etc @tls-ca,@x11
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,passwd,pki,pulse,resolv.conf,ssl
 private-tmp
 
 dbus-system none

--- a/etc/profile-m-z/qutebrowser.profile
+++ b/etc/profile-m-z/qutebrowser.profile
@@ -56,7 +56,7 @@ seccomp !chroot,!name_to_handle_at
 disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,localtime,machine-id,passwd,pki,pulse,resolv.conf,ssl
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/raincat.profile
+++ b/etc/profile-m-z/raincat.profile
@@ -39,7 +39,7 @@ private
 private-bin raincat
 private-cache
 private-dev
-private-etc @games,@x11
+private-etc alternatives,drirc,ld.so.cache,ld.so.preload,machine-id,passwd,pulse,timidity,timidity.cfg
 #private-lib
 private-tmp
 

--- a/etc/profile-m-z/rednotebook.profile
+++ b/etc/profile-m-z/rednotebook.profile
@@ -58,7 +58,7 @@ disable-mnt
 private-bin python3*,rednotebook
 private-cache
 private-dev
-private-etc @x11
+private-etc alternatives,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,pango,X11
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/regextester.profile
+++ b/etc/profile-m-z/regextester.profile
@@ -42,7 +42,7 @@ disable-mnt
 private-bin regextester
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 private-lib libgranite.so.*
 private-tmp
 

--- a/etc/profile-m-z/rsync-download_only.profile
+++ b/etc/profile-m-z/rsync-download_only.profile
@@ -48,7 +48,7 @@ disable-mnt
 private-bin rsync
 private-cache
 private-dev
-private-etc @tls-ca,host.conf,rpc,services
+private-etc alternatives,ca-certificates,crypto-policies,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,nsswitch.conf,pki,protocols,resolv.conf,rpc,services,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/rtv.profile
+++ b/etc/profile-m-z/rtv.profile
@@ -58,7 +58,7 @@ disable-mnt
 private-bin less,python*,rtv,sh,xdg-settings
 private-cache
 private-dev
-private-etc @tls-ca,@x11,host.conf,mailcap,mime.types,rpc,services,terminfo
+private-etc alternatives,ca-certificates,crypto-policies,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,mailcap,mime.types,nsswitch.conf,pki,protocols,resolv.conf,rpc,services,ssl,terminfo,xdg
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/scorchwentbonkers.profile
+++ b/etc/profile-m-z/scorchwentbonkers.profile
@@ -42,7 +42,7 @@ disable-mnt
 private-bin scorchwentbonkers
 private-cache
 private-dev
-private-etc
+private-etc alsa,alternatives,asound.conf,ld.so.cache,ld.so.preload,machine-id,pulse
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/seafile-applet.profile
+++ b/etc/profile-m-z/seafile-applet.profile
@@ -53,7 +53,7 @@ disable-mnt
 private-bin seaf-cli,seaf-daemon,seafile-applet
 private-cache
 private-dev
-private-etc @tls-ca,host.conf,rpc,services
+private-etc alternatives,ca-certificates,crypto-policies,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,nsswitch.conf,pki,protocols,resolv.conf,rpc,services,ssl
 #private-opt none
 private-tmp
 

--- a/etc/profile-m-z/seahorse-adventures.profile
+++ b/etc/profile-m-z/seahorse-adventures.profile
@@ -47,7 +47,7 @@ private
 private-bin bash,dash,python*,seahorse-adventures,sh
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload,machine-id
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/seahorse.profile
+++ b/etc/profile-m-z/seahorse.profile
@@ -57,7 +57,7 @@ tracelog
 disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca,@x11,gconf,host.conf,pkcs11,rpc,services,ssh
+private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gconf,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,login.defs,nsswitch.conf,pango,passwd,pkcs11,pki,protocols,resolv.conf,rpc,services,ssh,ssl,xdg
 private-tmp
 writable-run-user
 

--- a/etc/profile-m-z/shortwave.profile
+++ b/etc/profile-m-z/shortwave.profile
@@ -45,7 +45,7 @@ disable-mnt
 private-bin shortwave
 private-cache
 private-dev
-private-etc @tls-ca,@x11,gconf,host.conf,mime.types
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,dconf,fonts,gconf,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,pango,passwd,pki,pulse,resolv.conf,ssl,X11,xdg
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/shotwell.profile
+++ b/etc/profile-m-z/shotwell.profile
@@ -48,7 +48,7 @@ tracelog
 private-bin shotwell
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,machine-id
 private-opt none
 private-tmp
 

--- a/etc/profile-m-z/signal-cli.profile
+++ b/etc/profile-m-z/signal-cli.profile
@@ -46,7 +46,7 @@ private-bin java,sh,signal-cli
 private-cache
 private-dev
 # Does not work with all Java configurations. You will notice immediately, so you might want to give it a try
-#private-etc alternatives,ca-certificates,crypto-policies,dbus-1,host.conf,hostname,hosts,java-10-openjdk,java-7-openjdk,java-8-openjdk,java-9-openjdk,java.conf,machine-id,nsswitch.conf,passwd,pki,protocols,resolv.conf,rpc,services,ssl
+#private-etc alternatives,ca-certificates,crypto-policies,dbus-1,host.conf,hostname,hosts,java*,machine-id,nsswitch.conf,passwd,pki,protocols,resolv.conf,rpc,services,ssl
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/signal-cli.profile
+++ b/etc/profile-m-z/signal-cli.profile
@@ -46,7 +46,7 @@ private-bin java,sh,signal-cli
 private-cache
 private-dev
 # Does not work with all Java configurations. You will notice immediately, so you might want to give it a try
-#private-etc alternatives,ca-certificates,crypto-policies,dbus-1,host.conf,hostname,hosts,java*,machine-id,nsswitch.conf,passwd,pki,protocols,resolv.conf,rpc,services,ssl
+#private-etc alternatives,ca-certificates,crypto-policies,dbus-1,host.conf,hostname,hosts,java-10-openjdk,java-7-openjdk,java-8-openjdk,java-9-openjdk,java.conf,machine-id,nsswitch.conf,passwd,pki,protocols,resolv.conf,rpc,services,ssl
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/signal-desktop.profile
+++ b/etc/profile-m-z/signal-desktop.profile
@@ -19,7 +19,7 @@ read-only ${HOME}/.mozilla/firefox/profiles.ini
 mkdir ${HOME}/.config/Signal
 whitelist ${HOME}/.config/Signal
 
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,machine-id,nsswitch.conf,pki,resolv.conf,ssl
 
 dbus-user filter
 

--- a/etc/profile-m-z/slack.profile
+++ b/etc/profile-m-z/slack.profile
@@ -26,7 +26,7 @@ mkdir ${HOME}/.config/Slack
 whitelist ${HOME}/.config/Slack
 
 private-bin electron,electron[0-9],electron[0-9][0-9],locale,sh,slack
-private-etc @tls-ca,debian_version,fedora-release,os-release,redhat-release,system-release,system-release-cpe
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,debian_version,fedora-release,fonts,group,ld.so.cache,ld.so.conf,ld.so.preload,localtime,machine-id,os-release,passwd,pki,pulse,redhat-release,resolv.conf,ssl,system-release,system-release-cpe
 
 # Redirect
 include electron.profile

--- a/etc/profile-m-z/smuxi-frontend-gnome.profile
+++ b/etc/profile-m-z/smuxi-frontend-gnome.profile
@@ -47,7 +47,7 @@ disable-mnt
 private-bin bash,mono,mono-sgen,sh,smuxi-frontend-gnome
 private-cache
 private-dev
-private-etc @tls-ca,@x11,mono
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.preload,machine-id,mono,passwd,pki,pulse,resolv.conf,selinux,ssl,xdg
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/softmaker-common.profile
+++ b/etc/profile-m-z/softmaker-common.profile
@@ -42,7 +42,7 @@ tracelog
 private-bin freeoffice-planmaker,freeoffice-presentations,freeoffice-textmaker,planmaker18,planmaker18free,presentations18,presentations18free,sh,textmaker18,textmaker18free
 private-cache
 private-dev
-private-etc @tls-ca,SoftMaker
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,machine-id,nsswitch.conf,pki,SoftMaker,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/spectacle.profile
+++ b/etc/profile-m-z/spectacle.profile
@@ -55,7 +55,7 @@ disable-mnt
 private-bin spectacle
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/spectral.profile
+++ b/etc/profile-m-z/spectral.profile
@@ -45,7 +45,7 @@ disable-mnt
 private-cache
 private-bin spectral
 private-dev
-private-etc @tls-ca,@x11,host.conf,mime.types
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,mime.types,nsswitch.conf,pki,pulse,resolv.conf,selinux,ssl,X11,xdg
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/spotify.profile
+++ b/etc/profile-m-z/spotify.profile
@@ -45,7 +45,7 @@ disable-mnt
 private-bin bash,cat,dirname,find,grep,head,rm,sh,spotify,tclsh,touch,zenity
 private-dev
 # If you want to see album covers or want to use the radio, add 'ignore private-etc' to your spotify.local.
-private-etc @tls-ca,host.conf,spotify-adblock
+private-etc alternatives,ca-certificates,crypto-policies,fonts,group,host.conf,hosts,ld.so.cache,ld.so.preload,machine-id,nsswitch.conf,pki,pulse,resolv.conf,spotify-adblock,ssl
 private-opt spotify
 private-srv none
 private-tmp

--- a/etc/profile-m-z/sqlitebrowser.profile
+++ b/etc/profile-m-z/sqlitebrowser.profile
@@ -41,7 +41,7 @@ seccomp.block-secondary
 private-bin sqlitebrowser
 private-cache
 private-dev
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,group,ld.so.cache,ld.so.preload,machine-id,passwd,pki,resolv.conf,ssl
 private-tmp
 
 # breaks proxy creation

--- a/etc/profile-m-z/standardnotes-desktop.profile
+++ b/etc/profile-m-z/standardnotes-desktop.profile
@@ -38,7 +38,7 @@ seccomp !chroot
 disable-mnt
 private-dev
 private-tmp
-private-etc @tls-ca,@x11,host.conf
+private-etc alternatives,ca-certificates,crypto-policies,fonts,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,pki,resolv.conf,ssl,xdg
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -175,7 +175,7 @@ seccomp.32 !process_vm_readv
 private-dev
 # private-etc breaks a small selection of games on some systems. Add 'ignore private-etc'
 # to your steam.local to support those.
-private-etc @games,@tls-ca,@x11,bumblebee,dbus-1,host.conf,lsb-release,mime.types,os-release,services
+private-etc alsa,alternatives,asound.conf,bumblebee,ca-certificates,crypto-policies,dbus-1,drirc,fonts,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,lsb-release,machine-id,mime.types,nvidia,os-release,passwd,pki,pulse,resolv.conf,services,ssl,vulkan
 private-tmp
 
 #dbus-user none

--- a/etc/profile-m-z/strawberry.profile
+++ b/etc/profile-m-z/strawberry.profile
@@ -42,7 +42,7 @@ disable-mnt
 private-bin strawberry,strawberry-tagreader
 private-cache
 private-dev
-private-etc @tls-ca,host.conf
+private-etc alternatives,ca-certificates,crypto-policies,fonts,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,nsswitch.conf,pki,resolv.conf,ssl
 private-tmp
 
 dbus-system none

--- a/etc/profile-m-z/subdownloader.profile
+++ b/etc/profile-m-z/subdownloader.profile
@@ -43,7 +43,7 @@ tracelog
 
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/supertux2.profile
+++ b/etc/profile-m-z/supertux2.profile
@@ -43,7 +43,7 @@ tracelog
 disable-mnt
 # private-bin supertux2
 private-cache
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload,machine-id
 private-dev
 private-tmp
 

--- a/etc/profile-m-z/supertuxkart.profile
+++ b/etc/profile-m-z/supertuxkart.profile
@@ -53,7 +53,7 @@ private-bin supertuxkart
 private-cache
 # Add the next line to your supertuxkart.local if you do not need controller support.
 #private-dev
-private-etc @games,@tls-ca,@x11
+private-etc alternatives,ca-certificates,crypto-policies,drirc,hosts,ld.so.cache,ld.so.preload,machine-id,openal,pki,resolv.conf,ssl
 private-tmp
 private-opt none
 private-srv none

--- a/etc/profile-m-z/surf.profile
+++ b/etc/profile-m-z/surf.profile
@@ -33,7 +33,7 @@ tracelog
 disable-mnt
 private-bin bash,curl,dmenu,ls,printf,sed,sh,sleep,st,stterm,surf,xargs,xprop
 private-dev
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,group,hosts,ld.so.cache,ld.so.preload,machine-id,passwd,pki,resolv.conf,ssl
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/sysprof.profile
+++ b/etc/profile-m-z/sysprof.profile
@@ -62,7 +62,7 @@ disable-mnt
 #private-bin sysprof - breaks help menu
 private-cache
 private-dev
-private-etc @tls-ca
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,machine-id,ssl
 # private-lib - breaks help menu
 #private-lib gdk-pixbuf-2.*,gio,gtk3,gvfs/libgvfscommon.so,libgconf-2.so.*,librsvg-2.so.*,libsysprof-2.so,libsysprof-ui-2.so
 private-tmp

--- a/etc/profile-m-z/tar.profile
+++ b/etc/profile-m-z/tar.profile
@@ -17,7 +17,7 @@ ignore include disable-shell.inc
 # all capabilities this is automatically read-only.
 noblacklist /var/lib/pacman
 
-private-etc
+private-etc alternatives,group,ld.so.cache,ld.so.preload,localtime,login.defs,passwd
 #private-lib libfakeroot,liblzma.so.*,libreadline.so.*
 # Debian based distributions need this for 'dpkg --unpack' (incl. synaptic)
 writable-var

--- a/etc/profile-m-z/teams-for-linux.profile
+++ b/etc/profile-m-z/teams-for-linux.profile
@@ -22,7 +22,7 @@ mkdir ${HOME}/.config/teams-for-linux
 whitelist ${HOME}/.config/teams-for-linux
 
 private-bin bash,cut,echo,egrep,electron,electron[0-9],electron[0-9][0-9],grep,head,sed,sh,teams-for-linux,tr,xdg-mime,xdg-open,zsh
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,localtime,machine-id,pki,resolv.conf,ssl
 
 # Redirect
 include electron.profile

--- a/etc/profile-m-z/telegram.profile
+++ b/etc/profile-m-z/telegram.profile
@@ -46,7 +46,7 @@ disable-mnt
 private-bin bash,sh,telegram,Telegram,telegram-desktop,xdg-open
 private-cache
 private-dev
-private-etc @tls-ca,@x11,os-release
+private-etc alsa,alternatives,ca-certificates,crypto-policies,fonts,group,ld.so.cache,ld.so.preload,localtime,machine-id,os-release,passwd,pki,pulse,resolv.conf,ssl,xdg
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/terasology.profile
+++ b/etc/profile-m-z/terasology.profile
@@ -40,7 +40,7 @@ seccomp
 
 disable-mnt
 private-dev
-private-etc @tls-ca,@x11,dbus-1,host.conf,java*,lsb-release,mime.types
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,dbus-1,drirc,fonts,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,java-7-openjdk,java-8-openjdk,ld.so.cache,ld.so.preload,localtime,lsb-release,machine-id,mime.types,passwd,pki,pulse,resolv.conf,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/terasology.profile
+++ b/etc/profile-m-z/terasology.profile
@@ -40,7 +40,7 @@ seccomp
 
 disable-mnt
 private-dev
-private-etc alternatives,asound.conf,ca-certificates,crypto-policies,dbus-1,drirc,fonts,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,java-7-openjdk,java-8-openjdk,ld.so.cache,ld.so.preload,localtime,lsb-release,machine-id,mime.types,passwd,pki,pulse,resolv.conf,ssl
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,dbus-1,drirc,fonts,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,java*,ld.so.cache,ld.so.preload,localtime,lsb-release,machine-id,mime.types,passwd,pki,pulse,resolv.conf,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/tesseract.profile
+++ b/etc/profile-m-z/tesseract.profile
@@ -54,7 +54,7 @@ x11 none
 private-bin ambiguous_words,classifier_tester,cntraining,combine_lang_model,combine_tessdata,dawg2wordlist,lstmeval,lstmtraining,merge_unicharsets,mftraining,set_unicharset_properties,shapeclustering,tesseract,text2image,unicharset_extractor,wordlist2dawg
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload
 #private-lib libtesseract.so.*
 private-tmp
 

--- a/etc/profile-m-z/tilp.profile
+++ b/etc/profile-m-z/tilp.profile
@@ -29,7 +29,7 @@ tracelog
 disable-mnt
 private-bin tilp
 private-cache
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/tin.profile
+++ b/etc/profile-m-z/tin.profile
@@ -57,7 +57,7 @@ disable-mnt
 private-bin rtin,tin
 private-cache
 private-dev
-private-etc terminfo,tin
+private-etc alternatives,ld.so.cache,ld.so.preload,passwd,resolv.conf,terminfo,tin
 private-lib terminfo
 private-tmp
 

--- a/etc/profile-m-z/tor.profile
+++ b/etc/profile-m-z/tor.profile
@@ -45,7 +45,7 @@ private
 private-bin bash,tor
 private-cache
 private-dev
-private-etc @tls-ca,tor
+private-etc alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.preload,passwd,pki,ssl,tor
 private-tmp
 writable-var
 

--- a/etc/profile-m-z/torbrowser-launcher.profile
+++ b/etc/profile-m-z/torbrowser-launcher.profile
@@ -58,7 +58,7 @@ seccomp !chroot
 disable-mnt
 private-bin bash,cat,cp,cut,dirname,env,expr,file,gpg,grep,gxmessage,id,kdialog,ln,mkdir,mv,python*,rm,sed,sh,tail,tar,tclsh,test,tor-browser,tor-browser-en,torbrowser-launcher,update-desktop-database,xmessage,xz,zenity
 private-dev
-private-etc @tls-ca
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,machine-id,pki,pulse,resolv.conf,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/transgui.profile
+++ b/etc/profile-m-z/transgui.profile
@@ -44,7 +44,7 @@ tracelog
 private-bin geoiplookup,geoiplookup6,transgui
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,resolv.conf
 private-lib libgdk_pixbuf-2.0.so.*,libGeoIP.so*,libgthread-2.0.so.*,libgtk-x11-2.0.so.*,libX11.so.*
 private-tmp
 

--- a/etc/profile-m-z/transmission-cli.profile
+++ b/etc/profile-m-z/transmission-cli.profile
@@ -8,7 +8,7 @@ include transmission-cli.local
 include globals.local
 
 private-bin transmission-cli
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.preload,nsswitch.conf,pki,resolv.conf,ssl
 
 # Redirect
 include transmission-common.profile

--- a/etc/profile-m-z/transmission-daemon.profile
+++ b/etc/profile-m-z/transmission-daemon.profile
@@ -17,7 +17,7 @@ caps.keep ipc_lock,net_bind_service,setgid,setuid,sys_chroot
 protocol packet
 
 private-bin transmission-daemon
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.preload,nsswitch.conf,pki,resolv.conf,ssl
 
 read-write /var/lib/transmission
 writable-var-log

--- a/etc/profile-m-z/transmission-remote-gtk.profile
+++ b/etc/profile-m-z/transmission-remote-gtk.profile
@@ -12,7 +12,7 @@ noblacklist ${HOME}/.config/transmission-remote-gtk
 mkdir ${HOME}/.config/transmission-remote-gtk
 whitelist ${HOME}/.config/transmission-remote-gtk
 
-private-etc
+private-etc alternatives,fonts,hostname,hosts,ld.so.cache,ld.so.preload,resolv.conf
 
 ignore memory-deny-write-execute
 

--- a/etc/profile-m-z/transmission-remote.profile
+++ b/etc/profile-m-z/transmission-remote.profile
@@ -8,7 +8,7 @@ include transmission-remote.local
 include globals.local
 
 private-bin transmission-remote
-private-etc
+private-etc alternatives,hosts,ld.so.cache,ld.so.preload,nsswitch.conf
 
 # Redirect
 include transmission-common.profile

--- a/etc/profile-m-z/transmission-show.profile
+++ b/etc/profile-m-z/transmission-show.profile
@@ -8,7 +8,7 @@ include transmission-show.local
 include globals.local
 
 private-bin transmission-show
-private-etc
+private-etc alternatives,hosts,ld.so.cache,ld.so.preload,nsswitch.conf
 
 # Redirect
 include transmission-common.profile

--- a/etc/profile-m-z/trojita.profile
+++ b/etc/profile-m-z/trojita.profile
@@ -53,7 +53,7 @@ tracelog
 private-bin trojita
 private-cache
 private-dev
-private-etc @tls-ca,@x11
+private-etc alternatives,ca-certificates,crypto-policies,fonts,hostname,hosts,ld.so.cache,ld.so.preload,pki,resolv.conf,selinux,ssl,xdg
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/tutanota-desktop.profile
+++ b/etc/profile-m-z/tutanota-desktop.profile
@@ -24,7 +24,7 @@ whitelist ${HOME}/.mozilla/firefox/profiles.ini
 read-only ${HOME}/.mozilla/firefox/profiles.ini
 
 ?HAS_APPIMAGE: ignore private-dev
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,machine-id,nsswitch.conf,pki,resolv.conf,ssl
 private-opt tutanota-desktop
 
 # Redirect

--- a/etc/profile-m-z/twitch.profile
+++ b/etc/profile-m-z/twitch.profile
@@ -18,7 +18,7 @@ mkdir ${HOME}/.config/Twitch
 whitelist ${HOME}/.config/Twitch
 
 private-bin electron,electron[0-9],electron[0-9][0-9],twitch
-private-etc @tls-ca,@x11,bumblebee,host.conf,mime.types
+private-etc alsa,alternatives,asound.conf,ati,bumblebee,ca-certificates,crypto-policies,drirc,fonts,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,mime.types,nsswitch.conf,nvidia,pki,pulse,resolv.conf,selinux,ssl,X11,xdg
 private-opt Twitch
 
 # Redirect

--- a/etc/profile-m-z/udiskie.profile
+++ b/etc/profile-m-z/udiskie.profile
@@ -40,7 +40,7 @@ private-bin awk,cut,dbus-send,egrep,file,grep,head,python*,readlink,sed,sh,udisk
 # private-bin thunar
 private-cache
 private-dev
-private-etc @x11,mime.types
+private-etc alternatives,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,mime.types,xdg
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/unf.profile
+++ b/etc/profile-m-z/unf.profile
@@ -48,7 +48,7 @@ private-bin unf
 private-cache
 ?HAS_APPIMAGE: ignore private-dev
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 private-lib gcc/*/*/libgcc_s.so.*
 private-tmp
 

--- a/etc/profile-m-z/unrar.profile
+++ b/etc/profile-m-z/unrar.profile
@@ -8,7 +8,7 @@ include unrar.local
 include globals.local
 
 private-bin unrar
-private-etc
+private-etc alternatives,group,ld.so.cache,ld.so.preload,localtime,passwd
 private-tmp
 
 # Redirect

--- a/etc/profile-m-z/unzip.profile
+++ b/etc/profile-m-z/unzip.profile
@@ -10,7 +10,7 @@ include globals.local
 # GNOME Shell integration (chrome-gnome-shell)
 noblacklist ${HOME}/.local/share/gnome-shell
 
-private-etc
+private-etc alternatives,group,ld.so.cache,ld.so.preload,localtime,passwd
 
 # Redirect
 include archiver-common.profile

--- a/etc/profile-m-z/utox.profile
+++ b/etc/profile-m-z/utox.profile
@@ -42,7 +42,7 @@ disable-mnt
 private-bin utox
 private-cache
 private-dev
-private-etc @games,@tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,localtime,machine-id,openal,pki,pulse,resolv.conf,ssl
 private-tmp
 
 memory-deny-write-execute

--- a/etc/profile-m-z/uudeview.profile
+++ b/etc/profile-m-z/uudeview.profile
@@ -40,7 +40,7 @@ x11 none
 private-bin uudeview
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/viewnior.profile
+++ b/etc/profile-m-z/viewnior.profile
@@ -43,7 +43,7 @@ tracelog
 private-bin viewnior
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload,machine-id
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/virtualbox.profile
+++ b/etc/profile-m-z/virtualbox.profile
@@ -44,7 +44,7 @@ tracelog
 #disable-mnt
 #private-bin awk,basename,bash,env,gawk,grep,ps,readlink,sh,virtualbox,VirtualBox,VBox*,vbox*,whoami
 private-cache
-private-etc @tls-ca,@x11,conf.d
+private-etc alsa,alternatives,asound.conf,ca-certificates,conf.d,crypto-policies,dconf,fonts,hostname,hosts,ld.so.cache,ld.so.preload,localtime,machine-id,pki,pulse,resolv.conf,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/vmware-view.profile
+++ b/etc/profile-m-z/vmware-view.profile
@@ -48,7 +48,7 @@ tracelog
 disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca,@x11,bumblebee,gai.conf,gconf,glvnd,host.conf,magic,magic.mgc,mime.types,proxychains.conf,rpc,services,terminfo,vmware,vmware-tools,vmware-vix
+private-etc alsa,alternatives,asound.conf,bumblebee,ca-certificates,crypto-policies,dconf,drirc,fonts,gai.conf,gconf,glvnd,group,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,login.defs,machine-id,magic,magic.mgc,mime.types,nsswitch.conf,nvidia,pango,passwd,pki,protocols,proxychains.conf,pulse,resolv.conf,rpc,services,ssl,terminfo,vmware,vmware-tools,vmware-vix,X11,xdg
 # Logs are kept in /tmp. Add 'ignore private-tmp' to your vmware-view.local if you need them without joining the sandbox.
 private-tmp
 

--- a/etc/profile-m-z/vmware.profile
+++ b/etc/profile-m-z/vmware.profile
@@ -38,6 +38,6 @@ tracelog
 #disable-mnt
 # Add the next line to your vmware.local to enable private-bin.
 #private-bin env,bash,sh,ovftool,vmafossexec,vmaf_*,vmnet-*,vmplayer,vmrest,vmrun,vmss2core,vmstat,vmware,vmware-*
-private-etc @tls-ca,@x11,conf.d,mtab,vmware,vmware-installer,vmware-vix
+private-etc alsa,alternatives,asound.conf,ca-certificates,conf.d,crypto-policies,dconf,fonts,gtk-2.0,gtk-3.0,hostname,hosts,ld.so.cache,ld.so.preload,localtime,machine-id,mtab,passwd,pki,pulse,resolv.conf,ssl,vmware,vmware-installer,vmware-vix
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/w3m.profile
+++ b/etc/profile-m-z/w3m.profile
@@ -61,7 +61,7 @@ disable-mnt
 private-bin perl,sh,w3m
 private-cache
 private-dev
-private-etc @tls-ca,mailcap
+private-etc alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.preload,mailcap,nsswitch.conf,pki,resolv.conf,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/warmux.profile
+++ b/etc/profile-m-z/warmux.profile
@@ -48,7 +48,7 @@ disable-mnt
 private-bin warmux
 private-cache
 private-dev
-private-etc @tls-ca,host.conf,rpc,services
+private-etc alternatives,ca-certificates,crypto-policies,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,machine-id,nsswitch.conf,pki,protocols,resolv.conf,rpc,services,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/whalebird.profile
+++ b/etc/profile-m-z/whalebird.profile
@@ -22,7 +22,7 @@ whitelist ${HOME}/.config/Whalebird
 no3d
 
 private-bin electron,electron[0-9],electron[0-9][0-9],whalebird
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,machine-id,nsswitch.conf,pki,resolv.conf,ssl
 
 # Redirect
 include electron.profile

--- a/etc/profile-m-z/whois.profile
+++ b/etc/profile-m-z/whois.profile
@@ -46,7 +46,7 @@ private
 private-bin bash,sh,whois
 private-cache
 private-dev
-private-etc jwhois.conf,services,whois.conf
+private-etc alternatives,hosts,jwhois.conf,ld.so.cache,ld.so.preload,resolv.conf,services,whois.conf
 private-lib gconv
 private-tmp
 

--- a/etc/profile-m-z/wire-desktop.profile
+++ b/etc/profile-m-z/wire-desktop.profile
@@ -26,7 +26,7 @@ mkdir ${HOME}/.config/Wire
 whitelist ${HOME}/.config/Wire
 
 private-bin bash,electron,electron[0-9],electron[0-9][0-9],env,sh,wire-desktop
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,machine-id,pki,resolv.conf,ssl
 
 # Redirect
 include electron.profile

--- a/etc/profile-m-z/wordwarvi.profile
+++ b/etc/profile-m-z/wordwarvi.profile
@@ -44,7 +44,7 @@ private
 private-bin wordwarvi
 private-cache
 private-dev
-private-etc
+private-etc alsa,alternatives,asound.conf,ld.so.cache,ld.so.preload,machine-id,pulse
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/xbill.profile
+++ b/etc/profile-m-z/xbill.profile
@@ -43,7 +43,7 @@ private
 private-bin xbill
 private-cache
 private-dev
-private-etc
+private-etc alternatives,ld.so.cache,ld.so.preload
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/xfce4-mixer.profile
+++ b/etc/profile-m-z/xfce4-mixer.profile
@@ -45,7 +45,7 @@ disable-mnt
 private-bin xfce4-mixer,xfconf-query
 private-cache
 private-dev
-private-etc
+private-etc alternatives,asound.conf,fonts,ld.so.cache,ld.so.preload,machine-id,pulse
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/xfce4-screenshooter.profile
+++ b/etc/profile-m-z/xfce4-screenshooter.profile
@@ -41,7 +41,7 @@ tracelog
 disable-mnt
 private-bin xfce4-screenshooter,xfconf-query
 private-dev
-private-etc @tls-ca,@x11
+private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gtk-3.0,ld.so.cache,ld.so.preload,pki,resolv.conf,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/xiphos.profile
+++ b/etc/profile-m-z/xiphos.profile
@@ -46,7 +46,7 @@ disable-mnt
 private-bin xiphos
 private-cache
 private-dev
-private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,pki,resolv.conf,ssli,sword,sword.conf
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,pki,resolv.conf,ssl,sword,sword.conf
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/xiphos.profile
+++ b/etc/profile-m-z/xiphos.profile
@@ -46,7 +46,7 @@ disable-mnt
 private-bin xiphos
 private-cache
 private-dev
-private-etc @tls-ca,sword,sword.conf
+private-etc alternatives,ca-certificates,crypto-policies,fonts,ld.so.cache,ld.so.preload,pki,resolv.conf,ssli,sword,sword.conf
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/xlinks.profile
+++ b/etc/profile-m-z/xlinks.profile
@@ -14,7 +14,7 @@ include whitelist-common.inc
 # if you want to use user-configured programs add 'private-bin PROGRAM1,PROGRAM2'
 # to your xlinks.local or append 'PROGRAM1,PROGRAM2' to this private-bin line
 private-bin xlinks
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 
 # Redirect
 include links.profile

--- a/etc/profile-m-z/xlinks2.profile
+++ b/etc/profile-m-z/xlinks2.profile
@@ -14,7 +14,7 @@ include whitelist-common.inc
 # if you want to use user-configured programs add 'private-bin PROGRAM1,PROGRAM2'
 # to your xlinks.local or append 'PROGRAM1,PROGRAM2' to this private-bin line
 private-bin xlinks2
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 
 # Redirect
 include links2.profile

--- a/etc/profile-m-z/xmr-stak.profile
+++ b/etc/profile-m-z/xmr-stak.profile
@@ -37,7 +37,7 @@ disable-mnt
 private ${HOME}/.xmr-stak
 private-bin xmr-stak
 private-dev
-private-etc @tls-ca
+private-etc alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.preload,nsswitch.conf,pki,resolv.conf,ssl
 #private-lib libxmrstak_opencl_backend,libxmrstak_cuda_backend
 private-opt cuda
 private-tmp

--- a/etc/profile-m-z/xonotic.profile
+++ b/etc/profile-m-z/xonotic.profile
@@ -45,7 +45,7 @@ disable-mnt
 private-cache
 private-bin blind-id,darkplaces-glx,darkplaces-sdl,dirname,ldd,netstat,ps,readlink,sh,uname,xonotic*
 private-dev
-private-etc @tls-ca,@x11,host.conf
+private-etc alternatives,asound.conf,ca-certificates,crypto-policies,drirc,fonts,group,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,localtime,machine-id,nsswitch.conf,passwd,pki,pulse,resolv.conf,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/xournal.profile
+++ b/etc/profile-m-z/xournal.profile
@@ -42,7 +42,7 @@ tracelog
 private-bin xournal
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,group,ld.so.cache,ld.so.preload,machine-id,passwd
 # TODO should use private-lib
 private-tmp
 

--- a/etc/profile-m-z/xournalpp.profile
+++ b/etc/profile-m-z/xournalpp.profile
@@ -28,7 +28,7 @@ include whitelist-runuser-common.inc
 #include whitelist-common.inc
 
 private-bin kpsewhich,pdflatex,xournalpp
-private-etc latexmk.conf,texlive
+private-etc alternatives,latexmk.conf,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,texlive
 
 # Redirect
 include xournal.profile

--- a/etc/profile-m-z/xreader.profile
+++ b/etc/profile-m-z/xreader.profile
@@ -38,7 +38,7 @@ tracelog
 
 private-bin xreader,xreader-previewer,xreader-thumbnailer
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.preload
 private-tmp
 
 memory-deny-write-execute

--- a/etc/profile-m-z/yelp.profile
+++ b/etc/profile-m-z/yelp.profile
@@ -55,7 +55,7 @@ disable-mnt
 private-bin groff,man,tbl,troff,yelp
 private-cache
 private-dev
-private-etc @games,@tls-ca,@x11,cups,groff,man_db.conf,os-release,sgml,xml
+private-etc alsa,alternatives,asound.conf,crypto-policies,cups,dconf,drirc,fonts,gcrypt,groff,gtk-3.0,ld.so.cache,ld.so.preload,machine-id,man_db.conf,openal,os-release,pulse,sgml,xml
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/youtube-dl-gui.profile
+++ b/etc/profile-m-z/youtube-dl-gui.profile
@@ -48,7 +48,7 @@ disable-mnt
 private-bin atomicparsley,ffmpeg,ffprobe,python*,youtube-dl-gui
 private-cache
 private-dev
-private-etc @tls-ca,@x11
+private-etc alternatives,ca-certificates,crypto-policies,dconf,fonts,gtk-2.0,gtk-3.0,hostname,hosts,ld.so.cache,ld.so.preload,locale,locale.conf,passwd,pki,resolv.conf,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/youtube-dl.profile
+++ b/etc/profile-m-z/youtube-dl.profile
@@ -57,7 +57,7 @@ tracelog
 private-bin env,ffmpeg,python*,youtube-dl
 private-cache
 private-dev
-private-etc @tls-ca,mime.types,youtube-dl.conf
+private-etc alternatives,ca-certificates,crypto-policies,hostname,hosts,ld.so.cache,ld.so.preload,mime.types,pki,resolv.conf,ssl,youtube-dl.conf
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/youtube-viewers-common.profile
+++ b/etc/profile-m-z/youtube-viewers-common.profile
@@ -59,7 +59,7 @@ disable-mnt
 private-bin bash,ffmpeg,ffprobe,firefox,mpv,perl,python*,sh,smplayer,stty,wget,wget2,which,xterm,youtube-dl,yt-dlp
 private-cache
 private-dev
-private-etc @tls-ca,@x11,host.conf,mime.types
+private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,machine-id,mime.types,nsswitch.conf,passwd,pki,pulse,resolv.conf,ssl,X11,xdg
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/youtube.profile
+++ b/etc/profile-m-z/youtube.profile
@@ -17,7 +17,7 @@ mkdir ${HOME}/.config/Youtube
 whitelist ${HOME}/.config/Youtube
 
 private-bin electron,electron[0-9],electron[0-9][0-9],youtube
-private-etc @tls-ca,@x11,bumblebee,host.conf,mime.types
+private-etc alsa,alternatives,asound.conf,ati,bumblebee,ca-certificates,crypto-policies,drirc,fonts,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,mime.types,nsswitch.conf,nvidia,pki,pulse,resolv.conf,selinux,ssl,X11,xdg
 private-opt Youtube
 
 # Redirect

--- a/etc/profile-m-z/youtubemusic-nativefier.profile
+++ b/etc/profile-m-z/youtubemusic-nativefier.profile
@@ -14,7 +14,7 @@ mkdir ${HOME}/.config/youtubemusic-nativefier-040164
 whitelist ${HOME}/.config/youtubemusic-nativefier-040164
 
 private-bin electron,electron[0-9],electron[0-9][0-9],youtubemusic-nativefier
-private-etc @tls-ca,@x11,bumblebee,host.conf,mime.types
+private-etc alsa,alternatives,asound.conf,ati,bumblebee,ca-certificates,crypto-policies,drirc,fonts,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,mime.types,nsswitch.conf,nvidia,pki,pulse,resolv.conf,selinux,ssl,X11,xdg
 private-opt youtubemusic-nativefier
 
 # Redirect

--- a/etc/profile-m-z/yt-dlp.profile
+++ b/etc/profile-m-z/yt-dlp.profile
@@ -15,7 +15,7 @@ noblacklist ${HOME}/yt-dlp.conf
 noblacklist ${HOME}/yt-dlp.conf.txt
 
 private-bin ffprobe,yt-dlp
-private-etc yt-dlp.conf
+private-etc alternatives,ld.so.cache,ld.so.preload,yt-dlp.conf
 
 # Redirect
 include youtube-dl.profile

--- a/etc/profile-m-z/ytmdesktop.profile
+++ b/etc/profile-m-z/ytmdesktop.profile
@@ -14,7 +14,7 @@ mkdir ${HOME}/.config/youtube-music-desktop-app
 whitelist ${HOME}/.config/youtube-music-desktop-app
 
 # private-bin env,ytmdesktop
-private-etc @tls-ca,@x11,bumblebee,host.conf,mime.types
+private-etc alsa,alternatives,asound.conf,ati,bumblebee,ca-certificates,crypto-policies,drirc,fonts,gtk-2.0,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.preload,mime.types,nsswitch.conf,nvidia,pki,pulse,resolv.conf,selinux,ssl,X11,xdg
 # private-opt
 
 # Redirect

--- a/etc/profile-m-z/zathura.profile
+++ b/etc/profile-m-z/zathura.profile
@@ -48,7 +48,7 @@ tracelog
 private-bin zathura
 private-cache
 private-dev
-private-etc
+private-etc alternatives,fonts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,machine-id
 # private-lib has problems on Debian 10
 #private-lib gcc/*/*/libgcc_s.so.*,gcc/*/*/libstdc++.so.*,libarchive.so.*,libdjvulibre.so.*,libgirara-gtk*,libpoppler-glib.so.*,libspectre.so.*,zathura
 private-tmp

--- a/etc/profile-m-z/zeal.profile
+++ b/etc/profile-m-z/zeal.profile
@@ -60,7 +60,7 @@ disable-mnt
 private-bin zeal
 private-cache
 private-dev
-private-etc @tls-ca,@x11,host.conf,mime.types,rpc,services
+private-etc alternatives,ca-certificates,crypto-policies,fonts,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,mime.types,nsswitch.conf,pango,pki,protocols,resolv.conf,rpc,services,ssl,Trolltech.conf,X11,xdg
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/zim.profile
+++ b/etc/profile-m-z/zim.profile
@@ -63,7 +63,7 @@ disable-mnt
 private-bin python*,zim
 private-cache
 private-dev
-private-etc @x11,gconf
+private-etc alternatives,dconf,fonts,gconf,gtk-2.0,gtk-3.0,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,pango,X11
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/zulip.profile
+++ b/etc/profile-m-z/zulip.profile
@@ -43,7 +43,7 @@ disable-mnt
 private-bin locale,zulip
 private-cache
 private-dev
-private-etc
+private-etc alternatives,asound.conf,fonts,ld.so.cache,ld.so.preload,machine-id
 private-tmp
 
 restrict-namespaces

--- a/src/etc-cleanup/Makefile
+++ b/src/etc-cleanup/Makefile
@@ -1,9 +1,0 @@
-ROOT = ../..
--include $(ROOT)/config.mk
-
-PROG = etc-cleanup
-TARGET = $(PROG)
-
-MOD_HDRS = ../include/etc-groups.h
-
-include $(ROOT)/src/prog.mk

--- a/src/etc-cleanup/Makefile
+++ b/src/etc-cleanup/Makefile
@@ -1,0 +1,9 @@
+ROOT = ../..
+-include $(ROOT)/config.mk
+
+PROG = etc-cleanup
+TARGET = $(PROG)
+
+MOD_HDRS = ../include/etc-groups.h
+
+include $(ROOT)/src/prog.mk

--- a/src/etc-cleanup/main.c
+++ b/src/etc-cleanup/main.c
@@ -18,15 +18,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdarg.h>
-#include <assert.h>
 #include "../include/etc_groups.h"
-#define errExit(msg)    do { char msgout[500]; sprintf(msgout, "Error %s:%s(%d)", msg, __FUNCTION__, __LINE__); perror(msgout); exit(1);} while (0)
-
-
+#include "../include/common.h"
+#include <stdarg.h>
 
 #define MAX_BUF 4098
 #define MAX_ARR 1024
@@ -223,7 +217,7 @@ static void usage(void) {
 	printf("Group and clean private-etc entries in one or more profile files.\n");
 	printf("Options:\n");
 	printf("   --debug - print debug messages\n");
-	printf("   --help - this help screen\n");
+	printf("   -h, -?, --help - this help screen\n");
 	printf("   --replace - replace profile file\n");
 }
 

--- a/src/include/etc_groups.h
+++ b/src/include/etc_groups.h
@@ -39,6 +39,7 @@ static char *etc_list[ETC_MAX + 1] = { // plus 1 for ending NULL pointer
 	"login.defs", // firejail reading UID/GID MIN and MAX at startup
 	"nsswitch.conf",
 	"passwd",
+	"selinux",
 	NULL
 };
 
@@ -89,6 +90,7 @@ static char *etc_group_x11[] = {
 	"kde5rc",
 	"nvidia", // 3D
 	"pango", // text rendering/internationalization
+	"Trolltech.conf", // old QT config file
 	"X11",
 	"xdg",
 	NULL

--- a/src/include/etc_groups.h
+++ b/src/include/etc_groups.h
@@ -20,6 +20,7 @@
 
 #ifndef ETC_GROUPS_H
 #define ETC_GROUPS_H
+#include <stddef.h>
 
 #define ETC_MAX 256
 

--- a/src/include/etc_groups.h
+++ b/src/include/etc_groups.h
@@ -48,6 +48,7 @@ static char *etc_group_games[] = {
 	"openal", // 3D sound
 	"timidity", // MIDI
 	"timidity.cfg",
+	"vulkan", // next generation OpenGL stack
 	NULL
 };
 

--- a/src/include/etc_groups.h
+++ b/src/include/etc_groups.h
@@ -20,7 +20,6 @@
 
 #ifndef ETC_GROUPS_H
 #define ETC_GROUPS_H
-#include <stddef.h>
 
 #define ETC_MAX 256
 
@@ -40,7 +39,6 @@ static char *etc_list[ETC_MAX + 1] = { // plus 1 for ending NULL pointer
 	"login.defs", // firejail reading UID/GID MIN and MAX at startup
 	"nsswitch.conf",
 	"passwd",
-	"selinux",
 	NULL
 };
 
@@ -49,7 +47,6 @@ static char *etc_group_games[] = {
 	"openal", // 3D sound
 	"timidity", // MIDI
 	"timidity.cfg",
-	"vulkan", // next generation OpenGL stack
 	NULL
 };
 
@@ -92,7 +89,6 @@ static char *etc_group_x11[] = {
 	"kde5rc",
 	"nvidia", // 3D
 	"pango", // text rendering/internationalization
-	"Trolltech.conf", // old QT config file
 	"X11",
 	"xdg",
 	NULL


### PR DESCRIPTION

This reverts commit 5d0822c52c9a5e631676899e9642911d9143dba8 and later
commits that touch the same files (which is necessary in order to revert
the commit in question).

There seems to be a non-trivial amount of changes done in error in the
big refactor from commit 5d0822c52 ("private-etc: big profile changes",
2023-02-05).  For example, there are profiles for CLI programs
(including man.profile) and servers that now contain the @x11 group:

    $ git grep -l '^private-etc .*@x11' -- etc
    # [...]
    etc/profile-a-l/email-common.profile:private-etc @tls-ca,@x11,gnupg,hosts.conf,mailname,timezone
    etc/profile-m-z/man.profile:private-etc @x11,groff,man_db.conf,manpath.config,sysless
    etc/profile-m-z/mutt.profile:private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gai.conf,gnupg,gnutls,hosts.conf,mail,mailname,nntpserver,terminfo
    etc/profile-m-z/neomutt.profile:private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gnupg,hosts.conf,mail,mailname,neomuttrc,neomuttrc.d,nntpserver
    etc/profile-m-z/nextcloud.profile:private-etc @tls-ca,@x11,Nextcloud,host.conf,os-release
    etc/profile-m-z/nodejs-common.profile:private-etc @tls-ca,@x11,host.conf,mime.types,rpc,services

Note: These are just the ones that I immediately noticed; it is possible
that there are many that I missed.

Part of the issue is that the groups appear to be inconsistent and
rather broad.  For example, paths related to 3D graphics (vulkan) and
audio (openal) are in the @games group, which are not used only by games
and not all games use those standards/libraries.  As another example,
the @x11 group contains paths related to GTK, KDE and GPU hardware
acceleration, even though those are not necessarily tied to X11 (and
even though hardware acceleration may be used by headless programs).
Replacing the known paths with groups that are not very granular results
in loss of information about what exactly a profile actually needs and
so makes the profiles less self-documenting.  Note also that a given
path could potentially belong to multiple groups, which would preclude
using the "etc-cleanup" tool (in its current form at least), as it would
not know which is the correct group to replace the path with.

Command used to revert the changes:

    $ git revert \
      1be9bb3c78b3f129eb2a9fefc07211694c700e4e \
      e889db095873197e999c84077fe28c135b49e43c \
      e6f2374d557c94616b9b9db0bcebe0bbd5d78d88 \
      acb0154ea2a71edf935f7c45cc280b0244937336 \
      740f502aeef509ddec89679d2a9fc24270a8c953 \
      5649bd4568f194eb93eaefb7619d92b57fd27e9c \
      2e4e9d13add71bd0b96246e54e209a29583644b6 \
      0f996ea4de584dc061faf21853d61a600da1a1d8 \
      5d0822c52c9a5e631676899e9642911d9143dba8

Note: This reverts commits from PRs #5641 #5642 #5643, most of which are
later re-applied.

Relates to #5610.