### PR TITLE
bleachbit.profile: allow erasing Trash contents

### DIFF
--- a/etc/profile-a-l/bleachbit.profile
+++ b/etc/profile-a-l/bleachbit.profile
@@ -7,6 +7,9 @@ include bleachbit.local
 # Persistent global definitions
 include globals.local
 
+# Necessary for BleachBit to erase Trash contents.
+noblacklist ${HOME}/.local/share/Trash
+
 # Allow python (blacklisted by disable-interpreters.inc)
 include allow-python2.inc
 include allow-python3.inc


### PR DESCRIPTION
I made a feature request that was liked a while back (https://github.com/netblue30/firejail/issues/5337), and they suggested I make a pull request. It took me a long time to get around to it but here it is!

Explanation:
Bleachbit is used to permanently delete files by overwriting the memory. So the most popular feature of Bleachbit is emptying the Trash.

But bleachbit.profile includes disable-common.inc which blacklists ${HOME}/.local/share/Trash so it's not possible to empty the trash with Bleachbit.

These are the two lines i added: 

```
# Necessary for BleachBit to erase Trash contents. 
noblacklist ${HOME}/.local/share/Trash
```


