### PR TITLE
obs.profile: allow lua

### DIFF
--- a/etc/profile-m-z/obs.profile
+++ b/etc/profile-m-z/obs.profile
@@ -10,6 +10,9 @@ noblacklist ${MUSIC}
 noblacklist ${PICTURES}
 noblacklist ${VIDEOS}
 
+# Allow lua (blacklisted by disable-interpreters.inc)
+include allow-lua.inc
+
 # Allow python (blacklisted by disable-interpreters.inc)
 include allow-python2.inc
 include allow-python3.inc


### PR DESCRIPTION
Some plugins may require it[1]:

    error: os_dlopen([...]): libluajit-5.1.so.2: [...]: Permission denied

    warning: Module '/usr//lib/obs-plugins/frontend-tools.so' not loaded

[1] https://github.com/netblue30/firejail/issues/6130#issue-2040800338
