### PR TITLE
profiles: fix commented code and eol comments

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -33,7 +33,8 @@ blacklist-nolog ${HOME}/.viminfo
 blacklist-nolog /tmp/clipmenu*
 
 # X11 session autostart
-# blacklist ${HOME}/.xpra - this will kill --x11=xpra cmdline option for all programs
+# this will kill --x11=xpra cmdline option for all programs
+#blacklist ${HOME}/.xpra
 blacklist ${HOME}/.Xsession
 blacklist ${HOME}/.blackbox
 blacklist ${HOME}/.config/autostart
@@ -241,8 +242,9 @@ blacklist /var/lib/mysql/mysql.sock
 blacklist /var/lib/mysqld/mysql.sock
 blacklist /var/lib/pacman
 blacklist /var/lib/upower
-# blacklist /var/log - a virtual /var/log directory (mostly empty) is build up by default for
-# every sandbox, unless --writable-var-log switch is activated
+# a virtual /var/log directory (mostly empty) is build up by default for every
+# sandbox, unless --writable-var-log switch is activated
+#blacklist /var/log
 blacklist /var/mail
 blacklist /var/opt
 blacklist /var/run/acpid.socket
@@ -611,8 +613,8 @@ blacklist /tmp/tmux-*
 blacklist ${PATH}/gnome-terminal
 blacklist ${PATH}/gnome-terminal.wrapper
 blacklist ${PATH}/kgx
-# blacklist ${PATH}/konsole
 # konsole doesn't seem to have this problem - last tested on Ubuntu 16.04
+#blacklist ${PATH}/konsole
 blacklist ${PATH}/lilyterm
 blacklist ${PATH}/lxterminal
 blacklist ${PATH}/mate-terminal

--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -564,7 +564,7 @@ blacklist ${PATH}/bmon
 blacklist ${PATH}/fping
 blacklist ${PATH}/fping6
 blacklist ${PATH}/hostname
-# blacklist ${PATH}/ip - breaks --ip=dhcp
+#blacklist ${PATH}/ip # breaks --ip=dhcp
 blacklist ${PATH}/mtr
 blacklist ${PATH}/mtr-packet
 blacklist ${PATH}/netstat

--- a/etc/profile-a-l/abiword.profile
+++ b/etc/profile-a-l/abiword.profile
@@ -44,7 +44,7 @@ private-dev
 private-etc @x11
 private-tmp
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 restrict-namespaces

--- a/etc/profile-a-l/akonadi_control.profile
+++ b/etc/profile-a-l/akonadi_control.profile
@@ -34,7 +34,7 @@ include whitelist-var-common.inc
 # disabled options below are not compatible with the apparmor profile for mysqld-akonadi.
 # this affects ubuntu and debian currently
 
-# apparmor
+#apparmor
 caps.drop all
 ipc-namespace
 netfilter
@@ -42,17 +42,17 @@ no3d
 nodvd
 nogroups
 noinput
-# nonewprivs
+#nonewprivs
 noroot
 nosound
 notv
 nou2f
 novideo
-# protocol unix,inet,inet6,netlink
-# seccomp !io_destroy,!io_getevents,!io_setup,!io_submit,!ioprio_set
+#protocol unix,inet,inet6,netlink
+#seccomp !io_destroy,!io_getevents,!io_setup,!io_submit,!ioprio_set
 tracelog
 
 private-dev
-# private-tmp - breaks programs that depend on akonadi
+#private-tmp # breaks programs that depend on akonadi
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-a-l/akregator.profile
+++ b/etc/profile-a-l/akregator.profile
@@ -49,4 +49,4 @@ private-dev
 private-tmp
 
 deterministic-shutdown
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-a-l/alacarte.profile
+++ b/etc/profile-a-l/alacarte.profile
@@ -49,7 +49,7 @@ seccomp.block-secondary
 tracelog
 
 disable-mnt
-# private-bin alacarte,bash,python*,sh
+#private-bin alacarte,bash,python*,sh
 private-cache
 private-dev
 private-etc @tls-ca,@x11,mime.types

--- a/etc/profile-a-l/amarok.profile
+++ b/etc/profile-a-l/amarok.profile
@@ -26,11 +26,11 @@ notv
 nou2f
 novideo
 protocol unix,inet,inet6
-# seccomp
+#seccomp
 
-# private-bin amarok
+#private-bin amarok
 private-dev
-# private-etc alternatives,asound.conf,ca-certificates,crypto-policies,machine-id,pki,pulse,resolv.conf,ssl
+#private-etc alternatives,asound.conf,ca-certificates,crypto-policies,machine-id,pki,pulse,resolv.conf,ssl
 private-tmp
 
 dbus-user filter
@@ -45,4 +45,4 @@ dbus-user.talk org.freedesktop.Notifications
 #dbus-user.talk org.kde.knotify
 dbus-system none
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-a-l/android-studio.profile
+++ b/etc/profile-a-l/android-studio.profile
@@ -36,7 +36,7 @@ protocol unix,inet,inet6
 seccomp
 
 private-cache
-# private-tmp
+#private-tmp
 
 # noexec /tmp breaks 'Android Profiler'
 #noexec /tmp

--- a/etc/profile-a-l/anki.profile
+++ b/etc/profile-a-l/anki.profile
@@ -55,4 +55,4 @@ private-tmp
 dbus-user none
 dbus-system none
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-a-l/arduino.profile
+++ b/etc/profile-a-l/arduino.profile
@@ -21,7 +21,7 @@ caps.drop all
 netfilter
 no3d
 nodvd
-# nogroups
+#nogroups
 nonewprivs
 noroot
 nosound

--- a/etc/profile-a-l/aria2c.profile
+++ b/etc/profile-a-l/aria2c.profile
@@ -39,7 +39,7 @@ novideo
 protocol unix,inet,inet6,netlink
 seccomp
 
-# disable-mnt
+#disable-mnt
 # Add your custom event hook commands to 'private-bin' in your aria2c.local.
 private-bin aria2c,gzip
 # Add 'private-cache' to your aria2c.local if you don't use Lutris/winetricks (see issue #2772).

--- a/etc/profile-a-l/ark.profile
+++ b/etc/profile-a-l/ark.profile
@@ -22,7 +22,7 @@ include whitelist-var-common.inc
 
 apparmor
 caps.drop all
-# net none
+#net none
 netfilter
 nodvd
 nogroups
@@ -42,7 +42,7 @@ private-bin 7z,ark,bash,lrzip,lsar,lz4,lzop,p7zip,rar,sh,tclsh,unar,unrar,unzip,
 private-dev
 private-tmp
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 restrict-namespaces

--- a/etc/profile-a-l/artha.profile
+++ b/etc/profile-a-l/artha.profile
@@ -35,7 +35,7 @@ include whitelist-var-common.inc
 apparmor
 caps.drop all
 ipc-namespace
-# net none - breaks on Ubuntu
+#net none # breaks on Ubuntu
 no3d
 nodvd
 nogroups

--- a/etc/profile-a-l/asunder.profile
+++ b/etc/profile-a-l/asunder.profile
@@ -26,7 +26,7 @@ apparmor
 caps.drop all
 netfilter
 no3d
-# nogroups
+#nogroups
 noinput
 nonewprivs
 noroot
@@ -44,5 +44,5 @@ dbus-user none
 dbus-system none
 
 # mdwe is disabled due to breaking hardware accelerated decoding
-# memory-deny-write-execute
+#memory-deny-write-execute
 restrict-namespaces

--- a/etc/profile-a-l/atom.profile
+++ b/etc/profile-a-l/atom.profile
@@ -26,7 +26,7 @@ noblacklist ${HOME}/.config/Atom
 # Allows files commonly used by IDEs
 include allow-common-devel.inc
 
-# net none
+#net none
 nosound
 
 # Redirect

--- a/etc/profile-a-l/atril.profile
+++ b/etc/profile-a-l/atril.profile
@@ -22,7 +22,7 @@ include disable-xdg.inc
 
 include whitelist-var-common.inc
 
-# apparmor
+#apparmor
 caps.drop all
 machine-id
 no3d
@@ -44,7 +44,7 @@ private-dev
 private-etc
 # atril uses webkit gtk to display epub files
 # waiting for globbing support in private-lib; for now hardcoding it to webkit2gtk-4.0
-#private-lib webkit2gtk-4.0 - problems on Arch with the new version of WebKit
+#private-lib webkit2gtk-4.0 # problems on Arch with the new version of WebKit
 private-tmp
 
 # webkit gtk killed by memory-deny-write-execute

--- a/etc/profile-a-l/audacious.profile
+++ b/etc/profile-a-l/audacious.profile
@@ -36,7 +36,7 @@ protocol unix,inet,inet6
 seccomp
 tracelog
 
-# private-bin audacious
+#private-bin audacious
 private-cache
 private-dev
 private-tmp

--- a/etc/profile-a-l/audacity.profile
+++ b/etc/profile-a-l/audacity.profile
@@ -54,7 +54,7 @@ private-etc @x11
 private-tmp
 
 # problems on Fedora 27
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 restrict-namespaces

--- a/etc/profile-a-l/audio-recorder.profile
+++ b/etc/profile-a-l/audio-recorder.profile
@@ -41,7 +41,7 @@ seccomp
 tracelog
 
 disable-mnt
-# private-bin audio-recorder
+#private-bin audio-recorder
 private-cache
 private-etc
 private-tmp
@@ -50,5 +50,5 @@ dbus-user filter
 dbus-user.talk ca.desrt.dconf
 dbus-system none
 
-# memory-deny-write-execute - breaks on Arch
+#memory-deny-write-execute # breaks on Arch
 restrict-namespaces

--- a/etc/profile-a-l/authenticator.profile
+++ b/etc/profile-a-l/authenticator.profile
@@ -19,7 +19,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 
-# apparmor
+#apparmor
 caps.drop all
 netfilter
 no3d
@@ -31,19 +31,19 @@ noroot
 nosound
 notv
 nou2f
-# novideo
+#novideo
 protocol unix,inet,inet6
 seccomp
 
 disable-mnt
-# private-bin authenticator,python*
+#private-bin authenticator,python*
 private-dev
 private-etc @tls-ca
 private-tmp
 
 # makes settings immutable
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
-#memory-deny-write-execute - breaks on Arch (see issue #1803)
+#memory-deny-write-execute # breaks on Arch (see issue #1803)
 restrict-namespaces

--- a/etc/profile-a-l/autokey-common.profile
+++ b/etc/profile-a-l/autokey-common.profile
@@ -38,5 +38,5 @@ private-cache
 private-dev
 private-tmp
 
-#memory-deny-write-execute - breaks on Arch (see issue #1803)
+#memory-deny-write-execute # breaks on Arch (see issue #1803)
 restrict-namespaces

--- a/etc/profile-a-l/baloo_file.profile
+++ b/etc/profile-a-l/baloo_file.profile
@@ -7,10 +7,10 @@ include globals.local
 
 # Make home directory read-only and allow writing only to ${HOME}/.local/share/baloo
 # Note: Baloo will not be able to update the "first run" key in its configuration files.
-# mkdir ${HOME}/.local/share/baloo
-# read-only ${HOME}
-# read-write ${HOME}/.local/share/baloo
-# ignore read-write
+#mkdir ${HOME}/.local/share/baloo
+#read-only ${HOME}
+#read-write ${HOME}/.local/share/baloo
+#ignore read-write
 
 noblacklist ${HOME}/.config/baloofilerc
 noblacklist ${HOME}/.kde/share/config/baloofilerc
@@ -31,7 +31,7 @@ include whitelist-var-common.inc
 apparmor
 caps.drop all
 machine-id
-# net none
+#net none
 netfilter
 no3d
 nodvd
@@ -46,7 +46,7 @@ novideo
 protocol unix
 # blacklisting of ioprio_set system calls breaks baloo_file
 seccomp !ioprio_set
-# x11 xorg
+#x11 xorg
 
 private-bin baloo_file,baloo_file_extractor,baloo_filemetadata_temp_extractor,kbuildsycoca4
 private-cache

--- a/etc/profile-a-l/baobab.profile
+++ b/etc/profile-a-l/baobab.profile
@@ -6,13 +6,13 @@ include baobab.local
 # Persistent global definitions
 include globals.local
 
-# include disable-common.inc
+#include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
-# include disable-programs.inc
+#include disable-programs.inc
 include disable-shell.inc
-# include disable-xdg.inc
+#include disable-xdg.inc
 
 include whitelist-runuser-common.inc
 
@@ -37,8 +37,8 @@ private-bin baobab
 private-dev
 private-tmp
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 read-only ${HOME}
 restrict-namespaces

--- a/etc/profile-a-l/bcompare.profile
+++ b/etc/profile-a-l/bcompare.profile
@@ -19,7 +19,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 # Add the next line to your bcompare.local if you don't need to compare files in disable-programs.inc.
 #include disable-programs.inc
-#include disable-shell.inc - breaks launch
+#include disable-shell.inc # breaks launch
 include disable-write-mnt.inc
 
 apparmor

--- a/etc/profile-a-l/bibletime.profile
+++ b/etc/profile-a-l/bibletime.profile
@@ -48,7 +48,7 @@ protocol unix,inet,inet6,netlink
 seccomp !chroot
 
 disable-mnt
-# private-bin bibletime
+#private-bin bibletime
 private-cache
 private-dev
 private-etc @tls-ca,sword,sword.conf
@@ -57,4 +57,4 @@ private-tmp
 dbus-user none
 dbus-system none
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-a-l/bijiben.profile
+++ b/etc/profile-a-l/bijiben.profile
@@ -48,7 +48,7 @@ tracelog
 
 disable-mnt
 private-bin bijiben
-# private-cache -- access to .cache/tracker is required
+#private-cache # access to .cache/tracker is required
 private-dev
 private-etc @x11
 private-tmp

--- a/etc/profile-a-l/bitlbee.profile
+++ b/etc/profile-a-l/bitlbee.profile
@@ -10,7 +10,7 @@ ignore noexec ${HOME}
 
 noblacklist /sbin
 noblacklist /usr/sbin
-# noblacklist /var/log
+#noblacklist /var/log
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/profile-a-l/bleachbit.profile
+++ b/etc/profile-a-l/bleachbit.profile
@@ -18,7 +18,7 @@ include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
-# include disable-programs.inc
+#include disable-programs.inc
 
 caps.drop all
 net none
@@ -36,11 +36,11 @@ protocol unix
 seccomp
 
 private-dev
-# private-tmp
+#private-tmp
 
 dbus-user none
 dbus-system none
 
 # memory-deny-write-execute breaks some systems, see issue #1850
-# memory-deny-write-execute
+#memory-deny-write-execute
 restrict-namespaces

--- a/etc/profile-a-l/bless.profile
+++ b/etc/profile-a-l/bless.profile
@@ -31,7 +31,7 @@ novideo
 protocol unix
 seccomp
 
-# private-bin bash,bless,mono,sh
+#private-bin bash,bless,mono,sh
 private-cache
 private-dev
 private-etc mono

