### PR TITLE
modif: keep pipewire group unless nosound is used

### DIFF
--- a/RELNOTES
+++ b/RELNOTES
@@ -21,6 +21,7 @@ firejail (0.9.73) baseline; urgency=low
   * modif: Improve --version/--help & print version on startup (#5829)
   * modif: improve errExit error messages (#5871)
   * modif: drop deprecated 'shell' option references (#5894)
+  * modif: keep pipewire group unless nosound is used (#5992 #5993)
   * bugfix: qutebrowser: links will not open in the existing instance (#5601
     #5618)
   * bugfix: fix --hostname and --hosts-file commands

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -3217,9 +3217,14 @@ int main(int argc, char **argv, char **envp) {
 
 		gid_t g;
 		if (!arg_nogroups || !check_can_drop_all_groups()) {
-			// add audio group
+			// add audio groups
 			if (!arg_nosound) {
 				g = get_group_id("audio");
+				if (g) {
+					sprintf(ptr, "%d %d 1\n", g, g);
+					ptr += strlen(ptr);
+				}
+				g = get_group_id("pipewire");
 				if (g) {
 					sprintf(ptr, "%d %d 1\n", g, g);
 					ptr += strlen(ptr);

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -207,6 +207,8 @@ static void clean_supplementary_groups(gid_t gid) {
 	if (!arg_nosound) {
 		copy_group_ifcont("audio", groups, ngroups,
 		                  new_groups, &new_ngroups, MAX_GROUPS);
+		copy_group_ifcont("pipewire", groups, ngroups,
+		                  new_groups, &new_ngroups, MAX_GROUPS);
 	}
 
 	if (!arg_novideo) {


### PR DESCRIPTION
This group is apparently used on Gentoo[1].

Currently only the "audio" supplementary group is kept.

Fixes #5992.

See also commit f32938669 ("Keep vglusers group unless no3d is used
(virtualgl)", 2022-01-07) / PR #4851.

[1] https://wiki.gentoo.org/wiki/PipeWire

Reported-by: @amano-kenji
