### PR TITLE
build(deps): Update step-security/harden-runner and update allowed endpoints

### DIFF
--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@cba0d00b1fc9a034e1e642ea0f1103c282990604
+      uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09
       with:
         egress-policy: block
         allowed-endpoints: >
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@cba0d00b1fc9a034e1e642ea0f1103c282990604
+      uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09
       with:
         egress-policy: block
         allowed-endpoints: >
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@cba0d00b1fc9a034e1e642ea0f1103c282990604
+      uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09
       with:
         egress-policy: block
         allowed-endpoints: >
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@cba0d00b1fc9a034e1e642ea0f1103c282990604
+      uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09
       with:
         egress-policy: block
         allowed-endpoints: >
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@cba0d00b1fc9a034e1e642ea0f1103c282990604
+      uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09
       with:
         egress-policy: block
         allowed-endpoints: >

--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -58,8 +58,12 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: >
+          archive.ubuntu.com:80
           azure.archive.ubuntu.com:80
           github.com:443
+          packages.microsoft.com:443
+          ppa.launchpadcontent.net:443
+          security.ubuntu.com:80
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
     - name: update package information
       run: sudo apt-get update -qy
@@ -88,8 +92,12 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: >
+          archive.ubuntu.com:80
           azure.archive.ubuntu.com:80
           github.com:443
+          packages.microsoft.com:443
+          ppa.launchpadcontent.net:443
+          security.ubuntu.com:80
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
     - name: update package information
       run: sudo apt-get update -qy
@@ -114,8 +122,12 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: >
+          archive.ubuntu.com:80
           azure.archive.ubuntu.com:80
           github.com:443
+          packages.microsoft.com:443
+          ppa.launchpadcontent.net:443
+          security.ubuntu.com:80
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
     - name: update package information
       run: sudo apt-get update -qy
@@ -136,8 +148,13 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: >
+          archive.ubuntu.com:80
           azure.archive.ubuntu.com:80
           github.com:443
+          packages.microsoft.com:443
+          ppa.launchpad.net:80
+          ppa.launchpadcontent.net:443
+          security.ubuntu.com:80
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
     - name: update package information
       run: sudo apt-get update -qy
@@ -154,8 +171,12 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: >
+          archive.ubuntu.com:80
           azure.archive.ubuntu.com:80
           github.com:443
+          packages.microsoft.com:443
+          ppa.launchpadcontent.net:443
+          security.ubuntu.com:80
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
     - name: update package information
       run: sudo apt-get update -qy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
       SHELL: /bin/bash
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@cba0d00b1fc9a034e1e642ea0f1103c282990604
+      uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09
       with:
         egress-policy: block
         allowed-endpoints: >

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -75,7 +75,7 @@ jobs:
 
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@cba0d00b1fc9a034e1e642ea0f1103c282990604
+      uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09
       with:
         disable-sudo: true
         egress-policy: block

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -81,8 +81,10 @@ jobs:
         egress-policy: block
         allowed-endpoints: >
           api.github.com:443
+          files.pythonhosted.org:443
           github.com:443
           objects.githubusercontent.com:443
+          pypi.org:443
           uploads.github.com:443
 
     - name: Checkout repository

--- a/.github/workflows/profile-checks.yml
+++ b/.github/workflows/profile-checks.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@cba0d00b1fc9a034e1e642ea0f1103c282990604
+      uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09
       with:
         disable-sudo: true
         egress-policy: block


### PR DESCRIPTION
This PR does two things:

1. Updates `step-security/harden-runner` from 2.5.0 to 2.5.1 in the GitHub Actions workflows.

    GitHub Actions recently started making outbound calls to a few endpoints not in the default allowed list.   This causes the build to get stuck when using a `block` policy with `harden-runner`. This update to harden-runner (version v2.5.1), adds these new endpoints to the default allowed list. 
    
    I noticed that some of the workflows in this repository are getting stuck, so creating a PR to bump up the version to the latest. 
    
    Release notes for the latest version are here:
    https://github.com/step-security/harden-runner/releases/tag/v2.5.1

2. I also noticed while testing the workflows that some endpoints that should be allowed were not in the allowed list, and were getting blocked, so added them to the allowed list. 