### PR TITLE
sqlitebrowser remote support

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -1015,6 +1015,7 @@ blacklist ${HOME}/.local/share/signal-cli
 blacklist ${HOME}/.local/share/sink
 blacklist ${HOME}/.local/share/smuxi
 blacklist ${HOME}/.local/share/spotify
+blacklist ${HOME}/.local/share/sqlitebrowser
 blacklist ${HOME}/.local/share/steam
 blacklist ${HOME}/.local/share/strawberry
 blacklist ${HOME}/.local/share/supertux2

--- a/etc/profile-m-z/sqlitebrowser.profile
+++ b/etc/profile-m-z/sqlitebrowser.profile
@@ -7,6 +7,7 @@ include sqlitebrowser.local
 include globals.local
 
 noblacklist ${HOME}/.config/sqlitebrowser
+noblacklist ${HOME}/.local/share/sqlitebrowser
 noblacklist ${DOCUMENTS}
 
 include disable-common.inc


### PR DESCRIPTION
Sqlitebrowser supports editing remote databases. By default it clones such DB's and installs the needed CA certificates under `${HOME}/.local/share/sqlitebrowser`, which this PR makes accessible in the sandbox.