--- a/etc/profile-a-l/brackets.profile
+++ b/etc/profile-a-l/brackets.profile
@@ -32,4 +32,4 @@ seccomp !chroot,!ioperm
 private-cache
 private-dev
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-a-l/brasero.profile
+++ b/etc/profile-a-l/brasero.profile
@@ -29,9 +29,9 @@ protocol unix
 seccomp
 tracelog
 
-# private-bin brasero
+#private-bin brasero
 private-cache
-# private-dev
-# private-tmp
+#private-dev
+#private-tmp
 
 restrict-namespaces

--- a/etc/profile-a-l/build-systems-common.profile
+++ b/etc/profile-a-l/build-systems-common.profile
@@ -39,7 +39,7 @@ include whitelist-var-common.inc
 caps.drop all
 ipc-namespace
 machine-id
-# net none
+#net none
 netfilter
 no3d
 nodvd

--- a/etc/profile-a-l/calibre.profile
+++ b/etc/profile-a-l/calibre.profile
@@ -36,4 +36,4 @@ seccomp !chroot
 private-dev
 private-tmp
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-a-l/calligra.profile
+++ b/etc/profile-a-l/calligra.profile
@@ -15,7 +15,7 @@ include disable-programs.inc
 
 caps.drop all
 ipc-namespace
-# net none
+#net none
 netfilter
 nodvd
 nogroups
@@ -32,9 +32,9 @@ seccomp.block-secondary
 private-bin calligra,calligraauthor,calligraconverter,calligraflow,calligragemini,calligraplan,calligraplanwork,calligrasheets,calligrastage,calligrawords,dbus-launch,kbuildsycoca4,kdeinit4
 private-dev
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
-# noexec ${HOME}
+#noexec ${HOME}
 noexec /tmp
 restrict-namespaces

--- a/etc/profile-a-l/cameramonitor.profile
+++ b/etc/profile-a-l/cameramonitor.profile
@@ -48,8 +48,8 @@ private-cache
 private-etc
 private-tmp
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
-# memory-deny-write-execute - breaks on Arch
+#memory-deny-write-execute # breaks on Arch
 restrict-namespaces

--- a/etc/profile-a-l/cantata.profile
+++ b/etc/profile-a-l/cantata.profile
@@ -22,7 +22,7 @@ include disable-programs.inc
 include disable-shell.inc
 include disable-xdg.inc
 
-# apparmor
+#apparmor
 caps.drop all
 ipc-namespace
 netfilter
@@ -34,7 +34,7 @@ novideo
 protocol unix,inet,inet6,netlink
 seccomp
 
-# private-etc alternatives,drirc,fonts,gcrypt,hosts,kde5rc,mpd.conf,passwd,samba,ssl,xdg
+#private-etc alternatives,drirc,fonts,gcrypt,hosts,kde5rc,mpd.conf,passwd,samba,ssl,xdg
 private-bin cantata,mpd,perl
 private-dev
 

--- a/etc/profile-a-l/catfish.profile
+++ b/etc/profile-a-l/catfish.profile
@@ -15,10 +15,10 @@ noblacklist ${HOME}/.config/catfish
 include allow-python2.inc
 include allow-python3.inc
 
-# include disable-common.inc
-# include disable-devel.inc
+#include disable-common.inc
+#include disable-devel.inc
 include disable-interpreters.inc
-# include disable-programs.inc
+#include disable-programs.inc
 
 whitelist /var/lib/mlocate
 include whitelist-var-common.inc
@@ -40,9 +40,9 @@ tracelog
 
 # These options work but are disabled in case
 # a users wants to search in these directories.
-# private-bin bash,catfish,env,locate,ls,mlocate,python*
-# private-dev
-# private-tmp
+#private-bin bash,catfish,env,locate,ls,mlocate,python*
+#private-dev
+#private-tmp
 
 dbus-user none
 dbus-system none

--- a/etc/profile-a-l/cawbird.profile
+++ b/etc/profile-a-l/cawbird.profile
@@ -41,7 +41,7 @@ private-dev
 private-etc @tls-ca,@x11,host.conf,mime.types
 private-tmp
 
-# dbus-user none
+#dbus-user none
 dbus-system none
 
 restrict-namespaces

--- a/etc/profile-a-l/chromium-browser-privacy.profile
+++ b/etc/profile-a-l/chromium-browser-privacy.profile
@@ -13,7 +13,7 @@ mkdir ${HOME}/.config/ungoogled-chromium
 whitelist ${HOME}/.cache/ungoogled-chromium
 whitelist ${HOME}/.config/ungoogled-chromium
 
-# private-bin basename,bash,cat,chromium-browser-privacy,dirname,mkdir,readlink,sed,touch,which,xdg-settings
+#private-bin basename,bash,cat,chromium-browser-privacy,dirname,mkdir,readlink,sed,touch,which,xdg-settings
 
 # Redirect
 include chromium.profile

--- a/etc/profile-a-l/chromium-common.profile
+++ b/etc/profile-a-l/chromium-common.profile
@@ -33,7 +33,7 @@ include whitelist-run-common.inc
 ?BROWSER_DISABLE_U2F: nou2f
 
 ?BROWSER_DISABLE_U2F: private-dev
-#private-tmp - issues when using multiple browser sessions
+#private-tmp # issues when using multiple browser sessions
 
 blacklist ${PATH}/curl
 blacklist ${PATH}/wget

--- a/etc/profile-a-l/chromium-common.profile
+++ b/etc/profile-a-l/chromium-common.profile
@@ -39,7 +39,9 @@ blacklist ${PATH}/curl
 blacklist ${PATH}/wget
 blacklist ${PATH}/wget2
 
-#dbus-user none - prevents access to passwords saved in GNOME Keyring and KWallet, also breaks Gnome connector.
+# This prevents access to passwords saved in GNOME Keyring and KWallet, also
+# breaks Gnome connector.
+#dbus-user none
 
 # The file dialog needs to work without d-bus.
 ?HAS_NODBUS: env NO_CHROME_KDE_FILE_DIALOG=1

--- a/etc/profile-a-l/chromium.profile
+++ b/etc/profile-a-l/chromium.profile
@@ -17,7 +17,7 @@ whitelist ${HOME}/.config/chromium
 whitelist ${HOME}/.config/chromium-flags.conf
 whitelist /usr/share/chromium
 
-# private-bin chromium,chromium-browser,chromedriver
+#private-bin chromium,chromium-browser,chromedriver
 
 # Redirect
 include chromium-common.profile

--- a/etc/profile-a-l/clac.profile
+++ b/etc/profile-a-l/clac.profile
@@ -16,10 +16,10 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
-#include disable-X11.inc - x11 none
+#include disable-X11.inc # x11 none
 include disable-xdg.inc
 
-#include whitelist-common.inc - see #903
+#include whitelist-common.inc # see #903
 include whitelist-run-common.inc
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/claws-mail.profile
+++ b/etc/profile-a-l/claws-mail.profile
@@ -18,7 +18,7 @@ whitelist ${HOME}/.claws-mail
 
 whitelist /usr/share/doc/claws-mail
 
-# private-bin claws-mail,curl,gpg,gpg2,gpg-agent,gpgsm,gpgme-config,pinentry,pinentry-gtk-2
+#private-bin claws-mail,curl,gpg,gpg2,gpg-agent,gpgsm,gpgme-config,pinentry,pinentry-gtk-2
 
 # Redirect
 include email-common.profile

--- a/etc/profile-a-l/clawsker.profile
+++ b/etc/profile-a-l/clawsker.profile
@@ -50,5 +50,5 @@ private-tmp
 dbus-user none
 dbus-system none
 
-#memory-deny-write-execute - breaks on Arch (see issue #1803)
+#memory-deny-write-execute # breaks on Arch (see issue #1803)
 restrict-namespaces

--- a/etc/profile-a-l/clementine.profile
+++ b/etc/profile-a-l/clementine.profile
@@ -37,6 +37,6 @@ private-dev
 private-tmp
 
 dbus-system none
-# dbus-user none
+#dbus-user none
 
 restrict-namespaces

--- a/etc/profile-a-l/clion.profile
+++ b/etc/profile-a-l/clion.profile
@@ -37,7 +37,7 @@ seccomp
 
 private-cache
 private-dev
-# private-tmp
+#private-tmp
 
 noexec /tmp
 restrict-namespaces

--- a/etc/profile-a-l/clipgrab.profile
+++ b/etc/profile-a-l/clipgrab.profile
@@ -46,7 +46,7 @@ private-dev
 private-tmp
 
 # 'dbus-user none' breaks tray menu - add 'dbus-user none' to your clipgrab.local if you don't need it.
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-a-l/code.profile
+++ b/etc/profile-a-l/code.profile
@@ -35,7 +35,7 @@ nosound
 # Disabling noexec ${HOME} for now since it will
 # probably interfere with running some programmes
 # in VS Code
-# noexec ${HOME}
+#noexec ${HOME}
 noexec /tmp
 
 # Redirect

--- a/etc/profile-a-l/com.github.bleakgrey.tootle.profile
+++ b/etc/profile-a-l/com.github.bleakgrey.tootle.profile
@@ -48,9 +48,9 @@ private-etc @tls-ca,@x11,host.conf,mime.types
 private-tmp
 
 # Settings are immutable
-# dbus-user filter
-# dbus-user.own com.github.bleakgrey.tootle
-# dbus-user.talk ca.desrt.dconf
+#dbus-user filter
+#dbus-user.own com.github.bleakgrey.tootle
+#dbus-user.talk ca.desrt.dconf
 dbus-system none
 
 restrict-namespaces

--- a/etc/profile-a-l/cower.profile
+++ b/etc/profile-a-l/cower.profile
@@ -19,8 +19,8 @@ include disable-shell.inc
 include disable-xdg.inc
 
 # This profile could be significantly strengthened by adding the following to cower.local
-# whitelist ${HOME}/<Your Build Folder>
-# whitelist ${HOME}/.config/cower
+#whitelist ${HOME}/<Your Build Folder>
+#whitelist ${HOME}/.config/cower
 
 caps.drop all
 ipc-namespace

--- a/etc/profile-a-l/curl.profile
+++ b/etc/profile-a-l/curl.profile
@@ -50,10 +50,10 @@ protocol inet,inet6
 seccomp
 tracelog
 
-# private-bin curl
+#private-bin curl
 private-cache
 private-dev
-# private-etc alternatives,ca-certificates,crypto-policies,pki,resolv.conf,ssl
+#private-etc alternatives,ca-certificates,crypto-policies,pki,resolv.conf,ssl
 private-etc @tls-ca
 private-tmp
 

--- a/etc/profile-a-l/cyberfox.profile
+++ b/etc/profile-a-l/cyberfox.profile
@@ -15,7 +15,7 @@ whitelist ${HOME}/.cache/8pecxstudios
 whitelist /usr/share/8pecxstudios
 whitelist /usr/share/cyberfox
 
-# private-bin cyberfox,dbus-launch,dbus-send,env,sh,which
+#private-bin cyberfox,dbus-launch,dbus-send,env,sh,which
 # private-etc must first be enabled in firefox-common.profile
 #private-etc cyberfox
 

--- a/etc/profile-a-l/d-feet.profile
+++ b/etc/profile-a-l/d-feet.profile
@@ -31,7 +31,7 @@ include whitelist-var-common.inc
 apparmor
 caps.drop all
 ipc-namespace
-# net none - breaks on Ubuntu
+#net none # breaks on Ubuntu
 no3d
 nodvd
 nogroups
@@ -52,5 +52,5 @@ private-dev
 private-etc dbus-1
 private-tmp
 
-#memory-deny-write-execute - breaks on Arch (see issue #1803)
+#memory-deny-write-execute # breaks on Arch (see issue #1803)
 restrict-namespaces

--- a/etc/profile-a-l/dconf-editor.profile
+++ b/etc/profile-a-l/dconf-editor.profile
@@ -22,7 +22,7 @@ include whitelist-var-common.inc
 
 apparmor
 caps.drop all
-# net none - breaks application on older versions
+#net none # breaks application on older versions
 no3d
 nodvd
 nogroups

--- a/etc/profile-a-l/ddgtk.profile
+++ b/etc/profile-a-l/ddgtk.profile
@@ -50,5 +50,5 @@ private-tmp
 dbus-user none
 dbus-system none
 
-# memory-deny-write-execute - breaks on Arch
+#memory-deny-write-execute # breaks on Arch
 restrict-namespaces

--- a/etc/profile-a-l/default.profile
+++ b/etc/profile-a-l/default.profile
@@ -9,54 +9,54 @@ include globals.local
 # depending on your usage, you can enable some of the commands below:
 
 include disable-common.inc
-# include disable-devel.inc
-# include disable-exec.inc
-# include disable-interpreters.inc
+#include disable-devel.inc
+#include disable-exec.inc
+#include disable-interpreters.inc
 include disable-programs.inc
-# include disable-shell.inc
-# include disable-write-mnt.inc
-# include disable-xdg.inc
+#include disable-shell.inc
+#include disable-write-mnt.inc
+#include disable-xdg.inc
 
-# include whitelist-common.inc
-# include whitelist-runuser-common.inc
-# include whitelist-usr-share-common.inc
-# include whitelist-var-common.inc
+#include whitelist-common.inc
+#include whitelist-runuser-common.inc
+#include whitelist-usr-share-common.inc
+#include whitelist-var-common.inc
 
-# apparmor
+#apparmor
 caps.drop all
-# ipc-namespace
-# machine-id
-# net none
+#ipc-namespace
+#machine-id
+#net none
 netfilter
-# no3d
-# nodvd
-# nogroups
+#no3d
+#nodvd
+#nogroups
 noinput
 nonewprivs
 noroot
-# nosound
+#nosound
 notv
-# nou2f
+#nou2f
 novideo
 protocol unix,inet,inet6
 seccomp
-# tracelog
+#tracelog
 
-# disable-mnt
-# private
-# private-bin program
-# private-cache
+#disable-mnt
+#private
+#private-bin program
+#private-cache
 private-dev
 # see /usr/share/doc/firejail/profile.template for more common private-etc paths.
-# private-etc alternatives,fonts,machine-id
-# private-lib
-# private-opt none
+#private-etc alternatives,fonts,machine-id
+#private-lib
+#private-opt none
 private-tmp
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
-# deterministic-shutdown
-# memory-deny-write-execute
-# read-only ${HOME}
+#deterministic-shutdown
+#memory-deny-write-execute
+#read-only ${HOME}
 restrict-namespaces

--- a/etc/profile-a-l/deluge.profile
+++ b/etc/profile-a-l/deluge.profile
@@ -13,7 +13,7 @@ include allow-python2.inc
 include allow-python3.inc
 
 include disable-common.inc
-# include disable-devel.inc
+#include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc

--- a/etc/profile-a-l/devhelp.profile
+++ b/etc/profile-a-l/devhelp.profile
@@ -23,7 +23,7 @@ include whitelist-usr-share-common.inc
 
 apparmor
 caps.drop all
-# net none - makes settings immutable
+#net none # makes settings immutable
 nodvd
 nogroups
 noinput
@@ -45,9 +45,9 @@ private-etc @tls-ca,@x11
 private-tmp
 
 # makes settings immutable
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
-#memory-deny-write-execute - breaks on Arch (see issue #1803)
+#memory-deny-write-execute # breaks on Arch (see issue #1803)
 read-only ${HOME}
 restrict-namespaces

