### PR TITLE
ci: formatting and misc improvements

### DIFF
--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -113,6 +113,7 @@ jobs:
       run: sudo apt-get update
     - name: install cppcheck
       run: sudo apt-get install cppcheck
+    - run: cppcheck --version
     - name: cppcheck
       run: >
         cppcheck -q --force --error-exitcode=1 --enable=warning,performance
@@ -134,6 +135,7 @@ jobs:
       run: sudo apt-get update
     - name: install cppcheck
       run: sudo apt-get install cppcheck
+    - run: cppcheck --version
     - name: cppcheck
       run: cppcheck -q --force --error-exitcode=1 --enable=warning,performance .
   codespell:
@@ -151,5 +153,6 @@ jobs:
       run: sudo apt-get update
     - name: install dependencies
       run: sudo apt-get install codespell
+    - run: codespell --version
     - name: codespell
       run: make codespell

--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -67,6 +67,8 @@ jobs:
       run: sudo apt-get update
     - name: install dependencies
       run: sudo apt-get install libapparmor-dev libselinux1-dev
+    - name: print env
+      run: ./ci/printenv.sh
     - name: configure
       run: >
         CC=clang-14 ./configure --enable-fatal-warnings --enable-apparmor
@@ -92,6 +94,8 @@ jobs:
       run: sudo apt-get update
     - name: install clang-tools-14 and dependencies
       run: sudo apt-get install clang-tools-14 libapparmor-dev libselinux1-dev
+    - name: print env
+      run: ./ci/printenv.sh
     - name: configure
       run: >
         CC=clang-14 ./configure --enable-fatal-warnings --enable-apparmor

--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -12,6 +12,7 @@ on:
       - .git-blame-ignore-revs
       - .github/dependabot.yml
       - .github/pull_request_template.md
+      - .github/workflows/build.yml
       - .github/workflows/codeql-analysis.yml
       - .github/workflows/profile-checks.yml
       - .gitignore
@@ -34,6 +35,7 @@ on:
       - .git-blame-ignore-revs
       - .github/dependabot.yml
       - .github/pull_request_template.md
+      - .github/workflows/build.yml
       - .github/workflows/codeql-analysis.yml
       - .github/workflows/profile-checks.yml
       - .gitignore

--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -68,7 +68,9 @@ jobs:
     - name: install dependencies
       run: sudo apt-get install libapparmor-dev libselinux1-dev
     - name: configure
-      run: CC=clang-14 ./configure --enable-fatal-warnings --enable-apparmor --enable-selinux
+      run: >
+        CC=clang-14 ./configure --enable-fatal-warnings --enable-apparmor
+        --enable-selinux
     - name: make
       run: make
     - name: make install
@@ -91,7 +93,9 @@ jobs:
     - name: install clang-tools-14 and dependencies
       run: sudo apt-get install clang-tools-14 libapparmor-dev libselinux1-dev
     - name: configure
-      run: CC=clang-14 ./configure --enable-fatal-warnings --enable-apparmor --enable-selinux
+      run: >
+        CC=clang-14 ./configure --enable-fatal-warnings --enable-apparmor
+        --enable-selinux
     - name: scan-build
       run: NO_EXTRA_CFLAGS="yes" scan-build-14 --status-bugs make
   cppcheck:
@@ -110,9 +114,11 @@ jobs:
     - name: install cppcheck
       run: sudo apt-get install cppcheck
     - name: cppcheck
-      run: cppcheck -q --force --error-exitcode=1 --enable=warning,performance -i src/firejail/checkcfg.c -i src/firejail/main.c .
-  # new cppcheck version currently chokes on checkcfg.c and main.c, therefore scan all files also
-  # with older cppcheck version from ubuntu 20.04.
+      run: >
+        cppcheck -q --force --error-exitcode=1 --enable=warning,performance
+        -i src/firejail/checkcfg.c -i src/firejail/main.c .
+  # new cppcheck version currently chokes on checkcfg.c and main.c, therefore
+  # scan all files also with older cppcheck version from ubuntu 20.04.
   cppcheck_old:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,8 @@ jobs:
         sudo apt-get install
         gcc-12 libapparmor-dev libselinux1-dev expect xzdec whois
         bridge-utils
+    - name: print env
+      run: ./ci/printenv.sh
     - name: configure
       run: >
         CC=gcc-12 ./configure --prefix=/usr --enable-fatal-warnings

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
       - .git-blame-ignore-revs
       - .github/dependabot.yml
       - .github/pull_request_template.md
+      - .github/workflows/build-extra.yml
       - .github/workflows/codeql-analysis.yml
       - .github/workflows/profile-checks.yml
       - .gitignore
