### PR TITLE
profiles: move fakeroot blacklisting to disable-devel.inc

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -577,7 +577,6 @@ blacklist ${PATH}/ss
 blacklist ${PATH}/traceroute
 # since firejail version 0.9.73
 blacklist ${PATH}/dpkg*
-blacklist ${PATH}/fakeroot*
 blacklist ${PATH}/apt*
 blacklist ${PATH}/dumpcap
 blacklist ${PATH}/efibootdump

--- a/etc/inc/disable-devel.inc
+++ b/etc/inc/disable-devel.inc
@@ -15,6 +15,7 @@ blacklist ${PATH}/ifnames
 blacklist ${PATH}/aclocal*
 blacklist ${PATH}/automake*
 blacklist ${PATH}/dh_*
+blacklist ${PATH}/fakeroot*
 blacklist ${PATH}/m4
 
 # patch


### PR DESCRIPTION
As of https://github.com/netblue30/firejail/commit/96beb3358c430a5e470ce02fd64ffc3f7fc23706 `fakeroot` is blacklisted in disable-common.inc. Without that, makepkg will break, cfr. https://github.com/netblue30/firejail/commit/96beb3358c430a5e470ce02fd64ffc3f7fc23706#r125237349.