### PR TITLE
apostrophe: drop whitelist covered by wusc

### DIFF
--- a/etc/profile-a-l/apostrophe.profile
+++ b/etc/profile-a-l/apostrophe.profile
@@ -35,7 +35,6 @@ whitelist /usr/share/apostrophe
 whitelist /usr/share/texlive
 whitelist /usr/share/texmf
 whitelist /usr/share/pandoc-*
-whitelist /usr/share/perl5
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc


### PR DESCRIPTION
/usr/share/perl5 is already present in the included whitelist-usr-share-common.inc