### PR TITLE
profiles: dpkg fix

### DIFF
--- a/etc/profile-a-l/file-roller.profile
+++ b/etc/profile-a-l/file-roller.profile
@@ -6,7 +6,6 @@ include file-roller.local
 # Persistent global definitions
 include globals.local
 
-# Allow dpkg (blacklisted by disable-common.inc)
 noblacklist ${PATH}/dpkg*
 
 include disable-common.inc

--- a/etc/profile-a-l/file-roller.profile
+++ b/etc/profile-a-l/file-roller.profile
@@ -6,6 +6,9 @@ include file-roller.local
 # Persistent global definitions
 include globals.local
 
+# Allow dpkg (blacklisted by disable-common.inc)
+noblacklist ${PATH}/dpkg*
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
@@ -40,7 +43,7 @@ seccomp
 seccomp.block-secondary
 tracelog
 
-private-bin 7z,7za,7zr,ar,arj,atool,bash,brotli,bsdtar,bzip2,compress,cp,cpio,dpkg-deb,file-roller,gtar,gzip,isoinfo,lha,lrzip,lsar,lz4,lzip,lzma,lzop,mv,p7zip,rar,rm,rzip,sh,tar,unace,unalz,unar,uncompress,unrar,unsquashfs,unstuff,unzip,unzstd,xz,xzdec,zip,zoo,zstd
+private-bin 7z,7za,7zr,ar,arj,atool,bash,brotli,bsdtar,bzip2,compress,cp,cpio,dpkg*,file-roller,gtar,gzip,isoinfo,lha,lrzip,lsar,lz4,lzip,lzma,lzop,mv,p7zip,rar,rm,rzip,sh,tar,unace,unalz,unar,uncompress,unrar,unsquashfs,unstuff,unzip,unzstd,xz,xzdec,zip,zoo,zstd
 private-cache
 private-dev
 private-etc @x11

--- a/etc/profile-a-l/freemind.profile
+++ b/etc/profile-a-l/freemind.profile
@@ -9,7 +9,6 @@ include globals.local
 noblacklist ${DOCUMENTS}
 noblacklist ${HOME}/.freemind
 
-# Allow dpkg (blacklisted by disable-common.inc)
 noblacklist ${PATH}/dpkg*
 
 # Allow java (blacklisted by disable-devel.inc)

--- a/etc/profile-a-l/freemind.profile
+++ b/etc/profile-a-l/freemind.profile
@@ -9,6 +9,9 @@ include globals.local
 noblacklist ${DOCUMENTS}
 noblacklist ${HOME}/.freemind
 
+# Allow dpkg (blacklisted by disable-common.inc)
+noblacklist ${PATH}/dpkg*
+
 # Allow java (blacklisted by disable-devel.inc)
 include allow-java.inc
 
@@ -40,7 +43,7 @@ seccomp
 tracelog
 
 disable-mnt
-private-bin bash,cp,dirname,dpkg,echo,freemind,grep,java,lsb_release,mkdir,readlink,rpm,sed,sh,uname,which
+private-bin bash,cp,dirname,dpkg*,echo,freemind,grep,java,lsb_release,mkdir,readlink,rpm,sed,sh,uname,which
 private-cache
 private-dev
 #private-etc alternatives,fonts,java*


### PR DESCRIPTION
The two profiles with dpkg in private-bin didn't override `blacklist ${PATH}/dpkg*` from disable-common.inc. Let's fix that.