### PR TITLE
profiles: drop private-opt none

### DIFF
--- a/etc/profile-a-l/crow.profile
+++ b/etc/profile-a-l/crow.profile
@@ -39,7 +39,6 @@ disable-mnt
 private-bin crow
 private-dev
 private-etc @tls-ca,@x11
-private-opt none
 private-tmp
 private-srv none
 

--- a/etc/profile-a-l/daisy.profile
+++ b/etc/profile-a-l/daisy.profile
@@ -52,7 +52,6 @@ private-cache
 private-dev
 private-etc
 private-lib
-private-opt none
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/default.profile
+++ b/etc/profile-a-l/default.profile
@@ -50,7 +50,6 @@ private-dev
 # see /usr/share/doc/firejail/profile.template for more common private-etc paths.
 #private-etc alternatives,fonts,machine-id
 #private-lib
-#private-opt none
 private-tmp
 
 #dbus-user none

--- a/etc/profile-a-l/dolphin-emu.profile
+++ b/etc/profile-a-l/dolphin-emu.profile
@@ -55,7 +55,6 @@ private-cache
 # Add the next line to your dolphin-emu.local if you do not need controller support.
 #private-dev
 private-etc @tls-ca,@x11,bumblebee,gconf,glvnd,host.conf,mime.types,rpc,services
-private-opt none
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/freemind.profile
+++ b/etc/profile-a-l/freemind.profile
@@ -45,7 +45,6 @@ private-cache
 private-dev
 #private-etc alternatives,fonts,java*
 private-tmp
-private-opt none
 private-srv none
 
 dbus-user none

--- a/etc/profile-a-l/ipcalc.profile
+++ b/etc/profile-a-l/ipcalc.profile
@@ -51,7 +51,6 @@ private-dev
 # empty etc directory
 private-etc
 private-lib
-private-opt none
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/kid3.profile
+++ b/etc/profile-a-l/kid3.profile
@@ -38,7 +38,6 @@ private-cache
 private-dev
 private-etc @tls-ca,@x11
 private-tmp
-private-opt none
 private-srv none
 
 dbus-user none

--- a/etc/profile-a-l/klavaro.profile
+++ b/etc/profile-a-l/klavaro.profile
@@ -46,7 +46,6 @@ private-cache
 private-dev
 private-etc
 private-tmp
-private-opt none
 private-srv none
 
 dbus-user none

--- a/etc/profile-m-z/PCSX2.profile
+++ b/etc/profile-m-z/PCSX2.profile
@@ -48,7 +48,6 @@ private-cache
 # Add the next line to your PCSX2.local if you do not need controller support.
 #private-dev
 private-etc @tls-ca,@x11,bumblebee,gconf,glvnd,host.conf,mime.types,rpc,services
-private-opt none
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/mate-calc.profile
+++ b/etc/profile-m-z/mate-calc.profile
@@ -43,7 +43,6 @@ disable-mnt
 private-bin mate-calc,mate-calculator
 private-etc @x11
 private-dev
-private-opt none
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/nyx.profile
+++ b/etc/profile-m-z/nyx.profile
@@ -45,7 +45,6 @@ private-bin nyx,python*
 private-cache
 private-dev
 private-etc tor
-private-opt none
 private-srv none
 private-tmp
 

--- a/etc/profile-m-z/openmw.profile
+++ b/etc/profile-m-z/openmw.profile
@@ -53,7 +53,6 @@ private-bin bsatool,esmtool,niftest,openmw,openmw-cs,openmw-essimporter,openmw-i
 private-cache
 private-dev
 private-etc @x11,bumblebee,glvnd,mime.types,openmw
-private-opt none
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/pcsxr.profile
+++ b/etc/profile-m-z/pcsxr.profile
@@ -48,7 +48,6 @@ private-cache
 # Add the next line to your pcsxr.local if you do not need controller support.
 #private-dev
 private-etc @tls-ca,@x11,bumblebee,gconf,glvnd,host.conf,mime.types,rpc,services
-private-opt none
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/pkglog.profile
+++ b/etc/profile-m-z/pkglog.profile
@@ -44,7 +44,6 @@ private-bin pkglog,python*
 private-cache
 private-dev
 private-etc
-private-opt none
 private-tmp
 writable-var-log
 

--- a/etc/profile-m-z/plv.profile
+++ b/etc/profile-m-z/plv.profile
@@ -46,7 +46,6 @@ private-bin plv
 private-cache
 private-dev
 private-etc
-private-opt none
 private-tmp
 writable-var-log
 

--- a/etc/profile-m-z/qnapi.profile
+++ b/etc/profile-m-z/qnapi.profile
@@ -47,7 +47,6 @@ private-bin 7z,qnapi
 private-cache
 private-dev
 private-etc
-private-opt none
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/reader.profile
+++ b/etc/profile-m-z/reader.profile
@@ -52,7 +52,6 @@ private-cache
 private-dev
 private-etc @network,@tls-ca
 private-lib
-private-opt none
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/seafile-applet.profile
+++ b/etc/profile-m-z/seafile-applet.profile
@@ -54,7 +54,6 @@ private-bin seaf-cli,seaf-daemon,seafile-applet
 private-cache
 private-dev
 private-etc @tls-ca,host.conf,rpc,services
-#private-opt none
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/server.profile
+++ b/etc/profile-m-z/server.profile
@@ -80,7 +80,6 @@ private-dev
 # see /usr/share/doc/firejail/profile.template for more common private-etc paths.
 #private-etc alternatives
 #private-lib
-#private-opt none
 private-tmp
 #writable-run-user
 #writable-var

--- a/etc/profile-m-z/shotwell.profile
+++ b/etc/profile-m-z/shotwell.profile
@@ -49,7 +49,6 @@ private-bin shotwell
 private-cache
 private-dev
 private-etc
-private-opt none
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/silentarmy.profile
+++ b/etc/profile-m-z/silentarmy.profile
@@ -34,7 +34,6 @@ disable-mnt
 private
 private-bin python*,sa-solver,silentarmy
 private-dev
-private-opt none
 private-tmp
 
 restrict-namespaces

--- a/etc/profile-m-z/supertuxkart.profile
+++ b/etc/profile-m-z/supertuxkart.profile
@@ -55,7 +55,6 @@ private-cache
 #private-dev
 private-etc @games,@tls-ca,@x11
 private-tmp
-private-opt none
 private-srv none
 
 dbus-user none

--- a/etc/profile-m-z/x2goclient.profile
+++ b/etc/profile-m-z/x2goclient.profile
@@ -40,7 +40,6 @@ private-cache
 private-dev
 #private-etc alternatives,asound.conf,ca-certificates,crypto-policies,fonts,gtk-3.0,host.conf,hostname,hosts,machine-id,pki,pulse,resolv.conf,ssl,X11,xdg
 #private-lib
-private-opt none
 private-srv none
 private-tmp
 


### PR DESCRIPTION
Motivation:

Although `private-opt none` is technically valid, currently it is inconsistently used. Only a very small number of profiles have it. IMO we should discuss adding it to all profiles that are known to not use/need anything under /opt.