### PR TITLE
wusc: allow hyphenation

### DIFF
--- a/etc/inc/whitelist-usr-share-common.inc
+++ b/etc/inc/whitelist-usr-share-common.inc
@@ -29,6 +29,7 @@ whitelist /usr/share/gtk-engines
 whitelist /usr/share/gtksourceview-3.0
 whitelist /usr/share/gtksourceview-4
 whitelist /usr/share/hunspell
+whitelist /usr/share/hyphen
 whitelist /usr/share/hwdata
 whitelist /usr/share/icons
 whitelist /usr/share/icu

--- a/etc/profile-a-l/com.github.johnfactotum.Foliate.profile
+++ b/etc/profile-a-l/com.github.johnfactotum.Foliate.profile
@@ -28,7 +28,6 @@ whitelist ${HOME}/.local/share/com.github.johnfactotum.Foliate
 whitelist ${DOCUMENTS}
 whitelist ${DOWNLOADS}
 whitelist /usr/share/com.github.johnfactotum.Foliate
-whitelist /usr/share/hyphen
 include whitelist-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc


### PR DESCRIPTION
We already allow spelling-checkers. Hyphenation is also part of language usage toolkits.