@@ -25,6 +26,7 @@ on:
       - .git-blame-ignore-revs
       - .github/dependabot.yml
       - .github/pull_request_template.md
+      - .github/workflows/build-extra.yml
       - .github/workflows/codeql-analysis.yml
       - .github/workflows/profile-checks.yml
       - .gitignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,9 +64,14 @@ jobs:
     - name: update package information
       run: sudo apt-get update
     - name: install dependencies
-      run: sudo apt-get install gcc-12 libapparmor-dev libselinux1-dev expect xzdec whois bridge-utils
+      run: >
+        sudo apt-get install
+        gcc-12 libapparmor-dev libselinux1-dev expect xzdec whois
+        bridge-utils
     - name: configure
-      run: CC=gcc-12 ./configure --prefix=/usr --enable-fatal-warnings --enable-analyzer --enable-apparmor --enable-selinux
+      run: >
+        CC=gcc-12 ./configure --prefix=/usr --enable-fatal-warnings
+        --enable-analyzer --enable-apparmor --enable-selinux
     - name: make
       run: make
     - name: make install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,8 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
   build_and_test:
     runs-on: ubuntu-22.04
+    env:
+      SHELL: /bin/bash
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@6b3083af2869dc3314a0257a42f4af696cc79ba3
@@ -71,35 +73,19 @@ jobs:
       run: sudo make install
     - name: print firejail version
       run: command -V firejail && firejail --version
-    - name: lab setup
-      run: SHELL=/bin/bash make lab-setup
-    - name: run seccomp extra tests
-      run: SHELL=/bin/bash make test-seccomp-extra
-    - name: run firecfg tests
-      run: SHELL=/bin/bash make test-firecfg
-    - name: run capabilities tests
-      run: SHELL=/bin/bash make test-capabilities
-    - name: run apparmor tests
-      run: SHELL=/bin/bash make test-apparmor
-    - name: run appimage tests
-      run: SHELL=/bin/bash make test-appimage
-    - name: run chroot tests
-      run: SHELL=/bin/bash make test-chroot
-    - name: run sysutils tests
-      run: SHELL=/bin/bash make test-sysutils
-    - name: run private-etc tests
-      run: SHELL=/bin/bash make test-private-etc
-    - name: run profile tests
-      run: SHELL=/bin/bash make test-profiles
-    - name: run fcopy tests
-      run: SHELL=/bin/bash make test-fcopy
-    - name: run fnetfilter tests
-      run: SHELL=/bin/bash make test-fnetfilter
-    - name: run fs tests
-      run: SHELL=/bin/bash make test-fs
-    - name: run utils tests
-      run: SHELL=/bin/bash make test-utils
-    - name: run environment tests
-      run: SHELL=/bin/bash make test-environment
-    - name: run network tests
-      run: SHELL=/bin/bash make test-network
+    - run: make lab-setup
+    - run: make test-seccomp-extra
+    - run: make test-firecfg
+    - run: make test-capabilities
+    - run: make test-apparmor
+    - run: make test-appimage
+    - run: make test-chroot
+    - run: make test-sysutils
+    - run: make test-private-etc
+    - run: make test-profiles
+    - run: make test-fcopy
+    - run: make test-fnetfilter
+    - run: make test-fs
+    - run: make test-utils
+    - run: make test-environment
+    - run: make test-network

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,8 @@ on:
       - .git-blame-ignore-revs
       - .github/dependabot.yml
       - .github/pull_request_template.md
+      - .github/workflows/build-extra.yml
+      - .github/workflows/build.yml
       - .github/workflows/profile-checks.yml
       - .gitignore
       - .gitlab-ci.yml
@@ -39,6 +41,8 @@ on:
       - .git-blame-ignore-revs
       - .github/dependabot.yml
       - .github/pull_request_template.md
+      - .github/workflows/build-extra.yml
+      - .github/workflows/build.yml
       - .github/workflows/profile-checks.yml
       - .gitignore
       - .gitlab-ci.yml

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -91,6 +91,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
 
+    - name: print env
+      run: ./ci/printenv.sh
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@b2c19fb9a2a485599ccf4ed5d65527d94bc57226

--- a/.github/workflows/profile-checks.yml
+++ b/.github/workflows/profile-checks.yml
@@ -35,11 +35,19 @@ jobs:
 
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
 #   - name: sort.py
-#      run: ./ci/check/profiles/sort.py etc/inc/*.inc etc/{profile-a-l,profile-m-z}/*.profile
+#     run: >
+#       ./ci/check/profiles/sort.py
+#       etc/inc/*.inc etc/{profile-a-l,profile-m-z}/*.profile
 # Currently broken (see #5610)
