### PR TITLE
mpv.profile: add XDG_CACHE_HOME & missing paths

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -171,6 +171,7 @@ blacklist ${HOME}/.cache/mirage
 blacklist ${HOME}/.cache/moonchild productions/basilisk
 blacklist ${HOME}/.cache/moonchild productions/pale moon
 blacklist ${HOME}/.cache/mozilla
+blacklist ${HOME}/.cache/mpv
 blacklist ${HOME}/.cache/ms-excel-online
 blacklist ${HOME}/.cache/ms-office-online
 blacklist ${HOME}/.cache/ms-onenote-online

--- a/etc/profile-a-l/chatterino.profile
+++ b/etc/profile-a-l/chatterino.profile
@@ -12,11 +12,13 @@ include globals.local
 #whitelist ${MUSIC}
 
 # Also allow access to mpv/vlc, they're usable via streamlink.
+noblacklist ${HOME}/.cache/mpv
 noblacklist ${HOME}/.config/mpv
 noblacklist ${HOME}/.config/pulse
 noblacklist ${HOME}/.config/vlc
 noblacklist ${HOME}/.local/share/chatterino
 noblacklist ${HOME}/.local/share/vlc
+noblacklist ${HOME}/.local/state/mpv
 
 # Allow Lua for mpv (blacklisted by disable-interpreters.inc)
 include allow-lua.inc

--- a/etc/profile-a-l/firefox-common-addons.profile
+++ b/etc/profile-a-l/firefox-common-addons.profile
@@ -11,6 +11,7 @@ ignore include whitelist-runuser-common.inc
 
 ignore private-cache
 
+noblacklist ${HOME}/.cache/mpv
 noblacklist ${HOME}/.cache/youtube-dl
 noblacklist ${HOME}/.config/kgetrc
 noblacklist ${HOME}/.config/mpv
@@ -32,9 +33,11 @@ noblacklist ${HOME}/.local/share/kget
 noblacklist ${HOME}/.local/share/kxmlgui5/okular
 noblacklist ${HOME}/.local/share/okular
 noblacklist ${HOME}/.local/share/qpdfview
+noblacklist ${HOME}/.local/state/mpv
 noblacklist ${HOME}/.netrc
 
 whitelist ${HOME}/.cache/gnome-mplayer/plugin
+whitelist ${HOME}/.cache/mpv
 whitelist ${HOME}/.cache/youtube-dl/youtube-sigfuncs
 whitelist ${HOME}/.config/gnome-mplayer
 whitelist ${HOME}/.config/kgetrc
@@ -62,6 +65,7 @@ whitelist ${HOME}/.local/share/kxmlgui5/okular
 whitelist ${HOME}/.local/share/okular
 whitelist ${HOME}/.local/share/qpdfview
 whitelist ${HOME}/.local/share/tridactyl
+whitelist ${HOME}/.local/state/mpv
 whitelist ${HOME}/.netrc
 whitelist ${HOME}/.pentadactyl
 whitelist ${HOME}/.pentadactylrc

--- a/etc/profile-m-z/QMediathekView.profile
+++ b/etc/profile-m-z/QMediathekView.profile
@@ -9,6 +9,7 @@ include globals.local
 noblacklist ${HOME}/.config/QMediathekView
 noblacklist ${HOME}/.local/share/QMediathekView
 
+noblacklist ${HOME}/.cache/mpv
 noblacklist ${HOME}/.config/mpv
 noblacklist ${HOME}/.config/smplayer
 noblacklist ${HOME}/.config/totem
@@ -16,6 +17,7 @@ noblacklist ${HOME}/.config/vlc
 noblacklist ${HOME}/.config/xplayer
 noblacklist ${HOME}/.local/share/totem
 noblacklist ${HOME}/.local/share/xplayer
+noblacklist ${HOME}/.local/state/mpv
 noblacklist ${HOME}/.mplayer
 noblacklist ${VIDEOS}
 
@@ -35,6 +37,7 @@ whitelist ${HOME}/.local/share/QMediathekView
 whitelist ${DOWNLOADS}
 whitelist ${VIDEOS}
 
+whitelist ${HOME}/.cache/mpv
 whitelist ${HOME}/.config/mpv
 whitelist ${HOME}/.config/smplayer
 whitelist ${HOME}/.config/totem
@@ -42,6 +45,7 @@ whitelist ${HOME}/.config/vlc
 whitelist ${HOME}/.config/xplayer
 whitelist ${HOME}/.local/share/totem
 whitelist ${HOME}/.local/share/xplayer
+whitelist ${HOME}/.local/state/mpv
 whitelist ${HOME}/.mplayer
 whitelist /usr/share/qtchooser
 include whitelist-common.inc

--- a/etc/profile-m-z/mediathekview.profile
+++ b/etc/profile-m-z/mediathekview.profile
@@ -6,6 +6,7 @@ include mediathekview.local
 # Persistent global definitions
 include globals.local
 
+noblacklist ${HOME}/.cache/mpv
 noblacklist ${HOME}/.config/mpv
 noblacklist ${HOME}/.config/smplayer
 noblacklist ${HOME}/.config/totem
@@ -13,6 +14,7 @@ noblacklist ${HOME}/.config/vlc
 noblacklist ${HOME}/.config/xplayer
 noblacklist ${HOME}/.local/share/totem
 noblacklist ${HOME}/.local/share/xplayer
