### PR TITLE
build: fix some shellcheck issues & use config.sh in more scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,12 +347,12 @@ deb: dist config.sh
 	./mkdeb.sh
 
 .PHONY: test-compile
-test-compile: dist config.mk
-	cd test/compile; ./compile.sh $(TARNAME)-$(VERSION)
+test-compile: dist config.sh
+	cd test/compile; ./compile.sh
 
 .PHONY: rpms
-rpms: src/man config.mk
-	./platform/rpm/mkrpm.sh $(TARNAME) $(VERSION)
+rpms: src/man config.sh
+	./platform/rpm/mkrpm.sh
 
 .PHONY: extras
 extras: all

--- a/mkasc.sh
+++ b/mkasc.sh
@@ -3,7 +3,7 @@
 # Copyright (C) 2014-2023 Firejail Authors
 # License GPL v2
 
-. "$(dirname "$0")/config.sh"
+. "$(dirname "$0")/config.sh" || exit 1
 
 printf 'Calculating SHA256 for all files in /transfer - %s version %s' "$TARNAME" "$VERSION"
 

--- a/platform/rpm/mkrpm.sh
+++ b/platform/rpm/mkrpm.sh
@@ -8,18 +8,18 @@
 # Builds rpms in a temporary directory then places the result in the
 # current working directory.
 
-name=$1
+name="$1"
 # Strip any trailing prefix from the version like -rc1 etc
-version=$(echo "$2" | sed 's/\-.*//g')
-config_opt=$3
+version="$(printf '%s\n' "$2" | sed 's/\-.*//g')"
+config_opt="$3"
 
-if [[ ! -f platform/rpm/${name}.spec ]]; then
-    echo error: spec file not found for name \"${name}\"
+if [[ ! -f "platform/rpm/${name}.spec" ]]; then
+    printf 'error: spec file not found for name %s\n' "${name}" >&2
     exit 1
 fi
 
 if [[ -z "${version}" ]]; then
-    echo error: version must be given
+    printf 'error: version must be given\n' >&2
     exit 1
 fi
 
@@ -28,26 +28,27 @@ if [[ -z "${config_opt}" ]]; then
 fi
 
 # Make a temporary directory and arrange to clean up on exit
-tmpdir=$(mktemp -d)
-mkdir -p ${tmpdir}/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+tmpdir="$(mktemp -d)"
+mkdir -p "${tmpdir}"/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 function cleanup {
-    rm -rf ${tmpdir}
+    rm -rf "${tmpdir}"
 }
 trap cleanup EXIT
 
 # Create the spec file
-tmp_spec_file=${tmpdir}/SPECS/${name}.spec
+tmp_spec_file="${tmpdir}/SPECS/${name}.spec"
 sed -e "s/__NAME__/${name}/g" \
     -e "s/__VERSION__/${version}/g" \
     -e "s/__CONFIG_OPT__/${config_opt}/g" \
-    platform/rpm/${name}.spec >${tmp_spec_file}
+    "platform/rpm/${name}.spec" >"${tmp_spec_file}"
 # FIXME: We could parse RELNOTES and create a %changelog section here
 
 # Copy the source to build into a tarball
-tar --exclude='./.git*' --transform "s/^./${name}-${version}/" -czf ${tmpdir}/SOURCES/${name}-${version}.tar.gz .
+tar --exclude='./.git*' --transform "s/^./${name}-${version}/" \
+    -czf "${tmpdir}/SOURCES/${name}-${version}.tar.gz" .
 
 # Build the files (rpm, debug rpm and source rpm)
-rpmbuild --quiet --define "_topdir ${tmpdir}" -ba ${tmp_spec_file}
+rpmbuild --quiet --define "_topdir ${tmpdir}" -ba "${tmp_spec_file}"
 
 # Copy the results to cwd
-mv ${tmpdir}/SRPMS/*.rpm ${tmpdir}/RPMS/*/*rpm .
+mv "${tmpdir}/SRPMS"/*.rpm "${tmpdir}/RPMS"/*/*rpm .

