### PR TITLE
contrib/syntax: remove 'text/plain' from firejail-profile.lang.in

### DIFF
--- a/contrib/syntax/files/firejail-profile.lang.in
+++ b/contrib/syntax/files/firejail-profile.lang.in
@@ -7,7 +7,7 @@
 -->
 <language id="firejail-profile" name="Firejail Profile" version="2.0" _section="Other">
   <metadata>
-    <property name="mimetypes">text/plain;text/x-firejail-profile</property>
+    <property name="mimetypes">text/x-firejail-profile</property>
     <property name="globs">*.profile;*.local;*.inc</property>
     <property name="line-comment-start">#</property>
   </metadata>


### PR DESCRIPTION
PR to fix https://github.com/netblue30/firejail/issues/6057