--- a/etc/profile-a-l/dig.profile
+++ b/etc/profile-a-l/dig.profile
@@ -14,13 +14,13 @@ blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
 
 include disable-common.inc
-# include disable-devel.inc
+#include disable-devel.inc
 include disable-exec.inc
-# include disable-interpreters.inc
+#include disable-interpreters.inc
 include disable-programs.inc
 include disable-xdg.inc
 
-#mkfile ${HOME}/.digrc - see #903
+#mkfile ${HOME}/.digrc # see #903
 whitelist ${HOME}/.digrc
 include whitelist-common.inc
 include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/digikam.profile
+++ b/etc/profile-a-l/digikam.profile
@@ -43,7 +43,7 @@ seccomp !chroot
 #private-etc alternatives,ca-certificates,crypto-policies,pki,ssl
 private-tmp
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-a-l/digikam.profile
+++ b/etc/profile-a-l/digikam.profile
@@ -37,8 +37,10 @@ protocol unix,inet,inet6,netlink
 # QtWebengine needs chroot to set up its own sandbox
 seccomp !chroot
 
-# private-dev - prevents libdc1394 loading; this lib is used to connect to a camera device
-# private-etc alternatives,ca-certificates,crypto-policies,pki,ssl
+# private-dev prevents libdc1394 from loading; this lib is used to connect to a
+# camera device
+#private-dev
+#private-etc alternatives,ca-certificates,crypto-policies,pki,ssl
 private-tmp
 
 # dbus-user none

--- a/etc/profile-a-l/dino.profile
+++ b/etc/profile-a-l/dino.profile
@@ -40,7 +40,8 @@ tracelog
 disable-mnt
 private-bin dino
 private-dev
-# private-etc alternatives,ca-certificates,crypto-policies,fonts,pki,ssl -- breaks server connection
+# breaks server connection
+#private-etc alternatives,ca-certificates,crypto-policies,fonts,pki,ssl
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/display.profile
+++ b/etc/profile-a-l/display.profile
@@ -34,7 +34,7 @@ notv
 nou2f
 protocol unix
 seccomp
-# x11 xorg - problems on kubuntu 17.04
+#x11 xorg # problems on kubuntu 17.04
 
 private-bin display,python*
 private-dev

--- a/etc/profile-a-l/dolphin-emu.profile
+++ b/etc/profile-a-l/dolphin-emu.profile
@@ -36,7 +36,7 @@ apparmor
 caps.drop all
 ipc-namespace
 # Add the next line to your dolphin-emu.local if you do not need NetPlay support.
-# net none
+#net none
 netfilter
 # Add the next line to your dolphin-emu.local if you do not need disc support.
 #nodvd

--- a/etc/profile-a-l/drawio.profile
+++ b/etc/profile-a-l/drawio.profile
@@ -39,7 +39,7 @@ nou2f
 novideo
 protocol unix
 seccomp !chroot
-# tracelog - breaks on Arch
+#tracelog # breaks on Arch
 
 private-bin drawio
 private-cache
@@ -50,5 +50,5 @@ private-tmp
 dbus-user none
 dbus-system none
 
-# memory-deny-write-execute - breaks on Arch
-# restrict-namespaces
+#memory-deny-write-execute # breaks on Arch
+#restrict-namespaces

--- a/etc/profile-a-l/drill.profile
+++ b/etc/profile-a-l/drill.profile
@@ -13,9 +13,9 @@ blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
 
 include disable-common.inc
-# include disable-devel.inc
+#include disable-devel.inc
 include disable-exec.inc
-# include disable-interpreters.inc
+#include disable-interpreters.inc
 include disable-programs.inc
 include disable-xdg.inc
 

--- a/etc/profile-a-l/easystroke.profile
+++ b/etc/profile-a-l/easystroke.profile
@@ -49,8 +49,8 @@ private-etc
 #private-lib gdk-pixbuf-2.*,gio,gvfs/libgvfscommon.so,libgconf-2.so.*,librsvg-2.so.*
 private-tmp
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 memory-deny-write-execute
 restrict-namespaces

--- a/etc/profile-a-l/electrum.profile
+++ b/etc/profile-a-l/electrum.profile
@@ -49,7 +49,7 @@ private-dev
 private-etc @tls-ca,@x11
 private-tmp
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 restrict-namespaces

--- a/etc/profile-a-l/email-common.profile
+++ b/etc/profile-a-l/email-common.profile
@@ -75,7 +75,7 @@ seccomp
 seccomp.block-secondary
 tracelog
 
-# disable-mnt
+#disable-mnt
 private-cache
 private-dev
 private-etc @tls-ca,@x11,bogofilter,bogofilter.cf,gnupg,hosts.conf,mailname,timezone

--- a/etc/profile-a-l/engrampa.profile
+++ b/etc/profile-a-l/engrampa.profile
@@ -35,9 +35,9 @@ seccomp
 seccomp.block-secondary
 tracelog
 
-# private-bin engrampa
+#private-bin engrampa
 private-dev
-# private-tmp
+#private-tmp
 
 dbus-user filter
 dbus-user.talk ca.desrt.dconf

--- a/etc/profile-a-l/enpass.profile
+++ b/etc/profile-a-l/enpass.profile
@@ -58,5 +58,5 @@ private-dev
 private-opt Enpass
 private-tmp
 
-#memory-deny-write-execute - breaks on Arch (see issue #1803)
+#memory-deny-write-execute # breaks on Arch (see issue #1803)
 restrict-namespaces

--- a/etc/profile-a-l/ephemeral.profile
+++ b/etc/profile-a-l/ephemeral.profile
@@ -59,7 +59,7 @@ private-cache
 private-tmp
 
 # breaks preferences
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 restrict-namespaces

--- a/etc/profile-a-l/etr.profile
+++ b/etc/profile-a-l/etr.profile
@@ -48,7 +48,7 @@ disable-mnt
 private-bin etr
 private-cache
 private-dev
-# private-etc alternatives,drirc,machine-id,openal,passwd
+#private-etc alternatives,drirc,machine-id,openal,passwd
 private-etc @games,@x11
 private-tmp
 

--- a/etc/profile-a-l/evince.profile
+++ b/etc/profile-a-l/evince.profile
@@ -34,7 +34,7 @@ include whitelist-var-common.inc
 
 caps.drop all
 machine-id
-# net none - breaks AppArmor on Ubuntu systems
+#net none # breaks AppArmor on Ubuntu systems
 netfilter
 no3d
 nodvd

--- a/etc/profile-a-l/falkon.profile
+++ b/etc/profile-a-l/falkon.profile
@@ -41,17 +41,17 @@ nou2f
 protocol unix,inet,inet6,netlink
 # blacklisting of chroot system calls breaks falkon
 seccomp !chroot
-# tracelog
+#tracelog
 
 disable-mnt
-# private-bin falkon
+#private-bin falkon
 private-cache
 private-dev
 private-etc @tls-ca,@x11,adobe,mailcap,mime.types
 private-tmp
 
-# dbus-user filter
-# dbus-user.own org.kde.Falkon
+#dbus-user filter
+#dbus-user.own org.kde.Falkon
 dbus-system none
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-a-l/fdns.profile
+++ b/etc/profile-a-l/fdns.profile
@@ -24,7 +24,7 @@ include disable-xdg.inc
 apparmor /usr/bin/fdns
 caps.keep kill,net_bind_service,setgid,setuid,sys_admin,sys_chroot
 ipc-namespace
-# netfilter /etc/firejail/webserver.net
+#netfilter /etc/firejail/webserver.net
 no3d
 nodvd
 nogroups
@@ -43,7 +43,7 @@ private-bin bash,fdns,sh
 private-cache
 #private-dev
 private-etc @tls-ca,fdns
-# private-lib
+#private-lib
 private-tmp
 
 memory-deny-write-execute

--- a/etc/profile-a-l/feedreader.profile
+++ b/etc/profile-a-l/feedreader.profile
@@ -29,13 +29,13 @@ include whitelist-var-common.inc
 
 caps.drop all
 netfilter
-# no3d
+#no3d
 nodvd
 nogroups
 noinput
 nonewprivs
 noroot
-# nosound
+#nosound
 notv
 nou2f
 novideo

--- a/etc/profile-a-l/ferdi.profile
+++ b/etc/profile-a-l/ferdi.profile
@@ -45,4 +45,4 @@ disable-mnt
 private-dev
 private-tmp
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-a-l/ffmpeg.profile
+++ b/etc/profile-a-l/ffmpeg.profile
@@ -53,5 +53,5 @@ private-tmp
 dbus-user none
 dbus-system none
 
-# memory-deny-write-execute - it breaks old versions of ffmpeg
+#memory-deny-write-execute # it breaks old versions of ffmpeg
 restrict-namespaces

--- a/etc/profile-a-l/file-roller.profile
+++ b/etc/profile-a-l/file-roller.profile
@@ -22,7 +22,7 @@ include whitelist-var-common.inc
 apparmor
 caps.drop all
 machine-id
-# net none - breaks on older Ubuntu versions
+#net none # breaks on older Ubuntu versions
 netfilter
 no3d
 nodvd
@@ -44,7 +44,7 @@ private-bin 7z,7za,7zr,ar,arj,atool,bash,brotli,bsdtar,bzip2,compress,cp,cpio,dp
 private-cache
 private-dev
 private-etc @x11
-# private-tmp
+#private-tmp
 
 dbus-user filter
 dbus-user.own org.gnome.ArchiveManager1

--- a/etc/profile-a-l/font-manager.profile
+++ b/etc/profile-a-l/font-manager.profile
@@ -33,7 +33,7 @@ include whitelist-var-common.inc
 apparmor
 caps.drop all
 machine-id
-# net none - issues on older versions
+#net none # issues on older versions
 no3d
 nodvd
 nogroups
@@ -53,5 +53,5 @@ private-bin font-manager,python*,yelp
 private-dev
 private-tmp
 
-#memory-deny-write-execute - breaks on Arch (see issue #1803)
+#memory-deny-write-execute # breaks on Arch (see issue #1803)
 restrict-namespaces

--- a/etc/profile-a-l/franz.profile
+++ b/etc/profile-a-l/franz.profile
@@ -45,4 +45,4 @@ disable-mnt
 private-dev
 private-tmp
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-a-l/frozen-bubble.profile
+++ b/etc/profile-a-l/frozen-bubble.profile
@@ -41,7 +41,7 @@ seccomp
 tracelog
 
 disable-mnt
-# private-bin frozen-bubble
+#private-bin frozen-bubble
 private-dev
 private-etc @games,@x11
 private-tmp

--- a/etc/profile-a-l/funnyboat.profile
+++ b/etc/profile-a-l/funnyboat.profile
@@ -16,7 +16,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
-# include disable-shell.inc
+#include disable-shell.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.funnyboat
@@ -41,7 +41,7 @@ notv
 novideo
 protocol unix,inet,inet6
 seccomp
-# tracelog
+#tracelog
 
 disable-mnt
 private-cache

--- a/etc/profile-a-l/galculator.profile
+++ b/etc/profile-a-l/galculator.profile
@@ -48,5 +48,5 @@ private-tmp
 dbus-user none
 dbus-system none
 
-#memory-deny-write-execute - breaks on Arch (see issue #1803)
+#memory-deny-write-execute # breaks on Arch (see issue #1803)
 restrict-namespaces

--- a/etc/profile-a-l/geary.profile
+++ b/etc/profile-a-l/geary.profile
@@ -53,7 +53,7 @@ include whitelist-var-common.inc
 
 apparmor
 caps.drop all
-#ipc-namespace - may cause issues with X11
+#ipc-namespace # may cause issues with X11
 #machine-id
 netfilter
 no3d
@@ -71,7 +71,7 @@ seccomp
 seccomp.block-secondary
 tracelog
 
-# disable-mnt
+#disable-mnt
 #private-bin geary,sh
 private-cache
 private-dev

--- a/etc/profile-a-l/gedit.profile
+++ b/etc/profile-a-l/gedit.profile
@@ -13,18 +13,18 @@ noblacklist ${HOME}/.config/gedit
 include allow-common-devel.inc
 
 include disable-common.inc
-# include disable-devel.inc
+#include disable-devel.inc
 include disable-exec.inc
-# include disable-interpreters.inc
+#include disable-interpreters.inc
 include disable-programs.inc
 
 include whitelist-runuser-common.inc
 include whitelist-var-common.inc
 
-# apparmor - makes settings immutable
+#apparmor # makes settings immutable
 caps.drop all
 machine-id
-# net none - makes settings immutable
+#net none # makes settings immutable
 no3d
 nodvd
 nogroups
@@ -40,14 +40,14 @@ seccomp
 seccomp.block-secondary
 tracelog
 
-# private-bin gedit
+#private-bin gedit
 private-dev
 # private-lib breaks python plugins - add the next line to your gedit.local if you don't use them.
 #private-lib aspell,gconv,gedit,libgspell-1.so.*,libgtksourceview-*,libpeas-gtk-1.0.so.*,libreadline.so.*,libtinfo.so.*
 private-tmp
 
 # makes settings immutable
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 restrict-namespaces

--- a/etc/profile-a-l/geekbench.profile
+++ b/etc/profile-a-l/geekbench.profile
@@ -43,7 +43,7 @@ seccomp
 tracelog
 
 disable-mnt
-#private-bin bash,geekbench*,sh -- #4576
+#private-bin bash,geekbench*,sh # #4576
 private-cache
 private-dev
 private-etc lsb-release

--- a/etc/profile-a-l/geeqie.profile
+++ b/etc/profile-a-l/geeqie.profile
@@ -32,7 +32,7 @@ novideo
 protocol unix,inet,inet6
 seccomp
 
-# private-bin geeqie
+#private-bin geeqie
 private-dev
 
 restrict-namespaces

--- a/etc/profile-a-l/gfeeds.profile
+++ b/etc/profile-a-l/gfeeds.profile
@@ -58,7 +58,7 @@ tracelog
 
 disable-mnt
 private-bin gfeeds,python3*
-# private-cache -- feeds are stored in ~/.cache
+#private-cache # feeds are stored in ~/.cache
 private-dev
 private-etc @tls-ca,@x11,dbus-1,gconf,host.conf,mime.types,rpc,services
 private-tmp

--- a/etc/profile-a-l/ghostwriter.profile
+++ b/etc/profile-a-l/ghostwriter.profile
@@ -45,7 +45,7 @@ novideo
 protocol unix,inet,inet6,netlink
 seccomp !chroot
 seccomp.block-secondary
-#tracelog -- breaks
+#tracelog # breaks
 
 private-bin context,gettext,ghostwriter,latex,mktexfmt,pandoc,pdflatex,pdfroff,prince,weasyprint,wkhtmltopdf
 private-cache

--- a/etc/profile-a-l/github-desktop.profile
+++ b/etc/profile-a-l/github-desktop.profile
@@ -29,14 +29,14 @@ noblacklist ${HOME}/.config/git
 noblacklist ${HOME}/.gitconfig
 noblacklist ${HOME}/.git-credentials
 
