### PR TITLE
Print the argument when failing with "too long arguments"

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1080,7 +1080,8 @@ int main(int argc, char **argv, char **envp) {
 	// sanity check for arguments
 	for (i = 0; i < argc; i++) {
 		if (strlen(argv[i]) >= MAX_ARG_LEN) {
-			fprintf(stderr, "Error: too long arguments: argv[%d] len (%zu) >= MAX_ARG_LEN (%d)\n", i, strlen(argv[i]), MAX_ARG_LEN);
+			fprintf(stderr, "Error: too long argument: argv[%d] len (%zu) >= MAX_ARG_LEN (%d): %s\n",
+			        i, strlen(argv[i]), MAX_ARG_LEN, argv[i]);
 			exit(1);
 		}
 	}


### PR DESCRIPTION
Also, s/arguments/argument/ since the message refers to one specific
argument.

Relates to commit 0d06369a8 ("Make env/arg sanity check failure messages
more useful", 2021-11-10) / PR #4676.

Relates to #5676.

Cc: @hlein (from #4676)
