### PR TITLE
profiles: vmware improvements and new redirect

### DIFF
--- a/etc/profile-m-z/vmplayer.profile
+++ b/etc/profile-m-z/vmplayer.profile
@@ -1,0 +1,8 @@
+# Firejail profile for vmware-player
+# Description: VMWare Workstation Player, used for running virtual machines
+# This file is overwritten after every install/update
+# Persistent local customizations
+include vmplayer.local
+
+# Redirect
+include vmware.profile

--- a/etc/profile-m-z/vmware-player.profile
+++ b/etc/profile-m-z/vmware-player.profile
@@ -1,5 +1,5 @@
 # Firejail profile for vmware-player
-# Description: The industry standard for running multiple operating systems as virtual machines on a single Linux PC.
+# Description: VMWare Workstation Player, used for running virtual machines
 # This file is overwritten after every install/update
 # Persistent local customizations
 include vmware-player.local

--- a/etc/profile-m-z/vmware-view.profile
+++ b/etc/profile-m-z/vmware-view.profile
@@ -1,5 +1,5 @@
 # Firejail profile for vmware-view
-# Description: VMware Horizon Client
+# Description: VMware Horizon Client, used as a remote desktop client
 # This file is overwritten after every install/update
 # Persistent local customizations
 include vmware-view.local

--- a/etc/profile-m-z/vmware-workstation.profile
+++ b/etc/profile-m-z/vmware-workstation.profile
@@ -1,5 +1,5 @@
 # Firejail profile for vmware-workstation
-# Description: The industry standard for running multiple operating systems as virtual machines on a single Linux PC.
+# Description: VMWare Workstation Player, used for running virtual machines
 # This file is overwritten after every install/update
 # Persistent local customizations
 include vmware-workstation.local

--- a/etc/profile-m-z/vmware.profile
+++ b/etc/profile-m-z/vmware.profile
@@ -1,5 +1,5 @@
 # Firejail profile for vmware
-# Description: The industry standard for running multiple operating systems as virtual machines on a single Linux PC.
+# Description: VMWare Workstation Player, used for running virtual machines
 # This file is overwritten after every install/update
 # Persistent local customizations
 include vmware.local

--- a/etc/profile-m-z/vmware.profile
+++ b/etc/profile-m-z/vmware.profile
@@ -11,7 +11,7 @@ noblacklist ${HOME}/.vmware
 noblacklist /usr/lib/vmware
 
 include disable-common.inc
-include disable-devel.inc
+#include disable-devel.inc # gcc is used to compile kernel modules
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -895,6 +895,7 @@ vivaldi-beta
 vivaldi-snapshot
 vivaldi-stable
 vlc
+vmplayer
 vmware
 vmware-player
 vmware-workstation

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -895,10 +895,10 @@ vivaldi-beta
 vivaldi-snapshot
 vivaldi-stable
 vlc
-vmplayer
-vmware
-vmware-player
-vmware-workstation
+#vmplayer - unable to install kernel modules (see #5861)
+#vmware - unable to install kernel modules (see #5861)
+#vmware-player - unable to install kernel modules (see #5861)
+#vmware-workstation - unable to install kernel modules (see #5861)
 vscodium
 vulturesclaw
 vultureseye


### PR DESCRIPTION
Add vmplayer.profile as a redirect to vmware.profile.

This is apparently the filename for the "VMWare Workstation Player" on
Linux Mint 20.3 (based on Ubuntu 20.04)[1].

Relates to #3526 #5861.

[1] https://github.com/netblue30/firejail/issues/5861#issuecomment-1598132860

Reported-by: @MikeNavy
