### PR TITLE
profiles: support more msmtp configuration paths

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -334,6 +334,7 @@ blacklist /etc/hosts.equiv
 read-only ${HOME}/.caffrc
 read-only ${HOME}/.cargo/env
 read-only ${HOME}/.config/mpv
+read-only ${HOME}/.config/msmtp
 read-only ${HOME}/.config/nano
 read-only ${HOME}/.config/nvim
 read-only ${HOME}/.config/pkcs11
@@ -424,6 +425,7 @@ blacklist /etc/group-
 blacklist /etc/gshadow
 blacklist /etc/gshadow+
 blacklist /etc/gshadow-
+blacklist /etc/msmtprc
 blacklist /etc/passwd+
 blacklist /etc/passwd-
 blacklist /etc/shadow
@@ -446,6 +448,7 @@ blacklist ${HOME}/.cargo/credentials.toml
 blacklist ${HOME}/.cert
 blacklist ${HOME}/.config/hub
 blacklist ${HOME}/.config/keybase
+blacklist ${HOME}/.config/msmtp
 blacklist ${HOME}/.davfs2/secrets
 blacklist ${HOME}/.ecryptfs
 blacklist ${HOME}/.fetchmailrc

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -559,6 +559,7 @@ blacklist ${HOME}/.config/mpDris2
 blacklist ${HOME}/.config/mpd
 blacklist ${HOME}/.config/mps-youtube
 blacklist ${HOME}/.config/mpv
+blacklist ${HOME}/.config/msmtp
 blacklist ${HOME}/.config/mullvad-browser-flags.conf
 blacklist ${HOME}/.config/mupen64plus
 blacklist ${HOME}/.config/mutt
@@ -1232,6 +1233,7 @@ blacklist ${RUNUSER}/*firefox*
 blacklist ${RUNUSER}/akonadi
 blacklist ${RUNUSER}/psd/*firefox*
 blacklist ${RUNUSER}/qutebrowser
+blacklist /etc/msmtprc
 blacklist /etc/ssmtp
 blacklist /tmp/.wine-*
 blacklist /tmp/akonadi-*

--- a/etc/profile-m-z/mutt.profile
+++ b/etc/profile-m-z/mutt.profile
@@ -13,6 +13,7 @@ noblacklist ${DOCUMENTS}
 noblacklist ${HOME}/.Mail
 noblacklist ${HOME}/.bogofilter
 noblacklist ${HOME}/.cache/mutt
+noblacklist ${HOME}/.config/msmtp
 noblacklist ${HOME}/.config/mutt
 noblacklist ${HOME}/.config/nano
 noblacklist ${HOME}/.elinks
@@ -35,6 +36,7 @@ noblacklist ${HOME}/Mail
 noblacklist ${HOME}/mail
 noblacklist ${HOME}/postponed
 noblacklist ${HOME}/sent
+noblacklist /etc/msmtprc
 
 blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
@@ -69,6 +71,7 @@ whitelist ${DOWNLOADS}
 whitelist ${HOME}/.Mail
 whitelist ${HOME}/.bogofilter
 whitelist ${HOME}/.cache/mutt
+whitelist ${HOME}/.config/msmtp
 whitelist ${HOME}/.config/mutt
 whitelist ${HOME}/.config/nano
 whitelist ${HOME}/.elinks
@@ -124,7 +127,7 @@ tracelog
 #disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gai.conf,gnupg,gnutls,hosts.conf,mail,mailname,nntpserver,terminfo
+private-etc @tls-ca,@x11,msmtprc,Mutt,Muttrc,Muttrc.d,gai.conf,gnupg,gnutls,hosts.conf,mail,mailname,nntpserver,terminfo
 private-tmp
 writable-run-user
 writable-var

--- a/etc/profile-m-z/neomutt.profile
+++ b/etc/profile-m-z/neomutt.profile
@@ -10,6 +10,7 @@ include globals.local
 noblacklist ${DOCUMENTS}
 noblacklist ${HOME}/.Mail
 noblacklist ${HOME}/.bogofilter
+noblacklist ${HOME}/.config/msmtp
 noblacklist ${HOME}/.config/mutt
 noblacklist ${HOME}/.config/nano
 noblacklist ${HOME}/.config/neomutt
@@ -34,6 +35,7 @@ noblacklist ${HOME}/Mail
 noblacklist ${HOME}/mail
 noblacklist ${HOME}/postponed
 noblacklist ${HOME}/sent
+noblacklist /etc/msmtprc
 noblacklist /var/mail
 noblacklist /var/spool/mail
 
@@ -59,6 +61,7 @@ whitelist ${DOCUMENTS}
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.Mail
 whitelist ${HOME}/.bogofilter
+whitelist ${HOME}/.config/msmtp
 whitelist ${HOME}/.config/mutt
 whitelist ${HOME}/.config/nano
 whitelist ${HOME}/.config/neomutt
@@ -116,7 +119,7 @@ tracelog
 #disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gnupg,hosts.conf,mail,mailname,neomuttrc,neomuttrc.d,nntpserver
+private-etc @tls-ca,@x11,msmtprc,Mutt,Muttrc,Muttrc.d,gnupg,hosts.conf,mail,mailname,neomuttrc,neomuttrc.d,nntpserver
 private-tmp
 writable-run-user
 writable-var


### PR DESCRIPTION
Since version 1.8.6 msmtp supports per-user configuration at either
~/.msmtprc (already supported by firejail) or
`$XDG_CONFIG_HOME/msmtp/config`. System-wide support can be placed at
/etc/msmtprc.

This adds the missing paths to the relevant .inc and .profile files.

Note that `blacklist ${HOME}/.msmtprc` is present on both
disable-common.inc and disable-programs.inc, so the new paths are added
to both files.

References:

https://wiki.archlinux.org/title/Msmtp#Basic_setup
https://marlam.de/msmtp/msmtp.html#Configuration-files