### PR TITLE
arp.c: ensure positive timeout on select(2)

### DIFF
--- a/src/firejail/arp.c
+++ b/src/firejail/arp.c
@@ -197,7 +197,11 @@ int arp_check(const char *dev, uint32_t destaddr) {
 		double timeout = timerend - now;
 		ts.tv_sec = timeout;
 		ts.tv_usec = (timeout - ts.tv_sec) * 1000000;
-		int nready = select(maxfd + 1,  &fds, (fd_set *) 0, (fd_set *) 0, &ts);
+		if (ts.tv_sec < 0)
+			ts.tv_sec = 0;
+		if (ts.tv_usec < 0)
+			ts.tv_usec = 0;
+		int nready = select(maxfd + 1, &fds, (fd_set *) 0, (fd_set *) 0, &ts);
 		if (nready < 0)
 			errExit("select");
 		else if (nready == 0) { // timeout


### PR DESCRIPTION
Log from build_and_test[1]:

    TESTING: network scan (net_scan.exp)
    [...]

    firejail /bin/bash
    Child process initialized in 1704.83 ms
    spawn /bin/bash
    firejail --net=br0 --ip=10.10.20.60
    runner@fv-az576-472:~/work/firejail/firejail/test/network$
    <l/test/network$ firejail --net=br0 --ip=10.10.20.60
    Reading profile /etc/firejail/default.profile
    Reading profile /etc/firejail/disable-common.inc
    Reading profile /etc/firejail/disable-programs.inc

    ** Note: you can use --noprofile to disable default.profile **

    Error select: arp.c:202 arp_check: Invalid argument
    runner@fv-az576-472:~/work/firejail/firejail/test/network$ TESTING ERROR 4

This "Invalid argument" error does not always happen, so I assume that
it may be due to a negative integer value in `ts` when calling select.

Misc: Found in #5805.

[1] https://github.com/netblue30/firejail/actions/runs/4806275219/jobs/8553597462