### PR TITLE
ci: allow running workflows manually

### DIFF
--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -3,6 +3,7 @@
 name: Build-extra
 
 on:
+  workflow_dispatch:
   push:
     branches-ignore:
       - 'dependabot/**'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ name: Build
 
 # Note: Keep this list in sync with DISTFILES in ../../Makefile.
 on:
+  workflow_dispatch:
   push:
     branches-ignore:
       - 'dependabot/**'

--- a/.github/workflows/check-c.yml
+++ b/.github/workflows/check-c.yml
@@ -3,6 +3,7 @@
 name: Check-C
 
 on:
+  workflow_dispatch:
   push:
     branches-ignore:
       - 'dependabot/**'

--- a/.github/workflows/check-profiles.yml
+++ b/.github/workflows/check-profiles.yml
@@ -3,6 +3,7 @@
 name: Check-Profiles
 
 on:
+  workflow_dispatch:
   push:
     branches-ignore:
       - 'dependabot/**'

--- a/.github/workflows/check-python.yml
+++ b/.github/workflows/check-python.yml
@@ -3,6 +3,7 @@
 name: Check-Python
 
 on:
+  workflow_dispatch:
   push:
     branches-ignore:
       - 'dependabot/**'

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,6 +3,7 @@
 name: Codespell
 
 on:
+  workflow_dispatch:
   push:
     branches-ignore:
       - 'dependabot/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@
 name: Test
 
 on:
+  workflow_dispatch:
   push:
     branches-ignore:
       - 'dependabot/**'


### PR DESCRIPTION
Add `on.workflow_dispatch`.

See:

* https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatch
* https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