-# no3d
+#no3d
 nosound
 
-# private-bin github-desktop
+#private-bin github-desktop
 ?HAS_APPIMAGE: ignore private-dev
-# private-lib
+#private-lib
 
-# memory-deny-write-execute
+#memory-deny-write-execute
 
 # Redirect
 include electron-common.profile

--- a/etc/profile-a-l/gjs.profile
+++ b/etc/profile-a-l/gjs.profile
@@ -38,9 +38,9 @@ protocol unix,inet,inet6
 seccomp
 tracelog
 
-# private-bin gjs,gnome-books,gnome-documents,gnome-maps,gnome-photos,gnome-weather
+#private-bin gjs,gnome-books,gnome-documents,gnome-maps,gnome-photos,gnome-weather
 private-dev
-# private-etc alternatives,ca-certificates,crypto-policies,fonts,pki,ssl
+#private-etc alternatives,ca-certificates,crypto-policies,fonts,pki,ssl
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-a-l/gmpc.profile
+++ b/etc/profile-a-l/gmpc.profile
@@ -51,5 +51,5 @@ dbus-user filter
 dbus-user.talk org.mpris.MediaPlayer2.mpd
 dbus-system none
 
-# memory-deny-write-execute - breaks on Arch
+#memory-deny-write-execute # breaks on Arch
 restrict-namespaces

--- a/etc/profile-a-l/gnome-books.profile
+++ b/etc/profile-a-l/gnome-books.profile
@@ -39,7 +39,7 @@ protocol unix
 seccomp
 tracelog
 
-# private-bin gjs,gnome-books
+#private-bin gjs,gnome-books
 private-dev
 private-tmp
 

--- a/etc/profile-a-l/gnome-calculator.profile
+++ b/etc/profile-a-l/gnome-calculator.profile
@@ -24,7 +24,7 @@ apparmor
 caps.drop all
 ipc-namespace
 machine-id
-#net none -- breaks currency conversion
+#net none # breaks currency conversion
 netfilter
 no3d
 nodvd

--- a/etc/profile-a-l/gnome-characters.profile
+++ b/etc/profile-a-l/gnome-characters.profile
@@ -52,8 +52,8 @@ private-etc @x11,gconf,mime.types
 private-tmp
 
 # Add the next lines to your gnome-characters.local if you don't need access to recently used chars.
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 read-only ${HOME}
 restrict-namespaces

--- a/etc/profile-a-l/gnome-contacts.profile
+++ b/etc/profile-a-l/gnome-contacts.profile
@@ -21,7 +21,7 @@ include whitelist-var-common.inc
 
 caps.drop all
 netfilter
-#no3d - breaks on Arch
+#no3d # breaks on Arch
 nodvd
 noinput
 nonewprivs

--- a/etc/profile-a-l/gnome-keyring.profile
+++ b/etc/profile-a-l/gnome-keyring.profile
@@ -55,7 +55,7 @@ private-dev
 #private-lib alternatives,gnome-keyring,libsecret-1.so.*,pkcs11,security
 private-tmp
 
-# dbus-user none
+#dbus-user none
 dbus-system none
 
 memory-deny-write-execute

--- a/etc/profile-a-l/gnome-maps.profile
+++ b/etc/profile-a-l/gnome-maps.profile
@@ -61,7 +61,7 @@ tracelog
 
 disable-mnt
 private-bin gjs,gnome-maps
-# private-cache -- gnome-maps cache all maps/satelite-images
+#private-cache # gnome-maps cache all maps/satelite-images
 private-dev
 private-etc @tls-ca,@x11,clutter-1.0,gconf,host.conf,mime.types,pkcs11,rpc,services
 private-tmp

--- a/etc/profile-a-l/gnome-mplayer.profile
+++ b/etc/profile-a-l/gnome-mplayer.profile
@@ -26,7 +26,7 @@ nou2f
 protocol unix,inet,inet6
 seccomp
 
-# private-bin gnome-mplayer,mplayer
+#private-bin gnome-mplayer,mplayer
 private-cache
 private-dev
 private-tmp

--- a/etc/profile-a-l/gnome-nettool.profile
+++ b/etc/profile-a-l/gnome-nettool.profile
@@ -14,7 +14,7 @@ include disable-programs.inc
 include disable-xdg.inc
 
 whitelist /usr/share/gnome-nettool
-#include whitelist-common.inc -- see #903
+#include whitelist-common.inc # see #903
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc

--- a/etc/profile-a-l/gnome-photos.profile
+++ b/etc/profile-a-l/gnome-photos.profile
@@ -36,7 +36,7 @@ seccomp
 seccomp.block-secondary
 tracelog
 
-# private-bin gjs,gnome-photos
+#private-bin gjs,gnome-photos
 private-dev
 private-tmp
 

--- a/etc/profile-a-l/gnome-pie.profile
+++ b/etc/profile-a-l/gnome-pie.profile
@@ -16,7 +16,7 @@ include disable-exec.inc
 
 caps.drop all
 ipc-namespace
-# net none - breaks dbus
+#net none # breaks dbus
 no3d
 nodvd
 nogroups

--- a/etc/profile-a-l/gnome-ring.profile
+++ b/etc/profile-a-l/gnome-ring.profile
@@ -27,7 +27,7 @@ protocol unix,inet,inet6,netlink
 seccomp
 
 disable-mnt
-# private-dev
+#private-dev
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-a-l/gnome-schedule.profile
+++ b/etc/profile-a-l/gnome-schedule.profile
@@ -46,7 +46,7 @@ apparmor
 caps.keep chown,dac_override,setgid,setuid
 ipc-namespace
 machine-id
-#net none - breaks on Ubuntu
+#net none # breaks on Ubuntu
 no3d
 nodvd
 nogroups

--- a/etc/profile-a-l/gnome-system-log.profile
+++ b/etc/profile-a-l/gnome-system-log.profile
@@ -22,7 +22,7 @@ include whitelist-var-common.inc
 apparmor
 caps.drop all
 ipc-namespace
-# net none - breaks dbus
+#net none # breaks dbus
 no3d
 nodvd
 # When using 'volatile' storage (https://www.freedesktop.org/software/systemd/man/journald.conf.html),
@@ -47,8 +47,8 @@ private-lib
 private-tmp
 writable-var-log
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 memory-deny-write-execute
 # Add 'ignore read-only ${HOME}' to your gnome-system-log.local if you export logs to a file under your ${HOME}.

--- a/etc/profile-a-l/gnome-weather.profile
+++ b/etc/profile-a-l/gnome-weather.profile
@@ -41,9 +41,9 @@ seccomp.block-secondary
 tracelog
 
 disable-mnt
-# private-bin gjs,gnome-weather
+#private-bin gjs,gnome-weather
 private-dev
-# private-etc alternatives,ca-certificates,crypto-policies,fonts,pki,ssl
+#private-etc alternatives,ca-certificates,crypto-policies,fonts,pki,ssl
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-a-l/godot.profile
+++ b/etc/profile-a-l/godot.profile
@@ -34,7 +34,7 @@ seccomp
 tracelog
 
 
-# private-bin godot
+#private-bin godot
 private-cache
 private-dev
 private-etc @games,@tls-ca,@x11,mono

--- a/etc/profile-a-l/goobox.profile
+++ b/etc/profile-a-l/goobox.profile
@@ -28,9 +28,9 @@ protocol unix,inet,inet6
 seccomp
 tracelog
 
-# private-bin goobox
+#private-bin goobox
 private-dev
-# private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,machine-id,pki,pulse,ssl
-# private-tmp
+#private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,machine-id,pki,pulse,ssl
+#private-tmp
 
 restrict-namespaces

--- a/etc/profile-a-l/google-play-music-desktop-player.profile
+++ b/etc/profile-a-l/google-play-music-desktop-player.profile
@@ -17,8 +17,8 @@ include disable-interpreters.inc
 include disable-programs.inc
 
 mkdir ${HOME}/.config/Google Play Music Desktop Player
-# whitelist ${HOME}/.config/pulse
-# whitelist ${HOME}/.pulse
+#whitelist ${HOME}/.config/pulse
+#whitelist ${HOME}/.pulse
 whitelist ${HOME}/.config/Google Play Music Desktop Player
 include whitelist-common.inc
 

--- a/etc/profile-a-l/gpa.profile
+++ b/etc/profile-a-l/gpa.profile
@@ -28,7 +28,7 @@ protocol unix,inet,inet6
 seccomp
 tracelog
 
-# private-bin gpa,gpg
+#private-bin gpa,gpg
 private-dev
 
 restrict-namespaces

--- a/etc/profile-a-l/gpg-agent.profile
+++ b/etc/profile-a-l/gpg-agent.profile
@@ -46,7 +46,7 @@ protocol unix,inet,inet6
 seccomp
 tracelog
 
-# private-bin gpg-agent
+#private-bin gpg-agent
 private-cache
 private-dev
 

--- a/etc/profile-a-l/gpg.profile
+++ b/etc/profile-a-l/gpg.profile
@@ -42,7 +42,7 @@ protocol unix,inet,inet6
 seccomp
 tracelog
 
-# private-bin gpg
+#private-bin gpg
 private-cache
 private-dev
 

--- a/etc/profile-a-l/gpg2.profile
+++ b/etc/profile-a-l/gpg2.profile
@@ -7,7 +7,7 @@ include gpg2.local
 # added by included profile
 #include globals.local
 
-# private-bin gpg2
+#private-bin gpg2
 
 # Redirect
 include gpg.profile

--- a/etc/profile-a-l/gucharmap.profile
+++ b/etc/profile-a-l/gucharmap.profile
@@ -22,7 +22,7 @@ include whitelist-var-common.inc
 apparmor
 caps.drop all
 machine-id
-#net none - breaks dbus
+#net none # breaks dbus
 no3d
 nodvd
 nogroups
@@ -47,8 +47,8 @@ private-lib
 private-tmp
 
 # breaks state saving
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 read-only ${HOME}
 restrict-namespaces

--- a/etc/profile-a-l/gwenview.profile
+++ b/etc/profile-a-l/gwenview.profile
@@ -30,7 +30,7 @@ include whitelist-var-common.inc
 
 apparmor
 caps.drop all
-# net none
+#net none
 netfilter
 nodvd
 nogroups
@@ -42,14 +42,14 @@ nou2f
 novideo
 protocol unix
 seccomp
-# tracelog
+#tracelog
 
 private-bin gimp*,gwenview,kbuildsycoca4,kdeinit4
 private-dev
 private-etc @x11,gimp
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
-# memory-deny-write-execute
+#memory-deny-write-execute
 restrict-namespaces

--- a/etc/profile-a-l/hexchat.profile
+++ b/etc/profile-a-l/hexchat.profile
@@ -32,7 +32,7 @@ include whitelist-common.inc
 include whitelist-var-common.inc
 
 caps.drop all
-#machine-id -- breaks sound
+#machine-id # breaks sound
 netfilter
 no3d
 nodvd
@@ -51,8 +51,8 @@ disable-mnt
 # debug note: private-bin requires perl, python, etc on some systems
 private-bin hexchat,python*,sh
 private-dev
-#private-lib - python problems
+#private-lib # python problems
 private-tmp
 
-# memory-deny-write-execute - breaks python
+#memory-deny-write-execute # breaks python
 restrict-namespaces

--- a/etc/profile-a-l/homebank.profile
+++ b/etc/profile-a-l/homebank.profile
@@ -28,7 +28,7 @@ include whitelist-var-common.inc
 apparmor
 caps.drop all
 machine-id
-# net none
+#net none
 netfilter
 nodvd
 no3d
@@ -55,5 +55,5 @@ private-tmp
 dbus-user none
 dbus-system none
 
-# memory-deny-write-execute
+#memory-deny-write-execute
 restrict-namespaces

--- a/etc/profile-a-l/iagno.profile
+++ b/etc/profile-a-l/iagno.profile
@@ -43,7 +43,7 @@ private-dev
 private-etc @x11,gconf
 private-tmp
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 restrict-namespaces

--- a/etc/profile-a-l/idea.sh.profile
+++ b/etc/profile-a-l/idea.sh.profile
@@ -36,7 +36,7 @@ seccomp
 
 private-cache
 private-dev
-# private-tmp
+#private-tmp
 
 noexec /tmp
 restrict-namespaces

--- a/etc/profile-a-l/img2txt.profile
+++ b/etc/profile-a-l/img2txt.profile
@@ -41,7 +41,7 @@ seccomp
 tracelog
 x11 none
 
-# private-bin img2txt
+#private-bin img2txt
 private-cache
 private-dev
 private-tmp

--- a/etc/profile-a-l/inkscape.profile
+++ b/etc/profile-a-l/inkscape.profile
@@ -61,7 +61,7 @@ protocol unix
 seccomp
 tracelog
 
-# private-bin inkscape,potrace,python* - problems on Debian stretch
+#private-bin inkscape,potrace,python* # problems on Debian stretch
 private-cache
 private-dev
 private-etc @x11,ImageMagick*,python*

--- a/etc/profile-a-l/ipcalc.profile
+++ b/etc/profile-a-l/ipcalc.profile
@@ -14,7 +14,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
-# include disable-shell.inc
+#include disable-shell.inc
 include disable-write-mnt.inc
 include disable-xdg.inc
 
@@ -26,7 +26,7 @@ include whitelist-var-common.inc
 apparmor
 caps.drop all
 ipc-namespace
-# machine-id
+#machine-id
 net none
 netfilter
 no3d
@@ -39,14 +39,14 @@ nosound
 notv
 nou2f
 novideo
-# protocol unix
+#protocol unix
 seccomp
-# tracelog
+#tracelog
 
 disable-mnt
 private
 private-bin bash,ipcalc,ipcalc-ng,perl,sh
-# private-cache
+#private-cache
 private-dev
 # empty etc directory
 private-etc
@@ -57,6 +57,6 @@ private-tmp
 dbus-user none
 dbus-system none
 
-# memory-deny-write-execute
-# read-only ${HOME}
+#memory-deny-write-execute
+#read-only ${HOME}
 restrict-namespaces

--- a/etc/profile-a-l/k3b.profile
+++ b/etc/profile-a-l/k3b.profile
@@ -21,19 +21,19 @@ include disable-xdg.inc
 include whitelist-var-common.inc
 
 caps.keep chown,dac_override,ipc_lock,net_bind_service,sys_admin,sys_nice,sys_rawio,sys_resource
-# net none
+#net none
 netfilter
 no3d
-# nonewprivs - breaks privileged helpers
+#nonewprivs # breaks privileged helpers
 noinput
-# noroot - breaks privileged helpers
+#noroot # breaks privileged helpers
 nosound
 notv
 novideo
-# protocol unix - breaks privileged helpers
-# seccomp - breaks privileged helpers
+#protocol unix # breaks privileged helpers
+#seccomp # breaks privileged helpers
 
 private-dev
-# private-tmp
+#private-tmp
 
-# restrict-namespaces - breaks privileged helpers
+#restrict-namespaces # breaks privileged helpers

--- a/etc/profile-a-l/kaffeine.profile
+++ b/etc/profile-a-l/kaffeine.profile
@@ -36,7 +36,7 @@ novideo
 protocol unix,inet,inet6
 seccomp
 
