### PR TITLE
keepassxc: Allow offering the Secret Service

### DIFF
--- a/etc/profile-a-l/keepassxc.profile
+++ b/etc/profile-a-l/keepassxc.profile
@@ -93,6 +93,7 @@ private-etc
 private-tmp
 
 dbus-user filter
+dbus-user.own org.freedesktop.secrets
 dbus-user.own org.keepassxc.KeePassXC.*
 dbus-user.talk com.canonical.Unity
 dbus-user.talk org.freedesktop.ScreenSaver


### PR DESCRIPTION
KeePassXC can offer a Secret Service (see https://specifications.freedesktop.org/secret-service/latest/) to store secrets for other programs
