### PR TITLE
email-common: fix bogofilter/bsfilter support

### DIFF
--- a/etc/profile-a-l/email-common.profile
+++ b/etc/profile-a-l/email-common.profile
@@ -20,6 +20,9 @@ noblacklist /var/spool/mail
 
 noblacklist ${DOCUMENTS}
 
+# Allow perl (blacklisted by disable-interpreters.inc)
+include allow-perl.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
@@ -30,15 +33,18 @@ include disable-xdg.inc
 mkdir ${HOME}/.gnupg
 mkfile ${HOME}/.config/mimeapps.list
 mkfile ${HOME}/.signature
+whitelist ${HOME}/.bogofilter
+whitelist ${HOME}/.bsfilter
 whitelist ${HOME}/.config/mimeapps.list
-whitelist ${HOME}/.mozilla/firefox/profiles.ini
 whitelist ${HOME}/.gnupg
+whitelist ${HOME}/.mozilla/firefox/profiles.ini
 whitelist ${HOME}/.signature
 whitelist ${DOCUMENTS}
 whitelist ${DOWNLOADS}
 # when storing mail outside the default ${HOME}/Mail path, 'whitelist' the custom path in your email-common.local
 whitelist ${HOME}/Mail
 whitelist ${RUNUSER}/gnupg
+whitelist /usr/share/bogofilter
 whitelist /usr/share/gnupg
 whitelist /usr/share/gnupg2
 whitelist /var/mail
@@ -70,7 +76,7 @@ tracelog
 # disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca,@x11,gnupg,hosts.conf,mailname,timezone
+private-etc @tls-ca,@x11,bogofilter,bogofilter.cf,gnupg,hosts.conf,mailname,timezone
 private-tmp
 # encrypting and signing email
 writable-run-user


### PR DESCRIPTION
Fixes #5809.
Additionally added bsfilter whitelisting (similar to bogofilter).