### PR TITLE
build: firecfg.config sorting improvements

### DIFF
--- a/ci/check/profiles/sort-firecfg.config.sh
+++ b/ci/check/profiles/sort-firecfg.config.sh
@@ -1,2 +1,5 @@
 #!/bin/sh
-tail -n +4 "$1" | sed 's/^# /#/' | LC_ALL=C sort -c -d
+# See ../../../src/firecfg/firecfg.config
+
+sed -E -e '/^#$/d' -e '/^# /d' -e 's/^#([^ ])/\1/' "$1" |
+LC_ALL=C sort -c -u

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -51,7 +51,7 @@ ani-cli
 anydesk
 apktool
 apostrophe
-# ar - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+#ar # disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
 arch-audit
 archaudit-report
 ardour4
@@ -63,9 +63,9 @@ arm
 artha
 assogiate
 asunder
-# atom
-# atom-beta
-# atool - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+#atom
+#atom-beta
+#atool # disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
 atril
 atril-previewer
 atril-thumbnailer
@@ -112,10 +112,10 @@ brave-browser-beta
 brave-browser-dev
 brave-browser-nightly
 brave-browser-stable
-# bunzip2 - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
-# bzcat - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+#bunzip2 # disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+#bzcat # disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
 bzflag
-# bzip2 - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+#bzip2 # disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
 cachy-browser
 calibre
 calligra
@@ -236,14 +236,14 @@ enpass
 eog
 eom
 ephemeral
-#epiphany - see #2995
+#epiphany # see #2995
 equalx
 et
 etr
 evince
 evince-previewer
 evince-thumbnailer
-#evolution - see #3647
+#evolution # see #3647
 exfalso
 exiftool
 falkon
@@ -319,7 +319,7 @@ git-cola
 gitg
 github-desktop
 gitter
-# gjs -- https://github.com/netblue30/firejail/issues/3333#issuecomment-612601102
+#gjs # https://github.com/netblue30/firejail/issues/3333#issuecomment-612601102
 gl-117
 glaxium
 globaltime
@@ -440,7 +440,7 @@ karbon
 kate
 kazam
 kcalc
-# kdeinit4
+#kdeinit4
 kdenlive
 kdiff3
 keepass
@@ -450,7 +450,7 @@ keepassx2
 keepassxc
 keepassxc-cli
 keepassxc-proxy
-# kfind
+#kfind
 kget
 kid3
 kid3-cli
@@ -467,15 +467,15 @@ kodi
 konversation
 kopete
 krita
-# krunner
+#krunner
 ktorrent
 ktouch
 kube
-# kwin_x11
+#kwin_x11
 kwrite
 lbry-viewer
 leafpad
-# less - breaks man
+#less # breaks man
 librecad
 libreoffice
 librewolf
@@ -500,12 +500,12 @@ lollypop
 lomath
 loweb
 lowriter
-# lrunzip - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
-# lrz - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
-# lrzcat - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
-# lrzip - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
-# lrztar - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
-# lrzuntar - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+#lrunzip # disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+#lrz # disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+#lrzcat # disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+#lrzip # disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+#lrztar # disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+#lrzuntar # disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
 luminance-hdr
 lximage-qt
 lxmusic
@@ -697,9 +697,9 @@ profanity
 psi
 psi-plus
 pybitmessage
-# pycharm-community - FB note: may enable later
-# pycharm-professional
-# pzstd - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+#pycharm-community # FB note: may enable later
+#pycharm-professional
+#pzstd # disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
 qbittorrent
 qcomicbook
 qemu-launcher
@@ -787,7 +787,7 @@ spectral
 spotify
 sqlitebrowser
 ssh
-# ssh-agent - problems on Arch with Fish shell (#1568)
+#ssh-agent # problems on Arch with Fish shell (#1568)
 standardnotes-desktop
 start-tor-browser
 steam
@@ -888,7 +888,7 @@ uget-gtk
 unbound
 unf
 unknown-horizons
-# unzstd - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+#unzstd # disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
 url-eater
 utox
 uudeview
@@ -901,10 +901,10 @@ vivaldi-beta
 vivaldi-snapshot
 vivaldi-stable
 vlc
-#vmplayer - unable to install kernel modules (see #5861)
-#vmware - unable to install kernel modules (see #5861)
-#vmware-player - unable to install kernel modules (see #5861)
-#vmware-workstation - unable to install kernel modules (see #5861)
+#vmplayer # unable to install kernel modules (see #5861)
+#vmware # unable to install kernel modules (see #5861)
+#vmware-player # unable to install kernel modules (see #5861)
+#vmware-workstation # unable to install kernel modules (see #5861)
 vscodium
 vulturesclaw
 vultureseye
