### PR TITLE
ci: standardize apt-get update/install & misc improvements

### DIFF
--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -62,9 +62,11 @@ jobs:
           github.com:443
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
     - name: update package information
-      run: sudo apt-get update
+      run: sudo apt-get update -qy
     - name: install dependencies
-      run: sudo apt-get install libapparmor-dev libselinux1-dev
+      run: >
+        sudo apt-get install -qy
+        libapparmor-dev libselinux1-dev
     - name: print env
       run: ./ci/printenv.sh
     - name: configure
@@ -90,9 +92,11 @@ jobs:
           github.com:443
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
     - name: update package information
-      run: sudo apt-get update
+      run: sudo apt-get update -qy
     - name: install clang-tools-14 and dependencies
-      run: sudo apt-get install clang-tools-14 libapparmor-dev libselinux1-dev
+      run: >
+        sudo apt-get install -qy
+        clang-tools-14 libapparmor-dev libselinux1-dev
     - name: print env
       run: ./ci/printenv.sh
     - name: configure
@@ -114,9 +118,9 @@ jobs:
           github.com:443
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
     - name: update package information
-      run: sudo apt-get update
+      run: sudo apt-get update -qy
     - name: install cppcheck
-      run: sudo apt-get install cppcheck
+      run: sudo apt-get install -qy cppcheck
     - run: cppcheck --version
     - name: cppcheck
       run: >
@@ -136,9 +140,9 @@ jobs:
           github.com:443
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
     - name: update package information
-      run: sudo apt-get update
+      run: sudo apt-get update -qy
     - name: install cppcheck
-      run: sudo apt-get install cppcheck
+      run: sudo apt-get install -qy cppcheck
     - run: cppcheck --version
     - name: cppcheck
       run: cppcheck -q --force --error-exitcode=1 --enable=warning,performance .
@@ -154,9 +158,9 @@ jobs:
           github.com:443
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
     - name: update package information
-      run: sudo apt-get update
+      run: sudo apt-get update -qy
     - name: install dependencies
-      run: sudo apt-get install codespell
+      run: sudo apt-get install -qy codespell
     - run: codespell --version
     - name: codespell
       run: make codespell

--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -71,6 +71,7 @@ jobs:
       run: >
         CC=clang-14 ./configure --enable-fatal-warnings --enable-apparmor
         --enable-selinux
+        || (cat config.log; exit 1)
     - name: make
       run: make
     - name: make install
@@ -98,6 +99,7 @@ jobs:
       run: >
         CC=clang-14 ./configure --enable-fatal-warnings --enable-apparmor
         --enable-selinux
+        || (cat config.log; exit 1)
     - name: scan-build
       run: NO_EXTRA_CFLAGS="yes" scan-build-14 --status-bugs make
   cppcheck:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
       run: >
         CC=gcc-12 ./configure --prefix=/usr --enable-fatal-warnings
         --enable-analyzer --enable-apparmor --enable-selinux
+        || (cat config.log; exit 1)
     - name: make
       run: make
     - name: make install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,10 +63,10 @@ jobs:
           yahoo.com:1025
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
     - name: update package information
-      run: sudo apt-get update
+      run: sudo apt-get update -qy
     - name: install dependencies
       run: >
-        sudo apt-get install
+        sudo apt-get install -qy
         gcc-12 libapparmor-dev libselinux1-dev expect xzdec whois
         bridge-utils
     - name: print env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,14 +12,12 @@ build_ubuntu_package:
         - apt-get update -qq
         - >
             DEBIAN_FRONTEND=noninteractive apt-get install -y -qq
-            build-essential lintian libapparmor-dev pkg-config python3 gawk
+            build-essential lintian libapparmor-dev pkg-config gawk
         - ./ci/printenv.sh
         - ./configure || (cat config.log; exit 1)
         - make deb
         - dpkg -i firejail*.deb
         - command -V firejail && firejail --version
-        # - python3 --version
-        # - python3 contrib/sort.py etc/profile-*/*.profile etc/inc/*.inc
 
 build_debian_package:
     image: debian:buster
@@ -55,22 +53,18 @@ build_fedora_package:
         - make rpms
         - rpm -i firejail*.rpm
         - command -V firejail && firejail --version
-        # - python3 --version
-        # - python3 contrib/sort.py etc/profile-*/*.profile etc/inc/*.inc
 
 build_src_package:
     image: alpine:latest
     script:
         - apk update
         - apk upgrade
-        - apk add build-base linux-headers python3 gawk
+        - apk add build-base linux-headers gawk
         - ./ci/printenv.sh
         - ./configure --prefix=/usr || (cat config.log; exit 1)
         - make
         - make install-strip
         - command -V firejail && firejail --version
-        # - python3 --version
-        # - python3 contrib/sort.py etc/profile-*/*.profile etc/inc/*.inc
 
 build_no_apparmor:
     image: ubuntu:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ build_ubuntu_package:
             DEBIAN_FRONTEND=noninteractive apt-get install -y -qq
             build-essential lintian libapparmor-dev pkg-config python3 gawk
         - ./ci/printenv.sh
-        - ./configure
+        - ./configure || (cat config.log; exit 1)
         - make deb
         - dpkg -i firejail*.deb
         - command -V firejail && firejail --version
@@ -29,7 +29,7 @@ build_debian_package:
             apt-get install -y -qq
             build-essential lintian libapparmor-dev pkg-config gawk
         - ./ci/printenv.sh
