### PR TITLE
profiles: standardize on just "GTK" on comments

### DIFF
--- a/etc/profile-a-l/apostrophe.profile
+++ b/etc/profile-a-l/apostrophe.profile
@@ -1,5 +1,5 @@
 # Firejail profile for apostrophe
-# Description: Distraction free Markdown editor for GNU/Linux made with GTK+
+# Description: Distraction free Markdown editor for GNU/Linux made with GTK
 # This file is overwritten after every install/update
 # Persistent local customizations
 include apostrophe.local

--- a/etc/profile-a-l/bluefish.profile
+++ b/etc/profile-a-l/bluefish.profile
@@ -1,5 +1,5 @@
 # Firejail profile for bluefish
-# Description: Advanced Gtk+ text editor for web and software development
+# Description: Advanced GTK text editor for web and software development
 # This file is overwritten after every install/update
 # Persistent local customizations
 include bluefish.local

--- a/etc/profile-a-l/celluloid.profile
+++ b/etc/profile-a-l/celluloid.profile
@@ -1,5 +1,5 @@
 # Firejail profile for celluloid
-# Description: Simple GTK+ frontend for mpv
+# Description: Simple GTK frontend for mpv
 # This file is overwritten after every install/update
 # Persistent local customizations
 include celluloid.local

--- a/etc/profile-a-l/claws-mail.profile
+++ b/etc/profile-a-l/claws-mail.profile
@@ -1,5 +1,5 @@
 # Firejail profile for claws-mail
-# Description: Fast, lightweight and user-friendly GTK based email client
+# Description: Fast, lightweight and user-friendly GTK-based email client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include claws-mail.local

--- a/etc/profile-a-l/clipit.profile
+++ b/etc/profile-a-l/clipit.profile
@@ -1,5 +1,5 @@
 # Firejail profile for clipit
-# Description: Lightweight GTK+ clipboard manager
+# Description: Lightweight GTK clipboard manager
 # This file is overwritten after every install/update
 # Persistent local customizations
 include clipit.local

--- a/etc/profile-a-l/com.github.bleakgrey.tootle.profile
+++ b/etc/profile-a-l/com.github.bleakgrey.tootle.profile
@@ -1,5 +1,5 @@
 # Firejail profile for com.github.bleakgrey.tootle
-# Description: Gtk Mastodon client
+# Description: GTK Mastodon client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include com.github.bleakgrey.tootle.local

--- a/etc/profile-a-l/corebird.profile
+++ b/etc/profile-a-l/corebird.profile
@@ -1,5 +1,5 @@
 # Firejail profile for corebird
-# Description: Native Gtk+ Twitter client for the Linux desktop
+# Description: Native GTK Twitter client for the Linux desktop
 # This file is overwritten after every install/update
 # Persistent local customizations
 include corebird.local

--- a/etc/profile-a-l/deadbeef.profile
+++ b/etc/profile-a-l/deadbeef.profile
@@ -1,5 +1,5 @@
 # Firejail profile for deadbeef
-# Description: A GTK+ audio player for GNU/Linux
+# Description: A GTK audio player for GNU/Linux
 # This file is overwritten after every install/update
 # Persistent local customizations
 include deadbeef.local

--- a/etc/profile-a-l/dino-im.profile
+++ b/etc/profile-a-l/dino-im.profile
@@ -1,5 +1,5 @@
 # Firejail profile for dino-im
-# Description: Modern XMPP Chat Client using GTK+/Vala, Ubuntu specific bin name
+# Description: Modern XMPP Chat Client using GTK/Vala, Ubuntu specific bin name
 # This file is overwritten after every install/update
 # Persistent local customizations
 include dino-im.local

--- a/etc/profile-a-l/dino.profile
+++ b/etc/profile-a-l/dino.profile
@@ -1,5 +1,5 @@
 # Firejail profile for dino
-# Description: Modern XMPP Chat Client using GTK+/Vala
+# Description: Modern XMPP Chat Client using GTK/Vala
 # This file is overwritten after every install/update
 # Persistent local customizations
 include dino.local

--- a/etc/profile-a-l/gajim.profile
+++ b/etc/profile-a-l/gajim.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gajim
-# Description: GTK+-based Jabber client
+# Description: GTK-based Jabber client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include gajim.local

--- a/etc/profile-a-l/geeqie.profile
+++ b/etc/profile-a-l/geeqie.profile
@@ -1,5 +1,5 @@
 # Firejail profile for geeqie
-# Description: Image viewer using GTK+
+# Description: Image viewer using GTK
 # This file is overwritten after every install/update
 # Persistent local customizations
 include geeqie.local

--- a/etc/profile-a-l/gtk-lbry-viewer.profile
+++ b/etc/profile-a-l/gtk-lbry-viewer.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gtk-lbry-viewer
-# Description: Gtk front-end to lbry-viewer
+# Description: GTK front-end to lbry-viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include gtk-lbry-viewer.local

--- a/etc/profile-a-l/gtk-pipe-viewer.profile
+++ b/etc/profile-a-l/gtk-pipe-viewer.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gtk-pipe-viewer
-# Description: Gtk front-end to pipe-viewer
+# Description: GTK front-end to pipe-viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include gtk-pipe-viewer.local

