### PR TITLE
pavucontrol-qt: fix broken whitelisting in ${HOME}

### DIFF
--- a/etc/profile-m-z/pavucontrol-qt.profile
+++ b/etc/profile-m-z/pavucontrol-qt.profile
@@ -9,8 +9,9 @@ include pavucontrol-qt.local
 
 noblacklist ${HOME}/.config/pavucontrol-qt
 
-mkdir ${HOME}/.config/pavucontrol-qt
-whitelist ${HOME}/.config/pavucontrol-qt
+# whitelisting in ${HOME} is broken, see #3112
+#mkdir ${HOME}/.config/pavucontrol-qt
+#whitelist ${HOME}/.config/pavucontrol-qt
 
 private-bin pavucontrol-qt
 ignore private-lib


### PR DESCRIPTION
Context: #6044.