### PR TITLE
profiles: patch fixes

### DIFF
--- a/etc/profile-a-l/ani-cli.profile
+++ b/etc/profile-a-l/ani-cli.profile
@@ -10,6 +10,7 @@ include ani-cli.local
 
 noblacklist ${HOME}/.cache/ani-cli
 noblacklist ${HOME}/.local/state/ani-cli
+noblacklist ${PATH}/patch
 
 # Allow /bin/sh (blacklisted by disable-shell.inc)
 include allow-bin-sh.inc

--- a/etc/profile-a-l/lobster.profile
+++ b/etc/profile-a-l/lobster.profile
@@ -17,6 +17,7 @@ noblacklist ${HOME}/.config/ueberzugpp
 noblacklist ${HOME}/.local/share/applications/lobster
 noblacklist ${HOME}/.local/share/lobster
 noblacklist ${PATH}/openssl
+noblacklist ${PATH}/patch
 
 # Allow /bin/sh (blacklisted by disable-shell.inc)
 include allow-bin-sh.inc

--- a/etc/profile-m-z/patch.profile
+++ b/etc/profile-m-z/patch.profile
@@ -10,6 +10,7 @@ include globals.local
 blacklist ${RUNUSER}
 
 noblacklist ${DOCUMENTS}
+noblacklist ${PATH}/patch
 
 include disable-common.inc
 include disable-devel.inc


### PR DESCRIPTION
Commit 3077b2d1f blacklists `${PATH}/patch` in disable-devel.inc[1]. We
need to noblacklist it in the profiles that need it.

[1] https://github.com/netblue30/firejail/commit/3077b2d1ff6c6e26a83487ae460985157b5c61fd