--- a/etc/profile-a-l/gtk-straw-viewer.profile
+++ b/etc/profile-a-l/gtk-straw-viewer.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gtk-straw-viewer
-# Description: Gtk front-end to straw-viewer
+# Description: GTK front-end to straw-viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include gtk-straw-viewer.local

--- a/etc/profile-a-l/gtk-youtube-viewer.profile
+++ b/etc/profile-a-l/gtk-youtube-viewer.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gtk-youtube-viewer
-# Description: Gtk front-end to youtube-viewer
+# Description: GTK front-end to youtube-viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include gtk-youtube-viewer.local

--- a/etc/profile-a-l/gtk2-youtube-viewer.profile
+++ b/etc/profile-a-l/gtk2-youtube-viewer.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gtk2-youtube-viewer
-# Description: Gtk front-end to youtube-viewer
+# Description: GTK front-end to youtube-viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include gtk2-youtube-viewer.local

--- a/etc/profile-a-l/gtk3-youtube-viewer.profile
+++ b/etc/profile-a-l/gtk3-youtube-viewer.profile
@@ -1,5 +1,5 @@
 # Firejail profile for gtk3-youtube-viewer
-# Description: Gtk front-end to youtube-viewer
+# Description: GTK front-end to youtube-viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include gtk3-youtube-viewer.local

--- a/etc/profile-a-l/guvcview.profile
+++ b/etc/profile-a-l/guvcview.profile
@@ -1,5 +1,5 @@
 # Firejail profile for guvcview
-# Description: GTK+ base UVC Viewer
+# Description: GTK-based UVC Viewer
 # This file is overwritten after every install/update
 # Persistent local customizations
 include guvcview.local

--- a/etc/profile-a-l/handbrake.profile
+++ b/etc/profile-a-l/handbrake.profile
@@ -1,5 +1,5 @@
 # Firejail profile for handbrake
-# Description: Versatile DVD ripper and video transcoder (GTK+ GUI)
+# Description: Versatile DVD ripper and video transcoder (GTK GUI)
 # This file is overwritten after every install/update
 # Persistent local customizations
 include handbrake.local

--- a/etc/profile-a-l/leafpad.profile
+++ b/etc/profile-a-l/leafpad.profile
@@ -1,5 +1,5 @@
 # Firejail profile for leafpad
-# Description: GTK+ based simple text editor
+# Description: GTK-based simple text editor
 # This file is overwritten after every install/update
 # Persistent local customizations
 include leafpad.local

--- a/etc/profile-m-z/marker.profile
+++ b/etc/profile-m-z/marker.profile
@@ -1,5 +1,5 @@
 # Firejail profile for marker
-# Description: Marker is a markdown editor for Linux made with Gtk+-3.0
+# Description: Marker is a markdown editor for Linux made with GTK
 # This file is overwritten after every install/update
 # Persistent local customizations
 include marker.local

--- a/etc/profile-m-z/mp3splt-gtk.profile
+++ b/etc/profile-m-z/mp3splt-gtk.profile
@@ -1,5 +1,5 @@
 # Firejail profile for mp3splt-gtk
-# Description: Gtk utility for mp3/ogg splitting without decoding
+# Description: GTK utility for mp3/ogg splitting without decoding
 # This file is overwritten after every install/update
 # Persistent local customizations
 include mp3splt-gtk.local

--- a/etc/profile-m-z/remmina.profile
+++ b/etc/profile-m-z/remmina.profile
@@ -1,5 +1,5 @@
 # Firejail profile for remmina
-# Description: GTK+ Remote Desktop Client
+# Description: GTK Remote Desktop Client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include remmina.local

--- a/etc/profile-m-z/sylpheed.profile
+++ b/etc/profile-m-z/sylpheed.profile
@@ -1,5 +1,5 @@
 # Firejail profile for sylpheed
-# Description: Light weight e-mail client with GTK+
+# Description: Lightweight e-mail client made with GTK
 # This file is overwritten after every install/update
 # Persistent local customizations
 include sylpheed.local


### PR DESCRIPTION
For consistency and to reduce confusion.

The toolkit has been renamed from "GTK+" to just "GTK" in 2019[1].

Note: This also fixes some adjacent typos.

Commands used to search and replace:

    $ git grep -lz 'G[Tt][Kk]' -- etc | xargs -0 -I '{}' sh -c \
      "printf '%s\n' \"\$(sed -E \
        -e 's/G[Tt][Kk]\+?/GTK/g' \
        -e 's/GTK-.\.0/GTK/g' \
        -e 's/GTK base/GTK-base/g' \
        -e 's/GTK-base /GTK-based /g' \
        -e 's/Light weight/Lightweight/g' \
        -e 's/client with GTK/client made with GTK/g' '{}')\" >'{}'"

Misc: I noticed this on #5722.

[1] https://mail.gnome.org/archives/gtk-devel-list/2019-February/msg00000.html

Cc: @pirate486743186 (from #5722)
