### PR TITLE
profiles: exchange private-opt with a whitelist

### DIFF
--- a/etc/profile-a-l/bitwarden.profile
+++ b/etc/profile-a-l/bitwarden.profile
@@ -17,6 +17,7 @@ include disable-shell.inc
 
 mkdir ${HOME}/.config/Bitwarden
 whitelist ${HOME}/.config/Bitwarden
+whitelist /opt/Bitwarden
 
 machine-id
 no3d
@@ -24,7 +25,6 @@ nosound
 
 ?HAS_APPIMAGE: ignore private-dev
 private-etc @tls-ca
-private-opt Bitwarden
 
 # Redirect
 include electron-common.profile

--- a/etc/profile-a-l/discord-canary.profile
+++ b/etc/profile-a-l/discord-canary.profile
@@ -9,9 +9,10 @@ noblacklist ${HOME}/.config/discordcanary
 
 mkdir ${HOME}/.config/discordcanary
 whitelist ${HOME}/.config/discordcanary
+whitelist /opt/DiscordCanary
+whitelist /opt/discord-canary
 
 private-bin discord-canary,DiscordCanary
-private-opt discord-canary,DiscordCanary
 
 # Redirect
 include discord-common.profile

--- a/etc/profile-a-l/discord-ptb.profile
+++ b/etc/profile-a-l/discord-ptb.profile
@@ -9,9 +9,10 @@ noblacklist ${HOME}/.config/discordptb
 
 mkdir ${HOME}/.config/discordptb
 whitelist ${HOME}/.config/discordptb
+whitelist /opt/DiscordPTB
+whitelist /opt/discord
 
 private-bin discord-ptb,DiscordPTB
-private-opt discord-ptb,DiscordPTB
 
 # Redirect
 include discord-common.profile

--- a/etc/profile-a-l/discord.profile
+++ b/etc/profile-a-l/discord.profile
@@ -9,9 +9,10 @@ noblacklist ${HOME}/.config/discord
 
 mkdir ${HOME}/.config/discord
 whitelist ${HOME}/.config/discord
+whitelist /opt/Discord
+whitelist /opt/discord
 
 private-bin discord,Discord
-private-opt discord,Discord
 
 # Redirect
 include discord-common.profile

--- a/etc/profile-a-l/electron-mail.profile
+++ b/etc/profile-a-l/electron-mail.profile
@@ -18,6 +18,7 @@ include disable-shell.inc
 
 mkdir ${HOME}/.config/electron-mail
 whitelist ${HOME}/.config/electron-mail
+whitelist /opt/ElectronMail
 
 # The lines below are needed to find the default Firefox profile name, to allow
 # opening links in an existing instance of Firefox (note that it still fails if
@@ -29,7 +30,6 @@ machine-id
 nosound
 
 private-etc @tls-ca,@x11
-private-opt ElectronMail
 
 dbus-user filter
 dbus-user.talk org.freedesktop.Notifications

--- a/etc/profile-a-l/element-desktop.profile
+++ b/etc/profile-a-l/element-desktop.profile
@@ -15,8 +15,6 @@ mkdir ${HOME}/.config/Element
 whitelist ${HOME}/.config/Element
 whitelist /opt/Element
 
-private-opt Element
-
 dbus-user filter
 dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.freedesktop.secrets

--- a/etc/profile-a-l/gitter.profile
+++ b/etc/profile-a-l/gitter.profile
@@ -18,6 +18,7 @@ mkdir ${HOME}/.config/Gitter
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.config/autostart
 whitelist ${HOME}/.config/Gitter
+whitelist /opt/Gitter
 include whitelist-var-common.inc
 
 caps.drop all
@@ -37,7 +38,6 @@ seccomp
 disable-mnt
 private-bin bash,env,gitter
 private-etc @tls-ca
-private-opt Gitter
 private-dev
 private-tmp
 

