### PR TITLE
ci: fix codeql unable to download its own bundle

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -81,6 +81,7 @@ jobs:
         allowed-endpoints: >
           api.github.com:443
           github.com:443
+          objects.githubusercontent.com:443
           uploads.github.com:443
 
     - name: Checkout repository


### PR DESCRIPTION
Due to step-security/harden-runner blocking access to
objects.githubusercontent.com.

Log from a recent run of CodeQL[1] [2]:

    ##[group]Setup CodeQL tools
    Did not find CodeQL tools version 2.12.6 in the toolcache.
    Downloading CodeQL tools from https://github.com/github/codeql-action/releases/download/codeql-bundle-20230403/codeql-bundle-linux64.tar.gz. This may take a while.
    connect ECONNREFUSED 54.185.253.63:443
    Waiting 13 seconds before trying again
    connect ECONNREFUSED 54.185.253.63:443
    Waiting 12 seconds before trying again
    ##[error]connect ECONNREFUSED 54.185.253.63:443
    ##[error]Unable to download and extract CodeQL CLI
    Post job cleanup.
    [...]
    Mon, 10 Apr 2023 07:20:18 GMT:endpoint called ip address:port 140.82.112.4:443, domain: github.com.
    Mon, 10 Apr 2023 07:20:20 GMT:endpoint called ip address:port 140.82.112.6:443, domain: api.github.com.
    Mon, 10 Apr 2023 07:20:23 GMT:domain not allowed: objects.githubusercontent.com.
    Mon, 10 Apr 2023 07:20:23 GMT:ip address dropped: 54.185.253.63
    Mon, 10 Apr 2023 07:20:23 GMT:endpoint called ip address:port 140.82.112.4:443, domain: github.com.
    Mon, 10 Apr 2023 07:20:23 GMT:endpoint called ip address:port 54.185.253.63:443, domain: objects.githubusercontent.com.
    Mon, 10 Apr 2023 07:20:35 GMT:domain not allowed: api.snapcraft.io.

[1] https://github.com/netblue30/firejail/pull/5781
[2] https://github.com/netblue30/firejail/actions/runs/4655304231/jobs/8238131624