### PR TITLE
nicotine: support Fcitx and dconf via dbus-user filter

### DIFF
--- a/etc/profile-m-z/nicotine.profile
+++ b/etc/profile-m-z/nicotine.profile
@@ -58,6 +58,8 @@ private-dev
 private-tmp
 
 dbus-user none
+dbus-user.own org.nicotine_plus.Nicotine
+dbus-user.talk ca.desrt.dconf
 dbus-system none
 
 restrict-namespaces

--- a/etc/profile-m-z/nicotine.profile
+++ b/etc/profile-m-z/nicotine.profile
@@ -57,7 +57,7 @@ private-cache
 private-dev
 private-tmp
 
-dbus-user none
+dbus-user filter
 dbus-user.own org.nicotine_plus.Nicotine
 dbus-user.talk ca.desrt.dconf
 dbus-system none


### PR DESCRIPTION
From https://github.com/netblue30/firejail/issues/6034. Nicotine+ needs `dbus-user.own org.nicotine_plus.Nicotine` or it will crash if started with options for Fcitx. And `dbus-user.talk ca.desrt.dconf` is to support dconf as stated [here]( https://github.com/netblue30/firejail/issues/6034#issuecomment-1750542403).