### PR TITLE
neochat: Allow netlink

### DIFF
--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -45,7 +45,7 @@ nosound
 notv
 nou2f
 novideo
-protocol unix,inet,inet6
+protocol unix,inet,inet6,netlink
 seccomp
 seccomp.block-secondary
 tracelog


### PR DESCRIPTION
The latest Neochat package on Arch (23.08.0-2, with libquotient 0.8.1.1-1) crashes otherwise.