-# private-bin kaffeine
+#private-bin kaffeine
 private-dev
 private-tmp
 

--- a/etc/profile-a-l/kalgebra.profile
+++ b/etc/profile-a-l/kalgebra.profile
@@ -35,7 +35,7 @@ nou2f
 novideo
 protocol unix,netlink
 seccomp !chroot
-# tracelog
+#tracelog
 
 disable-mnt
 private-bin kalgebra,kalgebramobile
@@ -47,4 +47,4 @@ private-tmp
 dbus-user none
 dbus-system none
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-a-l/kate.profile
+++ b/etc/profile-a-l/kate.profile
@@ -28,17 +28,17 @@ noblacklist ${HOME}/.local/share/kxmlgui5/katesearch
 include allow-common-devel.inc
 
 include disable-common.inc
-# include disable-devel.inc
+#include disable-devel.inc
 include disable-exec.inc
-# include disable-interpreters.inc
+#include disable-interpreters.inc
 include disable-programs.inc
 
 include whitelist-run-common.inc
 include whitelist-var-common.inc
 
-# apparmor
+#apparmor
 caps.drop all
-# net none
+#net none
 netfilter
 nodvd
 nogroups
@@ -52,13 +52,13 @@ novideo
 protocol unix
 seccomp
 
-# private-bin kate,kbuildsycoca4,kdeinit4
+#private-bin kate,kbuildsycoca4,kdeinit4
 private-dev
-# private-etc alternatives,fonts,kde4rc,kde5rc,ld.so.cache,machine-id,xdg
+#private-etc alternatives,fonts,kde4rc,kde5rc,ld.so.cache,machine-id,xdg
 private-tmp
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 restrict-namespaces
 join-or-start kate

--- a/etc/profile-a-l/kazam.profile
+++ b/etc/profile-a-l/kazam.profile
@@ -45,7 +45,7 @@ seccomp
 tracelog
 
 disable-mnt
-# private-bin kazam,python*
+#private-bin kazam,python*
 private-cache
 private-dev
 private-etc @x11

--- a/etc/profile-a-l/kcalc.profile
+++ b/etc/profile-a-l/kcalc.profile
@@ -60,7 +60,7 @@ private-bin kcalc
 private-cache
 private-dev
 private-etc
-# private-lib - problems on Arch
+#private-lib # problems on Arch
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/kdeinit4.profile
+++ b/etc/profile-a-l/kdeinit4.profile
@@ -22,7 +22,7 @@ no3d
 nogroups
 noinput
 nonewprivs
-# nosound - disabled for knotify
+#nosound # disabled for knotify
 noroot
 nou2f
 novideo

--- a/etc/profile-a-l/kdenlive.profile
+++ b/etc/profile-a-l/kdenlive.profile
@@ -21,7 +21,7 @@ include disable-programs.inc
 
 apparmor
 caps.drop all
-# net none
+#net none
 nodvd
 nogroups
 noinput
@@ -34,9 +34,9 @@ seccomp
 
 private-bin dbus-launch,dvdauthor,ffmpeg,ffplay,ffprobe,genisoimage,kdeinit4,kdeinit4_shutdown,kdeinit4_wrapper,kdeinit5,kdeinit5_shutdown,kdeinit5_wrapper,kdenlive,kdenlive_render,kshell4,kshell5,melt,mlt-melt,vlc,xine
 private-dev
-# private-etc alternatives,fonts,kde4rc,kde5rc,ld.so.cache,machine-id,passwd,pulse,X11,xdg
+#private-etc alternatives,fonts,kde4rc,kde5rc,ld.so.cache,machine-id,passwd,pulse,X11,xdg
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 restrict-namespaces

--- a/etc/profile-a-l/kfind.profile
+++ b/etc/profile-a-l/kfind.profile
@@ -9,21 +9,21 @@ include globals.local
 # searching in blacklisted or masked paths fails silently
 # adjust filesystem restrictions as necessary
 
-# noblacklist ${HOME}/.cache/kfind - disable-programs.inc is disabled, see below
-# noblacklist ${HOME}/.config/kfindrc
-# noblacklist ${HOME}/.kde/share/config/kfindrc
-# noblacklist ${HOME}/.kde4/share/config/kfindrc
+#noblacklist ${HOME}/.cache/kfind # disable-programs.inc is disabled, see below
+#noblacklist ${HOME}/.config/kfindrc
+#noblacklist ${HOME}/.kde/share/config/kfindrc
+#noblacklist ${HOME}/.kde4/share/config/kfindrc
 
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
-# include disable-programs.inc
+#include disable-programs.inc
 
 apparmor
 caps.drop all
 machine-id
-# net none
+#net none
 netfilter
 no3d
 nodvd
@@ -38,11 +38,11 @@ novideo
 protocol unix
 seccomp
 
-# private-bin kbuildsycoca4,kdeinit4,kfind
+#private-bin kbuildsycoca4,kdeinit4,kfind
 private-dev
 private-tmp
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 restrict-namespaces

--- a/etc/profile-a-l/kget.profile
+++ b/etc/profile-a-l/kget.profile
@@ -40,5 +40,5 @@ seccomp
 private-dev
 private-tmp
 
-# memory-deny-write-execute
+#memory-deny-write-execute
 restrict-namespaces

--- a/etc/profile-a-l/kiwix-desktop.profile
+++ b/etc/profile-a-l/kiwix-desktop.profile
@@ -27,13 +27,13 @@ apparmor
 caps.drop all
 ipc-namespace
 netfilter
-# no3d
+#no3d
 nodvd
 nogroups
 noinput
 nonewprivs
 noroot
-# nosound
+#nosound
 notv
 nou2f
 novideo
@@ -49,4 +49,4 @@ private-tmp
 dbus-user none
 dbus-system none
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-a-l/kmail.profile
+++ b/etc/profile-a-l/kmail.profile
@@ -41,7 +41,7 @@ include disable-programs.inc
 include whitelist-run-common.inc
 include whitelist-var-common.inc
 
-# apparmor
+#apparmor
 caps.drop all
 netfilter
 nodvd
@@ -56,11 +56,11 @@ novideo
 protocol unix,inet,inet6,netlink
 # we need to allow chroot, io_getevents, ioprio_set, io_setup, io_submit system calls
 seccomp !chroot,!io_getevents,!io_setup,!io_submit,!ioprio_set
-# tracelog
+#tracelog
 
 private-dev
-# private-tmp - interrupts connection to akonadi, breaks opening of email attachments
+#private-tmp # interrupts connection to akonadi, breaks opening of email attachments
 # writable-run-user is needed for signing and encrypting emails
 writable-run-user
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-a-l/kmplayer.profile
+++ b/etc/profile-a-l/kmplayer.profile
@@ -33,7 +33,7 @@ nou2f
 protocol unix,inet,inet6,netlink
 seccomp
 
-# private-bin kmplayer,mplayer
+#private-bin kmplayer,mplayer
 private-cache
 private-dev
 private-tmp

--- a/etc/profile-a-l/konversation.profile
+++ b/etc/profile-a-l/konversation.profile
@@ -42,5 +42,5 @@ private-cache
 private-dev
 private-tmp
 
-# memory-deny-write-execute
+#memory-deny-write-execute
 restrict-namespaces

--- a/etc/profile-a-l/krita.profile
+++ b/etc/profile-a-l/krita.profile
@@ -28,7 +28,7 @@ include disable-xdg.inc
 apparmor
 caps.drop all
 ipc-namespace
-# net none
+#net none
 netfilter
 nodvd
 nogroups
@@ -46,7 +46,7 @@ private-cache
 private-dev
 private-tmp
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 restrict-namespaces

--- a/etc/profile-a-l/krunner.profile
+++ b/etc/profile-a-l/krunner.profile
@@ -10,19 +10,19 @@ include globals.local
 # When a file is opened in krunner, the file viewer runs in its own sandbox
 # with its own profile, if it is sandboxed automatically.
 
-# noblacklist ${HOME}/.cache/krunner
-# noblacklist ${HOME}/.cache/krunnerbookmarkrunnerfirefoxdbfile.sqlite*
-# noblacklist ${HOME}/.config/chromium
+#noblacklist ${HOME}/.cache/krunner
+#noblacklist ${HOME}/.cache/krunnerbookmarkrunnerfirefoxdbfile.sqlite*
+#noblacklist ${HOME}/.config/chromium
 noblacklist ${HOME}/.config/krunnerrc
 noblacklist ${HOME}/.kde/share/config/krunnerrc
 noblacklist ${HOME}/.kde4/share/config/krunnerrc
-# noblacklist ${HOME}/.local/share/baloo
-# noblacklist ${HOME}/.mozilla
+#noblacklist ${HOME}/.local/share/baloo
+#noblacklist ${HOME}/.mozilla
 
 include disable-common.inc
-# include disable-devel.inc
-# include disable-interpreters.inc
-# include disable-programs.inc
+#include disable-devel.inc
+#include disable-interpreters.inc
+#include disable-programs.inc
 
 include whitelist-var-common.inc
 
@@ -34,6 +34,6 @@ noroot
 protocol unix,inet,inet6
 seccomp
 
-# private-cache
+#private-cache
 
 restrict-namespaces

--- a/etc/profile-a-l/ktorrent.profile
+++ b/etc/profile-a-l/ktorrent.profile
@@ -62,9 +62,9 @@ seccomp
 
 private-bin kbuildsycoca4,kdeinit4,ktmagnetdownloader,ktorrent,ktupnptest
 private-dev
-# private-lib - problems on Arch
+#private-lib # problems on Arch
 private-tmp
 
 deterministic-shutdown
-# memory-deny-write-execute
+#memory-deny-write-execute
 restrict-namespaces

--- a/etc/profile-a-l/kube.profile
+++ b/etc/profile-a-l/kube.profile
@@ -65,7 +65,7 @@ protocol unix,inet,inet6
 seccomp
 tracelog
 
-# disable-mnt
+#disable-mnt
 # Add "gpg,gpg2,gpg-agent,pinentry-curses,pinentry-emacs,pinentry-fltk,pinentry-gnome3,pinentry-gtk,pinentry-gtk2,pinentry-gtk-2,pinentry-qt,pinentry-qt4,pinentry-tty,pinentry-x2go,pinentry-kwallet" for gpg
 private-bin kube,sink_synchronizer
 private-cache

--- a/etc/profile-a-l/kwrite.profile
+++ b/etc/profile-a-l/kwrite.profile
@@ -29,14 +29,14 @@ include whitelist-var-common.inc
 
 apparmor
 caps.drop all
-# net none
+#net none
 netfilter
 nodvd
 nogroups
 noinput
 nonewprivs
 noroot
-# nosound - KWrite is using ALSA!
+#nosound # KWrite is using ALSA!
 notv
 nou2f
 novideo
@@ -49,8 +49,8 @@ private-dev
 private-etc @x11
 private-tmp
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 restrict-namespaces
 join-or-start kwrite

--- a/etc/profile-a-l/less.profile
+++ b/etc/profile-a-l/less.profile
@@ -36,8 +36,8 @@ x11 none
 
 # The user can have a custom coloring script configured in ${HOME}/.lessfilter.
 # Enable private-bin and private-lib if you are not using any filter.
-# private-bin less
-# private-lib
+#private-bin less
+#private-lib
 private-cache
 private-dev
 writable-var-log

--- a/etc/profile-a-l/liferea.profile
+++ b/etc/profile-a-l/liferea.profile
@@ -33,13 +33,13 @@ include whitelist-var-common.inc
 
 caps.drop all
 netfilter
-# no3d
+#no3d
 nodvd
 nogroups
 noinput
 nonewprivs
 noroot
-# nosound
+#nosound
 notv
 nou2f
 novideo

--- a/etc/profile-a-l/links-common.profile
+++ b/etc/profile-a-l/links-common.profile
@@ -52,7 +52,7 @@ private-cache
 private-dev
 private-etc @tls-ca
 # Add the next line to your links-common.local to allow external media players.
-# private-etc alsa,asound.conf,machine-id,openal,pulse
+#private-etc alsa,asound.conf,machine-id,openal,pulse
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/lutris.profile
+++ b/etc/profile-a-l/lutris.profile
@@ -13,7 +13,7 @@ noblacklist ${HOME}/.cache/wine
 noblacklist ${HOME}/.cache/winetricks
 noblacklist ${HOME}/.config/lutris
 noblacklist ${HOME}/.local/share/lutris
-# noblacklist ${HOME}/.wine
+#noblacklist ${HOME}/.wine
 noblacklist /tmp/.wine-*
 # Don't block access to /sbin and /usr/sbin to allow using ldconfig. Otherwise
 # Lutris won't even start.
@@ -39,7 +39,7 @@ mkdir ${HOME}/.cache/wine
 mkdir ${HOME}/.cache/winetricks
 mkdir ${HOME}/.config/lutris
 mkdir ${HOME}/.local/share/lutris
-# mkdir ${HOME}/.wine
+#mkdir ${HOME}/.wine
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/Games
 whitelist ${HOME}/.cache/lutris
@@ -47,7 +47,7 @@ whitelist ${HOME}/.cache/wine
 whitelist ${HOME}/.cache/winetricks
 whitelist ${HOME}/.config/lutris
 whitelist ${HOME}/.local/share/lutris
-# whitelist ${HOME}/.wine
+#whitelist ${HOME}/.wine
 whitelist /usr/share/lutris
 whitelist /usr/share/wine
 include whitelist-common.inc
@@ -55,11 +55,11 @@ include whitelist-usr-share-common.inc
 include whitelist-runuser-common.inc
 include whitelist-var-common.inc
 
-# allow-debuggers
-# apparmor
+#allow-debuggers
+#apparmor
 caps.drop all
 ipc-namespace
-# net none
+#net none
 netfilter
 nodvd
 nogroups

--- a/etc/profile-a-l/lynx.profile
+++ b/etc/profile-a-l/lynx.profile
@@ -34,10 +34,10 @@ protocol unix,inet,inet6
 seccomp
 tracelog
 
-# private-bin lynx
+#private-bin lynx
 private-cache
 private-dev
-# private-etc alternatives,ca-certificates,crypto-policies,pki,ssl
+#private-etc alternatives,ca-certificates,crypto-policies,pki,ssl
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-a-l/lyx.profile
+++ b/etc/profile-a-l/lyx.profile
@@ -31,7 +31,7 @@ include whitelist-usr-share-common.inc
 apparmor
 machine-id
 
-# private-bin atril,dvilualatex,env,latex,lua*,luatex,lyx,lyxclient,okular,pdf2latex,pdflatex,pdftex,perl*,python*,qpdf,qpdfview,sh,tex2lyx,texmf,xelatex
+#private-bin atril,dvilualatex,env,latex,lua*,luatex,lyx,lyxclient,okular,pdf2latex,pdflatex,pdftex,perl*,python*,qpdf,qpdfview,sh,tex2lyx,texmf,xelatex
 private-etc @x11,lyx,mime.types,texmf
 
 # Redirect

