### PR TITLE
build: disable all built-in implicit make rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = .
 -include config.mk
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = .
 -include config.mk
 

--- a/src/bash_completion/Makefile
+++ b/src/bash_completion/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/bash_completion/Makefile
+++ b/src/bash_completion/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/bash_completion/Makefile
+++ b/src/bash_completion/Makefile
@@ -1,8 +1,8 @@
-.PHONY: all
-all: firejail.bash_completion
-
 ROOT = ../..
 -include $(ROOT)/config.mk
+
+.PHONY: all
+all: firejail.bash_completion
 
 firejail.bash_completion: firejail.bash_completion.in $(ROOT)/config.mk
 	gawk -f ../man/preproc.awk -- $(MANFLAGS) < $< > $@.tmp

--- a/src/etc-cleanup/Makefile
+++ b/src/etc-cleanup/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/etc-cleanup/Makefile
+++ b/src/etc-cleanup/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fbuilder/Makefile
+++ b/src/fbuilder/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fbuilder/Makefile
+++ b/src/fbuilder/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fcopy/Makefile
+++ b/src/fcopy/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fcopy/Makefile
+++ b/src/fcopy/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fids/Makefile
+++ b/src/fids/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fids/Makefile
+++ b/src/fids/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/firecfg/Makefile
+++ b/src/firecfg/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/firecfg/Makefile
+++ b/src/firecfg/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/firejail/Makefile
+++ b/src/firejail/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/firejail/Makefile
+++ b/src/firejail/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/firemon/Makefile
+++ b/src/firemon/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/firemon/Makefile
+++ b/src/firemon/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fldd/Makefile
+++ b/src/fldd/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fldd/Makefile
+++ b/src/fldd/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fnet/Makefile
+++ b/src/fnet/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fnet/Makefile
+++ b/src/fnet/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fnetfilter/Makefile
+++ b/src/fnetfilter/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fnetfilter/Makefile
+++ b/src/fnetfilter/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fnettrace-dns/Makefile
+++ b/src/fnettrace-dns/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fnettrace-dns/Makefile
+++ b/src/fnettrace-dns/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fnettrace-icmp/Makefile
+++ b/src/fnettrace-icmp/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fnettrace-icmp/Makefile
+++ b/src/fnettrace-icmp/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fnettrace-sni/Makefile
+++ b/src/fnettrace-sni/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fnettrace-sni/Makefile
+++ b/src/fnettrace-sni/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fnettrace/Makefile
+++ b/src/fnettrace/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fnettrace/Makefile
+++ b/src/fnettrace/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fsec-optimize/Makefile
+++ b/src/fsec-optimize/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fsec-optimize/Makefile
+++ b/src/fsec-optimize/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fsec-print/Makefile
+++ b/src/fsec-print/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fsec-print/Makefile
+++ b/src/fsec-print/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fseccomp/Makefile
+++ b/src/fseccomp/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fseccomp/Makefile
+++ b/src/fseccomp/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/ftee/Makefile
+++ b/src/ftee/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/ftee/Makefile
+++ b/src/ftee/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fzenity/Makefile
+++ b/src/fzenity/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/fzenity/Makefile
+++ b/src/fzenity/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/jailcheck/Makefile
+++ b/src/jailcheck/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/jailcheck/Makefile
+++ b/src/jailcheck/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/libpostexecseccomp/Makefile
+++ b/src/libpostexecseccomp/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/libpostexecseccomp/Makefile
+++ b/src/libpostexecseccomp/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/libtrace/Makefile
+++ b/src/libtrace/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/libtrace/Makefile
+++ b/src/libtrace/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/libtracelog/Makefile
+++ b/src/libtracelog/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/libtracelog/Makefile
+++ b/src/libtracelog/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/man/Makefile
+++ b/src/man/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/man/Makefile
+++ b/src/man/Makefile
@@ -1,8 +1,8 @@
-.PHONY: all
-all: firecfg.man firejail.man firejail-login.man firejail-users.man firejail-profile.man firemon.man jailcheck.man
-
 ROOT = ../..
 -include $(ROOT)/config.mk
+
+.PHONY: all
+all: firecfg.man firejail.man firejail-login.man firejail-users.man firejail-profile.man firemon.man jailcheck.man
 
 %.man: %.txt $(ROOT)/config.mk
 	gawk -f ./preproc.awk -- $(MANFLAGS) < $< > $@

--- a/src/man/Makefile
+++ b/src/man/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/profstats/Makefile
+++ b/src/profstats/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/profstats/Makefile
+++ b/src/profstats/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/zsh_completion/Makefile
+++ b/src/zsh_completion/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/src/zsh_completion/Makefile
+++ b/src/zsh_completion/Makefile
@@ -1,8 +1,8 @@
-.PHONY: all
-all: _firejail
-
 ROOT = ../..
 -include $(ROOT)/config.mk
+
+.PHONY: all
+all: _firejail
 
 _firejail: _firejail.in $(ROOT)/config.mk
 	gawk -f ../man/preproc.awk -- $(MANFLAGS) < $< > $@.tmp

--- a/src/zsh_completion/Makefile
+++ b/src/zsh_completion/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ../..
 -include $(ROOT)/config.mk
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,3 +1,4 @@
+.SUFFIXES:
 ROOT = ..
 -include $(ROOT)/config.mk
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,4 +1,6 @@
 .SUFFIXES:
+MAKEFLAGS += -r
+
 ROOT = ..
 -include $(ROOT)/config.mk
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,3 +1,6 @@
+ROOT = ..
+-include $(ROOT)/config.mk
+
 TESTS=$(patsubst %/,%,$(wildcard */))
 
 .PHONY: $(TESTS)


### PR DESCRIPTION
To reduce unnecessary filesystem lookups.

Overall, this appears to reduce the amount of implicit rule searches by ~97.5%
for the default build and by ~99.3% for the "man" target (as an example):

    $ git show --pretty='%h %ai %s' -s
    a8f01a383 2023-06-20 05:26:23 +0000 Merge pull request #5859 from kmk3/build-remove-retpoline
    $ ./configure >/dev/null
    $ make clean >/dev/null && make --debug=i -j 4     | grep -F 'Trying implicit' | wc -l
    6798
    $ make clean >/dev/null && make --debug=i -j 4 man | grep -F 'Trying implicit' | wc -l
    1085
    # (with the second commit applied)
    $ make clean >/dev/null && make --debug=i -j 4     | grep -F 'Trying implicit' | wc -l
    2535
    $ make clean >/dev/null && make --debug=i -j 4 man | grep -F 'Trying implicit' | wc -l
    42
    # (with the third commit applied)
    $ make clean >/dev/null && make --debug=i -j 4     | grep -F 'Trying implicit' | wc -l
    170
    $ make clean >/dev/null && make --debug=i -j 4 man | grep -F 'Trying implicit' | wc -l
    7

Environment: GNU make 4.4.1-2 on Artix Linux.

Note: According to make(1p) in POSIX.1-2017, "If .SUFFIXES does not have
any prerequisites, the list of known suffixes shall be cleared.", while
"The result of setting MAKEFLAGS in the Makefile is unspecified."

See also commit f48886f25 ("build: mark most phony targets as such",
2023-02-01) / PR #5637.
