### PR TITLE
mpv: whitelist /usr/share/mpv

### DIFF
--- a/etc/profile-a-l/chatterino.profile
+++ b/etc/profile-a-l/chatterino.profile
@@ -42,6 +42,7 @@ whitelist-ro ${HOME}/.config/mpv
 whitelist-ro ${HOME}/.config/pulse
 whitelist-ro ${HOME}/.config/vlc
 whitelist-ro ${HOME}/.local/share/vlc
+whitelist-ro /usr/share/mpv
 include whitelist-common.inc
 include whitelist-run-common.inc
 include whitelist-runuser-common.inc

--- a/etc/profile-a-l/firefox-common-addons.profile
+++ b/etc/profile-a-l/firefox-common-addons.profile
@@ -78,6 +78,7 @@ whitelist ${HOME}/.zotero
 whitelist ${HOME}/dwhelper
 whitelist /usr/share/lua
 whitelist /usr/share/lua*
+whitelist /usr/share/mpv
 
 # GNOME Shell integration (chrome-gnome-shell) needs dbus and python
 noblacklist ${HOME}/.local/share/gnome-shell

--- a/etc/profile-m-z/QMediathekView.profile
+++ b/etc/profile-m-z/QMediathekView.profile
@@ -47,6 +47,7 @@ whitelist ${HOME}/.local/share/totem
 whitelist ${HOME}/.local/share/xplayer
 whitelist ${HOME}/.local/state/mpv
 whitelist ${HOME}/.mplayer
+whitelist /usr/share/mpv
 whitelist /usr/share/qtchooser
 include whitelist-common.inc
 include whitelist-run-common.inc

--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -66,6 +66,7 @@ whitelist ${HOME}/yt-dlp.conf
 whitelist ${HOME}/yt-dlp.conf.txt
 whitelist /usr/share/lua
 whitelist /usr/share/lua*
+whitelist /usr/share/mpv
 include whitelist-common.inc
 include whitelist-player-common.inc
 include whitelist-usr-share-common.inc


### PR DESCRIPTION
use case, you install scripts in  `/usr/share/mpv` but they remain inactive. You then symlnk them to `/etc/mpv` to activate them if you want.

Question, isn't `whitelist /usr/share/lua` redundant because of `whitelist /usr/share/lua*` ?