### PR TITLE
mpv: 0.36.0 requires system DBus access

### DIFF
--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -86,6 +86,6 @@ private-bin env,mpv,python*,waf,youtube-dl,yt-dlp
 private-dev
 
 dbus-user none
-dbus-system none
+dbus-system filter
 
 restrict-namespaces


### PR DESCRIPTION
Maybe could also use `dbus-system.talk org.freedesktop.DBus org.freedesktop.RealtimeKit1`. Not really sure how this works.