### PR TITLE
rsync-download_only: fix local override name

### DIFF
--- a/etc/profile-m-z/rsync-download_only.profile
+++ b/etc/profile-m-z/rsync-download_only.profile
@@ -3,7 +3,7 @@
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations
-include rsync.local
+include rsync-download_only.local
 # Persistent global definitions
 include globals.local
 


### PR DESCRIPTION
Streamline .local override name. No functional changes.