### PR TITLE
modif: Improve --version/--help & print version on startup

### DIFF
--- a/src/etc-cleanup/main.c
+++ b/src/etc-cleanup/main.c
@@ -212,13 +212,16 @@ static void process_file(const char *fname) {
 	}
 }
 
+static const char *const usage_str =
+	"usage: cleanup-etc [options] file.profile [file.profile]\n"
+	"Group and clean private-etc entries in one or more profile files.\n"
+	"Options:\n"
+	"   --debug - print debug messages\n"
+	"   -h, -?, --help - this help screen\n"
+	"   --replace - replace profile file\n";
+
 static void usage(void) {
-	printf("usage: cleanup-etc [options] file.profile [file.profile]\n");
-	printf("Group and clean private-etc entries in one or more profile files.\n");
-	printf("Options:\n");
-	printf("   --debug - print debug messages\n");
-	printf("   -h, -?, --help - this help screen\n");
-	printf("   --replace - replace profile file\n");
+	puts(usage_str);
 }
 
 int main(int argc, char **argv) {

--- a/src/fbuilder/main.c
+++ b/src/fbuilder/main.c
@@ -21,9 +21,12 @@
 int arg_debug = 0;
 int arg_appimage = 0;
 
+static const char *const usage_str =
+	"Firejail profile builder\n"
+	"Usage: firejail [--debug] --build[=profile-file] program-and-arguments\n";
+
 static void usage(void) {
-	printf("Firejail profile builder\n");
-	printf("Usage: firejail [--debug] --build[=profile-file] program-and-arguments\n");
+	puts(usage_str);
 }
 
 int main(int argc, char **argv) {

--- a/src/fcopy/main.c
+++ b/src/fcopy/main.c
@@ -416,17 +416,18 @@ static void duplicate_link(const char *src, const char *dest, struct stat *s) {
 	free(rdest);
 }
 
+static const char *const usage_str =
+	"Usage: fcopy [--follow-link] src dest\n"
+	"\n"
+	"Copy SRC to DEST/SRC. SRC may be a file, directory, or symbolic link.\n"
+	"If SRC is a directory it is copied recursively.  If it is a symlink,\n"
+	"the link itself is duplicated, unless --follow-link is given,\n"
+	"in which case the destination of the link is copied.\n"
+	"DEST must already exist and must be a directory.\n";
 
 static void usage(void) {
-	fputs("Usage: fcopy [--follow-link] src dest\n"
-		"\n"
-		"Copy SRC to DEST/SRC. SRC may be a file, directory, or symbolic link.\n"
-		"If SRC is a directory it is copied recursively.  If it is a symlink,\n"
-		"the link itself is duplicated, unless --follow-link is given,\n"
-		"in which case the destination of the link is copied.\n"
-		"DEST must already exist and must be a directory.\n", stderr);
+	fputs(usage_str, stderr);
 }
-
 
 int main(int argc, char **argv) {
 #if 0

--- a/src/fids/main.c
+++ b/src/fids/main.c
@@ -318,10 +318,11 @@ static void process_config(const char *fname) {
 	include_level--;
 }
 
-
+static const char *const usage_str =
+	"Usage: fids [--help|-h|-?] --init|--check homedir\n";
 
 void usage(void) {
-	printf("Usage: fids [--help|-h|-?] --init|--check homedir\n");
+	puts(usage_str);
 }
 
 int main(int argc, char **argv) {

--- a/src/firecfg/main.c
+++ b/src/firecfg/main.c
@@ -59,11 +59,14 @@ static char *usage_str =
 	"License GPL version 2 or later\n"
 	"Homepage: https://firejail.wordpress.com\n\n";
 
-static void usage(void) {
+static void print_version(void) {
 	printf("firecfg version %s\n\n", VERSION);
-	puts(usage_str);
 }
 
+static void usage(void) {
+	print_version();
+	puts(usage_str);
+}
 
 static void list(void) {
 	DIR *dir = opendir(arg_bindir);
@@ -364,7 +367,7 @@ int main(int argc, char **argv) {
 		else if (strcmp(argv[i], "--debug") == 0)
 			arg_debug = 1;
 		else if (strcmp(argv[i], "--version") == 0) {
-			printf("firecfg version %s\n\n", VERSION);
+			print_version();
 			return 0;
 		}
 		else if (strcmp(argv[i], "--clean") == 0) {

--- a/src/firecfg/main.c
+++ b/src/firecfg/main.c
@@ -24,7 +24,7 @@ int arg_debug = 0;
 char *arg_bindir = "/usr/local/bin";
 int arg_guide = 0;
 
-static char *usage_str =
+static const char *const usage_str =
 	"Firecfg is the desktop configuration utility for Firejail software. The utility\n"
 	"creates several symbolic links to firejail executable. This allows the user to\n"
 	"sandbox applications automatically, just by clicking on a regular desktop\n"

--- a/src/firecfg/main.c
+++ b/src/firecfg/main.c
@@ -60,7 +60,7 @@ static char *usage_str =
 	"Homepage: https://firejail.wordpress.com\n\n";
 
 static void usage(void) {
-	printf("firecfg - version %s\n\n", VERSION);
+	printf("firecfg version %s\n\n", VERSION);
 	puts(usage_str);
 }
 

--- a/src/firecfg/main.c
+++ b/src/firecfg/main.c
@@ -413,6 +413,7 @@ int main(int argc, char **argv) {
 		}
 	}
 
+	print_version();
 	if (arg_debug)
 		printf("%s %d %d %d %d\n", user, getuid(), getgid(), geteuid(), getegid());
 

--- a/src/firecfg/main.c
+++ b/src/firecfg/main.c
@@ -57,7 +57,7 @@ static const char *const usage_str =
 	"   [...]\n"
 	"\n"
 	"License GPL version 2 or later\n"
-	"Homepage: https://firejail.wordpress.com\n\n";
+	"Homepage: https://firejail.wordpress.com\n";
 
 static void print_version(void) {
 	printf("firecfg version %s\n\n", VERSION);

--- a/src/firejail/checkcfg.c
+++ b/src/firejail/checkcfg.c
@@ -305,13 +305,6 @@ errout:
 	exit(1);
 }
 
-void print_version(void) {
-	printf("firejail version %s\n", VERSION);
-	printf("\n");
-	print_compiletime_support();
-	printf("\n");
-}
-
 void print_compiletime_support(void) {
 	printf("Compile time support:\n");
 	printf("\t- always force nonewprivs support is %s\n",

--- a/src/firejail/checkcfg.c
+++ b/src/firejail/checkcfg.c
@@ -305,140 +305,128 @@ errout:
 	exit(1);
 }
 
-void print_compiletime_support(void) {
-	printf("Compile time support:\n");
-	printf("\t- always force nonewprivs support is %s\n",
+static const char *const compiletime_support =
+	"Compile time support:"
+	"\n\t- always force nonewprivs support is "
 #ifdef HAVE_FORCE_NONEWPRIVS
 		"enabled"
 #else
 		"disabled"
 #endif
-		);
 
-	printf("\t- AppArmor support is %s\n",
+	"\n\t- AppArmor support is "
 #ifdef HAVE_APPARMOR
 		"enabled"
 #else
 		"disabled"
 #endif
-		);
 
-	printf("\t- AppImage support is %s\n",
+	"\n\t- AppImage support is "
 #ifdef LOOP_CTL_GET_FREE	// test for older kernels; this definition is found in /usr/include/linux/loop.h
 		"enabled"
 #else
 		"disabled"
 #endif
-		);
 
-	printf("\t- chroot support is %s\n",
+	"\n\t- chroot support is "
 #ifdef HAVE_CHROOT
 		"enabled"
 #else
 		"disabled"
 #endif
-		);
 
-	printf("\t- D-BUS proxy support is %s\n",
+	"\n\t- D-BUS proxy support is "
 #ifdef HAVE_DBUSPROXY
 		"enabled"
 #else
 		"disabled"
 #endif
-		);
 
-	printf("\t- file transfer support is %s\n",
+	"\n\t- file transfer support is "
 #ifdef HAVE_FILE_TRANSFER
 		"enabled"
 #else
 		"disabled"
 #endif
-		);
 
-	printf("\t- firetunnel support is %s\n",
+	"\n\t- firetunnel support is "
 #ifdef HAVE_FIRETUNNEL
 		"enabled"
 #else
 		"disabled"
 #endif
-		);
 
-	printf("\t- IDS support is %s\n",
+	"\n\t- IDS support is "
 #ifdef HAVE_IDS
 		"enabled"
 #else
 		"disabled"
 #endif
-		);
 
-	printf("\t- networking support is %s\n",
+	"\n\t- networking support is "
 #ifdef HAVE_NETWORK
 		"enabled"
 #else
 		"disabled"
 #endif
-		);
 
-	printf("\t- output logging is %s\n",
+	"\n\t- output logging is "
 #ifdef HAVE_OUTPUT
 		"enabled"
 #else
 		"disabled"
 #endif
-		);
-	printf("\t- overlayfs support is %s\n",
+
+	"\n\t- overlayfs support is "
 #ifdef HAVE_OVERLAYFS
 		"enabled"
 #else
 		"disabled"
 #endif
-		);
 
-	printf("\t- private-home support is %s\n",
+	"\n\t- private-home support is "
 #ifdef HAVE_PRIVATE_HOME
 		"enabled"
 #else
 		"disabled"
 #endif
-		);
 
-	printf("\t- private-lib support is %s\n",
+	"\n\t- private-lib support is "
 #ifdef HAVE_PRIVATE_LIB
 		"enabled"
 #else
 		"disabled"
 #endif
-		);
 
-	printf("\t- private-cache and tmpfs as user %s\n",
+	"\n\t- private-cache and tmpfs as user "
 #ifdef HAVE_USERTMPFS
 		"enabled"
 #else
 		"disabled"
 #endif
-		);
 
-	printf("\t- SELinux support is %s\n",
+	"\n\t- SELinux support is "
 #ifdef HAVE_SELINUX
 		"enabled"
 #else
 		"disabled"
 #endif
-		);
 
-	printf("\t- user namespace support is %s\n",
+	"\n\t- user namespace support is "
 #ifdef HAVE_USERNS
 		"enabled"
 #else
 		"disabled"
 #endif
-		);
 
-	printf("\t- X11 sandboxing support is %s\n",
+	"\n\t- X11 sandboxing support is "
 #ifdef HAVE_X11
 		"enabled"
 #else
 		"disabled"
 #endif
-		);
+	"\n";
+
+void print_compiletime_support(void) {
+	puts(compiletime_support);
 }

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -478,6 +478,7 @@ void top(void);
 
 // usage.c
 void print_version(void);
+void print_version_full(void);
 void usage(void);
 
 // process.c

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -477,6 +477,7 @@ void tree(void);
 void top(void);
 
 // usage.c
+void print_version(void);
 void usage(void);
 
 // process.c
@@ -856,7 +857,6 @@ extern char *config_seccomp_filter_add;
 extern char **whitelist_reject_topdirs;
 
 int checkcfg(int val);
-void print_version(void);
 void print_compiletime_support(void);
 
 // appimage.c

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -369,7 +369,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 		exit(0);
 	}
 	else if (strcmp(argv[i], "--version") == 0) {
-		print_version();
+		print_version_full();
 		exit(0);
 	}
 #ifdef HAVE_OVERLAYFS
@@ -1128,7 +1128,7 @@ int main(int argc, char **argv, char **envp) {
 		EUID_USER();
 		if (rv == 0) {
 			if (check_arg(argc, argv, "--version", 1)) {
-				print_version();
+				print_version_full();
 				exit(0);
 			}
 

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -3010,6 +3010,11 @@ int main(int argc, char **argv, char **envp) {
 	}
 	EUID_ASSERT();
 
+	// Note: Only attempt to print non-debug information to stdout after
+	// all profiles have been loaded (because a profile may set arg_quiet)
+	if (!arg_quiet)
+		print_version();
+
 	// block X11 sockets
 	if (arg_x11_block)
 		x11_block();

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -314,6 +314,12 @@ static char *usage_str =
 	"Homepage: https://firejail.wordpress.com\n"
 	"\n";
 
+void print_version(void) {
+	printf("firejail version %s\n", VERSION);
+	printf("\n");
+	print_compiletime_support();
+	printf("\n");
+}
 
 void usage(void) {
 	printf("firejail version %s\n\n", VERSION);

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -311,8 +311,7 @@ static const char *const usage_str =
 	"\tlist all running sandboxes\n"
 	"\n"
 	"License GPL version 2 or later\n"
-	"Homepage: https://firejail.wordpress.com\n"
-	"\n";
+	"Homepage: https://firejail.wordpress.com\n";
 
 void print_version(void) {
 	printf("firejail version %s\n\n", VERSION);

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -321,7 +321,6 @@ void print_version(void) {
 void print_version_full(void) {
 	print_version();
 	print_compiletime_support();
-	printf("\n");
 }
 
 void usage(void) {

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -316,6 +316,6 @@ static char *usage_str =
 
 
 void usage(void) {
-	printf("firejail - version %s\n\n", VERSION);
+	printf("firejail version %s\n\n", VERSION);
 	puts(usage_str);
 }

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -315,13 +315,16 @@ static char *usage_str =
 	"\n";
 
 void print_version(void) {
-	printf("firejail version %s\n", VERSION);
-	printf("\n");
+	printf("firejail version %s\n\n", VERSION);
+}
+
+void print_version_full(void) {
+	print_version();
 	print_compiletime_support();
 	printf("\n");
 }
 
 void usage(void) {
-	printf("firejail version %s\n\n", VERSION);
+	print_version();
 	puts(usage_str);
 }

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -19,7 +19,7 @@
 */
 #include "firejail.h"
 
-static char *usage_str =
+static const char *const usage_str =
 	"Firejail is a SUID sandbox program that reduces the risk of security breaches by\n"
 	"restricting the running environment of untrusted applications using Linux\n"
 	"namespaces.\n"

--- a/src/firemon/firemon.c
+++ b/src/firemon/firemon.c
@@ -145,7 +145,7 @@ int main(int argc, char **argv) {
 			return 0;
 		}
 		else if (strcmp(argv[i], "--version") == 0) {
-			printf("firemon version %s\n\n", VERSION);
+			print_version();
 			return 0;
 		}
 		else if (strcmp(argv[i], "--debug") == 0)

--- a/src/firemon/firemon.h
+++ b/src/firemon/firemon.h
@@ -49,6 +49,7 @@ void firemon_sleep(int st);
 void procevent(pid_t pid) __attribute__((noreturn));
 
 // usage.c
+void print_version(void);
 void usage(void);
 
 // top.c

--- a/src/firemon/usage.c
+++ b/src/firemon/usage.c
@@ -79,6 +79,6 @@ static char *help_str =
 	"\n";
 
 void usage(void) {
-	printf("firemon - version %s\n", VERSION);
+	printf("firemon version %s\n", VERSION);
 	puts(help_str);
 }

--- a/src/firemon/usage.c
+++ b/src/firemon/usage.c
@@ -19,7 +19,7 @@
 */
 #include "firemon.h"
 
-static char *help_str =
+static const char *const usage_str =
 	"Usage: firemon [OPTIONS] [PID]\n\n"
 	"Monitor processes started in a Firejail sandbox. Without any PID specified,\n"
 	"all processes started by Firejail are monitored. Descendants of these processes\n"
@@ -84,5 +84,5 @@ void print_version(void) {
 
 void usage(void) {
 	print_version();
-	puts(help_str);
+	puts(usage_str);
 }

--- a/src/firemon/usage.c
+++ b/src/firemon/usage.c
@@ -75,8 +75,7 @@ static const char *const usage_str =
 	"\tUser - The owner of the sandbox.\n"
 	"\n"
 	"License GPL version 2 or later\n"
-	"Homepage: https://firejail.wordpress.com\n"
-	"\n";
+	"Homepage: https://firejail.wordpress.com\n";
 
 void print_version(void) {
 	printf("firemon version %s\n\n", VERSION);

--- a/src/firemon/usage.c
+++ b/src/firemon/usage.c
@@ -78,7 +78,11 @@ static char *help_str =
 	"Homepage: https://firejail.wordpress.com\n"
 	"\n";
 
+void print_version(void) {
+	printf("firemon version %s\n\n", VERSION);
+}
+
 void usage(void) {
-	printf("firemon version %s\n", VERSION);
+	print_version();
 	puts(help_str);
 }

--- a/src/fldd/main.c
+++ b/src/fldd/main.c
@@ -282,12 +282,13 @@ static void walk_directory(const char *dirname) {
 	}
 }
 
-
+static const char *const usage_str =
+	"Usage: fldd program_or_directory [file]\n"
+	"Print a list of libraries used by program or store it in the file.\n"
+	"Print a list of libraries used by all .so files in a directory or store it in the file.\n";
 
 static void usage(void) {
-	printf("Usage: fldd program_or_directory [file]\n");
-	printf("Print a list of libraries used by program or store it in the file.\n");
-	printf("Print a list of libraries used by all .so files in a directory or store it in the file.\n");
+	puts(usage_str);
 }
 
 int main(int argc, char **argv) {

--- a/src/fnet/main.c
+++ b/src/fnet/main.c
@@ -35,19 +35,21 @@ void fmessage(char* fmt, ...) { // TODO: this function is duplicated in src/fire
 	fflush(0);
 }
 
+static const char *const usage_str =
+	"Usage:\n"
+	"\tfnet create veth dev1 dev2 bridge child\n"
+	"\tfnet create macvlan dev parent child\n"
+	"\tfnet moveif dev proc\n"
+	"\tfnet printif\n"
+	"\tfnet printif scan\n"
+	"\tfnet config interface dev ip mask mtu\n"
+	"\tfnet config mac addr\n"
+	"\tfnet config ipv6 dev ip\n"
+	"\tfnet ifup dev\n"
+	"\tfnet waitll dev\n";
 
 static void usage(void) {
-	printf("Usage:\n");
-	printf("\tfnet create veth dev1 dev2 bridge child\n");
-	printf("\tfnet create macvlan dev parent child\n");
-	printf("\tfnet moveif dev proc\n");
-	printf("\tfnet printif\n");
-	printf("\tfnet printif scan\n");
-	printf("\tfnet config interface dev ip mask mtu\n");
-	printf("\tfnet config mac addr\n");
-	printf("\tfnet config ipv6 dev ip\n");
-	printf("\tfnet ifup dev\n");
-	printf("\tfnet waitll dev\n");
+	puts(usage_str);
 }
 
 int main(int argc, char **argv) {

--- a/src/fnetfilter/main.c
+++ b/src/fnetfilter/main.c
@@ -45,9 +45,12 @@ static char *default_filter =
 "-A OUTPUT -p tcp --dport 3479 -j DROP\n"
 "COMMIT\n";
 
+static const char *const usage_str =
+	"Usage:\n"
+	"\tfnetfilter netfilter-command destination-file\n";
+
 static void usage(void) {
-	printf("Usage:\n");
-	printf("\tfnetfilter netfilter-command destination-file\n");
+	puts(usage_str);
 }
 
 static void err_exit_cannot_open_file(const char *fname) {

--- a/src/fnettrace-dns/main.c
+++ b/src/fnettrace-dns/main.c
@@ -167,13 +167,13 @@ static void run_trace(void) {
 
 	close(s);
 }
-
+static const char *const usage_str =
+	"Usage: fnettrace-dns [OPTIONS]\n"
+	"Options:\n"
+	"   --help, -? - this help screen\n";
 
 static void usage(void) {
-	printf("Usage: fnettrace-dns [OPTIONS]\n");
-	printf("Options:\n");
-	printf("   --help, -? - this help screen\n");
-	printf("\n");
+	puts(usage_str);
 }
 
 int main(int argc, char **argv) {

--- a/src/fnettrace-icmp/main.c
+++ b/src/fnettrace-icmp/main.c
@@ -201,11 +201,13 @@ static void run_trace(void) {
 	close(s);
 }
 
+static const char *const usage_str =
+	"Usage: fnettrace-icmp [OPTIONS]\n"
+	"Options:\n"
+	"   --help, -? - this help screen\n";
+
 static void usage(void) {
-	printf("Usage: fnettrace-icmp [OPTIONS]\n");
-	printf("Options:\n");
-	printf("   --help, -? - this help screen\n");
-	printf("\n");
+	puts(usage_str);
 }
 
 int main(int argc, char **argv) {

--- a/src/fnettrace-sni/main.c
+++ b/src/fnettrace-sni/main.c
@@ -204,12 +204,13 @@ static void run_trace(void) {
 	close(s);
 }
 
+static const char *const usage_str =
+	"Usage: fnettrace-sni [OPTIONS]\n"
+	"Options:\n"
+	"   --help, -? - this help screen\n";
 
 static void usage(void) {
-	printf("Usage: fnettrace-sni [OPTIONS]\n");
-	printf("Options:\n");
-	printf("   --help, -? - this help screen\n");
-	printf("\n");
+	puts(usage_str);
 }
 
 int main(int argc, char **argv) {

--- a/src/fnettrace/main.c
+++ b/src/fnettrace/main.c
@@ -668,18 +668,20 @@ void logprintf(char *fmt, ...) {
 	va_end(args);
 }
 
+static const char *const usage_str =
+	"Usage: fnettrace [OPTIONS]\n"
+	"Options:\n"
+	"   --help, -? - this help screen\n"
+	"   --log=filename - netlocker logfile\n"
+	"   --netfilter - build the firewall rules and commit them.\n"
+	"   --tail - \"tail -f\" functionality\n"
+	"Examples:\n"
+	"   # fnettrace                              - traffic trace\n"
+	"   # fnettrace --netfilter --log=logfile    - netlocker, dump output in logfile\n"
+	"   # fnettrace --tail --log=logifile        - similar to \"tail -f logfile\"\n";
+
 static void usage(void) {
-	printf("Usage: fnettrace [OPTIONS]\n");
-	printf("Options:\n");
-	printf("   --help, -? - this help screen\n");
-	printf("   --log=filename - netlocker logfile\n");
-	printf("   --netfilter - build the firewall rules and commit them.\n");
-	printf("   --tail - \"tail -f\" functionality\n");
-	printf("Examples:\n");
-	printf("   # fnettrace                              - traffic trace\n");
-	printf("   # fnettrace --netfilter --log=logfile    - netlocker, dump output in logfile\n");
-	printf("   # fnettrace --tail --log=logifile        - similar to \"tail -f logfile\"\n");
-	printf("\n");
+	puts(usage_str);
 }
 
 int main(int argc, char **argv) {

--- a/src/fsec-optimize/main.c
+++ b/src/fsec-optimize/main.c
@@ -22,9 +22,12 @@
 
 int arg_seccomp_error_action = SECCOMP_RET_ERRNO | EPERM; // error action: errno, log or kill
 
+static const char *const usage_str =
+	"Usage:\n"
+	"\tfsec-optimize file - optimize seccomp filter\n";
+
 static void usage(void) {
-	printf("Usage:\n");
-	printf("\tfsec-optimize file - optimize seccomp filter\n");
+	puts(usage_str);
 }
 
 int main(int argc, char **argv) {

--- a/src/fsec-print/main.c
+++ b/src/fsec-print/main.c
@@ -19,9 +19,12 @@
 */
 #include "fsec_print.h"
 
+static const char *const usage_str =
+	"Usage:\n"
+	"\tfsec-print file - disassemble seccomp filter\n";
+
 static void usage(void) {
-	printf("Usage:\n");
-	printf("\tfsec-print file - disassemble seccomp filter\n");
+	puts(usage_str);
 }
 
 int arg_quiet = 0;

--- a/src/fseccomp/main.c
+++ b/src/fseccomp/main.c
@@ -22,34 +22,37 @@
 int arg_quiet = 0;
 int arg_seccomp_error_action = SECCOMP_RET_ERRNO | EPERM; // error action: errno, log or kill
 
+static const char *const usage_str =
+	"Usage:\n"
+	"\tfseccomp debug-syscalls\n"
+	"\tfseccomp debug-syscalls32\n"
+	"\tfseccomp debug-errnos\n"
+	"\tfseccomp debug-protocols\n"
+	"\tfseccomp protocol build list file\n"
+	"\tfseccomp secondary 64 file\n"
+	"\tfseccomp secondary 32 file\n"
+	"\tfseccomp secondary block file\n"
+	"\tfseccomp default file\n"
+	"\tfseccomp default file allow-debuggers\n"
+	"\tfseccomp default32 file\n"
+	"\tfseccomp default32 file allow-debuggers\n"
+	"\tfseccomp drop file1 file2 list\n"
+	"\tfseccomp drop file1 file2 list allow-debuggers\n"
+	"\tfseccomp drop32 file1 file2 list\n"
+	"\tfseccomp drop32 file1 file2 list allow-debuggers\n"
+	"\tfseccomp default drop file1 file2 list\n"
+	"\tfseccomp default drop file1 file2 list allow-debuggers\n"
+	"\tfseccomp default32 drop file1 file2 list\n"
+	"\tfseccomp default32 drop file1 file2 list allow-debuggers\n"
+	"\tfseccomp keep file1 file2 list\n"
+	"\tfseccomp keep32 file1 file2 list\n"
+	"\tfseccomp memory-deny-write-execute file\n"
+	"\tfseccomp memory-deny-write-execute.32 file\n"
+	"\tfseccomp restrict-namespaces file list\n"
+	"\tfseccomp restrict-namespaces.32 file list\n";
+
 static void usage(void) {
-	printf("Usage:\n"
-		"\tfseccomp debug-syscalls\n"
-		"\tfseccomp debug-syscalls32\n"
-		"\tfseccomp debug-errnos\n"
-		"\tfseccomp debug-protocols\n"
-		"\tfseccomp protocol build list file\n"
-		"\tfseccomp secondary 64 file\n"
-		"\tfseccomp secondary 32 file\n"
-		"\tfseccomp secondary block file\n"
-		"\tfseccomp default file\n"
-		"\tfseccomp default file allow-debuggers\n"
-		"\tfseccomp default32 file\n"
-		"\tfseccomp default32 file allow-debuggers\n"
-		"\tfseccomp drop file1 file2 list\n"
-		"\tfseccomp drop file1 file2 list allow-debuggers\n"
-		"\tfseccomp drop32 file1 file2 list\n"
-		"\tfseccomp drop32 file1 file2 list allow-debuggers\n"
-		"\tfseccomp default drop file1 file2 list\n"
-		"\tfseccomp default drop file1 file2 list allow-debuggers\n"
-		"\tfseccomp default32 drop file1 file2 list\n"
-		"\tfseccomp default32 drop file1 file2 list allow-debuggers\n"
-		"\tfseccomp keep file1 file2 list\n"
-		"\tfseccomp keep32 file1 file2 list\n"
-		"\tfseccomp memory-deny-write-execute file\n"
-		"\tfseccomp memory-deny-write-execute.32 file\n"
-		"\tfseccomp restrict-namespaces file list\n"
-		"\tfseccomp restrict-namespaces.32 file list\n");
+	puts(usage_str);
 }
 
 int main(int argc, char **argv) {

--- a/src/ftee/main.c
+++ b/src/ftee/main.c
@@ -180,8 +180,11 @@ static int is_link(const char *fname) {
 	return 0;
 }
 
+static const char *const usage_str =
+	"Usage: ftee filename\n";
+
 static void usage(void) {
-	printf("Usage: ftee filename\n");
+	puts(usage_str);
 }
 
 int main(int argc, char **argv) {

--- a/src/jailcheck/main.c
+++ b/src/jailcheck/main.c
@@ -29,7 +29,7 @@ char *user_home_dir = NULL;
 char *user_run_dir = NULL;
 int arg_debug = 0;
 
-static char *usage_str =
+static const char *const usage_str =
 	"Usage: jailcheck [options] directory [directory]\n\n"
 	"Options:\n"
 	"   --debug - print debug messages.\n"

--- a/src/jailcheck/main.c
+++ b/src/jailcheck/main.c
@@ -38,7 +38,7 @@ static char *usage_str =
 
 
 static void usage(void) {
-	printf("jailcheck - version %s\n\n", VERSION);
+	printf("jailcheck version %s\n\n", VERSION);
 	puts(usage_str);
 }
 

--- a/src/jailcheck/main.c
+++ b/src/jailcheck/main.c
@@ -38,7 +38,7 @@ static char *usage_str =
 
 
 static void usage(void) {
-	printf("firetest - version %s\n\n", VERSION);
+	printf("jailcheck - version %s\n\n", VERSION);
 	puts(usage_str);
 }
 

--- a/src/jailcheck/main.c
+++ b/src/jailcheck/main.c
@@ -36,9 +36,12 @@ static char *usage_str =
 	"   --help, -? - this help screen.\n"
 	"   --version - print program version and exit.\n";
 
+static void print_version(void) {
+	printf("jailcheck version %s\n\n", VERSION);
+}
 
 static void usage(void) {
-	printf("jailcheck version %s\n\n", VERSION);
+	print_version();
 	puts(usage_str);
 }
 
@@ -62,7 +65,7 @@ int main(int argc, char **argv) {
 			return 0;
 		}
 		else if (strcmp(argv[i], "--version") == 0) {
-			printf("firetest version %s\n\n", VERSION);
+			print_version();
 			return 0;
 		}
 		else if (strncmp(argv[i], "--hello=", 8) == 0) { // used by noexec test

--- a/src/profstats/main.c
+++ b/src/profstats/main.c
@@ -74,32 +74,34 @@ static int arg_restrict_namespaces = 0;
 
 static char *profile = NULL;
 
+static const char *const usage_str =
+	"profstats - print profile statistics\n"
+	"Usage: profstats [options] file[s]\n"
+	"Options:\n"
+	"   --apparmor - print profiles without apparmor\n"
+	"   --caps - print profiles without caps\n"
+	"   --dbus-system-none - print profiles without \"dbus-system none\"\n"
+	"   --dbus-user-none - print profiles without \"dbus-user none\"\n"
+	"   --ssh - print profiles without \"include disable-common.inc\"\n"
+	"   --noexec - print profiles without \"include disable-exec.inc\"\n"
+	"   --noroot - print profiles without \"noroot\"\n"
+	"   --private-bin - print profiles without private-bin\n"
+	"   --private-dev - print profiles without private-dev\n"
+	"   --private-etc - print profiles without private-etc\n"
+	"   --private-tmp - print profiles without private-tmp\n"
+	"   --print-blacklist - print all --blacklist for a profile\n"
+	"   --print-whitelist - print all --private and --whitelist for a profile\n"
+	"   --seccomp - print profiles without seccomp\n"
+	"   --memory-deny-write-execute - print profiles without \"memory-deny-write-execute\"\n"
+	"   --restrict-namespaces - print profiles without \"restrict-namespaces\"\n"
+	"   --whitelist-home - print profiles whitelisting home directory\n"
+	"   --whitelist-var - print profiles without \"include whitelist-var-common.inc\"\n"
+	"   --whitelist-runuser - print profiles without \"include whitelist-runuser-common.inc\" or \"blacklist ${RUNUSER}\"\n"
+	"   --whitelist-usrshare - print profiles without \"include whitelist-usr-share-common.inc\"\n"
+	"   --debug\n";
+
 static void usage(void) {
-	printf("profstats - print profile statistics\n");
-	printf("Usage: profstats [options] file[s]\n");
-	printf("Options:\n");
-	printf("   --apparmor - print profiles without apparmor\n");
-	printf("   --caps - print profiles without caps\n");
-	printf("   --dbus-system-none - print profiles without \"dbus-system none\"\n");
-	printf("   --dbus-user-none - print profiles without \"dbus-user none\"\n");
-	printf("   --ssh - print profiles without \"include disable-common.inc\"\n");
-	printf("   --noexec - print profiles without \"include disable-exec.inc\"\n");
-	printf("   --noroot - print profiles without \"noroot\"\n");
-	printf("   --private-bin - print profiles without private-bin\n");
-	printf("   --private-dev - print profiles without private-dev\n");
-	printf("   --private-etc - print profiles without private-etc\n");
-	printf("   --private-tmp - print profiles without private-tmp\n");
-	printf("   --print-blacklist - print all --blacklist for a profile\n");
-	printf("   --print-whitelist - print all --private and --whitelist for a profile\n");
-	printf("   --seccomp - print profiles without seccomp\n");
-	printf("   --memory-deny-write-execute - print profiles without \"memory-deny-write-execute\"\n");
-	printf("   --restrict-namespaces - print profiles without \"restrict-namespaces\"\n");
-	printf("   --whitelist-home - print profiles whitelisting home directory\n");
-	printf("   --whitelist-var - print profiles without \"include whitelist-var-common.inc\"\n");
-	printf("   --whitelist-runuser - print profiles without \"include whitelist-runuser-common.inc\" or \"blacklist ${RUNUSER}\"\n");
-	printf("   --whitelist-usrshare - print profiles without \"include whitelist-usr-share-common.inc\"\n");
-	printf("   --debug\n");
-	printf("\n");
+	puts(usage_str);
 }
 
 static void process_file(char *fname) {


### PR DESCRIPTION
It is not too uncommon for the firejail version to be missing when issues are
reported; this PR makes it more likely that any posted logs will contain the
program version.

Do so just for firejail and firecfg for now because they are the most common
user-facing programs.

Kind of relates to #5275.
