### PR TITLE
discord.profile: allow /usr/share/discord

### DIFF
--- a/etc/profile-a-l/discord.profile
+++ b/etc/profile-a-l/discord.profile
@@ -11,6 +11,7 @@ mkdir ${HOME}/.config/discord
 whitelist ${HOME}/.config/discord
 whitelist /opt/Discord
 whitelist /opt/discord
+whitelist /usr/share/discord
 
 private-bin discord,Discord
 


### PR DESCRIPTION
[discord_arch_electron](https://aur.archlinux.org/packages/discord_arch_electron) stores its files in /usr/share/discord, rather than the usual /opt/discord. this commit simply adds that directory to the whitelist.