--- a/etc/profile-a-l/google-earth.profile
+++ b/etc/profile-a-l/google-earth.profile
@@ -18,6 +18,7 @@ mkdir ${HOME}/.config/Google
 mkdir ${HOME}/.googleearth
 whitelist ${HOME}/.config/Google
 whitelist ${HOME}/.googleearth
+whitelist /opt/google
 include whitelist-common.inc
 
 caps.drop all
@@ -37,6 +38,5 @@ seccomp
 disable-mnt
 private-bin bash,dirname,google-earth,grep,ls,sed,sh
 private-dev
-private-opt google
 
 restrict-namespaces

--- a/etc/profile-a-l/linuxqq.profile
+++ b/etc/profile-a-l/linuxqq.profile
@@ -17,6 +17,7 @@ mkdir ${HOME}/.config/QQ
 whitelist ${HOME}/.config/QQ
 whitelist ${HOME}/.mozilla/firefox/profiles.ini
 whitelist ${DESKTOP}
+whitelist /opt/QQ
 
 ignore apparmor
 noprinters
@@ -24,7 +25,6 @@ noprinters
 # If you don't need/want to save anything to disk you can add `private` to your linuxqq.local.
 #private
 private-etc @tls-ca,@x11,host.conf,os-release
-private-opt QQ
 
 dbus-user filter
 dbus-user.talk org.freedesktop.Notifications

--- a/etc/profile-m-z/microsoft-edge-beta.profile
+++ b/etc/profile-m-z/microsoft-edge-beta.profile
@@ -14,10 +14,7 @@ mkdir ${HOME}/.cache/microsoft-edge-beta
 mkdir ${HOME}/.config/microsoft-edge-beta
 whitelist ${HOME}/.cache/microsoft-edge-beta
 whitelist ${HOME}/.config/microsoft-edge-beta
-
 whitelist /opt/microsoft/msedge-beta
-# private-opt might break the file-copy-limit, see #5307
-#private-opt microsoft
 
 # Redirect
 include chromium-common.profile

--- a/etc/profile-m-z/mullvad-browser.profile
+++ b/etc/profile-m-z/mullvad-browser.profile
@@ -79,7 +79,6 @@ disable-mnt
 private-bin bash,cat,cp,cut,dirname,env,expr,file,gpg,grep,gxmessage,id,kdialog,ln,mkdir,mullvad-browser,mv,python*,rm,sed,sh,tail,tar,tclsh,test,update-desktop-database,xmessage,xz,zenity
 private-dev
 private-etc @tls-ca
-#private-opt mullvad-browser # can cause slow startup
 private-tmp
 
 blacklist ${PATH}/curl

--- a/etc/profile-m-z/notable.profile
+++ b/etc/profile-m-z/notable.profile
@@ -14,11 +14,12 @@ include globals.local
 noblacklist ${HOME}/.config/Notable
 noblacklist ${HOME}/.notable
 
+whitelist /opt/Notable
+
 net none
 nosound
 
 ?HAS_APPIMAGE: ignore private-dev
-private-opt Notable
 
 dbus-user filter
 dbus-user.talk ca.desrt.dconf

--- a/etc/profile-m-z/nuclear.profile
+++ b/etc/profile-m-z/nuclear.profile
@@ -14,12 +14,12 @@ include disable-shell.inc
 
 mkdir ${HOME}/.config/nuclear
 whitelist ${HOME}/.config/nuclear
+whitelist /opt/nuclear
 
 no3d
 
 #private-bin nuclear
 private-etc @tls-ca,@x11,host.conf,mime.types
-private-opt nuclear
 
 # Redirect
 include electron-common.profile

--- a/etc/profile-m-z/ocenaudio.profile
+++ b/etc/profile-m-z/ocenaudio.profile
@@ -25,6 +25,7 @@ whitelist ${HOME}/.cache/ocenaudio
 whitelist ${HOME}/.local/share/ocenaudio
 whitelist ${DOWNLOADS}
 whitelist ${MUSIC}
