### PR TITLE
build: mkrpm.sh: append instead of override configure args

### DIFF
--- a/platform/rpm/mkrpm.sh
+++ b/platform/rpm/mkrpm.sh
@@ -14,7 +14,7 @@
 name="$TARNAME"
 # Strip any trailing prefix from the version like -rc1 etc
 version="$(printf '%s\n' "$VERSION" | sed 's/\-.*//g')"
-config_opt="$*"
+config_opt="--disable-userns --disable-contrib-install $*"
 
 if [[ ! -f "platform/rpm/${name}.spec" ]]; then
     printf 'error: spec file not found for name %s\n' "${name}" >&2
@@ -24,10 +24,6 @@ fi
 if [[ -z "${version}" ]]; then
     printf 'error: version must be given\n' >&2
     exit 1
-fi
-
-if [[ -z "${config_opt}" ]]; then
-    config_opt="--disable-userns --disable-contrib-install"
 fi
 
 # Make a temporary directory and arrange to clean up on exit


### PR DESCRIPTION
For consistency with mkdeb.sh.

Note: The default arguments and support for argument overriding was
added to to mkrpm.sh on commit 3d97332fd ("Add configure options when
building rpm (#3422)", 2020-05-19).

The support for appending arguments was added to mkdeb.sh on commit
9a0fbbd71 ("mkdeb.sh.in: pass remaining arguments to ./configure",
2022-05-13) / PR #5154.

Cc: @rusty-snake @sfc-gh-hyu (from #3422)