-#    - name: private-etc-always-required.sh
-#      run: ./ci/check/profiles/private-etc-always-required.sh etc/inc/*.inc etc/{profile-a-l,profile-m-z}/*.profile
+#   - name: private-etc-always-required.sh
+#     run: >
+#       ./ci/check/profiles/private-etc-always-required.sh
+#       etc/inc/*.inc etc/{profile-a-l,profile-m-z}/*.profile
     - name: sort-disable-programs.sh
-      run: ./ci/check/profiles/sort-disable-programs.sh etc/inc/disable-programs.inc
+      run: >
+        ./ci/check/profiles/sort-disable-programs.sh
+        etc/inc/disable-programs.inc
     - name: sort-firecfg.config.sh
-      run: ./ci/check/profiles/sort-firecfg.config.sh src/firecfg/firecfg.config
+      run: >
+        ./ci/check/profiles/sort-firecfg.config.sh
+        src/firecfg/firecfg.config

--- a/.github/workflows/profile-checks.yml
+++ b/.github/workflows/profile-checks.yml
@@ -34,6 +34,7 @@ jobs:
           github.com:443
 
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+    - run: python3 --version
 #   - name: sort.py
 #     run: >
 #       ./ci/check/profiles/sort.py

--- a/.github/workflows/profile-checks.yml
+++ b/.github/workflows/profile-checks.yml
@@ -34,7 +34,10 @@ jobs:
           github.com:443
 
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+    - name: print env
+      run: ./ci/printenv.sh
     - run: python3 --version
+
 #   - name: sort.py
 #     run: >
 #       ./ci/check/profiles/sort.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,11 +5,14 @@
 # and fedora:latest for new setups
 # 3. Alpine for installing directly from source
 # Also builds apparmor package for Ubuntu LTS
+
 build_ubuntu_package:
     image: ubuntu:rolling
     script:
         - apt-get update -qq
-        - DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential lintian libapparmor-dev pkg-config python3 gawk
+        - >
+            DEBIAN_FRONTEND=noninteractive apt-get install -y -qq
+            build-essential lintian libapparmor-dev pkg-config python3 gawk
         - ./configure
         - make deb
         - dpkg -i firejail*.deb
@@ -20,7 +23,9 @@ build_debian_package:
     image: debian:stretch
     script:
         - apt-get update -qq
-        - apt-get install -y -qq build-essential lintian libapparmor-dev pkg-config gawk
+        - >
+            apt-get install -y -qq
+            build-essential lintian libapparmor-dev pkg-config gawk
         - ./configure
         - make deb
         - dpkg -i firejail*.deb
@@ -63,7 +68,9 @@ build_no_apparmor:
     image: ubuntu:latest
     script:
         - apt-get update -qq
-        - DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential lintian pkg-config gawk
+        - >
+            DEBIAN_FRONTEND=noninteractive apt-get install -y -qq
+            build-essential lintian pkg-config gawk
         - ./configure
         - make dist
         - ./mkdeb.sh --disable-apparmor
@@ -80,16 +87,30 @@ debian_ci:
         - git checkout -B ci_build $CI_COMMIT_SHA
         - gitlab-ci-enable-sid
         - gitlab-ci-enable-experimental
-        - echo "deb-src http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
-        - echo "deb-src http://deb.debian.org/debian experimental main" >> /etc/apt/sources.list
+        - |
+            cat >>/etc/apt/sources.list <<EOF
+            deb-src http://deb.debian.org/debian sid main
+            deb-src http://deb.debian.org/debian experimental main
+            EOF
         - apt-get update
         - git config user.name "$DEBFULLNAME"
         - git config user.email "$DEBEMAIL"
-        - cd $CI_PROJECT_DIR/.. && (apt-get source --download-only -t experimental firejail || apt-get source --download-only firejail)
-        - cd $CI_PROJECT_DIR && tar xf ../firejail_*.debian.tar.*
+        - |
+            cd $CI_PROJECT_DIR/.. &&
+            (apt-get source --download-only -t experimental firejail ||
+            apt-get source --download-only firejail)
+        - |
+            cd $CI_PROJECT_DIR &&
+            tar xf ../firejail_*.debian.tar.*
         - rm -rf debian/patches/