--- a/etc/profile-m-z/PCSX2.profile
+++ b/etc/profile-m-z/PCSX2.profile
@@ -40,8 +40,8 @@ notv
 nou2f
 novideo
 protocol unix,netlink
-#seccomp - breaks loading with no logs
-#tracelog - 32/64 bit incompatibility
+#seccomp # breaks loading with no logs
+#tracelog # 32/64 bit incompatibility
 
 private-bin PCSX2
 private-cache

--- a/etc/profile-m-z/QMediathekView.profile
+++ b/etc/profile-m-z/QMediathekView.profile
@@ -57,7 +57,7 @@ include whitelist-var-common.inc
 apparmor
 caps.drop all
 netfilter
-# no3d
+#no3d
 nodvd
 nogroups
 noinput
@@ -81,5 +81,5 @@ private-tmp
 dbus-user none
 dbus-system none
 
-#memory-deny-write-execute - breaks on Arch (see issue #1803)
+#memory-deny-write-execute # breaks on Arch (see issue #1803)
 restrict-namespaces

--- a/etc/profile-m-z/Viber.profile
+++ b/etc/profile-m-z/Viber.profile
@@ -35,4 +35,4 @@ private-bin awk,bash,dig,sh,Viber
 private-etc @tls-ca,@x11,mailcap,proxychains.conf
 private-tmp
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-m-z/Xephyr.profile
+++ b/etc/profile-m-z/Xephyr.profile
@@ -25,7 +25,7 @@ nogroups
 noinput
 nonewprivs
 # In noroot mode, Xephyr cannot create a socket in the real /tmp/.X11-unix.
-# noroot
+#noroot
 nosound
 notv
 nou2f
@@ -35,10 +35,10 @@ seccomp
 disable-mnt
 # using a private home directory
 private
-# private-bin sh,Xephyr,xkbcomp
-# private-bin bash,cat,ls,sh,strace,Xephyr,xkbcomp
+#private-bin sh,Xephyr,xkbcomp
+#private-bin bash,cat,ls,sh,strace,Xephyr,xkbcomp
 private-dev
-# private-etc alternatives,gai.conf,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,nsswitch.conf,resolv.conf
+#private-etc alternatives,gai.conf,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,nsswitch.conf,resolv.conf
 #private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/Xvfb.profile
+++ b/etc/profile-m-z/Xvfb.profile
@@ -39,8 +39,8 @@ seccomp
 disable-mnt
 # using a private home directory
 private
-# private-bin sh,xkbcomp,Xvfb
-# private-bin bash,cat,ls,sh,strace,xkbcomp,Xvfb
+#private-bin sh,xkbcomp,Xvfb
+#private-bin bash,cat,ls,sh,strace,xkbcomp,Xvfb
 private-dev
 private-etc gai.conf,host.conf
 private-tmp

--- a/etc/profile-m-z/makepkg.profile
+++ b/etc/profile-m-z/makepkg.profile
@@ -14,8 +14,8 @@ blacklist ${RUNUSER}/wayland-*
 # for potential issues and their solutions when Firejailing makepkg
 
 # This profile could be significantly strengthened by adding the following to makepkg.local
-# whitelist ${HOME}/<Your Build Folder>
-# whitelist ${HOME}/.gnupg
+#whitelist ${HOME}/<Your Build Folder>
+#whitelist ${HOME}/.gnupg
 
 # Enable severely restricted access to ${HOME}/.gnupg
 noblacklist ${HOME}/.gnupg

--- a/etc/profile-m-z/midori.profile
+++ b/etc/profile-m-z/midori.profile
@@ -13,8 +13,8 @@ noblacklist ${HOME}/.cache/midori
 noblacklist ${HOME}/.config/midori
 noblacklist ${HOME}/.local/share/midori
 noblacklist ${HOME}/.local/share/pki
-# noblacklist ${HOME}/.local/share/webkit
-# noblacklist ${HOME}/.local/share/webkitgtk
+#noblacklist ${HOME}/.local/share/webkit
+#noblacklist ${HOME}/.local/share/webkitgtk
 noblacklist ${HOME}/.pki
 
 noblacklist ${HOME}/.cache/gnome-mplayer
@@ -54,7 +54,7 @@ caps.drop all
 netfilter
 nodvd
 nonewprivs
-# noroot - problems on Ubuntu 14.04
+#noroot # problems on Ubuntu 14.04
 notv
 protocol unix,inet,inet6,netlink
 seccomp

--- a/etc/profile-m-z/mpDris2.profile
+++ b/etc/profile-m-z/mpDris2.profile
@@ -56,7 +56,7 @@ dbus-user filter
 dbus-user.own org.mpris.MediaPlayer2.mpd
 dbus-system none
 
-#memory-deny-write-execute - breaks on Arch (see issue #1803)
+#memory-deny-write-execute # breaks on Arch (see issue #1803)
 
 read-only ${HOME}
 restrict-namespaces

--- a/etc/profile-m-z/mplayer.profile
+++ b/etc/profile-m-z/mplayer.profile
@@ -24,9 +24,9 @@ include whitelist-var-common.inc
 
 apparmor
 caps.drop all
-# net none - mplayer can be used for streaming.
+#net none # mplayer can be used for streaming.
 netfilter
-# nogroups
+#nogroups
 noinput
 nonewprivs
 noroot

--- a/etc/profile-m-z/mullvad-browser.profile
+++ b/etc/profile-m-z/mullvad-browser.profile
@@ -73,13 +73,13 @@ novideo
 protocol unix,inet,inet6
 seccomp !chroot
 seccomp.block-secondary
-#tracelog - may cause issues, see #1930
+#tracelog # may cause issues, see #1930
 
 disable-mnt
 private-bin bash,cat,cp,cut,dirname,env,expr,file,gpg,grep,gxmessage,id,kdialog,ln,mkdir,mullvad-browser,mv,python*,rm,sed,sh,tail,tar,tclsh,test,update-desktop-database,xmessage,xz,zenity
 private-dev
 private-etc @tls-ca
-#private-opt mullvad-browser - can cause slow startup
+#private-opt mullvad-browser # can cause slow startup
 private-tmp
 
 blacklist ${PATH}/curl

--- a/etc/profile-m-z/multimc5.profile
+++ b/etc/profile-m-z/multimc5.profile
@@ -41,12 +41,12 @@ notv
 nou2f
 novideo
 protocol unix,inet,inet6
-# seccomp
+#seccomp
 
 disable-mnt
 # private-bin works, but causes weirdness
-# private-bin apt-file,awk,bash,chmod,dirname,dnf,grep,java,kdialog,ldd,mkdir,multimc5,pfl,pkgfile,readlink,sort,valgrind,which,yum,zenity,zypper
+#private-bin apt-file,awk,bash,chmod,dirname,dnf,grep,java,kdialog,ldd,mkdir,multimc5,pfl,pkgfile,readlink,sort,valgrind,which,yum,zenity,zypper
 private-dev
 private-tmp
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-m-z/mumble.profile
+++ b/etc/profile-m-z/mumble.profile
@@ -41,5 +41,5 @@ disable-mnt
 private-bin mumble
 private-tmp
 
-#memory-deny-write-execute - breaks on Arch (see issue #1803)
+#memory-deny-write-execute # breaks on Arch (see issue #1803)
 restrict-namespaces

--- a/etc/profile-m-z/musescore.profile
+++ b/etc/profile-m-z/musescore.profile
@@ -37,7 +37,7 @@ protocol unix,inet,inet6
 seccomp !chroot
 tracelog
 
-# private-bin musescore,mscore
+#private-bin musescore,mscore
 private-tmp
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-m-z/musixmatch.profile
+++ b/etc/profile-m-z/musixmatch.profile
@@ -35,4 +35,4 @@ disable-mnt
 private-dev
 private-etc @tls-ca
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-m-z/mutt.profile
+++ b/etc/profile-m-z/mutt.profile
@@ -121,7 +121,7 @@ seccomp
 seccomp.block-secondary
 tracelog
 
-# disable-mnt
+#disable-mnt
 private-cache
 private-dev
 private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gai.conf,gnupg,gnutls,hosts.conf,mail,mailname,nntpserver,terminfo

--- a/etc/profile-m-z/nano.profile
+++ b/etc/profile-m-z/nano.profile
@@ -41,7 +41,7 @@ seccomp
 tracelog
 x11 none
 
-# disable-mnt
+#disable-mnt
 private-bin nano,rnano
 private-cache
 private-dev

--- a/etc/profile-m-z/ncdu.profile
+++ b/etc/profile-m-z/ncdu.profile
@@ -29,7 +29,7 @@ seccomp
 x11 none
 
 private-dev
-# private-tmp
+#private-tmp
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/neomutt.profile
+++ b/etc/profile-m-z/neomutt.profile
@@ -113,7 +113,7 @@ seccomp
 seccomp.block-secondary
 tracelog
 
-# disable-mnt
+#disable-mnt
 private-cache
 private-dev
 private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gnupg,hosts.conf,mail,mailname,neomuttrc,neomuttrc.d,nntpserver

--- a/etc/profile-m-z/nitroshare.profile
+++ b/etc/profile-m-z/nitroshare.profile
@@ -42,11 +42,11 @@ private-bin awk,grep,nitroshare,nitroshare-cli,nitroshare-nmh,nitroshare-send,ni
 private-cache
 private-dev
 private-etc @tls-ca,@x11
-# private-lib libnitroshare.so.*,libqhttpengine.so.*,libqmdnsengine.so.*,nitroshare
+#private-lib libnitroshare.so.*,libqhttpengine.so.*,libqmdnsengine.so.*,nitroshare
 private-tmp
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
-# memory-deny-write-execute
+#memory-deny-write-execute
 restrict-namespaces

--- a/etc/profile-m-z/nuclear.profile
+++ b/etc/profile-m-z/nuclear.profile
@@ -17,7 +17,7 @@ whitelist ${HOME}/.config/nuclear
 
 no3d
 
-# private-bin nuclear
+#private-bin nuclear
 private-etc @tls-ca,@x11,host.conf,mime.types
 private-opt nuclear
 

--- a/etc/profile-m-z/okular.profile
+++ b/etc/profile-m-z/okular.profile
@@ -44,7 +44,7 @@ include whitelist-var-common.inc
 apparmor
 caps.drop all
 machine-id
-# net none
+#net none
 netfilter
 nodvd
 nogroups
@@ -65,10 +65,10 @@ private-etc @x11,cups
 # on KDE we need access to the real /tmp for data exchange with email clients
 #private-tmp
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
-# memory-deny-write-execute
+#memory-deny-write-execute
 
 restrict-namespaces
 join-or-start okular

--- a/etc/profile-m-z/okular.profile
+++ b/etc/profile-m-z/okular.profile
@@ -62,7 +62,8 @@ tracelog
 private-bin kbuildsycoca4,kdeinit4,lpr,okular,unar,unrar
 private-dev
 private-etc @x11,cups
-# private-tmp - on KDE we need access to the real /tmp for data exchange with email clients
+# on KDE we need access to the real /tmp for data exchange with email clients
+#private-tmp
 
 # dbus-user none
 # dbus-system none

--- a/etc/profile-m-z/onionshare-gui.profile
+++ b/etc/profile-m-z/onionshare-gui.profile
@@ -50,7 +50,7 @@ novideo
 protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
-#tracelog - may cause issues, see #1930
+#tracelog # may cause issues, see #1930
 
 disable-mnt
 private-bin onionshare,onionshare-cli,onionshare-gui,python*,tor*

--- a/etc/profile-m-z/openclonk.profile
+++ b/etc/profile-m-z/openclonk.profile
@@ -24,7 +24,7 @@ include whitelist-var-common.inc
 apparmor
 caps.drop all
 ipc-namespace
-# net none - networked game
+#net none # networked game
 netfilter
 nodvd
 nogroups

--- a/etc/profile-m-z/orage.profile
+++ b/etc/profile-m-z/orage.profile
@@ -24,7 +24,7 @@ nogroups
 noinput
 nonewprivs
 noroot
-# nosound - calendar application, It must be able to play sound to wake you up.
+#nosound # calendar application, It must be able to play sound to wake you up.
 notv
 nou2f
 novideo

--- a/etc/profile-m-z/otter-browser.profile
+++ b/etc/profile-m-z/otter-browser.profile
@@ -57,4 +57,4 @@ private-tmp
 
 dbus-system none
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-m-z/pidgin.profile
+++ b/etc/profile-m-z/pidgin.profile
@@ -40,7 +40,7 @@ protocol unix,inet,inet6,netlink
 seccomp
 tracelog
 
-# private-bin pidgin
+#private-bin pidgin
 private-cache
 private-dev
 private-tmp

--- a/etc/profile-m-z/ping.profile
+++ b/etc/profile-m-z/ping.profile
@@ -55,7 +55,7 @@ tracelog
 
 disable-mnt
 private
-#private-bin ping - has mammoth problems with execvp: "No such file or directory"
+#private-bin ping # has mammoth problems with execvp: "No such file or directory"
 private-cache
 private-dev
 private-etc @tls-ca

--- a/etc/profile-m-z/pluma.profile
+++ b/etc/profile-m-z/pluma.profile
@@ -21,10 +21,10 @@ include disable-shell.inc
 
 include whitelist-var-common.inc
 
-# apparmor - makes settings immutable
+#apparmor # makes settings immutable
 caps.drop all
 machine-id
-# net none - makes settings immutable
+#net none # makes settings immutable
 no3d
 nodvd
 nogroups
@@ -45,8 +45,8 @@ private-lib aspell,gconv,libgspell-1.so.*,libreadline.so.*,libtinfo.so.*,pluma
 private-tmp
 
 # makes settings immutable
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 restrict-namespaces
 join-or-start pluma

--- a/etc/profile-m-z/plv.profile
+++ b/etc/profile-m-z/plv.profile
@@ -53,7 +53,7 @@ writable-var-log
 dbus-user none
 dbus-system none
 
-#memory-deny-write-execute - breaks opening file-chooser
+#memory-deny-write-execute # breaks opening file-chooser
 read-only ${HOME}
 read-write ${HOME}/.config/PacmanLogViewer
 read-only /var/log/pacman.log

--- a/etc/profile-m-z/psi-plus.profile
+++ b/etc/profile-m-z/psi-plus.profile
@@ -43,4 +43,4 @@ disable-mnt
 private-dev
 private-tmp
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-m-z/psi.profile
+++ b/etc/profile-m-z/psi.profile
@@ -62,7 +62,7 @@ novideo
 nou2f
 protocol unix,inet,inet6,netlink
 seccomp !chroot
-#tracelog - breaks on Arch
+#tracelog # breaks on Arch
 
 disable-mnt
 # Add the next line to your psi.local to enable GPG support.

--- a/etc/profile-m-z/pycharm-community.profile
+++ b/etc/profile-m-z/pycharm-community.profile
@@ -34,8 +34,8 @@ nou2f
 novideo
 tracelog
 
-# private-etc alternatives,fonts,passwd - minimal required to run but will probably break
-# program!
+# minimum required to run but will probably break the program!
+#private-etc alternatives,fonts,passwd
 private-dev
 private-tmp
 

