### PR TITLE
modif: improve errExit error messages

### DIFF
--- a/config.mk.in
+++ b/config.mk.in
@@ -83,7 +83,7 @@ LDFLAGS=@LDFLAGS@
 # Project variables
 EXTRA_CFLAGS  =@EXTRA_CFLAGS@
 COMMON_CFLAGS = \
-	-ggdb -O2 -DVERSION='"$(VERSION)"' \
+	-ggdb -O2 -DVERSION='"$(VERSION)"' -DMOD_DIR='"$(MOD_DIR)"' \
 	-Wall -Wextra $(HAVE_FATAL_WARNINGS) \
 	-Wformat -Wformat-security \
 	-fstack-protector-all -D_FORTIFY_SOURCE=2 \

--- a/src/etc-cleanup/Makefile
+++ b/src/etc-cleanup/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/etc-cleanup
 PROG = etc-cleanup
 TARGET = $(PROG)
 

--- a/src/fbuilder/Makefile
+++ b/src/fbuilder/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/fbuilder
 PROG = fbuilder
 TARGET = $(PROG)
 

--- a/src/fbuilder/utils.c
+++ b/src/fbuilder/utils.c
@@ -34,10 +34,8 @@ int is_dir(const char *fname) {
 		rv = stat(fname, &s);
 	else {
 		char *tmp;
-		if (asprintf(&tmp, "%s/", fname) == -1) {
-			fprintf(stderr, "Error: cannot allocate memory, %s:%d\n", __FILE__, __LINE__);
+		if (asprintf(&tmp, "%s/", fname) == -1)
 			errExit("asprintf");
-		}
 		rv = stat(tmp, &s);
 		free(tmp);
 	}

--- a/src/fcopy/Makefile
+++ b/src/fcopy/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/fcopy
 PROG = fcopy
 TARGET = $(PROG)
 

--- a/src/fids/Makefile
+++ b/src/fids/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/fids
 PROG = fids
 TARGET = $(PROG)
 

--- a/src/firecfg/Makefile
+++ b/src/firecfg/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/firecfg
 PROG = firecfg
 TARGET = $(PROG)
 

--- a/src/firejail/Makefile
+++ b/src/firejail/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/firejail
 PROG = firejail
 TARGET = $(PROG)
 

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -559,10 +559,8 @@ int is_dir(const char *fname) {
 		rv = stat_as_user(fname, &s);
 	else {
 		char *tmp;
-		if (asprintf(&tmp, "%s/", fname) == -1) {
-			fprintf(stderr, "Error: cannot allocate memory, %s:%d\n", __FILE__, __LINE__);
+		if (asprintf(&tmp, "%s/", fname) == -1)
 			errExit("asprintf");
-		}
 		rv = stat_as_user(tmp, &s);
 		free(tmp);
 	}

--- a/src/firemon/Makefile
+++ b/src/firemon/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/firemon
 PROG = firemon
 TARGET = $(PROG)
 

--- a/src/fldd/Makefile
+++ b/src/fldd/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/fldd
 PROG = fldd
 TARGET = $(PROG)
 

--- a/src/fnet/Makefile
+++ b/src/fnet/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/fnet
 PROG = fnet
 TARGET = $(PROG)
 

--- a/src/fnetfilter/Makefile
+++ b/src/fnetfilter/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/fnetfilter
 PROG = fnetfilter
 TARGET = $(PROG)
 

--- a/src/fnettrace-dns/Makefile
+++ b/src/fnettrace-dns/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/fnettrace-dns
 PROG = fnettrace-dns
 TARGET = $(PROG)
 

--- a/src/fnettrace-icmp/Makefile
+++ b/src/fnettrace-icmp/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/fnettrace-icmp
 PROG = fnettrace-icmp
 TARGET = $(PROG)
 

--- a/src/fnettrace-sni/Makefile
+++ b/src/fnettrace-sni/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/fnettrace-sni
 PROG = fnettrace-sni
 TARGET = $(PROG)
 

--- a/src/fnettrace/Makefile
+++ b/src/fnettrace/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/fnettrace
 PROG = fnettrace
 TARGET = $(PROG)
 

--- a/src/fsec-optimize/Makefile
+++ b/src/fsec-optimize/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/fsec-optimize
 PROG = fsec-optimize
 TARGET = $(PROG)
 

--- a/src/fsec-print/Makefile
+++ b/src/fsec-print/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/fsec-print
 PROG = fsec-print
 TARGET = $(PROG)
 

--- a/src/fseccomp/Makefile
+++ b/src/fseccomp/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/fseccomp
 PROG = fseccomp
 TARGET = $(PROG)
 

--- a/src/ftee/Makefile
+++ b/src/ftee/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/ftee
 PROG = ftee
 TARGET = $(PROG)
 

--- a/src/ftee/main.c
+++ b/src/ftee/main.c
@@ -148,10 +148,8 @@ static int is_dir(const char *fname) {
 		rv = stat(fname, &s);
 	else {
 		char *tmp;
-		if (asprintf(&tmp, "%s/", fname) == -1) {
-			fprintf(stderr, "Error: cannot allocate memory, %s:%d\n", __FILE__, __LINE__);
-			exit(1);
-		}
+		if (asprintf(&tmp, "%s/", fname) == -1)
+			errExit("asprintf");
 		rv = stat(tmp, &s);
 		free(tmp);
 	}

--- a/src/fzenity/Makefile
+++ b/src/fzenity/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/fzenity
 PROG = fzenity
 TARGET = $(PROG)
 

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -32,12 +32,16 @@
 #include <ctype.h>
 #include <assert.h>
 
+#if !defined(__func__) && defined(__FUNCTION__)
+#define __func__ __FUNCTION__
+#endif
+
 // dbus proxy path used by firejail and firemon
 #define XDG_DBUS_PROXY_PATH "/usr/bin/xdg-dbus-proxy"
 
 #define errExit(msg) do { \
 	char msgout[500]; \
-	snprintf(msgout, 500, "Error %s: %s:%d %s", msg, __FILE__, __LINE__, __FUNCTION__); \
+	snprintf(msgout, 500, "Error %s: %s:%d %s", msg, __FILE__, __LINE__, __func__); \
 	perror(msgout); \
 	exit(1); \
 } while (0)

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -41,7 +41,8 @@
 
 #define errExit(msg) do { \
 	char msgout[500]; \
-	snprintf(msgout, 500, "Error %s: %s:%d %s", msg, __FILE__, __LINE__, __func__); \
+	snprintf(msgout, 500, "Error %s/%s:%d %s(): %s", \
+	         MOD_DIR, __FILE__, __LINE__, __func__, msg); \
 	perror(msgout); \
 	exit(1); \
 } while (0)

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -35,8 +35,12 @@
 // dbus proxy path used by firejail and firemon
 #define XDG_DBUS_PROXY_PATH "/usr/bin/xdg-dbus-proxy"
 
-
-#define errExit(msg)    do { char msgout[500]; snprintf(msgout, 500, "Error %s: %s:%d %s", msg, __FILE__, __LINE__, __FUNCTION__); perror(msgout); exit(1);} while (0)
+#define errExit(msg) do { \
+	char msgout[500]; \
+	snprintf(msgout, 500, "Error %s: %s:%d %s", msg, __FILE__, __LINE__, __FUNCTION__); \
+	perror(msgout); \
+	exit(1); \
+} while (0)
 
 // macro to print ip addresses in a printf statement
 #define PRINT_IP(A) \