+whitelist /opt/ocenaudio
 include whitelist-common.inc
 include whitelist-run-common.inc
 include whitelist-runuser-common.inc
@@ -54,7 +55,6 @@ private-bin ocenaudio,ocenvst
 private-cache
 private-dev
 private-etc @tls-ca,@x11,mime.types
-private-opt ocenaudio
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/palemoon.profile
+++ b/etc/profile-m-z/palemoon.profile
@@ -12,6 +12,7 @@ mkdir ${HOME}/.cache/moonchild productions/pale moon
 mkdir ${HOME}/.moonchild productions
 whitelist ${HOME}/.cache/moonchild productions/pale moon
 whitelist ${HOME}/.moonchild productions
+whitelist /opt/palemoon
 whitelist /usr/share/moonchild productions
 whitelist /usr/share/palemoon
 
@@ -22,7 +23,6 @@ ignore seccomp
 #private-bin palemoon
 # private-etc must first be enabled in firefox-common.profile
 #private-etc palemoon
-#private-opt palemoon
 
 restrict-namespaces
 ignore restrict-namespaces

--- a/etc/profile-m-z/spotify.profile
+++ b/etc/profile-m-z/spotify.profile
@@ -26,6 +26,7 @@ whitelist ${HOME}/.cache/spotify
 whitelist ${HOME}/.config/spotify
 whitelist ${HOME}/.config/spotify-adblock
 whitelist ${HOME}/.local/share/spotify
+whitelist /opt/spotify
 include whitelist-common.inc
 include whitelist-var-common.inc
 
@@ -48,7 +49,6 @@ private-bin bash,cat,dirname,find,grep,head,rm,sh,spotify,tclsh,touch,zenity
 private-dev
 # If you want to see album covers or want to use the radio, add 'ignore private-etc' to your spotify.local.
 private-etc @tls-ca,host.conf,spotify-adblock
-private-opt spotify
 private-srv none
 private-tmp
 

--- a/etc/profile-m-z/thunderbird-beta.profile
+++ b/etc/profile-m-z/thunderbird-beta.profile
@@ -6,7 +6,7 @@ include thunderbird-beta.local
 # added by included profile
 #include globals.local
 
-private-opt thunderbird-beta
+whitelist /opt/thunderbird-beta
 
 # Redirect
 include thunderbird.profile

--- a/etc/profile-m-z/torbrowser-launcher.profile
+++ b/etc/profile-m-z/torbrowser-launcher.profile
@@ -62,7 +62,6 @@ disable-mnt
 private-bin bash,cat,cp,cut,dirname,env,expr,file,gpg,grep,gxmessage,id,kdialog,ln,mkdir,mv,python*,rm,sed,sh,tail,tar,tclsh,test,tor-browser,tor-browser-en,torbrowser-launcher,update-desktop-database,xmessage,xz,zenity
 private-dev
 private-etc @tls-ca
-#private-opt tor-browser # can cause slow startup
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/tutanota-desktop.profile
+++ b/etc/profile-m-z/tutanota-desktop.profile
@@ -22,6 +22,7 @@ mkdir ${HOME}/.config/tuta_integration
 mkdir ${HOME}/.config/tutanota-desktop
 whitelist ${HOME}/.config/tuta_integration
 whitelist ${HOME}/.config/tutanota-desktop
+whitelist /opt/tutanota-desktop
 
 # The lines below are needed to find the default Firefox profile name, to allow
 # opening links in an existing instance of Firefox (note that it still fails if
@@ -34,7 +35,6 @@ nosound
 
 ?HAS_APPIMAGE: ignore private-dev
 private-etc @tls-ca
-private-opt tutanota-desktop
 
 dbus-user filter
 dbus-user.talk org.freedesktop.Notifications

