### PR TITLE
contrib/vim: match profile files more broadly

### DIFF
--- a/contrib/vim/ftdetect/firejail.vim
+++ b/contrib/vim/ftdetect/firejail.vim
@@ -1,6 +1,12 @@
+" Default paths
 autocmd BufNewFile,BufRead /etc/firejail/*.inc          setfiletype firejail
 autocmd BufNewFile,BufRead /etc/firejail/*.local        setfiletype firejail
 autocmd BufNewFile,BufRead /etc/firejail/*.profile      setfiletype firejail
 autocmd BufNewFile,BufRead ~/.config/firejail/*.inc     setfiletype firejail
 autocmd BufNewFile,BufRead ~/.config/firejail/*.local   setfiletype firejail
 autocmd BufNewFile,BufRead ~/.config/firejail/*.profile setfiletype firejail
+
+" Arbitrary paths
+autocmd BufNewFile,BufRead */firejail/*.inc             set filetype=firejail
+autocmd BufNewFile,BufRead */firejail/*.local           set filetype=firejail
+autocmd BufNewFile,BufRead */firejail/*.profile         set filetype=firejail

--- a/contrib/vim/ftdetect/firejail.vim
+++ b/contrib/vim/ftdetect/firejail.vim
@@ -1,6 +1,6 @@
-autocmd BufNewFile,BufRead /etc/firejail/*.profile      setfiletype firejail
-autocmd BufNewFile,BufRead /etc/firejail/*.local        setfiletype firejail
 autocmd BufNewFile,BufRead /etc/firejail/*.inc          setfiletype firejail
-autocmd BufNewFile,BufRead ~/.config/firejail/*.profile setfiletype firejail
-autocmd BufNewFile,BufRead ~/.config/firejail/*.local   setfiletype firejail
+autocmd BufNewFile,BufRead /etc/firejail/*.local        setfiletype firejail
+autocmd BufNewFile,BufRead /etc/firejail/*.profile      setfiletype firejail
 autocmd BufNewFile,BufRead ~/.config/firejail/*.inc     setfiletype firejail
+autocmd BufNewFile,BufRead ~/.config/firejail/*.local   setfiletype firejail
+autocmd BufNewFile,BufRead ~/.config/firejail/*.profile setfiletype firejail


### PR DESCRIPTION
Currently it only sets the appropriate filetype for files in
`/etc/firejail` and `~/.config/firejail`.

With this commit, the firejail filetype should also be set when opening
`etc/inc/*.inc`, for example, as long as there is a "firejail" directory
somewhere before that (such as in `/foo/firejail/bar/etc/inc/*.inc`).

Note: At least `*/firejail/*.inc` needs to force the match (by using
`set filetype` rather than `setfiletype`), or else the default vim
checks take precedence (and the filetype for all files in
`etc/inc/*.inc` gets set to `pov`).

Fixes #4319.

Relates to #2679.

Cc: @laomaiweng @reinerh @rusty-snake (from #2679 #4319)