--- a/platform/rpm/mkrpm.sh
+++ b/platform/rpm/mkrpm.sh
@@ -3,15 +3,18 @@
 # Copyright (C) 2014-2023 Firejail Authors
 # License GPL v2
 #
-# Usage: ./platform/rpm/mkrpm.sh firejail <version> "<config options>"
+# Usage: ./platform/rpm/mkrpm.sh <config options>
 #
 # Builds rpms in a temporary directory then places the result in the
 # current working directory.
 
-name="$1"
+# shellcheck source=config.sh
+. "$(dirname "$0")/../../config.sh" || exit 1
+
+name="$TARNAME"
 # Strip any trailing prefix from the version like -rc1 etc
-version="$(printf '%s\n' "$2" | sed 's/\-.*//g')"
-config_opt="$3"
+version="$(printf '%s\n' "$VERSION" | sed 's/\-.*//g')"
+config_opt="$*"
 
 if [[ ! -f "platform/rpm/${name}.spec" ]]; then
     printf 'error: spec file not found for name %s\n' "${name}" >&2

--- a/test/compile/compile.sh
+++ b/test/compile/compile.sh
@@ -11,7 +11,8 @@
 #                          install contrib scripts
 #  --enable-analyzer       enable GCC 10 static analyzer
 
-
+# shellcheck source=config.sh
+. "$(dirname "$0")/../../config.sh" || exit 1
 
 arr[1]="TEST 1: standard compilation"
 arr[2]="TEST 2: compile dbus proxy disabled"
@@ -51,7 +52,7 @@ print_title() {
 	echo "**************************************************"
 }
 
