### PR TITLE
build: deb: enable apparmor by default & remove deb-apparmor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
     - name: install dependencies
       run: sudo apt-get install gcc-12 libapparmor-dev libselinux1-dev expect xzdec
     - name: configure
-      run: CC=gcc-12 ./configure --enable-fatal-warnings --enable-analyzer --enable-apparmor --enable-selinux --prefix=/usr
+      run: CC=gcc-12 ./configure --prefix=/usr --enable-fatal-warnings --enable-analyzer --enable-apparmor --enable-selinux
     - name: make
       run: make
     - name: make install

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ build_ubuntu_package:
     script:
         - apt-get update -qq
         - DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential lintian pkg-config python3 gawk
-        - ./configure --prefix=/usr && make deb && dpkg -i firejail*.deb
+        - ./configure && make deb && dpkg -i firejail*.deb
         - command -V firejail && firejail --version
         - python3 contrib/sort.py etc/profile-*/*.profile etc/inc/*.inc
 
@@ -19,7 +19,7 @@ build_debian_package:
     script:
         - apt-get update -qq
         - apt-get install -y -qq build-essential lintian pkg-config gawk
-        - ./configure --prefix=/usr && make deb && dpkg -i firejail*.deb
+        - ./configure && make deb && dpkg -i firejail*.deb
         - command -V firejail && firejail --version
 
 build_redhat_package:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ build_ubuntu_package:
     image: ubuntu:rolling
     script:
         - apt-get update -qq
-        - DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential lintian pkg-config python3 gawk
+        - DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential lintian libapparmor-dev pkg-config python3 gawk
         - ./configure && make deb && dpkg -i firejail*.deb
         - command -V firejail && firejail --version
         - python3 contrib/sort.py etc/profile-*/*.profile etc/inc/*.inc
@@ -18,7 +18,7 @@ build_debian_package:
     image: debian:stretch
     script:
         - apt-get update -qq
-        - apt-get install -y -qq build-essential lintian pkg-config gawk
+        - apt-get install -y -qq build-essential lintian libapparmor-dev pkg-config gawk
         - ./configure && make deb && dpkg -i firejail*.deb
         - command -V firejail && firejail --version
 
@@ -49,14 +49,14 @@ build_src_package:
         - command -V firejail && firejail --version
         # - python3 contrib/sort.py etc/*.{profile,inc}
 
-build_apparmor:
+build_no_apparmor:
     image: ubuntu:latest
     script:
         - apt-get update -qq
-        - DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential lintian libapparmor-dev pkg-config gawk
-        - ./configure && make deb-apparmor && dpkg -i firejail*.deb
+        - DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential lintian pkg-config gawk
+        - ./configure && make dist && ./mkdeb.sh --disable-apparmor && dpkg -i firejail*.deb
         - command -V firejail && firejail --version
-        - firejail --version | grep -F 'AppArmor support is enabled'
+        - firejail --version | grep -F 'AppArmor support is disabled'
 
 debian_ci:
     image: registry.salsa.debian.org/salsa-ci-team/ci-image-git-buildpackage:latest

--- a/Makefile
+++ b/Makefile
@@ -339,10 +339,6 @@ asc: config.mk
 deb: dist config.sh
 	./mkdeb.sh
 
-.PHONY: deb-apparmor
-deb-apparmor: dist config.sh
-	env EXTRA_VERSION=-apparmor ./mkdeb.sh --enable-apparmor
-
 .PHONY: test-compile
 test-compile: dist config.mk
 	cd test/compile; ./compile.sh $(TARNAME)-$(VERSION)

--- a/README
+++ b/README
@@ -34,7 +34,7 @@ $ sudo apt-get install git build-essential libapparmor-dev pkg-config gawk
 For --selinux option, add libselinux1-dev (libselinux-devel for Fedora).
 
 We build our release firejail.tar.xz and firejail.deb packages using the following command:
-$ make distclean && ./configure && make deb-apparmor
+$ make distclean && ./configure && make deb
 
 
 Maintainer:

--- a/contrib/update_deb.sh
+++ b/contrib/update_deb.sh
@@ -15,7 +15,7 @@ cd firejail
 sed -i "s/# restricted-network .*/restricted-network yes/" \
     etc/firejail.config
 
-make deb-apparmor
+make deb
 sudo dpkg -i firejail*.deb
 echo "Firejail updated."
 cd ..

--- a/mkdeb.sh
+++ b/mkdeb.sh
@@ -25,7 +25,7 @@ echo "*****************************************"
 tar -xJvf "$CODE_ARCHIVE"
 #mkdir -p "$INSTALL_DIR"
 cd "$CODE_DIR"
-./configure --prefix=/usr "$@"
+./configure --prefix=/usr --enable-apparmor "$@"
 make -j2
 mkdir debian
 DESTDIR=debian make install-strip


### PR DESCRIPTION
The official .deb package is always built with apparmor support, so use
`--enable-apparmor` in mkdeb.sh and remove the "deb-apparmor" target in
order to reduce redundancy.

Note that custom configure options may be specified by calling
./mkdeb.sh directly.

For example, to build the .deb package without apparmor support, instead
of running `make deb`, the following commands can be used:

    make dist
    ./mkdeb.sh --disable-apparmor

Also, change the `build_apparmor` GitLab CI job into
`build_no_apparmor`, which is intended to check that building without
apparmor still works.

Note: This commit makes the resulting .deb package not have an
"-apparmor" suffix (see `EXTRA_VERSION` in mkdeb.sh), to avoid
redundancy (as having apparmor support becomes the default).

Misc: This is a follow-up to #5654.

Relates to #5154 #5176 #5547.