### PR TITLE
build: sort.py: use case-sensitive sorting

### DIFF
--- a/contrib/sort.py
+++ b/contrib/sort.py
@@ -38,7 +38,7 @@ Exit Codes:
 
 def sort_alphabetical(original_items):
     items = original_items.split(",")
-    items.sort(key=str.casefold)
+    items.sort()
     return ",".join(items)
 
 

--- a/etc/profile-a-l/ani-cli.profile
+++ b/etc/profile-a-l/ani-cli.profile
@@ -33,7 +33,7 @@ notv
 disable-mnt
 private-bin ani-cli,aria2c,cat,cp,curl,cut,ffmpeg,fzf,grep,head,mkdir,mktemp,mv,nl,nohup,patch,printf,rm,rofi,sed,sh,sort,tail,tput,tr,uname,wc
 #private-cache
-private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,pango,pki,protocols,pulse,resolv.conf,rpc,services,ssl,X11,xdg
+private-etc X11,alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,pango,pki,protocols,pulse,resolv.conf,rpc,services,ssl,xdg
 private-tmp
 
 # Redirect

--- a/etc/profile-a-l/discord-canary.profile
+++ b/etc/profile-a-l/discord-canary.profile
@@ -12,7 +12,7 @@ whitelist ${HOME}/.config/discordcanary
 whitelist /opt/DiscordCanary
 whitelist /opt/discord-canary
 
-private-bin discord-canary,DiscordCanary
+private-bin DiscordCanary,discord-canary
 
 # Redirect
 include discord-common.profile

--- a/etc/profile-a-l/discord-ptb.profile
+++ b/etc/profile-a-l/discord-ptb.profile
@@ -12,7 +12,7 @@ whitelist ${HOME}/.config/discordptb
 whitelist /opt/DiscordPTB
 whitelist /opt/discord
 
-private-bin discord-ptb,DiscordPTB
+private-bin DiscordPTB,discord-ptb
 
 # Redirect
 include discord-common.profile

--- a/etc/profile-a-l/discord.profile
+++ b/etc/profile-a-l/discord.profile
@@ -12,7 +12,7 @@ whitelist ${HOME}/.config/discord
 whitelist /opt/Discord
 whitelist /opt/discord
 
-private-bin discord,Discord
+private-bin Discord,discord
 
 # Redirect
 include discord-common.profile

--- a/etc/profile-a-l/display.profile
+++ b/etc/profile-a-l/display.profile
@@ -40,7 +40,7 @@ private-bin display,python*
 private-dev
 # On Debian-based systems, display is a symlink in /etc/alternatives
 private-etc ImageMagick-6,ImageMagick-7
-private-lib gcc/*/*/libgcc_s.so.*,gcc/*/*/libgomp.so.*,ImageMagick*,libfreetype.so.*,libltdl.so.*,libMagickWand-*.so.*,libXext.so.*
+private-lib ImageMagick*,gcc/*/*/libgcc_s.so.*,gcc/*/*/libgomp.so.*,libMagickWand-*.so.*,libXext.so.*,libfreetype.so.*,libltdl.so.*
 private-tmp
 
 dbus-user none

--- a/etc/profile-a-l/enpass.profile
+++ b/etc/profile-a-l/enpass.profile
@@ -52,7 +52,7 @@ protocol unix,inet,inet6,netlink
 seccomp
 tracelog
 
-private-bin dirname,Enpass,importer_enpass,readlink,sh
+private-bin Enpass,dirname,importer_enpass,readlink,sh
 ?HAS_APPIMAGE: ignore private-dev
 private-dev
 private-opt Enpass

--- a/etc/profile-a-l/fbreader.profile
+++ b/etc/profile-a-l/fbreader.profile
@@ -33,7 +33,7 @@ novideo
 protocol unix,inet,inet6
 seccomp
 
-private-bin fbreader,FBReader
+private-bin FBReader,fbreader
 private-dev
 private-tmp
 

--- a/etc/profile-a-l/fluffychat.profile
+++ b/etc/profile-a-l/fluffychat.profile
@@ -60,7 +60,7 @@ disable-mnt
 private-bin firefox,fluffychat,sh,which,zenity
 private-cache
 private-dev
-private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,dconf,fonts,gconf,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,pango,pki,protocols,pulse,resolv.conf,rpc,services,ssl,X11,xdg
+private-etc X11,alsa,alternatives,asound.conf,ca-certificates,crypto-policies,dconf,fonts,gconf,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,pango,pki,protocols,pulse,resolv.conf,rpc,services,ssl,xdg
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/hugin.profile
+++ b/etc/profile-a-l/hugin.profile
@@ -38,7 +38,7 @@ novideo
 protocol unix
 seccomp
 