--- a/src/jailcheck/Makefile
+++ b/src/jailcheck/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/jailcheck
 PROG = jailcheck
 TARGET = $(PROG)
 

--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/lib
 TARGET = lib
 
 include $(ROOT)/src/prog.mk

--- a/src/libpostexecseccomp/Makefile
+++ b/src/libpostexecseccomp/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/libpostexecseccomp
 SO = libpostexecseccomp.so
 TARGET = $(SO)
 

--- a/src/libtrace/Makefile
+++ b/src/libtrace/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/libtrace
 SO = libtrace.so
 TARGET = $(SO)
 

--- a/src/libtracelog/Makefile
+++ b/src/libtracelog/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/libtracelog
 SO = libtracelog.so
 TARGET = $(SO)
 

--- a/src/profstats/Makefile
+++ b/src/profstats/Makefile
@@ -2,6 +2,7 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
+MOD_DIR = src/profstats
 PROG = profstats
 TARGET = $(PROG)
 

--- a/test/appimage/filename.exp
+++ b/test/appimage/filename.exp
@@ -24,7 +24,7 @@ after 100
 send -- "firejail --appimage appimage.sh\r"
 expect {
 	timeout {puts "TESTING ERROR 2\n";exit}
-	"Error mounting appimage"
+	-re "Error .*mounting appimage"
 }
 after 100
 


### PR DESCRIPTION
Main changes:

* Move msg to the end of errExit (right before perror(3p))
* Include the full file path (within the repository)
* Add "()" to function name for clarity

Before:

    Error malloc: main.c:123 main: Cannot allocate memory

After:

    Error src/firejail/main.c:123 main(): malloc: Cannot allocate memory

Note: This clarifies which is the exact file that the error message
comes from, as there are many source files with the same name.  For
example:

    $ git ls-files 'src/*/main.c' | wc -l
    20

Kind of relates to #3325.