--- a/etc/profile-m-z/qbittorrent.profile
+++ b/etc/profile-m-z/qbittorrent.profile
@@ -55,12 +55,12 @@ seccomp
 
 private-bin python*,qbittorrent
 private-dev
-# private-etc alternatives,ca-certificates,crypto-policies,fonts,pki,resolv.conf,ssl,X11,xdg
+#private-etc alternatives,ca-certificates,crypto-policies,fonts,pki,resolv.conf,ssl,X11,xdg
 private-tmp
 
 # See https://github.com/netblue30/firejail/issues/3707 for tray-icon
 dbus-user none
 dbus-system none
 
-# memory-deny-write-execute - problems on Arch, see #1690 on GitHub repo
+#memory-deny-write-execute # problems on Arch, see #1690 on GitHub repo
 restrict-namespaces

--- a/etc/profile-m-z/qmmp.profile
+++ b/etc/profile-m-z/qmmp.profile
@@ -18,7 +18,7 @@ include disable-xdg.inc
 
 caps.drop all
 netfilter
-# no3d
+#no3d
 nogroups
 noinput
 nonewprivs

--- a/etc/profile-m-z/qpdfview.profile
+++ b/etc/profile-m-z/qpdfview.profile
@@ -41,7 +41,7 @@ private-dev
 private-tmp
 
 # needs D-Bus when started from a file manager
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 restrict-namespaces

--- a/etc/profile-m-z/qtox.profile
+++ b/etc/profile-m-z/qtox.profile
@@ -48,5 +48,5 @@ private-tmp
 dbus-user none
 dbus-system none
 
-#memory-deny-write-execute - breaks on Arch (see issue #1803)
+#memory-deny-write-execute # breaks on Arch (see issue #1803)
 restrict-namespaces

--- a/etc/profile-m-z/quassel.profile
+++ b/etc/profile-m-z/quassel.profile
@@ -25,4 +25,4 @@ seccomp !chroot
 private-cache
 private-tmp
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-m-z/quiterss.profile
+++ b/etc/profile-m-z/quiterss.profile
@@ -50,6 +50,6 @@ tracelog
 disable-mnt
 private-bin quiterss
 private-dev
-# private-etc alternatives,ca-certificates,crypto-policies,pki,ssl,X11
+#private-etc alternatives,ca-certificates,crypto-policies,pki,ssl,X11
 
 restrict-namespaces

--- a/etc/profile-m-z/rpcs3.profile
+++ b/etc/profile-m-z/rpcs3.profile
@@ -54,7 +54,8 @@ tracelog
 
 disable-mnt
 #private-cache
-#private-etc alternatives,ca-certificates,crypto-policies,machine-id,pki,resolv.conf,ssl # seems to need awk
+# seems to need awk
+#private-etc alternatives,ca-certificates,crypto-policies,machine-id,pki,resolv.conf,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/rssguard.profile
+++ b/etc/profile-m-z/rssguard.profile
@@ -31,13 +31,13 @@ include whitelist-var-common.inc
 apparmor
 caps.drop all
 netfilter
-# no3d
+#no3d
 nodvd
 nogroups
 noinput
 nonewprivs
 noroot
-# nosound
+#nosound
 notv
 nou2f
 novideo

--- a/etc/profile-m-z/scribus.profile
+++ b/etc/profile-m-z/scribus.profile
@@ -55,7 +55,7 @@ protocol unix
 seccomp
 tracelog
 
-# private-bin gimp*,gs,scribus
+#private-bin gimp*,gs,scribus
 private-dev
 private-tmp
 

--- a/etc/profile-m-z/seamonkey.profile
+++ b/etc/profile-m-z/seamonkey.profile
@@ -55,7 +55,7 @@ seccomp
 tracelog
 
 disable-mnt
-# private-etc adobe,alternatives,asound.conf,ca-certificates,crypto-policies,firefox,fonts,group,gtk-2.0,hostname,hosts,iceweasel,localtime,machine-id,mailcap,mime.types,nsswitch.conf,pango,passwd,pki,pulse,resolv.conf,ssl
+#private-etc adobe,alternatives,asound.conf,ca-certificates,crypto-policies,firefox,fonts,group,gtk-2.0,hostname,hosts,iceweasel,localtime,machine-id,mailcap,mime.types,nsswitch.conf,pango,passwd,pki,pulse,resolv.conf,ssl
 writable-run-user
 
 restrict-namespaces

--- a/etc/profile-m-z/server.profile
+++ b/etc/profile-m-z/server.profile
@@ -34,36 +34,36 @@ include globals.local
 noblacklist /sbin
 noblacklist /usr/sbin
 noblacklist /etc/init.d
-# noblacklist /var/opt
+#noblacklist /var/opt
 
 blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
-# include disable-devel.inc
-# include disable-exec.inc
-# include disable-interpreters.inc
+#include disable-devel.inc
+#include disable-exec.inc
+#include disable-interpreters.inc
 include disable-programs.inc
 include disable-write-mnt.inc
 include disable-xdg.inc
 
-# include whitelist-runuser-common.inc
-# include whitelist-usr-share-common.inc
-# include whitelist-var-common.inc
+#include whitelist-runuser-common.inc
+#include whitelist-usr-share-common.inc
+#include whitelist-var-common.inc
 
 # people use to install servers all over the place!
 # apparmor runs executable only from default system locations
-# apparmor
+#apparmor
 caps
-# ipc-namespace
+#ipc-namespace
 machine-id
-# netfilter /etc/firejail/webserver.net
+#netfilter /etc/firejail/webserver.net
 no3d
 nodvd
-# nogroups
+#nogroups
 noinput
 nonewprivs
-# noroot
+#noroot
 nosound
 notv
 nou2f
@@ -74,22 +74,22 @@ tab # allow tab completion
 
 disable-mnt
 private
-# private-bin program
-# private-cache
+#private-bin program
+#private-cache
 private-dev
 # see /usr/share/doc/firejail/profile.template for more common private-etc paths.
-# private-etc alternatives
-# private-lib
-# private-opt none
+#private-etc alternatives
+#private-lib
+#private-opt none
 private-tmp
-# writable-run-user
-# writable-var
-# writable-var-log
+#writable-run-user
+#writable-var
+#writable-var-log
 
 dbus-user none
-# dbus-system none
+#dbus-system none
 
-# deterministic-shutdown
-# memory-deny-write-execute
-# read-only ${HOME}
-# restrict-namespaces
+#deterministic-shutdown
+#memory-deny-write-execute
+#read-only ${HOME}
+#restrict-namespaces

--- a/etc/profile-m-z/silentarmy.profile
+++ b/etc/profile-m-z/silentarmy.profile
@@ -7,7 +7,7 @@ include globals.local
 
 
 include disable-common.inc
-# include disable-devel.inc
+#include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc

--- a/etc/profile-m-z/simple-scan.profile
+++ b/etc/profile-m-z/simple-scan.profile
@@ -28,15 +28,15 @@ nonewprivs
 noroot
 nosound
 notv
-# novideo
+#novideo
 protocol unix,inet,inet6,netlink
 # blacklisting of ioperm system calls breaks simple-scan
 seccomp !ioperm
 tracelog
 
-# private-bin simple-scan
-# private-dev
-# private-etc alternatives,ca-certificates,crypto-policies,fonts,pki,ssl
-# private-tmp
+#private-bin simple-scan
+#private-dev
+#private-etc alternatives,ca-certificates,crypto-policies,fonts,pki,ssl
+#private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/simutrans.profile
+++ b/etc/profile-m-z/simutrans.profile
@@ -33,7 +33,7 @@ novideo
 protocol unix
 seccomp
 
-# private-bin simutrans
+#private-bin simutrans
 private-dev
 private-etc @games,@x11
 private-tmp

--- a/etc/profile-m-z/skanlite.profile
+++ b/etc/profile-m-z/skanlite.profile
@@ -22,16 +22,16 @@ nonewprivs
 noroot
 nosound
 notv
-# novideo
+#novideo
 protocol unix,inet,inet6,netlink
 # blacklisting of ioperm system calls breaks skanlite
 seccomp !ioperm
 
-# private-bin kbuildsycoca4,kdeinit4,skanlite
-# private-dev
-# private-tmp
+#private-bin kbuildsycoca4,kdeinit4,skanlite
+#private-dev
+#private-tmp
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 restrict-namespaces

--- a/etc/profile-m-z/smplayer.profile
+++ b/etc/profile-m-z/smplayer.profile
@@ -36,7 +36,7 @@ include whitelist-var-common.inc
 apparmor
 caps.drop all
 netfilter
-# nogroups
+#nogroups
 noinput
 nonewprivs
 noroot
@@ -49,7 +49,7 @@ private-dev
 private-tmp
 
 # problems with KDE
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 restrict-namespaces

--- a/etc/profile-m-z/sniffnet.profile
+++ b/etc/profile-m-z/sniffnet.profile
@@ -29,8 +29,8 @@ netfilter
 nodvd
 nogroups
 noinput
-# nonewprivs - breaks network traffic capture for unprivileged users
-# noroot
+#nonewprivs # breaks network traffic capture for unprivileged users
+#noroot
 notv
 nou2f
 novideo

--- a/etc/profile-m-z/sol.profile
+++ b/etc/profile-m-z/sol.profile
@@ -21,13 +21,13 @@ apparmor
 caps.drop all
 ipc-namespace
 net none
-# no3d
+#no3d
 nodvd
 nogroups
 noinput
 nonewprivs
 noroot
-# nosound
+#nosound
 notv
 nou2f
 novideo
@@ -43,5 +43,5 @@ private-tmp
 dbus-user none
 dbus-system none
 
-# memory-deny-write-execute
+#memory-deny-write-execute
 restrict-namespaces

--- a/etc/profile-m-z/sound-juicer.profile
+++ b/etc/profile-m-z/sound-juicer.profile
@@ -38,7 +38,7 @@ private-cache
 private-dev
 private-tmp
 
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 restrict-namespaces

--- a/etc/profile-m-z/sqlitebrowser.profile
+++ b/etc/profile-m-z/sqlitebrowser.profile
@@ -46,8 +46,8 @@ private-etc @tls-ca
 private-tmp
 
 # breaks proxy creation
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
-#memory-deny-write-execute - breaks on Arch (see issue #1803)
+#memory-deny-write-execute # breaks on Arch (see issue #1803)
 restrict-namespaces

--- a/etc/profile-m-z/ssh.profile
+++ b/etc/profile-m-z/ssh.profile
@@ -32,10 +32,10 @@ nodvd
 nogroups
 noinput
 nonewprivs
-# noroot - see issue #1543
+#noroot # see issue #1543
 nosound
 notv
-# nou2f - OpenSSH >= 8.2 supports U2F
+#nou2f # OpenSSH >= 8.2 supports U2F
 novideo
 protocol unix,inet,inet6
 seccomp
@@ -43,7 +43,7 @@ tracelog
 
 private-cache
 private-dev
-# private-tmp # Breaks when exiting
+#private-tmp # Breaks when exiting
 writable-run-user
 
 dbus-user none

--- a/etc/profile-m-z/standardnotes-desktop.profile
+++ b/etc/profile-m-z/standardnotes-desktop.profile
@@ -47,4 +47,4 @@ private-etc @tls-ca,@x11,host.conf
 dbus-user none
 dbus-system none
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-m-z/subdownloader.profile
+++ b/etc/profile-m-z/subdownloader.profile
@@ -49,5 +49,5 @@ private-tmp
 dbus-user none
 dbus-system none
 
-#memory-deny-write-execute - breaks on Arch (see issue #1803)
+#memory-deny-write-execute # breaks on Arch (see issue #1803)
 restrict-namespaces

--- a/etc/profile-m-z/supertux2.profile
+++ b/etc/profile-m-z/supertux2.profile
@@ -41,7 +41,7 @@ seccomp.block-secondary
 tracelog
 
 disable-mnt
-# private-bin supertux2
+#private-bin supertux2
 private-cache
 private-etc
 private-dev

--- a/etc/profile-m-z/sushi.profile
+++ b/etc/profile-m-z/sushi.profile
@@ -13,7 +13,7 @@ include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
-# include disable-programs.inc
+#include disable-programs.inc
 include disable-shell.inc
 
 include whitelist-runuser-common.inc

--- a/etc/profile-m-z/sylpheed.profile
+++ b/etc/profile-m-z/sylpheed.profile
@@ -13,7 +13,7 @@ whitelist ${HOME}/.sylpheed-2.0
 
 whitelist /usr/share/sylpheed
 
-# private-bin curl,gpg,gpg2,gpg-agent,gpgsm,pinentry,pinentry-gtk-2,sylpheed
+#private-bin curl,gpg,gpg2,gpg-agent,gpgsm,pinentry,pinentry-gtk-2,sylpheed
 
 # Redirect
 include email-common.profile

--- a/etc/profile-m-z/sysprof.profile
+++ b/etc/profile-m-z/sysprof.profile
@@ -59,11 +59,11 @@ seccomp
 tracelog
 
 disable-mnt
-#private-bin sysprof - breaks help menu
+#private-bin sysprof # breaks help menu
 private-cache
 private-dev
 private-etc @tls-ca
-# private-lib - breaks help menu
+#private-lib # breaks help menu
 #private-lib gdk-pixbuf-2.*,gio,gtk3,gvfs/libgvfscommon.so,libgconf-2.so.*,librsvg-2.so.*,libsysprof-2.so,libsysprof-ui-2.so
 private-tmp
 
@@ -73,5 +73,5 @@ dbus-user.own org.gnome.Yelp
 dbus-user.own org.gnome.Sysprof3
 dbus-user.talk ca.desrt.dconf
 
-# memory-deny-write-execute - breaks on Arch
+#memory-deny-write-execute # breaks on Arch
 restrict-namespaces

--- a/etc/profile-m-z/teamspeak3.profile
+++ b/etc/profile-m-z/teamspeak3.profile
@@ -39,4 +39,4 @@ disable-mnt
 private-dev
 private-tmp
 
-# restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-m-z/thunderbird.profile
+++ b/etc/profile-m-z/thunderbird.profile
@@ -35,7 +35,7 @@ whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 noblacklist ${HOME}/.cache/thunderbird
 noblacklist ${HOME}/.gnupg
-# noblacklist ${HOME}/.icedove
+#noblacklist ${HOME}/.icedove
 noblacklist ${HOME}/.thunderbird
 
 include disable-xdg.inc
@@ -46,11 +46,11 @@ include disable-xdg.inc
 # See https://github.com/netblue30/firejail/issues/2357
 mkdir ${HOME}/.cache/thunderbird
 mkdir ${HOME}/.gnupg
-# mkdir ${HOME}/.icedove
+#mkdir ${HOME}/.icedove
 mkdir ${HOME}/.thunderbird
 whitelist ${HOME}/.cache/thunderbird
 whitelist ${HOME}/.gnupg
-# whitelist ${HOME}/.icedove
+#whitelist ${HOME}/.icedove
 whitelist ${HOME}/.thunderbird
 
 whitelist /usr/share/gnupg

--- a/etc/profile-m-z/tmux.profile
+++ b/etc/profile-m-z/tmux.profile
@@ -12,10 +12,10 @@ blacklist ${RUNUSER}
 
 noblacklist /tmp/tmux-*
 