--- a/etc/profile-m-z/twitch.profile
+++ b/etc/profile-m-z/twitch.profile
@@ -16,10 +16,10 @@ include disable-shell.inc
 
 mkdir ${HOME}/.config/Twitch
 whitelist ${HOME}/.config/Twitch
+whitelist /opt/Twitch
 
 private-bin electron,electron[0-9],electron[0-9][0-9],twitch
 private-etc @tls-ca,@x11,bumblebee,host.conf,mime.types
-private-opt Twitch
 
 # Redirect
 include electron-common.profile

--- a/etc/profile-m-z/xmr-stak.profile
+++ b/etc/profile-m-z/xmr-stak.profile
@@ -16,6 +16,7 @@ include disable-shell.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.xmr-stak
+whitelist /opt/cuda
 include whitelist-var-common.inc
 
 caps.drop all
@@ -39,7 +40,6 @@ private-bin xmr-stak
 private-dev
 private-etc @tls-ca
 #private-lib libxmrstak_opencl_backend,libxmrstak_cuda_backend
-private-opt cuda
 private-tmp
 
 memory-deny-write-execute

--- a/etc/profile-m-z/youtube.profile
+++ b/etc/profile-m-z/youtube.profile
@@ -15,10 +15,10 @@ include disable-shell.inc
 
 mkdir ${HOME}/.config/Youtube
 whitelist ${HOME}/.config/Youtube
+whitelist /opt/Youtube
 
 private-bin electron,electron[0-9],electron[0-9][0-9],youtube
 private-etc @tls-ca,@x11,bumblebee,host.conf,mime.types
-private-opt Youtube
 
 # Redirect
 include electron-common.profile

--- a/etc/profile-m-z/youtubemusic-nativefier.profile
+++ b/etc/profile-m-z/youtubemusic-nativefier.profile
@@ -12,10 +12,10 @@ include disable-shell.inc
 
 mkdir ${HOME}/.config/youtubemusic-nativefier-040164
 whitelist ${HOME}/.config/youtubemusic-nativefier-040164
+whitelist /opt/youtubemusic-nativefier
 
 private-bin electron,electron[0-9],electron[0-9][0-9],youtubemusic-nativefier
 private-etc @tls-ca,@x11,bumblebee,host.conf,mime.types
-private-opt youtubemusic-nativefier
 
 # Redirect
 include electron-common.profile

--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -196,6 +196,13 @@ include globals.local
 #    Extra: gai.conf,proxychains.conf
 #  Qt: Trolltech.conf
 ##private-lib LIBS
+## Note: private-opt copies the entire path(s) to RAM, which may break
+## file-copy-limit in firejail.config (see firejail(1)).
+## For sizeable apps (if in doubt, do this):
+##  - never use 'private-opt NAME'
+##  - place 'whitelist /opt/NAME' in the whitelist section above
+## For acceptable apps:
+##  - use 'private-opt NAME'
 ##private-opt NAME
 #private-tmp
 ##writable-etc

--- a/src/man/firejail.1.in
+++ b/src/man/firejail.1.in
@@ -2263,6 +2263,18 @@ All modifications are discarded when the sandbox is closed.
 Example:
 .br
 $ firejail --private-opt=firefox /opt/firefox/firefox
+.br
+
+.br
+Note: Program installations in /opt tend to be relatively large and private-opt
+copies the entire path(s) into RAM, which may significantly increase RAM usage
+and break \fBfile-copy-limit\fR in firejail.config.
+Therefore, in general it is recommended to use "whitelist /opt/PATH" instead of
+"private-opt PATH".
+For details, see
+.UR https://github.com/netblue30/firejail/discussions/5307
+#5307
+.UE
 
 .TP
 \fB\-\-private-srv=file,directory


### PR DESCRIPTION
private-opt breaks file-copy-limit, use a whitelist instead of draining RAM
cfr. https://github.com/netblue30/firejail/discussions/5307

This PR streamlines the comment and does the relevant whitelisting in /opt.
