### PR TITLE
build: mkdeb.sh: pass all arguments to ./configure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,7 +341,7 @@ deb: dist config.sh
 
 .PHONY: deb-apparmor
 deb-apparmor: dist config.sh
-	./mkdeb.sh -apparmor --enable-apparmor
+	env EXTRA_VERSION=-apparmor ./mkdeb.sh --enable-apparmor
 
 .PHONY: test-compile
 test-compile: dist config.mk

--- a/mkdeb.sh
+++ b/mkdeb.sh
@@ -10,10 +10,6 @@ set -e
 
 . "$(dirname "$0")/config.sh"
 
-EXTRA_VERSION=$1
-
-test "$#" -gt 0 && shift
-
 CODE_ARCHIVE="$TARNAME-$VERSION.tar.xz"
 CODE_DIR="$TARNAME-$VERSION"
 INSTALL_DIR="${INSTALL_DIR}${CODE_DIR}/debian"


### PR DESCRIPTION

Instead of using the first argument as the `EXTRA_VERSION` variable.
This should make the usage of mkdeb.sh less confusing, especially when
one is not trying to set the variable.

As for using `EXTRA_VERSION` (which is still optional with this commit),
make sure that it is set as an environment variable before caling
mkdeb.sh.  Example:

    env EXTRA_VERSION=-apparmor ./mkdeb.sh --enable-apparmor

See also commit 9a0fbbd71 ("mkdeb.sh.in: pass remaining arguments to
./configure", 2022-05-13) / PR #5154.