### PR TITLE
telegram.profile: allow ~/.local/share/telegram-desktop

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -1030,6 +1030,7 @@ blacklist ${HOME}/.local/share/strawberry
 blacklist ${HOME}/.local/share/supertux2
 blacklist ${HOME}/.local/share/supertuxkart
 blacklist ${HOME}/.local/share/swell-foop
+blacklist ${HOME}/.local/share/telegram-desktop
 blacklist ${HOME}/.local/share/telepathy
 blacklist ${HOME}/.local/share/terasology
 blacklist ${HOME}/.local/share/torbrowser

--- a/etc/profile-m-z/telegram.profile
+++ b/etc/profile-m-z/telegram.profile
@@ -7,6 +7,7 @@ include globals.local
 
 noblacklist ${HOME}/.TelegramDesktop
 noblacklist ${HOME}/.local/share/TelegramDesktop
+noblacklist ${HOME}/.local/share/telegram-desktop
 
 # Allow opening hyperlinks
 include allow-bin-sh.inc
@@ -21,8 +22,10 @@ include disable-xdg.inc
 
 mkdir ${HOME}/.TelegramDesktop
 mkdir ${HOME}/.local/share/TelegramDesktop
+mkdir ${HOME}/.local/share/telegram-desktop
 whitelist ${HOME}/.TelegramDesktop
 whitelist ${HOME}/.local/share/TelegramDesktop
+whitelist ${HOME}/.local/share/telegram-desktop
 whitelist ${DOWNLOADS}
 whitelist /usr/share/TelegramDesktop
 include whitelist-common.inc


### PR DESCRIPTION
New TelegramWebApps uses another directory for saving local storage.