-DIST="$1"
+DIST="$(TARNAME)-$(VERSION)"
 while [[ $# -gt 0 ]]; do    # Until you run out of parameters . . .
 	case "$1" in
 	--clean)

--- a/test/compile/compile.sh
+++ b/test/compile/compile.sh
@@ -79,7 +79,7 @@ echo "$DIST"
 tar -xJvf ../../"$DIST.tar.xz"
 mv "$DIST" firejail
 
-cd firejail
+cd firejail || exit 1
 ./configure --prefix=/usr --enable-fatal-warnings 2>&1 | tee ../output-configure
 make -j4 2>&1 | tee ../output-make
 cd ..
@@ -95,7 +95,7 @@ rm output-configure output-make
 # - disable dbus proxy configuration
 #*****************************************************************
 print_title "${arr[2]}"
-cd firejail
+cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-dbusproxy --enable-fatal-warnings 2>&1 | tee ../output-configure
 make -j4 2>&1 | tee ../output-make
@@ -112,7 +112,7 @@ rm output-configure output-make
 # - disable chroot configuration
 #*****************************************************************
 print_title "${arr[3]}"
-cd firejail
+cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-chroot --enable-fatal-warnings 2>&1 | tee ../output-configure
 make -j4 2>&1 | tee ../output-make
@@ -129,7 +129,7 @@ rm output-configure output-make
 # - disable firetunnel configuration
 #*****************************************************************
 print_title "${arr[4]}"
-cd firejail
+cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-firetunnel --enable-fatal-warnings 2>&1 | tee ../output-configure
 make -j4 2>&1 | tee ../output-make
@@ -146,7 +146,7 @@ rm output-configure output-make
 # - disable user namespace configuration
 #*****************************************************************
 print_title "${arr[5]}"
-cd firejail
+cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-userns --enable-fatal-warnings 2>&1 | tee ../output-configure
 make -j4 2>&1 | tee ../output-make
@@ -164,7 +164,7 @@ rm output-configure output-make
 # - check compilation
 #*****************************************************************
 print_title "${arr[6]}"
-cd firejail
+cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-network --enable-fatal-warnings 2>&1 | tee ../output-configure
 make -j4 2>&1 | tee ../output-make
@@ -181,7 +181,7 @@ rm output-configure output-make
 # - disable X11 support
 #*****************************************************************
 print_title "${arr[7]}"
-cd firejail
+cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-x11 --enable-fatal-warnings 2>&1 | tee ../output-configure
 make -j4 2>&1 | tee ../output-make
@@ -198,7 +198,7 @@ rm output-configure output-make
 # - enable selinux
 #*****************************************************************
 print_title "${arr[8]}"
-cd firejail
+cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --enable-selinux --enable-fatal-warnings 2>&1 | tee ../output-configure
 make -j4 2>&1 | tee ../output-make
@@ -215,7 +215,7 @@ rm output-configure output-make
 # - disable file transfer
 #*****************************************************************
 print_title "${arr[9]}"
-cd firejail
+cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-file-transfer --enable-fatal-warnings 2>&1 | tee ../output-configure
 make -j4 2>&1 | tee ../output-make
@@ -232,7 +232,7 @@ rm output-configure output-make
 # - disable whitelist
 #*****************************************************************
 print_title "${arr[10]}"
-cd firejail
+cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-whitelist --enable-fatal-warnings 2>&1 | tee ../output-configure
 make -j4 2>&1 | tee ../output-make
@@ -249,7 +249,7 @@ rm output-configure output-make
 # - disable global config
 #*****************************************************************
 print_title "${arr[11]}"
-cd firejail
+cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-globalcfg --enable-fatal-warnings 2>&1 | tee ../output-configure
 make -j4 2>&1 | tee ../output-make
@@ -266,7 +266,7 @@ rm output-configure output-make
 # - enable apparmor
 #*****************************************************************
 print_title "${arr[12]}"
-cd firejail
+cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --enable-apparmor --enable-fatal-warnings 2>&1 | tee ../output-configure
 make -j4 2>&1 | tee ../output-make
@@ -283,7 +283,7 @@ rm output-configure output-make
 # - enable busybox workaround
 #*****************************************************************
 print_title "${arr[13]}"
-cd firejail
+cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --enable-busybox-workaround --enable-fatal-warnings 2>&1 | tee ../output-configure
 make -j4 2>&1 | tee ../output-make
@@ -300,7 +300,7 @@ rm output-configure output-make
 # - disable overlayfs
 #*****************************************************************
 print_title "${arr[14]}"
-cd firejail
+cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-overlayfs --enable-fatal-warnings 2>&1 | tee ../output-configure
 make -j4 2>&1 | tee ../output-make
@@ -317,7 +317,7 @@ rm output-configure output-make
 # - disable private home
 #*****************************************************************
 print_title "${arr[15]}"
-cd firejail
+cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-private-home --enable-fatal-warnings 2>&1 | tee ../output-configure
 make -j4 2>&1 | tee ../output-make
@@ -334,7 +334,7 @@ rm output-configure output-make
 # - disable manpages
 #*****************************************************************
 print_title "${arr[16]}"
-cd firejail
+cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-man --enable-fatal-warnings 2>&1 | tee ../output-configure
 make -j4 2>&1 | tee ../output-make
@@ -351,7 +351,7 @@ rm output-configure output-make
 # - disable tmpfs as regular user"
 #*****************************************************************
 print_title "${arr[17]}"
-cd firejail
+cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-usertmpfs --enable-fatal-warnings 2>&1 | tee ../output-configure
 make -j4 2>&1 | tee ../output-make
@@ -368,7 +368,7 @@ rm output-configure output-make
 # - disable private home feature
 #*****************************************************************
 print_title "${arr[18]}"
-cd firejail
+cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-private-home --enable-fatal-warnings 2>&1 | tee ../output-configure
 make -j4 2>&1 | tee ../output-make
@@ -385,7 +385,7 @@ rm output-configure output-make
 # - enable ids
 #*****************************************************************
 print_title "${arr[19]}"
-cd firejail
+cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --enable-ids --enable-fatal-warnings 2>&1 | tee ../output-configure
 make -j4 2>&1 | tee ../output-make


### PR DESCRIPTION
This removes the need to manually pass variables such as `$(TARNAME)`
and `$(VERSION)` to shell scripts in the root Makefile.

Relates to #5140.