### PR TITLE
disable-common.inc: add systemd v253 blacklists

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -168,8 +168,10 @@ blacklist ${HOME}/.local/share/systemd
 blacklist ${PATH}/systemctl
 blacklist ${PATH}/systemd-run
 blacklist ${RUNUSER}/systemd
+blacklist /etc/credstore*
 blacklist /etc/systemd/network
 blacklist /etc/systemd/system
+blacklist /run/credentials
 blacklist /var/lib/systemd
 # creates problems on Arch where /etc/resolv.conf is a symlink to /var/run/systemd/resolve/resolv.conf
 #blacklist /var/run/systemd


### PR DESCRIPTION
Arch Linux got [systemd v253](https://github.com/archlinux/svntogit-packages/commit/05d0aedb2b83a2e1ba07cab47205772f82cb4814). It adds a few new files we should blacklist in `disable-common.inc`:
- /etc/credstore
- /etc/credstore.encrypted
- /run/credentials/systemd-sysctl.service
- /run/credentials/systemd-sysusers.service
- /run/credentials/systemd-tmpfiles-setup.service
- /run/credentials/systemd-tmpfiles-setup-dev.service