### PR TITLE
profiles: gnome-logs: fix missing machine-id in private-etc

### DIFF
--- a/etc/profile-a-l/gnome-logs.profile
+++ b/etc/profile-a-l/gnome-logs.profile
@@ -39,7 +39,7 @@ disable-mnt
 private-bin gnome-logs
 private-cache
 private-dev
-private-etc
+private-etc machine-id
 private-lib gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libgconf-2.so.*,librsvg-2.so.*
 private-tmp
 writable-var-log


### PR DESCRIPTION
Relates to #5610.

Side-note: although `private-etc machine-id` also fixes this, I opted to go with the 'new' groups syntax to avoid potential mishaps in future work on #5610 (e.g. etc-cleanup seeing machine-id again).