### PR TITLE
Revert "Lookup xauth in PATH."

### DIFF
--- a/src/firejail/fs_lib2.c
+++ b/src/firejail/fs_lib2.c
@@ -166,12 +166,8 @@ void fslib_install_firejail(void) {
 		fslib_mount_libs(RUN_MNT_DIR "/dhclient", 1); // parse as user
 
 	// bring in xauth libraries
-
-	char *xauth_bin = find_in_path("xauth");
 	if (arg_x11_xorg)
-		fslib_mount_libs(xauth_bin, 1); // parse as user
-
-	free(xauth_bin);
+		fslib_mount_libs("/usr/bin/xauth", 1); // parse as user
 
 	fmessage("Firejail libraries installed in %0.2f ms\n", timetrace_end());
 }

--- a/src/firejail/x11.c
+++ b/src/firejail/x11.c
@@ -1164,6 +1164,7 @@ void x11_start(int argc, char **argv) {
 }
 #endif
 
+
 void x11_xorg(void) {
 #ifdef HAVE_X11
 
@@ -1174,38 +1175,31 @@ void x11_xorg(void) {
 		exit(1);
 	}
 
-	char *xauth_bin = find_in_path("xauth");
-
 	// check xauth utility is present in the system
-	if (!xauth_bin) {
-		fprintf(stderr, "Error: xauth utility not found in PATH. Please install it:\n");
+	struct stat s;
+	if (stat("/usr/bin/xauth", &s) == -1) {
+		fprintf(stderr, "Error: xauth utility not found in /usr/bin. Please install it:\n");
 		fprintf(stderr, "   Debian/Ubuntu/Mint: sudo apt-get install xauth\n");
 		fprintf(stderr, "   Arch: sudo pacman -S xorg-xauth\n");
 		fprintf(stderr, "   Fedora: sudo dnf install xorg-x11-xauth\n");
 		exit(1);
 	}
-
-	struct stat s;
-	if (stat(xauth_bin, &s) == -1) {
-		fprintf(stderr, "Error: %s: %s\n", xauth_bin, strerror(errno));
-		exit(1);
-	}
 	if ((s.st_uid != 0 && s.st_gid != 0) || (s.st_mode & S_IWOTH)) {
-		fprintf(stderr, "Error: invalid %s executable\n", xauth_bin);
+		fprintf(stderr, "Error: invalid /usr/bin/xauth executable\n");
 		exit(1);
 	}
 	if (s.st_size > 1024 * 1024) {
-		fprintf(stderr, "Error: %s executable is too large\n", xauth_bin);
+		fprintf(stderr, "Error: /usr/bin/xauth executable is too large\n");
 		exit(1);
 	}
-	// copy xauth in the sandbox and set mode to 0711
+	// copy /usr/bin/xauth in the sandbox and set mode to 0711
 	// users are not able to trace the running xauth this way
 	if (arg_debug)
-		printf("Copying %s to %s\n", xauth_bin, RUN_XAUTH_FILE);
-
-	copy_file_from_user_to_root(xauth_bin, RUN_XAUTH_FILE, 0, 0, 0711);
-
-	free(xauth_bin);
+		printf("Copying /usr/bin/xauth to %s\n", RUN_XAUTH_FILE);
+	if (copy_file("/usr/bin/xauth", RUN_XAUTH_FILE, 0, 0, 0711)) {
+		fprintf(stderr, "Error: cannot copy /usr/bin/xauth executable\n");
+		exit(1);
+	}
 
 	fmessage("Generating a new .Xauthority file\n");
 	mkdir_attr(RUN_XAUTHORITY_SEC_DIR, 0700, getuid(), getgid());


### PR DESCRIPTION
This reverts commit 407c05ebefe23e725f858b6170b3e52659e044a2.

If --private-lib is used (and firejail is configured with
--enable-private-lib), the following error occurs:

    $ firejail --quiet --noprofile --private-lib true
    firejail: fs_lib.c:56: find_in_path: Assertion `geteuid() != 0' failed.
    Error: proc 10000 cannot sync with peer: unexpected EOF
    Peer 10001 unexpectedly killed (Segmentation fault)

Given that it causes an uid assertion failure, the logic appears to not
be correct and the current behavior may be unsafe, so for now revert
that commit until the issue is properly addressed.

Relates to #6006 #6087.

Fixes #6113.

Cc: @chestnykh @hashelq