### PR TITLE
ci: run for every branch instead of just master

### DIFF
--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -2,7 +2,6 @@ name: Build-extra CI
 
 on:
   push:
-    branches: [ master ]
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - 'contrib/syntax/**'
@@ -25,7 +24,6 @@ on:
       - SECURITY.md
       - src/firecfg/firecfg.config
   pull_request:
-    branches: [ master ]
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - 'contrib/syntax/**'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: Build CI
 
 on:
   push:
-    branches: [ master ]
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - .git-blame-ignore-revs
@@ -20,7 +19,6 @@ on:
       - RELNOTES
       - SECURITY.md
   pull_request:
-    branches: [ master ]
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - .git-blame-ignore-revs

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,6 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - 'contrib/syntax/**'
@@ -30,8 +29,6 @@ on:
       - SECURITY.md
       - src/firecfg/firecfg.config
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ master ]
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - 'contrib/syntax/**'

--- a/.github/workflows/profile-checks.yml
+++ b/.github/workflows/profile-checks.yml
@@ -2,7 +2,6 @@ name: Profile Checks
 
 on:
   push:
-    branches: [ master ]
     paths:
       - 'ci/check/profiles/**'
       - 'etc/**'
@@ -10,7 +9,6 @@ on:
       - contrib/sort.py
       - src/firecfg/firecfg.config
   pull_request:
-    branches: [ master ]
     paths:
       - 'ci/check/profiles/**'
       - 'etc/**'


### PR DESCRIPTION
Having CI always run on WIP branches without having to open a PR
beforehand makes it easier to debug CI issues.

GitHub currently does not have any apparent limit for CI runs and there
are no project-specific secrets as far as I know, so it should be safe
to remove these restrictions.