-private-bin align_image_stack,autooptimiser,calibrate_lens_gui,celeste_standalone,checkpto,cpclean,cpfind,deghosting_mask,enblend,exiftool,fulla,geocpset,hugin,hugin_executor,hugin_hdrmerge,hugin_lensdb,hugin_stitch_project,icpfind,linefind,nona,pano_modify,pano_trafo,perl,PTBatcherGUI,pto_gen,pto_lensstack,pto_mask,pto_merge,pto_move,pto_template,pto_var,sh,tca_correct,uname,verdandi,vig_optimize
+private-bin PTBatcherGUI,align_image_stack,autooptimiser,calibrate_lens_gui,celeste_standalone,checkpto,cpclean,cpfind,deghosting_mask,enblend,exiftool,fulla,geocpset,hugin,hugin_executor,hugin_hdrmerge,hugin_lensdb,hugin_stitch_project,icpfind,linefind,nona,pano_modify,pano_trafo,perl,pto_gen,pto_lensstack,pto_mask,pto_merge,pto_move,pto_template,pto_var,sh,tca_correct,uname,verdandi,vig_optimize
 private-cache
 private-dev
 private-tmp

--- a/etc/profile-a-l/lobster.profile
+++ b/etc/profile-a-l/lobster.profile
@@ -44,7 +44,7 @@ notv
 disable-mnt
 private-bin base64,bash,cat,command,curl,cut,date,dirname,echo,ffmpeg,ffprobe,find,fzf,grep,head,hxunent,ln,lobster,ls,mkdir,mkfifo,nano,nohup,openssl,patch,pgrep,ps,rm,rofi,sed,sh,sleep,socat,tail,tee,tput,tr,ueberzugpp,uname,uuidgen,vim,wc
 #private-cache
-private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,pango,pki,protocols,pulse,resolv.conf,rpc,services,ssl,X11,xdg
+private-etc X11,alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,pango,pki,protocols,pulse,resolv.conf,rpc,services,ssl,xdg
 private-tmp
 
 # Redirect

--- a/etc/profile-m-z/QMediathekView.profile
+++ b/etc/profile-m-z/QMediathekView.profile
@@ -72,7 +72,7 @@ seccomp
 tracelog
 
 disable-mnt
-private-bin mplayer,mpv,QMediathekView,smplayer,totem,vlc,xplayer
+private-bin QMediathekView,mplayer,mpv,smplayer,totem,vlc,xplayer
 private-cache
 private-dev
 private-etc @tls-ca

--- a/etc/profile-m-z/QOwnNotes.profile
+++ b/etc/profile-m-z/QOwnNotes.profile
@@ -47,7 +47,7 @@ seccomp
 tracelog
 
 disable-mnt
-private-bin gio,QOwnNotes
+private-bin QOwnNotes,gio
 private-dev
 private-etc @tls-ca,host.conf
 private-tmp

--- a/etc/profile-m-z/Viber.profile
+++ b/etc/profile-m-z/Viber.profile
@@ -31,7 +31,7 @@ protocol unix,inet,inet6
 seccomp !chroot
 
 disable-mnt
-private-bin awk,bash,dig,sh,Viber
+private-bin Viber,awk,bash,dig,sh
 private-etc @tls-ca,@x11,mailcap,proxychains.conf
 private-tmp
 

--- a/etc/profile-m-z/XMind.profile
+++ b/etc/profile-m-z/XMind.profile
@@ -31,7 +31,7 @@ protocol unix,inet,inet6
 seccomp
 
 disable-mnt
-private-bin cp,sh,XMind
+private-bin XMind,cp,sh
 private-tmp
 private-dev
 

--- a/etc/profile-m-z/mov-cli.profile
+++ b/etc/profile-m-z/mov-cli.profile
@@ -26,7 +26,7 @@ notv
 disable-mnt
 private-bin ffmpeg,fzf,mov-cli
 #private-cache
-private-etc alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,group,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,magic,magic.mgc,mime.types,nsswitch.conf,pango,passwd,pki,protocols,pulse,resolv.conf,rpc,services,ssl,X11,xdg
+private-etc X11,alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,group,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,magic,magic.mgc,mime.types,nsswitch.conf,pango,passwd,pki,protocols,pulse,resolv.conf,rpc,services,ssl,xdg
 private-tmp
 
 # Redirect

--- a/etc/profile-m-z/mutt.profile
+++ b/etc/profile-m-z/mutt.profile
@@ -127,7 +127,7 @@ tracelog
 #disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca,@x11,msmtprc,Mutt,Muttrc,Muttrc.d,gai.conf,gnupg,gnutls,hosts.conf,mail,mailname,nntpserver,terminfo
+private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gai.conf,gnupg,gnutls,hosts.conf,mail,mailname,msmtprc,nntpserver,terminfo
 private-tmp
 writable-run-user
 writable-var

