### PR TITLE
wireshark: fix access to dumpcap

### DIFF
--- a/etc/profile-m-z/wireshark.profile
+++ b/etc/profile-m-z/wireshark.profile
@@ -9,6 +9,7 @@ include globals.local
 noblacklist ${HOME}/.config/wireshark
 noblacklist ${HOME}/.wireshark
 noblacklist ${DOCUMENTS}
+noblacklist ${PATH}/dumpcap
 
 # Allow lua (blacklisted by disable-interpreters.inc)
 include allow-lua.inc


### PR DESCRIPTION
Grant access to ${PATH}/dumpcap (blacklisted in disable-common.inc).

Came up [here](https://github.com/netblue30/firejail/issues/4241#issuecomment-1750809663). 