### PR TITLE
lutris.profile: allow more syscalls

### DIFF
--- a/etc/profile-a-l/lutris.profile
+++ b/etc/profile-a-l/lutris.profile
@@ -69,7 +69,7 @@ notv
 nou2f
 novideo
 protocol unix,inet,inet6,netlink
-seccomp !modify_ldt
+seccomp !clone3,modify_ldt,!process_vm_readv,!ptrace
 seccomp.32 !modify_ldt
 
 # Add the next line to your lutris.local if you do not need controller support.


### PR DESCRIPTION
Need to whitelist `ptrace` and `clone3` for Ubisoft Connect to work.

journalctl did list `process_vm_readv` when a game was running, but it
didn't crash the game; see
https://github.com/netblue30/firejail/issues/6035#issuecomment-1776513877

Fixes #6035.