### PR TITLE
New profiles: qpdf and redirects

### DIFF
--- a/RELNOTES
+++ b/RELNOTES
@@ -17,6 +17,7 @@ firejail (0.9.73) baseline; urgency=low
     support (#5589)
   * docs: selinux.c: Split Copyright notice & use same license as upstream
     (#5667)
+  * new profiles: fix-qdf, qpdf, zlib-flate 
  -- netblue30 <netblue30@yahoo.com>  Mon, 16 Jan 2023 09:00:00 -0500
 
 firejail (0.9.72) baseline; urgency=low

--- a/etc/profile-a-l/fix-qdf.profile
+++ b/etc/profile-a-l/fix-qdf.profile
@@ -1,0 +1,13 @@
+# Firejail profile for fix-qdf
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include fix-qdf.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+private-bin fix-qdf
+
+# Redirect
+include qpdf.profile

--- a/etc/profile-m-z/qpdf.profile
+++ b/etc/profile-m-z/qpdf.profile
@@ -1,0 +1,68 @@
+# Firejail profile for qpdf
+# Description: A Content-Preserving PDF Transformation System
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include qpdf.local
+# Persistent global definitions
+include globals.local
+
+blacklist ${RUNUSER}/wayland-*
+
+noblacklist ${DOCUMENTS}
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-proc.inc
+include disable-programs.inc
+include disable-shell.inc
+include disable-X11.inc
+include disable-xdg.inc
+
+whitelist ${DOCUMENTS}
+whitelist ${DOWNLOADS}
+include whitelist-common.inc
+include whitelist-run-common.inc
+include whitelist-runuser-common.inc
+include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
+
+apparmor
+caps.drop all
+hostname qpdf
+ipc-namespace
+machine-id
+net none
+no3d
+nodvd
+nogroups
+noinput
+nonewprivs
+noprinters
+noroot
+nosound
+notv
+nou2f
+novideo
+protocol unix
+seccomp
+tracelog
+x11 none
+
+private-bin qpdf
+private-cache
+private-dev
+private-etc
+private-lib libqpdf.so.*
+#private-tmp # breaks on Arch Linux
+
+dbus-user none
+dbus-system none
+
+memory-deny-write-execute
+restrict-namespaces
+read-only ${HOME}
+read-write ${DOCUMENTS}
+read-write ${DOWNLOADS}

--- a/etc/profile-m-z/qpdf.profile
+++ b/etc/profile-m-z/qpdf.profile
@@ -46,8 +46,8 @@ nosound
 notv
 nou2f
 novideo
-protocol unix
-seccomp
+# block the socket syscall to simulate an be empty protocol line, see #639
+seccomp socket
 tracelog
 x11 none
 

--- a/etc/profile-m-z/zlib-flate.profile
+++ b/etc/profile-m-z/zlib-flate.profile
@@ -1,0 +1,13 @@
+# Firejail profile for zlib-flate
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include zlib-flate.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+private-bin zlib-flate
+
+# Redirect
+include qpdf.profile

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -260,6 +260,7 @@ firefox-nightly
 firefox-wayland
 firefox-x11
 five-or-more
+fix-qdf
 flacsplt
 flameshot
 flashpeak-slimjet
@@ -694,6 +695,7 @@ qgis
 qlipper
 qmmp
 qnapi
+qpdf
 qpdfview
 qq
 qt-faststart
@@ -957,6 +959,7 @@ zart
 zathura
 zeal
 zim
+zlib-flate
 zoom
 # zpaq - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
 # zstd - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)


### PR DESCRIPTION
qpdf (CLI) provides PDF metadata cleaning.

See [privacy-handbuch.de](https://www.privacy-handbuch.de/handbuch_43a.htm) for details. The site offers [pdf-meta-clean.sh](https://www.privacy-handbuch.de/download/pdf-meta-clean.sh), which works very well with firejailed qpdf.