-# include disable-common.inc
-# include disable-devel.inc
-# include disable-exec.inc
-# include disable-programs.inc
+#include disable-common.inc
+#include disable-devel.inc
+#include disable-exec.inc
+#include disable-programs.inc
 
 caps.drop all
 ipc-namespace
@@ -36,9 +36,9 @@ seccomp
 seccomp.block-secondary
 tracelog
 
-# private-cache
+#private-cache
 private-dev
-# private-tmp
+#private-tmp
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/torbrowser-launcher.profile
+++ b/etc/profile-m-z/torbrowser-launcher.profile
@@ -56,13 +56,13 @@ novideo
 protocol unix,inet,inet6
 seccomp !chroot
 seccomp.block-secondary
-#tracelog - may cause issues, see #1930
+#tracelog # may cause issues, see #1930
 
 disable-mnt
 private-bin bash,cat,cp,cut,dirname,env,expr,file,gpg,grep,gxmessage,id,kdialog,ln,mkdir,mv,python*,rm,sed,sh,tail,tar,tclsh,test,tor-browser,tor-browser-en,torbrowser-launcher,update-desktop-database,xmessage,xz,zenity
 private-dev
 private-etc @tls-ca
-#private-opt tor-browser - can cause slow startup
+#private-opt tor-browser # can cause slow startup
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/totem.profile
+++ b/etc/profile-m-z/totem.profile
@@ -35,7 +35,7 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
-# apparmor - makes settings immutable
+#apparmor # makes settings immutable
 caps.drop all
 netfilter
 nogroups
@@ -55,7 +55,7 @@ private-etc @tls-ca,@x11,python*
 private-tmp
 
 # makes settings immutable
-# dbus-user none
+#dbus-user none
 dbus-system none
 
 restrict-namespaces

--- a/etc/profile-m-z/tracker.profile
+++ b/etc/profile-m-z/tracker.profile
@@ -33,8 +33,8 @@ protocol unix
 seccomp
 tracelog
 
-# private-bin tracker
-# private-dev
-# private-tmp
+#private-bin tracker
+#private-dev
+#private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/trojita.profile
+++ b/etc/profile-m-z/trojita.profile
@@ -52,7 +52,7 @@ protocol unix,inet,inet6,netlink
 seccomp
 tracelog
 
-# disable-mnt
+#disable-mnt
 private-bin trojita
 private-cache
 private-dev

--- a/etc/profile-m-z/udiskie.profile
+++ b/etc/profile-m-z/udiskie.profile
@@ -36,8 +36,8 @@ tracelog
 
 private-bin awk,cut,dbus-send,egrep,file,grep,head,python*,readlink,sed,sh,udiskie,uname,which,xdg-mime,xdg-open,xprop
 # add your configured file browser in udiskie.local, e. g.
-# private-bin nautilus
-# private-bin thunar
+#private-bin nautilus
+#private-bin thunar
 private-cache
 private-dev
 private-etc @x11,mime.types

--- a/etc/profile-m-z/unknown-horizons.profile
+++ b/etc/profile-m-z/unknown-horizons.profile
@@ -34,11 +34,11 @@ protocol unix,inet,inet6,netlink
 seccomp
 
 disable-mnt
-# private-bin unknown-horizons
+#private-bin unknown-horizons
 private-dev
-# private-etc alternatives,ca-certificates,crypto-policies,pki,ssl
+#private-etc alternatives,ca-certificates,crypto-policies,pki,ssl
 private-tmp
 
 # doesn't work - maybe all Tcl/Tk programs have this problem
-# memory-deny-write-execute
+#memory-deny-write-execute
 restrict-namespaces

--- a/etc/profile-m-z/viewnior.profile
+++ b/etc/profile-m-z/viewnior.profile
@@ -49,5 +49,5 @@ private-tmp
 dbus-user none
 dbus-system none
 
-#memory-deny-write-execute - breaks on Arch (see issues #1803 and #1808)
+#memory-deny-write-execute # breaks on Arch (see issues #1803 and #1808)
 restrict-namespaces

--- a/etc/profile-m-z/virtualbox.profile
+++ b/etc/profile-m-z/virtualbox.profile
@@ -9,7 +9,7 @@ include globals.local
 noblacklist ${HOME}/.VirtualBox
 noblacklist ${HOME}/.config/VirtualBox
 noblacklist ${HOME}/VirtualBox VMs
-# noblacklist /usr/bin/virtualbox
+#noblacklist /usr/bin/virtualbox
 noblacklist /usr/lib/virtualbox
 noblacklist /usr/lib64/virtualbox
 

--- a/etc/profile-m-z/warzone2100.profile
+++ b/etc/profile-m-z/warzone2100.profile
@@ -15,7 +15,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
-#include disable-shell.inc - problems on Debian 11
+#include disable-shell.inc # problems on Debian 11
 
 mkdir ${HOME}/.local/share/warzone2100
 mkdir ${HOME}/.local/share/warzone2100-3.3.0

--- a/etc/profile-m-z/wine.profile
+++ b/etc/profile-m-z/wine.profile
@@ -20,23 +20,23 @@ include disable-devel.inc
 include disable-interpreters.inc
 include disable-programs.inc
 
-# whitelist /usr/share/wine
-# include whitelist-usr-share-common.inc
+#whitelist /usr/share/wine
+#include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
 # Some applications don't need allow-debuggers. Add 'ignore allow-debuggers' to your wine.local if you want to override this.
 allow-debuggers
 caps.drop all
-# net none
+#net none
 netfilter
 nodvd
 nogroups
 noinput
 nonewprivs
 noroot
-# nosound
+#nosound
 notv
-# novideo
+#novideo
 seccomp
 
 private-dev

--- a/etc/profile-m-z/wireshark.profile
+++ b/etc/profile-m-z/wireshark.profile
@@ -25,14 +25,14 @@ include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
 apparmor
-# caps.drop all
+#caps.drop all
 caps.keep dac_override,dac_read_search,net_admin,net_raw
 netfilter
 no3d
-# nogroups - breaks network traffic capture for unprivileged users
+#nogroups # breaks network traffic capture for unprivileged users
 noinput
-# nonewprivs - breaks network traffic capture for unprivileged users
-# noroot
+#nonewprivs # breaks network traffic capture for unprivileged users
+#noroot
 nodvd
 nosound
 notv
@@ -43,12 +43,12 @@ novideo
 #seccomp
 tracelog
 
-# private-bin wireshark
+#private-bin wireshark
 private-cache
 # private-dev prevents (some) interfaces from being shown.
 # Add the below line to your wirehsark.local if you only want to inspect pcap files.
 #private-dev
-# private-etc alternatives,ca-certificates,crypto-policies,fonts,group,hosts,machine-id,passwd,pki,resolv.conf,ssl
+#private-etc alternatives,ca-certificates,crypto-policies,fonts,group,hosts,machine-id,passwd,pki,resolv.conf,ssl
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/wireshark.profile
+++ b/etc/profile-m-z/wireshark.profile
@@ -38,7 +38,8 @@ nosound
 notv
 nou2f
 novideo
-# protocol unix,inet,inet6,netlink,packet,bluetooth - commented out in case they bring in new protocols
+# commented out in case they bring in new protocols
+#protocol unix,inet,inet6,netlink,packet,bluetooth
 #seccomp
 tracelog
 

--- a/etc/profile-m-z/xed.profile
+++ b/etc/profile-m-z/xed.profile
@@ -23,10 +23,10 @@ include disable-shell.inc
 
 include whitelist-var-common.inc
 
-# apparmor - makes settings immutable
+#apparmor # makes settings immutable
 caps.drop all
 machine-id
-# net none - makes settings immutable
+#net none # makes settings immutable
 no3d
 nodvd
 nogroups
@@ -46,9 +46,9 @@ private-dev
 private-tmp
 
 # makes settings immutable
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 # xed uses python plugins, memory-deny-write-execute breaks python
-# memory-deny-write-execute
+#memory-deny-write-execute
 restrict-namespaces

--- a/etc/profile-m-z/xfburn.profile
+++ b/etc/profile-m-z/xfburn.profile
@@ -25,8 +25,8 @@ protocol unix
 seccomp
 tracelog
 
-# private-bin xfburn
-# private-dev
-# private-tmp
+#private-bin xfburn
+#private-dev
+#private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/xfce4-mixer.profile
+++ b/etc/profile-m-z/xfce4-mixer.profile
@@ -53,5 +53,5 @@ dbus-user.own org.xfce.xfce4-mixer
 dbus-user.talk org.xfce.Xfconf
 dbus-system none
 
-# memory-deny-write-execute - breaks on Arch
+#memory-deny-write-execute # breaks on Arch
 restrict-namespaces

--- a/etc/profile-m-z/xfce4-screenshooter.profile
+++ b/etc/profile-m-z/xfce4-screenshooter.profile
@@ -47,5 +47,5 @@ private-tmp
 dbus-user none
 dbus-system none
 
-# memory-deny-write-execute -- see #3790
+#memory-deny-write-execute # see #3790
 restrict-namespaces

--- a/etc/profile-m-z/xplayer.profile
+++ b/etc/profile-m-z/xplayer.profile
@@ -27,7 +27,7 @@ include whitelist-common.inc
 include whitelist-player-common.inc
 include whitelist-var-common.inc
 
-# apparmor - makes settings immutable
+#apparmor # makes settings immutable
 caps.drop all
 netfilter
 nogroups
@@ -41,11 +41,11 @@ tracelog
 
 private-bin xplayer,xplayer-audio-preview,xplayer-video-thumbnailer
 private-dev
-# private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,machine-id,pki,pulse,ssl
+#private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,machine-id,pki,pulse,ssl
 private-tmp
 
 # makes settings immutable
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 restrict-namespaces

--- a/etc/profile-m-z/xpra.profile
+++ b/etc/profile-m-z/xpra.profile
@@ -45,11 +45,11 @@ seccomp
 
 disable-mnt
 # private home directory doesn't work on some distros, so we go for a regular home
-# private
+#private
 # older Xpra versions also use Xvfb
-# private-bin bash,cat,dbus-launch,ldconfig,ls,pactl,python*,sh,strace,which,xauth,xkbcomp,Xorg,xpra,Xvfb
+#private-bin bash,cat,dbus-launch,ldconfig,ls,pactl,python*,sh,strace,which,xauth,xkbcomp,Xorg,xpra,Xvfb
 private-dev
-# private-etc alternatives,gai.conf,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,machine-id,nsswitch.conf,resolv.conf,X11,xpra
+#private-etc alternatives,gai.conf,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,machine-id,nsswitch.conf,resolv.conf,X11,xpra
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/xreader.profile
+++ b/etc/profile-m-z/xreader.profile
@@ -18,9 +18,9 @@ include disable-programs.inc
 include disable-xdg.inc
 
 # Breaks xreader on Mint 18.3
-# include whitelist-var-common.inc
+#include whitelist-var-common.inc
 
-# apparmor
+#apparmor
 caps.drop all
 no3d
 nodvd

--- a/etc/profile-m-z/xviewer.profile
+++ b/etc/profile-m-z/xviewer.profile
@@ -19,9 +19,9 @@ include disable-shell.inc
 
 include whitelist-var-common.inc
 
-# apparmor - makes settings immutable
+#apparmor # makes settings immutable
 caps.drop all
-# net none - makes settings immutable
+#net none # makes settings immutable
 no3d
 nodvd
 nogroups
@@ -42,8 +42,8 @@ private-lib
 private-tmp
 
 # makes settings immutable
-# dbus-user none
-# dbus-system none
+#dbus-user none
+#dbus-system none
 
 memory-deny-write-execute
 restrict-namespaces

--- a/etc/profile-m-z/yelp.profile
+++ b/etc/profile-m-z/yelp.profile
@@ -33,16 +33,14 @@ include whitelist-var-common.inc
 
 apparmor
 caps.drop all
-# machine-id breaks sound - add the next line to your yelp.local if you don't need sound support.
-#machine-id
+#machine-id # add this to your yelp.local if you don't need sound support.
 net none
 nodvd
 nogroups
 noinput
 nonewprivs
 noroot
-# nosound - add the next line to your yelp.local if you don't need sound support.
-#nosound
+#nosound # add this to your yelp.local if you don't need sound support.
 notv
 nou2f
 novideo

--- a/etc/profile-m-z/ytmdesktop.profile
+++ b/etc/profile-m-z/ytmdesktop.profile
@@ -13,9 +13,9 @@ noblacklist ${HOME}/.config/youtube-music-desktop-app
 mkdir ${HOME}/.config/youtube-music-desktop-app
 whitelist ${HOME}/.config/youtube-music-desktop-app
 
-# private-bin env,ytmdesktop
+#private-bin env,ytmdesktop
 private-etc @tls-ca,@x11,bumblebee,host.conf,mime.types
-# private-opt
+#private-opt
 
 # Redirect
 include electron-common.profile

--- a/etc/profile-m-z/zeal.profile
+++ b/etc/profile-m-z/zeal.profile
@@ -67,5 +67,5 @@ dbus-user.talk org.mozilla.*
 ?ALLOW_TRAY: dbus-user.talk org.kde.StatusNotifierWatcher
 dbus-system none
 
-# memory-deny-write-execute - breaks on Arch
+#memory-deny-write-execute # breaks on Arch
 restrict-namespaces


### PR DESCRIPTION
Main changes:

* Remove the space after `#` for commented code lines to distinguish
  them from normal comments
* Use `#` instead of `-` for comments at the end of the line so that
  commented code lines work after being uncommented

Commands used to search and replace:

    arg0="$(cat contrib/syntax/lists/profile_commands_arg0.list |
      LC_ALL=C sort -u | tr '\n' '|' | sed -e 's/|$//' -e 's/\./\\./g')"
    arg1="$(cat contrib/syntax/lists/profile_commands_arg1.list |
      LC_ALL=C sort -u | tr '\n' '|' | sed -e 's/|$//' -e 's/\./\\./g')"
    git ls-files -z -- etc/inc etc/profile* | xargs -0 -I '{}' \
      sh -c "printf '%s\n' \"\$(sed -E \
        -e 's/^# ($arg0)( [#-]-? .*)?\$/#\\1\\2/' \
        -e 's/^# ($arg1)( [^ ]*)?( [#-]-? .*)?\$/#\\1\\2\\3/' \
        -e 's/^# (whitelist \\$)/#\\1/' \
        -e 's/^(#[^ ].+) --? /\\1 # /' \
        '{}')\" >'{}'"

Commands used to check for leftover entries:

    arg0="$(cat contrib/syntax/lists/profile_commands_arg0.list |
      LC_ALL=C sort -u | tr '\n' '|' | sed -e 's/|$//' -e 's/\./\\./g')"
    arg1="$(cat contrib/syntax/lists/profile_commands_arg1.list |
      LC_ALL=C sort -u | tr '\n' '|' | sed -e 's/|$//' -e 's/\./\\./g')"
    git grep -E "^# ($arg0|$arg1)( +|$)" -- etc/inc etc/profile*

See also commit 30f9ad908 ("build: improve comments in firecfg.config",
2023-08-05) / PR #5942.