### PR TITLE
archivers: drop private-etc now that it's in archiver-common

### DIFF
--- a/etc/profile-a-l/atool.profile
+++ b/etc/profile-a-l/atool.profile
@@ -12,8 +12,6 @@ include allow-perl.inc
 
 noroot
 
-# without login.defs atool complains and uses UID/GID 1000 by default
-private-etc
 private-tmp
 
 # Redirect

--- a/etc/profile-a-l/bsdtar.profile
+++ b/etc/profile-a-l/bsdtar.profile
@@ -6,7 +6,5 @@ include bsdtar.local
 # Persistent global definitions
 include globals.local
 
-private-etc
-
 # Redirect
 include archiver-common.profile

--- a/etc/profile-m-z/tar.profile
+++ b/etc/profile-m-z/tar.profile
@@ -17,7 +17,6 @@ ignore include disable-shell.inc
 # all capabilities this is automatically read-only.
 noblacklist /var/lib/pacman
 
-private-etc
 #private-lib libfakeroot,liblzma.so.*,libreadline.so.*
 # Debian based distributions need this for 'dpkg --unpack' (incl. synaptic)
 writable-var

--- a/etc/profile-m-z/unrar.profile
+++ b/etc/profile-m-z/unrar.profile
@@ -8,7 +8,6 @@ include unrar.local
 include globals.local
 
 private-bin unrar
-private-etc
 private-tmp
 
 # Redirect

--- a/etc/profile-m-z/unzip.profile
+++ b/etc/profile-m-z/unzip.profile
@@ -10,7 +10,5 @@ include globals.local
 # GNOME Shell integration (chrome-gnome-shell)
 noblacklist ${HOME}/.local/share/gnome-shell
 
-private-etc
-
 # Redirect
 include archiver-common.profile


### PR DESCRIPTION
Commit https://github.com/netblue30/firejail/commit/29da82d08aab5120262f42032fed6dc7807e5b0d added `private-etc` to `archiver-common.profile`. To avoid doubled options this PR removes it from archiver profiles which already had it.

Relates to #5610.