### PR TITLE
softmaker-common.profile: add fstab to private-etc

### DIFF
--- a/etc/profile-m-z/softmaker-common.profile
+++ b/etc/profile-m-z/softmaker-common.profile
@@ -42,7 +42,7 @@ tracelog
 private-bin freeoffice-planmaker,freeoffice-presentations,freeoffice-textmaker,planmaker18,planmaker18free,presentations18,presentations18free,sh,textmaker18,textmaker18free
 private-cache
 private-dev
-private-etc @tls-ca,SoftMaker
+private-etc @tls-ca,fstab,SoftMaker
 private-tmp
 
 dbus-user none


### PR DESCRIPTION
When using `private-etc`, app "forgets" it's product key and
asks for license activation, despite it has already been done.

Allow access to "/etc/fstab" to avoid it & related GUI error:

    The application cannot create a unique identifier.
    Please make sure the application has sufficient permissions.

Fixes #5773.