### PR TITLE
Fix typo in pycharm-professional include

### DIFF
--- a/etc/profile-m-z/pycharm-professional.profile
+++ b/etc/profile-m-z/pycharm-professional.profile
@@ -1,7 +1,7 @@
 # Firejail profilen alias for pycharm-professional
 # This file is overwritten after every install/update
 # Persistent local customizations
-include pyucharm-professional.local
+include pycharm-professional.local
 # Persistent global definitions
 # added by included profile
 #include globals.local


### PR DESCRIPTION
Tiny fix, pycharm-professional.local was being incorrectly included:
include py**u**charm-professional.local