### PR TITLE
fcopy: Use lstat when copy directory.

### DIFF
--- a/src/fcopy/main.c
+++ b/src/fcopy/main.c
@@ -277,7 +277,7 @@ static int fs_copydir(const char *infname, const struct stat *st, int ftype, str
 
 	// don't copy it if we already have the file
 	struct stat s;
-	if (stat(outfname, &s) == 0) {
+	if (lstat(outfname, &s) == 0) {
 		if (first)
 			first = 0;
 		else if (!arg_quiet)
@@ -286,7 +286,7 @@ static int fs_copydir(const char *infname, const struct stat *st, int ftype, str
 	}
 
 	// extract mode and ownership
-	if (stat(infname, &s) != 0)
+	if (lstat(infname, &s) != 0)
 		goto out;
 
 	uid_t uid = s.st_uid;


### PR DESCRIPTION
When copying directories use lstat when reading info about source files.

Closes #5378.