### PR TITLE
profiles: move ~/.rustup blacklist to disable-programs.inc

### DIFF
--- a/etc/inc/allow-common-devel.inc
+++ b/etc/inc/allow-common-devel.inc
@@ -37,3 +37,4 @@ noblacklist ${HOME}/.bundle
 
 # Rust
 noblacklist ${HOME}/.cargo
+noblacklist ${HOME}/.rustup

--- a/etc/inc/disable-devel.inc
+++ b/etc/inc/disable-devel.inc
@@ -92,7 +92,6 @@ blacklist ${PATH}/openssl
 blacklist ${PATH}/openssl-1.0
 
 # Rust
-blacklist ${HOME}/.rustup
 blacklist ${PATH}/rust-gdb
 blacklist ${PATH}/rust-lldb
 blacklist ${PATH}/rustc

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -1129,6 +1129,7 @@ blacklist ${HOME}/.repo_.gitconfig.json
 blacklist ${HOME}/.repoconfig
 blacklist ${HOME}/.retroshare
 blacklist ${HOME}/.ripperXrc
+blacklist ${HOME}/.rustup
 blacklist ${HOME}/.sbt
 blacklist ${HOME}/.scorched3d
 blacklist ${HOME}/.scribus


### PR DESCRIPTION
Which also blacklists ~/.cargo.

Note that ~/.rustup is the only `${HOME}` entry in disable-devel.inc.

Added on commit 8d9b12d1c ("New profiles + fixes + hardening",
2020-09-14).