### PR TITLE
Drop hostname option from all profiles

### DIFF
--- a/etc/profile-a-l/agetpkg.profile
+++ b/etc/profile-a-l/agetpkg.profile
@@ -28,7 +28,6 @@ include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
 caps.drop all
-hostname agetpkg
 ipc-namespace
 machine-id
 netfilter

--- a/etc/profile-a-l/archiver-common.profile
+++ b/etc/profile-a-l/archiver-common.profile
@@ -23,7 +23,6 @@ include disable-shell.inc
 
 apparmor
 caps.drop all
-hostname archiver
 ipc-namespace
 machine-id
 net none

--- a/etc/profile-a-l/file.profile
+++ b/etc/profile-a-l/file.profile
@@ -15,7 +15,6 @@ include disable-programs.inc
 
 apparmor
 caps.drop all
-hostname file
 ipc-namespace
 machine-id
 net none

--- a/etc/profile-a-l/galculator.profile
+++ b/etc/profile-a-l/galculator.profile
@@ -23,7 +23,6 @@ include whitelist-var-common.inc
 
 apparmor
 caps.drop all
-#hostname galculator - breaks Arch Linux
 #ipc-namespace
 net none
 nodvd

--- a/etc/profile-a-l/geekbench.profile
+++ b/etc/profile-a-l/geekbench.profile
@@ -25,7 +25,6 @@ include whitelist-var-common.inc
 
 apparmor
 caps.drop all
-hostname geekbench
 ipc-namespace
 machine-id
 netfilter

--- a/etc/profile-m-z/mdr.profile
+++ b/etc/profile-m-z/mdr.profile
@@ -21,7 +21,6 @@ include whitelist-var-common.inc
 
 apparmor
 caps.drop all
-hostname mdr
 ipc-namespace
 machine-id
 net none

--- a/etc/profile-m-z/qpdf.profile
+++ b/etc/profile-m-z/qpdf.profile
@@ -31,7 +31,6 @@ include whitelist-var-common.inc
 
 apparmor
 caps.drop all
-hostname qpdf
 ipc-namespace
 machine-id
 net none

--- a/etc/profile-m-z/tesseract.profile
+++ b/etc/profile-m-z/tesseract.profile
@@ -31,7 +31,6 @@ include whitelist-var-common.inc
 
 apparmor
 caps.drop all
-hostname tesseract
 ipc-namespace
 machine-id
 net none

--- a/etc/profile-m-z/unf.profile
+++ b/etc/profile-m-z/unf.profile
@@ -24,7 +24,6 @@ include whitelist-var-common.inc
 
 apparmor
 caps.drop all
-hostname unf
 ipc-namespace
 machine-id
 net none

--- a/etc/profile-m-z/uudeview.profile
+++ b/etc/profile-m-z/uudeview.profile
@@ -19,7 +19,6 @@ include disable-shell.inc
 include whitelist-usr-share-common.inc
 
 caps.drop all
-hostname uudeview
 ipc-namespace
 machine-id
 net none

--- a/etc/profile-m-z/whois.profile
+++ b/etc/profile-m-z/whois.profile
@@ -22,7 +22,6 @@ include whitelist-var-common.inc
 
 apparmor
 caps.drop all
-hostname whois
 ipc-namespace
 machine-id
 netfilter


### PR DESCRIPTION
Now we have randomized [UTS namespaces support](https://github.com/netblue30/firejail/discussions/5597#discussioncomment-4996357) by default for every sandbox there's no longer a need to set hostname to a fixed value. This PR removes such fixed hostname entrees from all profiles that had it.
