### PR TITLE
steam.profile: noblacklist ~/.config/unity3d

### DIFF
--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -12,6 +12,7 @@ noblacklist ${HOME}/.config/MangoHud
 noblacklist ${HOME}/.config/ModTheSpire
 noblacklist ${HOME}/.config/RogueLegacy
 noblacklist ${HOME}/.config/RogueLegacyStorageContainer
+noblacklist ${HOME}/.config/unity3d
 noblacklist ${HOME}/.factorio
 noblacklist ${HOME}/.killingfloor
 noblacklist ${HOME}/.klei


### PR DESCRIPTION
unity3d folder missing noblacklist flag

[question] If a folder is whitelisted, then is it necessary to `noblacklist` it? 
