### PR TITLE
docs: selinux.c: Split Copyright notice & use same license as upstream

### DIFF
--- a/src/firejail/selinux.c
+++ b/src/firejail/selinux.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2020-2023 Firejail and systemd authors
+ * Copyright (C) 2009-2020 The systemd Authors
+ * Copyright (C) 2014-2023 Firejail Authors
  *
  * This file is part of firejail project, from systemd selinux-util.c
  *

--- a/src/firejail/selinux.c
+++ b/src/firejail/selinux.c
@@ -1,22 +1,9 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
 /*
  * Copyright (C) 2009-2020 The systemd Authors
  * Copyright (C) 2014-2023 Firejail Authors
  *
  * This file is part of firejail project, from systemd selinux-util.c
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 #if HAVE_SELINUX
 #include "firejail.h"


### PR DESCRIPTION
selinux.c: Split Copyright notice in two

This makes firejail's Copyright notice match the ones in basically
every other file, which simplifies updating the Copyright years.

selinux.c was added on commit 1ad2d54c0 ("Add support for SELinux
labeling", 2020-02-18) and it claims to be "from systemd
selinux-util.c".

As for systemd's Copyright notice, the current version of that file on
the systemd project does not have any[1].

The first commit in the systemd repository is from 2009[2] and the file
was copied in 2020 (and does not seem to have been synced since), so set
the years in its Copyright notice to 2009-2020.

Since there is no Copyright notice (and no author) in the upstream file,
list "The systemd Authors" in the Copyright notice.

See also systemd commit 0c69794138 ("tree-wide: remove Lennart's
copyright lines", 2018-06-12)[3] [4].

[1] https://github.com/systemd/systemd/blob/254d1313ae5a69c08c9b93032aaaf3d6083cfc07/src/shared/selinux-util.c
[2] https://github.com/systemd/systemd/commit/6091827530d6dd43479d6709fb6e9f745c11e900
[3] https://github.com/systemd/systemd/commit/0c697941389b7379c4471bc0a067ede02814bc57
[4] https://github.com/systemd/systemd/pull/9274

---

selinux.c: Use same license as upstream file (LGPLv2.1+)

The upstream file is licensed under the LGPLv2.1+ and it uses an SPDX
license identifier rather than an LGPL license notice[1].

And according to the GNU project, the LGPLv2.1+ is compatible with both
the GPLv2 (with the result being GPLv2) and the GPLv3 (with the result
being GPLv3), though the reverse (GPL -> LGPL) does not apply[2] [3].
This means that if we make changes that are only available under the
GPLv2, systemd would be unable to copy them back and release the result
under the LGPLv2.1 without being in violation of the GPLv2.

So replace the GPL license notice with the SPDX license identifier of
the upstream file ("LGPL-2.1-or-later"), to make it easier to share
changes between both projects.

See also the following systemd commits[4] [5] [6] [7]:

* 53e1b68390 ("Add SPDX license identifiers to source files under the
  LGPL", 2017-11-18)
* db9ecf0501 ("license: LGPL-2.1+ -> LGPL-2.1-or-later", 2020-11-09)

[1] https://github.com/systemd/systemd/blob/254d1313ae5a69c08c9b93032aaaf3d6083cfc07/src/shared/selinux-util.c
[2] https://www.gnu.org/licenses/license-list.en.html#LGPLv2.1
[3] https://www.gnu.org/licenses/license-compatibility.html
[4] https://github.com/systemd/systemd/commit/53e1b683907c2f12330f00feb9630150196f064d
[5] https://github.com/systemd/systemd/pull/7386
[6] https://github.com/systemd/systemd/commit/db9ecf050165fd1033c6f81485917e229c4be537
[7] https://github.com/systemd/systemd/pull/17548

---

This is a follow-up to #5664.

Cc: @reinerh @smitsohu @topimiettinen (as contributors to selinux.c)
