### PR TITLE
profiles: remove /usr/share/vulkan already whitelisted by wusc

### DIFF
--- a/etc/profile-a-l/firefox-common-addons.profile
+++ b/etc/profile-a-l/firefox-common-addons.profile
@@ -74,7 +74,6 @@ whitelist ${HOME}/.zotero
 whitelist ${HOME}/dwhelper
 whitelist /usr/share/lua
 whitelist /usr/share/lua*
-whitelist /usr/share/vulkan
 
 # GNOME Shell integration (chrome-gnome-shell) needs dbus and python
 noblacklist ${HOME}/.local/share/gnome-shell

--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -60,7 +60,6 @@ whitelist ${HOME}/yt-dlp.conf
 whitelist ${HOME}/yt-dlp.conf.txt
 whitelist /usr/share/lua
 whitelist /usr/share/lua*
-whitelist /usr/share/vulkan
 include whitelist-common.inc
 include whitelist-player-common.inc
 include whitelist-usr-share-common.inc

--- a/etc/profile-m-z/smplayer.profile
+++ b/etc/profile-m-z/smplayer.profile
@@ -30,7 +30,6 @@ include disable-xdg.inc
 
 whitelist /usr/share/lua*
 whitelist /usr/share/smplayer
-whitelist /usr/share/vulkan
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 


### PR DESCRIPTION
No need for whitelisting /usr/share/vulkan twice in profiles that include wusc. We already do it there:

https://github.com/netblue30/firejail/blob/9863f982ca148f687a56690e2aeed10014d05e59/etc/inc/whitelist-usr-share-common.inc#L70