### PR TITLE
ssh-agent: hardening

### DIFF
--- a/etc/profile-m-z/ssh-agent.profile
+++ b/etc/profile-m-z/ssh-agent.profile
@@ -7,6 +7,7 @@ include ssh-agent.local
 # Persistent global definitions
 include globals.local
 
+blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 # Allow ssh (blacklisted by disable-common.inc)
@@ -42,12 +43,10 @@ noprinters
 noroot
 nosound
 notv
-nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
 tracelog
-x11 none
 
 disable-mnt
 private-bin ssh-agent

--- a/etc/profile-m-z/ssh-agent.profile
+++ b/etc/profile-m-z/ssh-agent.profile
@@ -7,7 +7,6 @@ include ssh-agent.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 # Allow ssh (blacklisted by disable-common.inc)

--- a/etc/profile-m-z/ssh-agent.profile
+++ b/etc/profile-m-z/ssh-agent.profile
@@ -1,4 +1,5 @@
 # Firejail profile for ssh-agent
+# Description: OpenSSH authentication agent
 # This file is overwritten after every install/update
 quiet
 # Persistent local customizations
@@ -6,32 +7,56 @@ include ssh-agent.local
 # Persistent global definitions
 include globals.local
 
+blacklist ${RUNUSER}/wayland-*
+
 # Allow ssh (blacklisted by disable-common.inc)
 include allow-ssh.inc
 
-blacklist /tmp/.X11-unix
-blacklist ${RUNUSER}/wayland-*
+ignore noexec ${RUNUSER}
 
 include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-proc.inc
 include disable-programs.inc
+include disable-shell.inc
+include disable-X11.inc
+include disable-xdg.inc
 
+include whitelist-common.inc
+include whitelist-run-common.inc
+include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 
+apparmor
 caps.drop all
+machine-id
 netfilter
 no3d
 nodvd
+noinput
+nogroups
 nonewprivs
+noprinters
 noroot
+nosound
 notv
+nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
 tracelog
+x11 none
 
+disable-mnt
+private-bin ssh-agent
+private-cache
+private-dev
 writable-run-user
 
 dbus-user none
 dbus-system none
 
+memory-deny-write-execute
 restrict-namespaces


### PR DESCRIPTION
IMO there's nothing holding back making the (OpenSSH) authenticator agent profile very tight. Contrary to the SSH client its functionality is very limited and it doesn't need access to much of the file system.