+noblacklist ${HOME}/.local/state/mpv
 noblacklist ${HOME}/.mediathek3
 noblacklist ${HOME}/.mplayer
 noblacklist ${VIDEOS}

--- a/etc/profile-m-z/mpsyt.profile
+++ b/etc/profile-m-z/mpsyt.profile
@@ -6,9 +6,11 @@ include mpsyt.local
 # Persistent global definitions
 include globals.local
 
+noblacklist ${HOME}/.cache/mpv
 noblacklist ${HOME}/.config/mps-youtube
 noblacklist ${HOME}/.config/mpv
 noblacklist ${HOME}/.config/youtube-dl
+noblacklist ${HOME}/.local/state/mpv
 noblacklist ${HOME}/.mplayer
 noblacklist ${HOME}/.netrc
 noblacklist ${HOME}/mps
@@ -34,9 +36,11 @@ include disable-xdg.inc
 mkdir ${HOME}/.config/mps-youtube
 mkdir ${HOME}/.mplayer
 mkdir ${HOME}/mps
+whitelist ${HOME}/.cache/mpv
 whitelist ${HOME}/.config/mps-youtube
 whitelist ${HOME}/.config/mpv
 whitelist ${HOME}/.config/youtube-dl
+whitelist ${HOME}/.local/state/mpv
 whitelist ${HOME}/.mplayer
 whitelist ${HOME}/.netrc
 whitelist ${HOME}/mps

--- a/etc/profile-m-z/mpsyt.profile
+++ b/etc/profile-m-z/mpsyt.profile
@@ -32,8 +32,6 @@ include disable-shell.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.config/mps-youtube
-mkdir ${HOME}/.config/mpv
-mkdir ${HOME}/.config/youtube-dl
 mkdir ${HOME}/.mplayer
 mkdir ${HOME}/mps
 whitelist ${HOME}/.config/mps-youtube

--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -24,6 +24,7 @@ include globals.local
 #include allow-bin-sh.inc
 #private-bin sh
 
+noblacklist ${HOME}/.cache/mpv
 noblacklist ${HOME}/.config/mpv
 noblacklist ${HOME}/.config/youtube-dl
 noblacklist ${HOME}/.config/yt-dlp
@@ -50,9 +51,11 @@ include disable-programs.inc
 include disable-shell.inc
 
 read-only ${DESKTOP}
+mkdir ${HOME}/.cache/mpv
 mkdir ${HOME}/.config/mpv
 mkdir ${HOME}/.local/state/mpv
 mkfile ${HOME}/.netrc
+whitelist ${HOME}/.cache/mpv
 whitelist ${HOME}/.config/mpv
 whitelist ${HOME}/.config/youtube-dl
 whitelist ${HOME}/.config/yt-dlp

--- a/etc/profile-m-z/rtv-addons.profile
+++ b/etc/profile-m-z/rtv-addons.profile
@@ -11,13 +11,17 @@ ignore nosound
 ignore private-bin
 ignore dbus-user none
 
+noblacklist ${HOME}/.cache/mpv
 noblacklist ${HOME}/.config/mpv
+noblacklist ${HOME}/.local/state/mpv
 noblacklist ${HOME}/.mailcap
 noblacklist ${HOME}/.netrc
 noblacklist ${HOME}/.w3m
 
+whitelist ${HOME}/.cache/mpv
 whitelist ${HOME}/.cache/youtube-dl/youtube-sigfuncs
 whitelist ${HOME}/.config/mpv
+whitelist ${HOME}/.local/state/mpv
 whitelist ${HOME}/.mailcap
 whitelist ${HOME}/.netrc
 whitelist ${HOME}/.w3m

--- a/etc/profile-m-z/smtube.profile
+++ b/etc/profile-m-z/smtube.profile
@@ -6,12 +6,14 @@ include smtube.local
 # Persistent global definitions
 include globals.local
 
+noblacklist ${HOME}/.cache/mpv
+noblacklist ${HOME}/.config/mpv
 noblacklist ${HOME}/.config/smplayer
 noblacklist ${HOME}/.config/smtube
-noblacklist ${HOME}/.config/mpv
-noblacklist ${HOME}/.mplayer
 noblacklist ${HOME}/.config/vlc
 noblacklist ${HOME}/.local/share/vlc
+noblacklist ${HOME}/.local/state/mpv
+noblacklist ${HOME}/.mplayer
 noblacklist ${MUSIC}
 noblacklist ${VIDEOS}
 

--- a/etc/profile-m-z/youtube-viewers-common.profile
+++ b/etc/profile-m-z/youtube-viewers-common.profile
@@ -7,8 +7,10 @@ include youtube-viewers-common.local
 # added by caller profile
 #include globals.local
 
+noblacklist ${HOME}/.cache/mpv
 noblacklist ${HOME}/.cache/youtube-dl
 noblacklist ${HOME}/.config/mpv
+noblacklist ${HOME}/.local/state/mpv
 
 # Allow lua (blacklisted by disable-interpreters.inc)
 include allow-lua.inc


### PR DESCRIPTION
mpv v0.36.0 uses ~/.cache/mpv[1] [2]:

Relates to #2838 #5936.

[1] https://github.com/mpv-player/mpv/releases/tag/v0.36.0
[2] https://github.com/mpv-player/mpv/pull/10838
