### PR TITLE
build: fix hardcoded make & remove unnecessary distclean targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,7 @@ DISTFILES_TEST = test/Makefile test/apps test/apps-x11 test/apps-x11-xorg test/c
 dist: config.mk
 	mv config.sh config.sh.old
 	mv config.status config.status.old
-	make distclean
+	$(MAKE) distclean
 	mv config.status.old config.status
 	mv config.sh.old config.sh
 	rm -fr $(TARNAME)-$(VERSION) $(TARNAME)-$(VERSION).tar.xz
@@ -358,7 +358,7 @@ cppcheck: clean
 
 .PHONY: scan-build
 scan-build: clean
-	scan-build make
+	scan-build $(MAKE)
 
 .PHONY: codespell
 codespell: clean

--- a/Makefile
+++ b/Makefile
@@ -184,10 +184,6 @@ clean:
 
 .PHONY: distclean
 distclean: clean
-	for dir in $$(dirname $(ALL_ITEMS)) $(MYDIRS); do \
-		$(MAKE) -C $$dir distclean; \
-	done
-	$(MAKE) -C test distclean
 	rm -fr autom4te.cache config.log config.mk config.sh config.status
 
 .PHONY: realinstall

--- a/src/bash_completion/Makefile
+++ b/src/bash_completion/Makefile
@@ -13,6 +13,3 @@ firejail.bash_completion: firejail.bash_completion.in $(ROOT)/config.mk
 .PHONY: clean
 clean:
 	rm -fr firejail.bash_completion
-
-.PHONY: distclean
-distclean: clean

--- a/src/prog.mk
+++ b/src/prog.mk
@@ -20,6 +20,3 @@ $(PROG): $(OBJS) $(ROOT)/config.mk
 
 .PHONY: clean
 clean:; rm -fr $(PROG) $(CLEANFILES)
-
-.PHONY: distclean
-distclean: clean

--- a/src/so.mk
+++ b/src/so.mk
@@ -20,6 +20,3 @@ $(SO): $(OBJS) $(ROOT)/config.mk
 
 .PHONY: clean
 clean:; rm -fr $(SO) $(CLEANFILES)
-
-.PHONY: distclean
-distclean: clean

--- a/src/zsh_completion/Makefile
+++ b/src/zsh_completion/Makefile
@@ -13,6 +13,3 @@ _firejail: _firejail.in $(ROOT)/config.mk
 .PHONY: clean
 clean:
 	rm -fr _firejail
-
-.PHONY: distclean
-distclean: clean

--- a/test/Makefile
+++ b/test/Makefile
@@ -12,6 +12,3 @@ $(TESTS):
 .PHONY: clean
 clean:
 	for test in $(TESTS); do rm -f "$$test/$$test.log"; done
-
-.PHONY: distclean
-distclean: clean


### PR DESCRIPTION
This also fixes the duplicate execution of the "clean" targets.