### PR TITLE
ci: fix swapped name/email arguments in debian_ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,7 +83,8 @@ debian_ci:
         - echo "deb-src http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
         - echo "deb-src http://deb.debian.org/debian experimental main" >> /etc/apt/sources.list
         - apt-get update
-        - git config user.email "$GITLAB_USER_NAME" && git config user.name "$GITLAB_USER_EMAIL"
+        - git config user.name "$DEBFULLNAME"
+        - git config user.email "$DEBEMAIL"
         - cd $CI_PROJECT_DIR/.. && (apt-get source --download-only -t experimental firejail || apt-get source --download-only firejail)
         - cd $CI_PROJECT_DIR && tar xf ../firejail_*.debian.tar.*
         - rm -rf debian/patches/


### PR DESCRIPTION

Currently, the author name is used as the author email in git and vice
versa.

Changes:

* Split the commands to make them easier to read
* Put the name command first to match the usual git usage
* Fix swapped name/email arguments
* Use the DEBFULLNAME / DEBEMAIL environment variables instead of
  GitLab-specific ones

Added on commit 4cf51b591 ("extend gitlab-ci configuration to run Debian
CI tests", 2019-06-21).