-        - VERSION=$(grep ^PACKAGE_VERSION= configure | cut -d"'" -f2) && dch -v ${VERSION}-0.1~ci "Non-maintainer upload." && git archive -o ../firejail_${VERSION}.orig.tar.gz HEAD && pristine-tar commit ../firejail_${VERSION}.orig.tar.gz ci_build && git branch -m pristine-tar origin/pristine-tar
-        - git add debian && git commit -m "add debian/"
+        - |
+            VERSION=$(grep ^PACKAGE_VERSION= configure | cut -d "'" -f 2) &&
+            dch -v ${VERSION}-0.1~ci "Non-maintainer upload." &&
+            git archive -o ../firejail_${VERSION}.orig.tar.gz HEAD &&
+            pristine-tar commit ../firejail_${VERSION}.orig.tar.gz ci_build &&
+            git branch -m pristine-tar origin/pristine-tar
+        - git add debian
+        - git commit -m "add debian/"
         - export CI_COMMIT_SHA=$(git rev-parse HEAD)
     script:
         - apt-get --no-install-recommends install -y -qq gawk

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,7 @@ debian_ci:
         DEBFULLNAME: "$GITLAB_USER_NAME"
         DEBEMAIL: "$GITLAB_USER_EMAIL"
     before_script:
-        - git checkout -B ci_build $CI_COMMIT_SHA
+        - git checkout -B ci_build "$CI_COMMIT_SHA"
         - gitlab-ci-enable-sid
         - gitlab-ci-enable-experimental
         - |
@@ -96,22 +96,22 @@ debian_ci:
         - git config user.name "$DEBFULLNAME"
         - git config user.email "$DEBEMAIL"
         - |
-            cd $CI_PROJECT_DIR/..
+            cd "$CI_PROJECT_DIR/.."
             apt-get source --download-only -t experimental firejail ||
             apt-get source --download-only firejail
         - |
-            cd $CI_PROJECT_DIR
+            cd "$CI_PROJECT_DIR"
             tar xf ../firejail_*.debian.tar.*
         - rm -rf debian/patches/
         - |
-            VERSION=$(grep ^PACKAGE_VERSION= configure | cut -d "'" -f 2)
-            dch -v ${VERSION}-0.1~ci "Non-maintainer upload."
-            git archive -o ../firejail_${VERSION}.orig.tar.gz HEAD
-            pristine-tar commit ../firejail_${VERSION}.orig.tar.gz ci_build
+            VERSION="$(grep ^PACKAGE_VERSION= configure | cut -d "'" -f 2)"
+            dch -v "${VERSION}-0.1~ci" 'Non-maintainer upload.'
+            git archive -o "../firejail_${VERSION}.orig.tar.gz" HEAD
+            pristine-tar commit "../firejail_${VERSION}.orig.tar.gz" ci_build
             git branch -m pristine-tar origin/pristine-tar
         - git add debian
-        - git commit -m "add debian/"
-        - export CI_COMMIT_SHA=$(git rev-parse HEAD)
+        - git commit -m 'add debian/'
+        - export CI_COMMIT_SHA="$(git rev-parse HEAD)"
     script:
         - apt-get --no-install-recommends install -y -qq gawk
         - gitlab-ci-git-buildpackage

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,7 @@ build_ubuntu_package:
         - >
             DEBIAN_FRONTEND=noninteractive apt-get install -y -qq
             build-essential lintian libapparmor-dev pkg-config python3 gawk
+        - ./ci/printenv.sh
         - ./configure
         - make deb
         - dpkg -i firejail*.deb
@@ -27,6 +28,7 @@ build_debian_package:
         - >
             apt-get install -y -qq
             build-essential lintian libapparmor-dev pkg-config gawk
+        - ./ci/printenv.sh
         - ./configure
         - make deb
         - dpkg -i firejail*.deb
@@ -37,6 +39,7 @@ build_redhat_package:
     script:
         - dnf update -y
         - dnf install -y rpm-build gcc make
+        - ./ci/printenv.sh
         - ./configure --prefix=/usr
         - make rpms
         - rpm -i firejail*.rpm
@@ -47,6 +50,7 @@ build_fedora_package:
     script:
         - dnf update -y
         - dnf install -y rpm-build gcc make
+        - ./ci/printenv.sh
         - ./configure --prefix=/usr
         - make rpms
         - rpm -i firejail*.rpm
@@ -60,6 +64,7 @@ build_src_package:
         - apk update
         - apk upgrade
         - apk add build-base linux-headers python3 gawk
+        - ./ci/printenv.sh
         - ./configure --prefix=/usr
         - make
         - make install-strip
@@ -74,6 +79,7 @@ build_no_apparmor:
         - >
             DEBIAN_FRONTEND=noninteractive apt-get install -y -qq
             build-essential lintian pkg-config gawk
+        - ./ci/printenv.sh
         - ./configure
         - make dist
         - ./mkdeb.sh --disable-apparmor
