### PR TITLE
modif: drop deprecated 'shell' option references

### DIFF
--- a/etc/profile-a-l/beaker.profile
+++ b/etc/profile-a-l/beaker.profile
@@ -13,7 +13,6 @@ ignore include whitelist-usr-share-common.inc
 ignore include whitelist-var-common.inc
 ignore nou2f
 ignore novideo
-ignore shell none
 ignore disable-mnt
 ignore private-cache
 ignore private-dev

--- a/etc/profile-a-l/default.profile
+++ b/etc/profile-a-l/default.profile
@@ -40,7 +40,6 @@ notv
 novideo
 protocol unix,inet,inet6
 seccomp
-# shell none
 # tracelog
 
 # disable-mnt

--- a/etc/profile-a-l/fdns.profile
+++ b/etc/profile-a-l/fdns.profile
@@ -36,7 +36,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink
 #seccomp
-#shell none
 
 disable-mnt
 private

--- a/etc/profile-a-l/gnome-nettool.profile
+++ b/etc/profile-a-l/gnome-nettool.profile
@@ -35,7 +35,6 @@ notv
 nou2f
 novideo
 #seccomp
-#shell none
 
 disable-mnt
 private

--- a/etc/profile-a-l/jitsi-meet-desktop.profile
+++ b/etc/profile-a-l/jitsi-meet-desktop.profile
@@ -9,7 +9,6 @@ include globals.local
 # Disabled until someone reported positive feedback
 ignore nou2f
 ignore novideo
-ignore shell none
 
 ignore noexec /tmp
 

--- a/etc/profile-m-z/pidgin.profile
+++ b/etc/profile-m-z/pidgin.profile
@@ -38,7 +38,6 @@ notv
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp
-# shell none
 tracelog
 
 # private-bin pidgin

--- a/etc/profile-m-z/rocketchat.profile
+++ b/etc/profile-m-z/rocketchat.profile
@@ -15,7 +15,6 @@ ignore include whitelist-usr-share-common.inc
 ignore include whitelist-var-common.inc
 ignore nou2f
 ignore novideo
-ignore shell none
 ignore disable-mnt
 ignore private-cache
 ignore private-dev

--- a/etc/profile-m-z/server.profile
+++ b/etc/profile-m-z/server.profile
@@ -70,7 +70,6 @@ nou2f
 novideo
 protocol unix,inet,inet6,netlink,packet
 seccomp
-# shell none
 tab # allow tab completion
 
 disable-mnt

--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -31,7 +31,7 @@
 #   MKDIRS
 #   WHITELISTS
 #   WHITELIST INCLUDES
-#   OPTIONS (caps*, net*, no*, protocol, seccomp*, shell none, tracelog)
+#   OPTIONS (caps*, net*, no*, protocol, seccomp*, tracelog)
 #   PRIVATE OPTIONS (disable-mnt, private-*, writable-*)
 #   DBUS FILTER
 #   SPECIAL OPTIONS (mdwx, noexec, read-only, join-or-start)
@@ -172,7 +172,6 @@ include globals.local
 ##seccomp.drop SYSCALLS (see syscalls.txt)
 #seccomp.block-secondary
 ##seccomp-error-action log (only for debugging seccomp issues)
-#shell none
 #tracelog
 # Prefer 'x11 none' instead of 'disable-X11.inc' if 'net none' is set
 ##x11 none

--- a/src/bash_completion/firejail.bash_completion.in
+++ b/src/bash_completion/firejail.bash_completion.in
@@ -82,10 +82,6 @@ _firejail()
             _filedir
             return 0
             ;;
-        --shell)
-            _filedir
-            return 0
-            ;;
         --net)
             comps=$(__interfaces)
             COMPREPLY=( $(compgen -W '$comps' -- "$cur") )

