### PR TITLE
Fix displaying of large file sizes.

### DIFF
--- a/src/firejail/ls.c
+++ b/src/firejail/ls.c
@@ -154,7 +154,7 @@ static void print_file_or_dir(const char *path, const char *fname) {
 
 	// file size
 	char *sz;
-	if (asprintf(&sz, "%d", (int) s.st_size) == -1)
+	if (asprintf(&sz, "%jd", (intmax_t) s.st_size) == -1)
 		errExit("asprintf");
 
 	// file name


### PR DESCRIPTION
The most generic way is to use `intmax_t`
because we dont't know what is the "parent" type of `off_t`.
This fixes https://github.com/netblue30/firejail/issues/5982 .