### PR TITLE
steam.profile: allow process_vm_readv syscall

### DIFF
--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -163,7 +163,7 @@ protocol unix,inet,inet6,netlink
 # Add 'ignore seccomp' to your steam.local if you experience this.
 # mount, name_to_handle_at, pivot_root and umount2 are used by Proton >= 5.13
 # (see #4366).
-seccomp !chroot,!mount,!name_to_handle_at,!pivot_root,!ptrace,!umount2
+seccomp !chroot,!mount,!name_to_handle_at,!pivot_root,!process_vm_readv,!ptrace,!umount2
 # process_vm_readv is used by GE-Proton7-18 (see #5185).
 seccomp.32 !process_vm_readv
 # tracelog breaks integrated browser


### PR DESCRIPTION
EA Origin (game launcher) won't launch without this.

See https://github.com/netblue30/firejail/issues/5185#issuecomment-1776516159
