### PR TITLE
0ad.profile: fix libmozjs error on OpenSUSE Tumbleweed

### DIFF
--- a/etc/profile-a-l/0ad.profile
+++ b/etc/profile-a-l/0ad.profile
@@ -10,6 +10,9 @@ noblacklist ${HOME}/.cache/0ad
 noblacklist ${HOME}/.config/0ad
 noblacklist ${HOME}/.local/share/0ad
 
+# Allow gjs (blacklisted by disable-interpreters.inc)
+include allow-gjs.inc
+
 blacklist /usr/libexec
 
 include disable-common.inc


### PR DESCRIPTION
Se [this issue](https://github.com/netblue30/firejail/issues/5938#issue-1833607321) that describes it all.