### PR TITLE
firecfg.config: drop geary

### DIFF
--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -308,7 +308,7 @@ gcloud
 gconf-editor
 gdu
 geany
-geary
+#geary # webkit2gtk-4.x requires bwrap (see #3647)
 gedit
 geekbench
 geeqie


### PR DESCRIPTION
Geary uses bubblewrap now.

Fixes #6103.