### PR TITLE
build: enable compiler warnings by default

### DIFF
--- a/configure
+++ b/configure
@@ -1391,7 +1391,7 @@ Optional Features:
   --disable-x11           disable X11 sandboxing support
   --disable-file-transfer disable file transfer
   --disable-suid          install as a non-SUID executable
-  --enable-fatal-warnings -W -Wall -Werror
+  --enable-fatal-warnings -W -Werror
   --enable-busybox-workaround
                           enable busybox workaround
   --enable-gcov           Gcov instrumentation
@@ -3601,7 +3601,7 @@ fi
 
 if test "x$enable_fatal_warnings" = "xyes"; then :
 
-	HAVE_FATAL_WARNINGS="-W -Wall -Werror"
+	HAVE_FATAL_WARNINGS="-W -Werror"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -215,9 +215,9 @@ AS_IF([test "x$enable_suid" != "xno"], [
 HAVE_FATAL_WARNINGS=""
 AC_SUBST([HAVE_FATAL_WARNINGS])
 AC_ARG_ENABLE([fatal_warnings],
-    [AS_HELP_STRING([--enable-fatal-warnings], [-W -Wall -Werror])])
+    [AS_HELP_STRING([--enable-fatal-warnings], [-W -Werror])])
 AS_IF([test "x$enable_fatal_warnings" = "xyes"], [
-	HAVE_FATAL_WARNINGS="-W -Wall -Werror"
+	HAVE_FATAL_WARNINGS="-W -Werror"
 ])
 
 BUSYBOX_WORKAROUND="no"

--- a/src/prog.mk
+++ b/src/prog.mk
@@ -10,8 +10,10 @@ SRCS := $(sort $(wildcard *.c)) $(MOD_SRCS)
 OBJS := $(SRCS:.c=.o) $(MOD_OBJS)
 
 PROG_CFLAGS = \
-	-ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' \
-	-fstack-protector-all -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security \
+	-ggdb -O2 -DVERSION='"$(VERSION)"' \
+	$(HAVE_FATAL_WARNINGS) \
+	-Wformat -Wformat-security \
+	-fstack-protector-all -D_FORTIFY_SOURCE=2 \
 	-fPIE \
 	-DPREFIX='"$(prefix)"' -DSYSCONFDIR='"$(sysconfdir)/firejail"' \
 	-DLIBDIR='"$(libdir)"' -DBINDIR='"$(bindir)"' \

--- a/src/prog.mk
+++ b/src/prog.mk
@@ -11,7 +11,7 @@ OBJS := $(SRCS:.c=.o) $(MOD_OBJS)
 
 PROG_CFLAGS = \
 	-ggdb -O2 -DVERSION='"$(VERSION)"' \
-	$(HAVE_FATAL_WARNINGS) \
+	-Wall -Wextra $(HAVE_FATAL_WARNINGS) \
 	-Wformat -Wformat-security \
 	-fstack-protector-all -D_FORTIFY_SOURCE=2 \
 	-fPIE \

--- a/src/so.mk
+++ b/src/so.mk
@@ -10,8 +10,10 @@ SRCS := $(sort $(wildcard *.c)) $(MOD_SRCS)
 OBJS := $(SRCS:.c=.o) $(MOD_OBJS)
 
 SO_CFLAGS = \
-	-ggdb $(HAVE_FATAL_WARNINGS) -O2 -DVERSION='"$(VERSION)"' \
-	-fstack-protector-all -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security \
+	-ggdb -O2 -DVERSION='"$(VERSION)"' \
+	$(HAVE_FATAL_WARNINGS) \
+	-Wformat -Wformat-security \
+	-fstack-protector-all -D_FORTIFY_SOURCE=2 \
 	-fPIC
 
 SO_LDFLAGS = -pie -fPIE -Wl,-z,relro -Wl,-z,now

--- a/src/so.mk
+++ b/src/so.mk
@@ -11,7 +11,7 @@ OBJS := $(SRCS:.c=.o) $(MOD_OBJS)
 
 SO_CFLAGS = \
 	-ggdb -O2 -DVERSION='"$(VERSION)"' \
-	$(HAVE_FATAL_WARNINGS) \
+	-Wall -Wextra $(HAVE_FATAL_WARNINGS) \
 	-Wformat -Wformat-security \
 	-fstack-protector-all -D_FORTIFY_SOURCE=2 \
 	-fPIC


### PR DESCRIPTION
Enable -Wall by default and add -Wextra.