--- a/src/fbuilder/build_profile.c
+++ b/src/fbuilder/build_profile.c
@@ -143,7 +143,6 @@ void build_profile(int argc, char **argv, int index, FILE *fp) {
 		fprintf(fp, "#novideo\t# disable video capture devices\n");
 		build_protocol(trace_output, fp);
 		fprintf(fp, "seccomp !chroot\t# allowing chroot, just in case this is an Electron app\n");
-		fprintf(fp, "shell none\n");
 		fprintf(fp, "#tracelog\t# send blacklist violations to syslog\n");
 		fprintf(fp, "\n");
 

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -2806,7 +2806,7 @@ int main(int argc, char **argv, char **envp) {
 			// already handled
 		}
 		else if (strncmp(argv[i], "--shell=", 8) == 0) {
-			fprintf(stderr, "Warning: --shell feature has been deprecated\n");
+			fprintf(stderr, "Error: \"shell none\" is done by default now; the \"shell\" command has been removed\n");
 			exit(1);
 		}
 		else if (strcmp(argv[i], "-c") == 0) {

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -371,8 +371,8 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		arg_caps_drop_all = 1;
 		return 0;
 	}
-	else if (strcmp(ptr, "shell none") == 0) {
-		fprintf(stderr, "Warning: \"shell none\" command in the profile file is done by default; the command will be deprecated\n");
+	else if (strcmp(ptr, "shell ") == 0) {
+		fprintf(stderr, "Warning: \"shell none\" is done by default now; the \"shell\" command has been removed\n");
 		return 0;
 	}
 	else if (strcmp(ptr, "tracelog") == 0) {

--- a/src/man/firejail-profile.5.in
+++ b/src/man/firejail-profile.5.in
@@ -799,11 +799,6 @@ Disable video capture devices.
 .TP
 \fBmachine-id
 Spoof id number in /etc/machine-id file - a new random id is generated inside the sandbox.
-.TP
-\fBshell none
-Run the program directly, without a shell.
-
-
 #ifdef HAVE_NETWORK
 .SH Networking
 Networking features available in profile files.

--- a/src/zsh_completion/_firejail.in
+++ b/src/zsh_completion/_firejail.in
@@ -160,8 +160,6 @@ _firejail_args=(
     '*--seccomp.32.keep=-[enable seccomp filter, and whitelist the 32 bit syscalls specified by the command]: :'
     # FIXME: Add errnos
     '--seccomp-error-action=-[change error code, kill process or log the attempt]: :(kill log)'
-    '--shell=none[run the program directly without a user shell]'
-    '--shell=-[set default user shell]: :_values $(cat /etc/shells)'
     '--timeout=-[kill the sandbox automatically after the time has elapsed]: :'
     #'(--tracelog)--trace[trace open, access and connect system calls]'
     '(--tracelog)--trace=-[trace open, access and connect system calls]: :_files'

--- a/test/environment/shell-none.profile
+++ b/test/environment/shell-none.profile
@@ -1,1 +1,0 @@
-shell none

--- a/test/profiles/ignore.exp
+++ b/test/profiles/ignore.exp
@@ -23,7 +23,7 @@ after 100
 send -- "exit\r"
 sleep 1
 
-send -- "firejail --ignore=seccomp --ignore=shell --profile=ignore.profile \r"
+send -- "firejail --ignore=seccomp --ignore=name --profile=ignore.profile \r"
 expect {
 	timeout {puts "TESTING ERROR 3\n";exit}
 	-re "Child process initialized in \[0-9\]+.\[0-9\]+ ms"
@@ -39,7 +39,7 @@ after 100
 send -- "exit\r"
 sleep 1
 
-send -- "firejail --ignore=private --ignore=shell --profile=ignore.profile \r"
+send -- "firejail --ignore=private --ignore=name --profile=ignore.profile \r"
 expect {
 	timeout {puts "TESTING ERROR 5\n";exit}
 	-re "Child process initialized in \[0-9\]+.\[0-9\]+ ms"
@@ -66,7 +66,7 @@ after 100
 send -- "exit\r"
 sleep 1
 
-send -- "firejail --ignore=quiet --ignore=shell --profile=ignore.profile \r"
+send -- "firejail --ignore=quiet --ignore=name --profile=ignore.profile \r"
 expect {
 	timeout {puts "TESTING ERROR 9\n";exit}
 	-re "Child process initialized in \[0-9\]+.\[0-9\]+ ms"

--- a/test/profiles/ignore.profile
+++ b/test/profiles/ignore.profile
@@ -1,3 +1,3 @@
 private
 seccomp
-shell none
+name test

--- a/test/profiles/ignore2.profile
+++ b/test/profiles/ignore2.profile
@@ -1,5 +1,5 @@
 ignore seccomp
-ignore shell
+ignore name
 private
 seccomp
-shell none
+name test

--- a/test/profiles/ignore3.profile
+++ b/test/profiles/ignore3.profile
@@ -1,4 +1,4 @@
 quiet
 private
 seccomp
-shell none
+name test

--- a/test/utils/build.exp
+++ b/test/utils/build.exp
@@ -57,10 +57,6 @@ expect {
 }
 expect {
 	timeout {puts "TESTING ERROR 11\n";exit}
-	"shell none"
-}
-expect {
-	timeout {puts "TESTING ERROR 11\n";exit}
 	"private-bin cat,"
 }
 expect {


### PR DESCRIPTION
The `shell` option has been removed. Remove stale references.

This does NOT remove `shell none`-related code comments in:

- [src/firejail/fs_lib.c](https://github.com/netblue30/firejail/blob/1d5fff9034796d69f287abbcfedff0342990fb7c/src/firejail/fs_lib.c#L433-L441)
- [src/firejail/join.c](https://github.com/netblue30/firejail/blob/1d5fff9034796d69f287abbcfedff0342990fb7c/src/firejail/join.c#L415-L417)

Relates to #5196.

Suggested by #5891.