### PR TITLE
curl: add support for ~/.config/curlrc

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -411,6 +411,7 @@ blacklist ${HOME}/.config/com.github.bleakgrey.tootle
 blacklist ${HOME}/.config/com.lettura.dev
 blacklist ${HOME}/.config/corebird
 blacklist ${HOME}/.config/coyim
+blacklist ${HOME}/.config/curlrc
 blacklist ${HOME}/.config/d-feet
 blacklist ${HOME}/.config/darktable
 blacklist ${HOME}/.config/deadbeef

--- a/etc/profile-a-l/curl.profile
+++ b/etc/profile-a-l/curl.profile
@@ -7,6 +7,7 @@ include curl.local
 # Persistent global definitions
 include globals.local
 
+noblacklist ${HOME}/.config/curlrc # since curl 7.73.0
 # curl 7.74.0 introduces experimental support for HSTS cache
 # https://daniel.haxx.se/blog/2020/11/03/hsts-your-curl/
 # Technically this file can be anywhere but let's assume users have it in ${HOME}/.curl-hsts.


### PR DESCRIPTION
curl supports several locations for rc file according to its man page:
[...]
When curl is invoked, it (unless -q, --disable is used) checks for a default config file and uses it if found, even when -K, --config is used. The default config file is checked for in the following places in this order:
1) "$CURL_HOME/.curlrc"
2) "$XDG_CONFIG_HOME/curlrc" (Added in 7.73.0)
3) "$HOME/.curlrc"

[...]

This PR adds support for ~/.config/curlrc.