### PR TITLE
New profile: parsecd

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -1077,6 +1077,7 @@ blacklist ${HOME}/.ostrichriders
 blacklist ${HOME}/.paradoxinteractive
 blacklist ${HOME}/.paradoxlauncher
 blacklist ${HOME}/.parallelrealities/blobwars
+blacklist ${HOME}/.parsec
 blacklist ${HOME}/.pcsxr
 blacklist ${HOME}/.penguin-command
 blacklist ${HOME}/.pine-crash

--- a/etc/profile-m-z/parsecd.profile
+++ b/etc/profile-m-z/parsecd.profile
@@ -7,12 +7,25 @@ include parsecd.local
 include globals.local
 
 noblacklist ${HOME}/.parsec
+ignore noexec ${HOME}
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-proc.inc
+include disable-programs.inc
+include disable-shell.inc
+include disable-xdg.inc
 
 mkdir ${HOME}/.parsec
 whitelist ${HOME}/.parsec
 whitelist /usr/share/parsec
 include whitelist-common.inc
 include whitelist-usr-share-common.inc
+include whitelist-run-common.inc
+include whitelist-runuser-common.inc
+include whitelist-var-common.inc
 
 # Due to the nature of parsec, the following directives will not work:
 # - no3d

--- a/etc/profile-m-z/parsecd.profile
+++ b/etc/profile-m-z/parsecd.profile
@@ -1,0 +1,44 @@
+# Firejail profile for Parsec
+# Description: Remote desktop application focused on gaming and other 3D applications
+# This file is overwritten after every install/update
+# Persistent local customizations
+include parsecd.local
+# Persistent global definitions
+include globals.local
+
+noblacklist ${HOME}/.parsec
+
+mkdir ${HOME}/.parsec
+whitelist ${HOME}/.parsec
+whitelist /usr/share/parsec
+include whitelist-common.inc
+include whitelist-usr-share-common.inc
+
+# Due to the nature of parsec, the following directives will not work:
+# - no3d
+# - novideo
+# - nosound
+# - noinput (it does remote passthrough stuff for gamepads)
+# - private-dev (because of the above)
+apparmor
+caps.drop all
+nodvd
+nogroups
+nonewprivs
+notv
+nou2f
+noroot
+# Will fail to start with mty_evdev_create: 'udev_monitor_new_from_netlink' failed without netlink
+protocol unix,inet,inet6,netlink
+seccomp !tgkill
+seccomp.block-secondary
+
+# Will not start with zenity missing
+private-bin parsecd,zenity
+private-tmp
+
+dbus-user none
+dbus-system none
+
+memory-deny-write-execute
+restrict-namespaces


### PR DESCRIPTION
Upstream website: https://parsec.app
It is partly open source, see https://github.com/chrisd1100/libmatoya

Directives that wont work:

- private-dev - it needs that for the passthrough of input devices
- noinput, novideo, noaudio, no3d - because it needs all that
- netfilter - would need custom rules because it connects to STUN stuff
- private-cache - because it does not need any cache and having just ~/.parsec is enough
- the no-exec include - it has executable .so stuff in ~/.parsec for whatever reason and not just in /usr/share/parsec

Did not try seccomp because I am not in the mood to debug segfaults due to missing syscalls, but it otherwise works perfectly with the given profile. The profile is probably missing comments, too.