-        - ./configure
+        - ./configure || (cat config.log; exit 1)
         - make deb
         - dpkg -i firejail*.deb
         - command -V firejail && firejail --version
@@ -40,7 +40,7 @@ build_redhat_package:
         - dnf update -y
         - dnf install -y rpm-build gcc make
         - ./ci/printenv.sh
-        - ./configure --prefix=/usr
+        - ./configure --prefix=/usr || (cat config.log; exit 1)
         - make rpms
         - rpm -i firejail*.rpm
         - command -V firejail && firejail --version
@@ -51,7 +51,7 @@ build_fedora_package:
         - dnf update -y
         - dnf install -y rpm-build gcc make
         - ./ci/printenv.sh
-        - ./configure --prefix=/usr
+        - ./configure --prefix=/usr || (cat config.log; exit 1)
         - make rpms
         - rpm -i firejail*.rpm
         - command -V firejail && firejail --version
@@ -65,7 +65,7 @@ build_src_package:
         - apk upgrade
         - apk add build-base linux-headers python3 gawk
         - ./ci/printenv.sh
-        - ./configure --prefix=/usr
+        - ./configure --prefix=/usr || (cat config.log; exit 1)
         - make
         - make install-strip
         - command -V firejail && firejail --version
@@ -80,7 +80,7 @@ build_no_apparmor:
             DEBIAN_FRONTEND=noninteractive apt-get install -y -qq
             build-essential lintian pkg-config gawk
         - ./ci/printenv.sh
-        - ./configure
+        - ./configure || (cat config.log; exit 1)
         - make dist
         - ./mkdeb.sh --disable-apparmor
         - dpkg -i firejail*.deb

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,11 +8,14 @@
 
 build_ubuntu_package:
     image: ubuntu:rolling
+    variables:
+        DEBIAN_FRONTEND: noninteractive
     script:
-        - apt-get update -qq
+        - apt-get update -qy
         - >
-            DEBIAN_FRONTEND=noninteractive apt-get install -y -qq
-            build-essential lintian libapparmor-dev pkg-config gawk
+            apt-get install --no-install-recommends -qy
+            build-essential fakeroot lintian libapparmor-dev pkg-config gawk
+            | grep -Ev '^(Selecting|Preparing to unpack|Unpacking)'
         - ./ci/printenv.sh
         - ./configure || (cat config.log; exit 1)
         - make deb
@@ -21,11 +24,14 @@ build_ubuntu_package:
 
 build_debian_package:
     image: debian:buster
+    variables:
+        DEBIAN_FRONTEND: noninteractive
     script:
-        - apt-get update -qq
+        - apt-get update -qy
         - >
-            apt-get install -y -qq
-            build-essential lintian libapparmor-dev pkg-config gawk
+            apt-get install --no-install-recommends -qy
+            build-essential fakeroot lintian libapparmor-dev pkg-config gawk
+            | grep -Ev '^(Selecting|Preparing to unpack|Unpacking)'
         - ./ci/printenv.sh
         - ./configure || (cat config.log; exit 1)
         - make deb
@@ -68,11 +74,14 @@ build_src_package:
 
 build_no_apparmor:
     image: ubuntu:latest
+    variables:
+        DEBIAN_FRONTEND: noninteractive
     script:
-        - apt-get update -qq
+        - apt-get update -qy
         - >
-            DEBIAN_FRONTEND=noninteractive apt-get install -y -qq
-            build-essential lintian pkg-config gawk
+            apt-get install --no-install-recommends -qy
+            build-essential fakeroot lintian pkg-config gawk
+            | grep -Ev '^(Selecting|Preparing to unpack|Unpacking)'
         - ./ci/printenv.sh
         - ./configure || (cat config.log; exit 1)
         - make dist
@@ -86,6 +95,7 @@ debian_ci:
     variables:
         DEBFULLNAME: "$GITLAB_USER_NAME"
         DEBEMAIL: "$GITLAB_USER_EMAIL"
+        DEBIAN_FRONTEND: noninteractive
     before_script:
         - git checkout -B ci_build "$CI_COMMIT_SHA"
         - gitlab-ci-enable-sid
@@ -95,7 +105,7 @@ debian_ci:
             deb-src http://deb.debian.org/debian sid main
             deb-src http://deb.debian.org/debian experimental main
             EOF
-        - apt-get update
+        - apt-get update -qy
         - git config user.name "$DEBFULLNAME"
         - git config user.email "$DEBEMAIL"
         - |
@@ -116,7 +126,7 @@ debian_ci:
         - git commit -m 'add debian/'
         - export CI_COMMIT_SHA="$(git rev-parse HEAD)"
     script:
-        - apt-get --no-install-recommends install -y -qq gawk
+        - apt-get install --no-install-recommends -qy gawk
         - ./ci/printenv.sh
         - gitlab-ci-git-buildpackage
         - gitlab-ci-lintian


### PR DESCRIPTION
General changes:

* Use a single -q on update, as the output is not too long
* Use a single -q on install, to show all packages at once

GitLab-specific changes:

* Use `DEBIAN_FRONTEND=noninteractive` to reduce noise
* Use --no-install-recommends to avoid installing unnecessary packages
* Filter out uninteresting lines on install

Note: `DEBIAN_FRONTEND` does not appear to be needed in the default
GitHub runner container and not many packages are currently being
downloaded/installed in them, so do the above changes only jobs that use
custom Docker images.