### PR TITLE
mpd: allow MPRIS2

### DIFF
--- a/etc/profile-a-l/gmpc.profile
+++ b/etc/profile-a-l/gmpc.profile
@@ -47,8 +47,9 @@ private-etc
 private-tmp
 writable-run-user
 
-# dbus-user none
-# dbus-system none
+dbus-user filter
+dbus-user.talk org.mpris.MediaPlayer2.mpd
+dbus-system none
 
 # memory-deny-write-execute - breaks on Arch
 restrict-namespaces

--- a/etc/profile-m-z/mpDris2.profile
+++ b/etc/profile-m-z/mpDris2.profile
@@ -52,6 +52,10 @@ private-etc
 private-lib libdbus-1.so.*,libdbus-glib-1.so.*,libgirepository-1.0.so.*,libnotify.so.*,libpython*,python2*,python3*
 private-tmp
 
+dbus-user filter
+dbus-user.own org.mpris.MediaPlayer2.mpd
+dbus-system none
+
 #memory-deny-write-execute - breaks on Arch (see issue #1803)
 
 read-only ${HOME}

--- a/etc/profile-m-z/mpd.profile
+++ b/etc/profile-m-z/mpd.profile
@@ -41,4 +41,8 @@ private-cache
 private-dev
 private-tmp
 
+dbus-user filter
+dbus-user.talk org.mpris.MediaPlayer2.mpd
+dbus-system none
+
 restrict-namespaces


### PR DESCRIPTION
mpDris2 brings MPRIS2 support to MPD:

https://github.com/eonpatapon/mpDris2

Let's use our dbus-filtering options for some hardening.