### PR TITLE
element-desktop: allow notifications in profile

### DIFF
--- a/etc/profile-a-l/element-desktop.profile
+++ b/etc/profile-a-l/element-desktop.profile
@@ -19,6 +19,7 @@ private-opt Element
 
 dbus-user filter
 dbus-user.talk org.freedesktop.secrets
+dbus-user.talk org.freedesktop.Notifications
 
 # Redirect
 include riot-desktop.profile


### PR DESCRIPTION
I assume most people want this on, since it is a messenger application, and you can control whether you turn it on or off in the app.
