### PR TITLE
ci: fix dependabot duplicated workflow runs

### DIFF
--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -4,6 +4,8 @@ name: Build-extra
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
     paths:
       - 'm4/**'
       - 'src/**.c'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ name: Build
 # Note: Keep this list in sync with DISTFILES in ../../Makefile.
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
     paths:
       - 'contrib/**'
       - 'etc/**'

--- a/.github/workflows/check-c.yml
+++ b/.github/workflows/check-c.yml
@@ -4,6 +4,8 @@ name: Check-C
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
     paths:
       - 'm4/**'
       - 'src/**.c'

--- a/.github/workflows/check-profiles.yml
+++ b/.github/workflows/check-profiles.yml
@@ -4,6 +4,8 @@ name: Check-Profiles
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
     paths:
       - 'ci/check/profiles/**'
       - 'etc/**'

--- a/.github/workflows/check-python.yml
+++ b/.github/workflows/check-python.yml
@@ -4,6 +4,8 @@ name: Check-Python
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
     paths:
       - '**.py'
       - .github/workflows/check-python.yml

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -4,6 +4,8 @@ name: Codespell
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
     paths-ignore:
       - 'm4/**'
       - COPYING

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ name: Test
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
     paths:
       - 'm4/**'
       - 'src/**.c'


### PR DESCRIPTION
Every workflow is being executed twice for dependabot: Once when its
branch is pushed to this repository and again when a PR is opened for
it.

For example, see the checks in #5979 ("29 checks passed").

This happens because both `on.push` and `on.pull_request` are specified
in the workflow files.

There does not seem to be a simple and generic way to avoid such
duplicated runs directly in GitHub Actions (such as preventing the same
check from running for the same exact commit)[1], so just ignore the
dependabot branches on push for now.

See also and commit 5871b08a4 ("ci: run for every branch instead of just
master", 2023-04-23) / PR #5815.

[1] https://github.com/orgs/community/discussions/26276