### PR TITLE
archiver-common: add mkinitcpio support to private-etc

### DIFF
--- a/etc/profile-a-l/archiver-common.profile
+++ b/etc/profile-a-l/archiver-common.profile
@@ -44,7 +44,7 @@ x11 none
 
 private-cache
 private-dev
-private-etc
+private-etc mkinitcpio*
 
 dbus-user none
 dbus-system none


### PR DESCRIPTION
[mkinitcpio](https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio) (used to generate initramfs images) supports [several compression formats](https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/blob/master/mkinitcpio.conf#L54-L64). On Arch Linux (based distributions) at least this implies the supported archivers to have access to mkinitcpio-related files under /etc.

This was no problem before https://github.com/netblue30/firejail/commit/29da82d08aab5120262f42032fed6dc7807e5b0d added `private-etc` to `archivers-common.profile`. This PR adds the now needed extra private-etc items to mkinitcpio's supported compressors.

Relates to #5610.

Side-note: mkinitcpio also supports `lz4` compression. I was a bit surprised to notice we don't have a profile for that yet. I'll add one in a follow-up PR.