### PR TITLE
minecraft-launcher.profile: allow keyring access

### DIFF
--- a/etc/profile-m-z/minecraft-launcher.profile
+++ b/etc/profile-m-z/minecraft-launcher.profile
@@ -56,6 +56,7 @@ private-etc @tls-ca,@x11,host.conf,java*,mime.types,services,timezone
 private-opt minecraft-launcher
 private-tmp
 
+dbus-user filter
 dbus-user.talk org.freedesktop.secrets
 dbus-user.talk org.gnome.keyring.*
 dbus-user.talk org.gnome.seahorse.*

--- a/etc/profile-m-z/minecraft-launcher.profile
+++ b/etc/profile-m-z/minecraft-launcher.profile
@@ -25,6 +25,8 @@ include disable-xdg.inc
 
 mkdir ${HOME}/.minecraft
 whitelist ${HOME}/.minecraft
+# Needs keyring access in order to save logins
+whitelist ${RUNUSER}/keyring
 include whitelist-common.inc
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
@@ -54,7 +56,9 @@ private-etc @tls-ca,@x11,host.conf,java*,mime.types,services,timezone
 private-opt minecraft-launcher
 private-tmp
 
-dbus-user none
+dbus-user.talk org.freedesktop.secrets
+dbus-user.talk org.gnome.keyring.*
+dbus-user.talk org.gnome.seahorse.*
 dbus-system none
 
 restrict-namespaces


### PR DESCRIPTION
It turns out it is using it to save logins and will error out with just a generic "something went wrong, so we can not save your login".

I copied the directives from email-common.inc. Unsure which specific dbus topic thingy is actually used here but it works and I think it is fine to leave all 3.

Dear maintainers, if the ordering of the directives, my arch nemesis, is wrong, please apply your suggestion or edit without asking.