### PR TITLE
thunderbird: D-Bus hardening

### DIFF
--- a/etc/profile-m-z/thunderbird.profile
+++ b/etc/profile-m-z/thunderbird.profile
@@ -8,9 +8,17 @@ include globals.local
 
 ignore include whitelist-runuser-common.inc
 
-# writable-run-user and dbus are needed by enigmail
+# TB stopped supporting enigmail in 2020 (v78) - let's harden D-Bus
+# https://support.mozilla.org/en-US/kb/openpgp-thunderbird-howto-and-faq
 ignore dbus-user none
-ignore dbus-system none
+dbus-user filter
+dbus-user.own org.mozilla.thunderbird.*
+dbus-user.talk ca.desrt.dconf
+dbus-user.talk org.freedesktop.Notifications
+# allow D-Bus communication with firefox for opening links
+dbus-user.talk org.mozilla.*
+# e2ee email needs writable-run-user
+# https://support.mozilla.org/en-US/kb/introduction-to-e2e-encryption
 writable-run-user
 
 # If you want to read local mail stored in /var/mail edit /etc/apparmor.d/firejail-default accordingly


### PR DESCRIPTION
The `Enigmail` add-on was replaced with built-in support for OpenPGP in Thunderbird 78. Development has [stopped](https://enigmail.net/index.php/en/home/news/70-2019-10-08-future-openpgp-support-in-thunderbird) in 2019. IMO it's time to drop allowing full access to the user and system bus and introduce selective filtering. 