--- a/etc/profile-m-z/natron.profile
+++ b/etc/profile-m-z/natron.profile
@@ -30,7 +30,7 @@ nou2f
 protocol unix
 seccomp
 
-private-bin natron,Natron,NatronRenderer
+private-bin Natron,NatronRenderer,natron
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/neomutt.profile
+++ b/etc/profile-m-z/neomutt.profile
@@ -119,7 +119,7 @@ tracelog
 #disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca,@x11,msmtprc,Mutt,Muttrc,Muttrc.d,gnupg,hosts.conf,mail,mailname,neomuttrc,neomuttrc.d,nntpserver
+private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gnupg,hosts.conf,mail,mailname,msmtprc,neomuttrc,neomuttrc.d,nntpserver
 private-tmp
 writable-run-user
 writable-var

--- a/etc/profile-m-z/postman.profile
+++ b/etc/profile-m-z/postman.profile
@@ -17,7 +17,7 @@ include whitelist-run-common.inc
 
 protocol unix,inet,inet6,netlink
 
-private-bin electron,electron[0-9],electron[0-9][0-9],locale,node,Postman,postman,sh
+private-bin Postman,electron,electron[0-9],electron[0-9][0-9],locale,node,postman,sh
 private-etc alternatives,ca-certificates,crypto-policies,fonts,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,nsswitch.conf,pki,resolv.conf,ssl
 # private-opt breaks file-copy-limit, use a whitelist instead of draining RAM
 # https://github.com/netblue30/firejail/discussions/5307

--- a/etc/profile-m-z/ppsspp.profile
+++ b/etc/profile-m-z/ppsspp.profile
@@ -39,7 +39,7 @@ novideo
 protocol unix,netlink
 seccomp
 
-private-bin ppsspp,PPSSPP,PPSSPPQt,PPSSPPSDL
+private-bin PPSSPP,PPSSPPQt,PPSSPPSDL,ppsspp
 # Add the next line to your ppsspp.local if you do not need controller support.
 #private-dev
 private-etc @tls-ca,@x11,host.conf

--- a/etc/profile-m-z/softmaker-common.profile
+++ b/etc/profile-m-z/softmaker-common.profile
@@ -42,7 +42,7 @@ tracelog
 private-bin freeoffice-planmaker,freeoffice-presentations,freeoffice-textmaker,planmaker18,planmaker18free,presentations18,presentations18free,sh,textmaker18,textmaker18free
 private-cache
 private-dev
-private-etc @tls-ca,fstab,SoftMaker
+private-etc @tls-ca,SoftMaker,fstab
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/telegram.profile
+++ b/etc/profile-m-z/telegram.profile
@@ -46,7 +46,7 @@ seccomp
 seccomp.block-secondary
 
 disable-mnt
-private-bin bash,sh,telegram,Telegram,telegram-desktop,xdg-open
+private-bin Telegram,bash,sh,telegram,telegram-desktop,xdg-open
 private-cache
 private-dev
 private-etc @tls-ca,@x11,os-release

--- a/etc/profile-m-z/transgui.profile
+++ b/etc/profile-m-z/transgui.profile
@@ -49,7 +49,7 @@ private-bin geoiplookup,geoiplookup6,transgui
 private-cache
 private-dev
 private-etc @network,@tls-ca,@x11
-private-lib libgdk_pixbuf-2.0.so.*,libGeoIP.so*,libgthread-2.0.so.*,libgtk-x11-2.0.so.*,libX11.so.*
+private-lib libGeoIP.so*,libX11.so.*,libgdk_pixbuf-2.0.so.*,libgthread-2.0.so.*,libgtk-x11-2.0.so.*
 private-tmp
 
 dbus-user none


### PR DESCRIPTION
To match how things are sorted elsewhere, such as with `noblacklist` /
`whitelist` lines (vertically) in profiles and in
ci/check/profiles/sort-disable-programs.sh and src/etc-cleanup/main.c.

This makes the order in `private-etc` always be groups (`@group`), then
uppercase paths, then lowercase paths.  Example from
etc/profile-m-z/softmaker-common.profile:

    private-etc @tls-ca,SoftMaker,fstab

Note that this does not affect a significant amount of profiles; most
changes are in `private-bin` / `private-lib` lines and in `private-etc`
lines for newer profiles that do not use groups.  This is partly due to
commit 5d0822c52 ("private-etc: big profile changes", 2023-02-05)
replacing `X11` with `@x11` in `private-etc` lines and then commit
0f996ea4d ("private-etc: groups modified", 2023-02-05) removing
`Trolltech.conf` from `private-etc` lines and using case-sensitive
sorting in them.

Relates to #5610.