@@ -117,5 +123,6 @@ debian_ci:
         - export CI_COMMIT_SHA="$(git rev-parse HEAD)"
     script:
         - apt-get --no-install-recommends install -y -qq gawk
+        - ./ci/printenv.sh
         - gitlab-ci-git-buildpackage
         - gitlab-ci-lintian

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,7 @@ build_ubuntu_package:
         - make deb
         - dpkg -i firejail*.deb
         - command -V firejail && firejail --version
+        # - python3 --version
         # - python3 contrib/sort.py etc/profile-*/*.profile etc/inc/*.inc
 
 build_debian_package:
@@ -50,6 +51,7 @@ build_fedora_package:
         - make rpms
         - rpm -i firejail*.rpm
         - command -V firejail && firejail --version
+        # - python3 --version
         # - python3 contrib/sort.py etc/profile-*/*.profile etc/inc/*.inc
 
 build_src_package:
@@ -62,6 +64,7 @@ build_src_package:
         - make
         - make install-strip
         - command -V firejail && firejail --version
+        # - python3 --version
         # - python3 contrib/sort.py etc/profile-*/*.profile etc/inc/*.inc
 
 build_no_apparmor:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ build_src_package:
         - make
         - make install-strip
         - command -V firejail && firejail --version
-        # - python3 contrib/sort.py etc/*.{profile,inc}
+        # - python3 contrib/sort.py etc/profile-*/*.profile etc/inc/*.inc
 
 build_no_apparmor:
     image: ubuntu:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,18 +96,18 @@ debian_ci:
         - git config user.name "$DEBFULLNAME"
         - git config user.email "$DEBEMAIL"
         - |
-            cd $CI_PROJECT_DIR/.. &&
-            (apt-get source --download-only -t experimental firejail ||
-            apt-get source --download-only firejail)
+            cd $CI_PROJECT_DIR/..
+            apt-get source --download-only -t experimental firejail ||
+            apt-get source --download-only firejail
         - |
-            cd $CI_PROJECT_DIR &&
+            cd $CI_PROJECT_DIR
             tar xf ../firejail_*.debian.tar.*
         - rm -rf debian/patches/
         - |
-            VERSION=$(grep ^PACKAGE_VERSION= configure | cut -d "'" -f 2) &&
-            dch -v ${VERSION}-0.1~ci "Non-maintainer upload." &&
-            git archive -o ../firejail_${VERSION}.orig.tar.gz HEAD &&
-            pristine-tar commit ../firejail_${VERSION}.orig.tar.gz ci_build &&
+            VERSION=$(grep ^PACKAGE_VERSION= configure | cut -d "'" -f 2)
+            dch -v ${VERSION}-0.1~ci "Non-maintainer upload."
+            git archive -o ../firejail_${VERSION}.orig.tar.gz HEAD
+            pristine-tar commit ../firejail_${VERSION}.orig.tar.gz ci_build
             git branch -m pristine-tar origin/pristine-tar
         - git add debian
         - git commit -m "add debian/"

--- a/Makefile
+++ b/Makefile
@@ -364,6 +364,10 @@ scan-build: clean
 codespell: clean
 	codespell --ignore-regex "UE|creat|shotcut|ether" src test
 
+.PHONY: print-env
+print-env:
+	./ci/printenv.sh
+
 #
 # make test
 #

--- a/ci/printenv.sh
+++ b/ci/printenv.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Print information that may be useful for debugging CI.
+
+test -f /etc/os-release && . /etc/os-release
+
+cat <<EOF
+nproc:  $(nproc)
+kernel: $(uname -srvm)
+distro: $PRETTY_NAME
+sh:     $(ls -l /bin/sh | sed 's|.* /bin|/bin|')
+user:   $(id | cut -f -2 -d ' ')
+
+[/etc/os-release]
+$(cat /etc/os-release)
+EOF
+
+if test -z "$CI_VERBOSE"; then
+	exit
+fi
+
+cat <<EOF
+
+[env]
+$(env | LC_ALL=C sort)
+EOF


### PR DESCRIPTION
Commits:

```console
$ git log --reverse --pretty='* %s' master..
* ci: fix commented sort.py code in alpine job
* ci: ignore build workflows on more workflows
* ci: simplify test steps in build.yml
* ci: line-wrap and split/join some commands
* ci: use one command per line instead of chaining them
* ci: improve quotes in gitlab ci
* ci: print some program versions
* ci: print env-related settings in each job
```

The changes are mostly about making the workflows easier to read and debug.

This is a follow-up to #5795.

Relates to #5481.
