### PR TITLE
lutris.profile: allow mangohud

### DIFF
--- a/etc/profile-a-l/lutris.profile
+++ b/etc/profile-a-l/lutris.profile
@@ -11,6 +11,7 @@ noblacklist ${HOME}/Games
 noblacklist ${HOME}/.cache/lutris
 noblacklist ${HOME}/.cache/wine
 noblacklist ${HOME}/.cache/winetricks
+noblacklist ${HOME}/.config/MangoHud
 noblacklist ${HOME}/.config/lutris
 noblacklist ${HOME}/.local/share/lutris
 #noblacklist ${HOME}/.wine
@@ -45,6 +46,7 @@ whitelist ${HOME}/Games
 whitelist ${HOME}/.cache/lutris
 whitelist ${HOME}/.cache/wine
 whitelist ${HOME}/.cache/winetricks
+whitelist ${HOME}/.config/MangoHud
 whitelist ${HOME}/.config/lutris
 whitelist ${HOME}/.local/share/lutris
 #whitelist ${HOME}/.wine


### PR DESCRIPTION
Similarly to steam.profile (see #4864).

Fixes #6106.