@@ -979,10 +979,10 @@ zeal
 zim
 zlib-flate
 zoom
-# zpaq - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
-# zstd - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
-# zstdcat - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
-# zstdgrep - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
-# zstdless - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
-# zstdmt - disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+#zpaq # disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+#zstd # disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+#zstdcat # disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+#zstdgrep # disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+#zstdless # disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
+#zstdmt # disable until we fix CLI archivers for makepkg on Arch (see discussion in #3095)
 zulip

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -1,6 +1,8 @@
 # /etc/firejail/firecfg.config - firecfg utility configuration file
 # This is the list of programs in alphabetical order handled by firecfg utility
 #
+# Note: Normal comment lines should start with `# ` and commented code lines
+# should start with just `#` (no spaces).
 0ad
 1password
 2048-qt
@@ -149,8 +151,8 @@ clamdscan
 clamdtop
 clamscan
 clamtk
-clawsker
 claws-mail
+clawsker
 clementine
 clion
 clion-eap
@@ -182,6 +184,7 @@ crow
 cryptocat
 cvlc
 cyberfox
+d-feet
 daisy
 darktable
 dconf-editor
@@ -192,7 +195,6 @@ deluge
 desktopeditors
 devhelp
 dex2jar
-d-feet
 dia
 dig
 digikam
@@ -271,8 +273,8 @@ flacsplt
 flameshot
 flashpeak-slimjet
 flowblade
-fontforge
 font-manager
+fontforge
 fossamail
 four-in-a-row
 fractal
@@ -384,12 +386,12 @@ gradio
 gramps
 gravity-beams-and-evaporating-stars
 gthumb
-gtk2-youtube-viewer
-gtk3-youtube-viewer
 gtk-lbry-viewer
 gtk-pipe-viewer
 gtk-straw-viewer
 gtk-youtube-viewer
+gtk2-youtube-viewer
+gtk3-youtube-viewer
 guayadeque
 gucharmap
 gummi
@@ -410,8 +412,8 @@ icecat
 icedove
 iceweasel
 idea
-ideaIC
 idea.sh
+ideaIC
 imagej
 img2txt
 impressive
@@ -559,7 +561,6 @@ mp3wrap
 mpDris2
 mpg123
 mpg123-alsa
-mpg123.bin
 mpg123-id3dump
 mpg123-jack
 mpg123-nas
@@ -568,6 +569,7 @@ mpg123-oss
 mpg123-portaudio
 mpg123-pulse
 mpg123-strip
+mpg123.bin
 mplayer
 mpsyt
 mpv
@@ -636,11 +638,11 @@ onionshare-cli
 onionshare-gui
 ooffice
 ooviewdoc
+open-invaders
 openarena
 openarena_ded
 opencity
 openclonk
-open-invaders
 openmw
 openmw-launcher
 openoffice.org
@@ -780,8 +782,8 @@ sniffnet
 snox
 soffice
 sol
-soundconverter
 sound-juicer
+soundconverter
 spectacle
 spectral
 spotify
@@ -794,8 +796,8 @@ steam
 steam-native
 steam-runtime
 stellarium
-strawberry
 straw-viewer
+strawberry
 strings
 studio.sh
 subdownloader
@@ -826,7 +828,6 @@ thunderbird-beta
 thunderbird-wayland
 tilp
 tor-browser
-torbrowser
 tor-browser-ar
 tor-browser-ca
 tor-browser-cs
@@ -848,7 +849,6 @@ tor-browser-it
 tor-browser-ja
 tor-browser-ka
 tor-browser-ko
-torbrowser-launcher
 tor-browser-nb
 tor-browser-nl
 tor-browser-pl
@@ -859,6 +859,8 @@ tor-browser-tr
 tor-browser-vi
 tor-browser-zh-cn
 tor-browser-zh-tw
+torbrowser
+torbrowser-launcher
 torcs
 totem
 tracker
@@ -968,8 +970,8 @@ yelp
 youtube
 youtube-dl
 youtube-dl-gui
-youtubemusic-nativefier
 youtube-viewer
+youtubemusic-nativefier
 yt-dlp
 ytmdesktop
 zaproxy


### PR DESCRIPTION
Remove the space after `#` for commented code and use `#` instead of `-`
for comments at the end of the line.

Currently the CI check does not consider certain special characters
(such as `-`) when sorting due to `sort -d`.

So remove `-d`, sort firecfg using `LC_ALL=C` and enforce that order.

Also add `sort -u` to check for duplicates.

This also allows the CI check to ignore normal comments (lines starting
with `# `) anywhere in the file.

Relates to #4643.