### PR TITLE
Forbid control chars in names

### DIFF
--- a/src/firejail/output.c
+++ b/src/firejail/output.c
@@ -66,8 +66,8 @@ void check_output(int argc, char **argv) {
 	}
 
 	// do not accept directories, links, and files with ".."
-	if (strstr(outfile, "..") || is_link(outfile) || is_dir(outfile)) {
-		fprintf(stderr, "Error: invalid output file. Links, directories and files with \"..\" are not allowed.\n");
+	if (strstr(outfile, "..") || is_link(outfile) || is_dir(outfile) || has_cntrl_chars(outfile)) {
+		fprintf(stderr, "Error: invalid output file. Links, directories, files with \"..\" and control characters in filenames are not allowed.\n");
 		exit(1);
 	}
 


### PR DESCRIPTION
Forbid control characters in names and filenames. https://github.com/netblue30/firejail/pull/5613.

Syntax for hostnames from https://en.wikipedia.org/wiki/Hostname#Syntax
