### PR TITLE
profiles: use only /usr/share/lua*

### DIFF
--- a/etc/inc/allow-lua.inc
+++ b/etc/inc/allow-lua.inc
@@ -8,5 +8,4 @@ noblacklist /usr/lib/liblua*
 noblacklist /usr/lib/lua
 noblacklist /usr/lib64/liblua*
 noblacklist /usr/lib64/lua
-noblacklist /usr/share/lua
 noblacklist /usr/share/lua*

--- a/etc/profile-a-l/firefox-common-addons.profile
+++ b/etc/profile-a-l/firefox-common-addons.profile
@@ -76,7 +76,6 @@ whitelist ${HOME}/.wine-pipelight
 whitelist ${HOME}/.wine-pipelight64
 whitelist ${HOME}/.zotero
 whitelist ${HOME}/dwhelper
-whitelist /usr/share/lua
 whitelist /usr/share/lua*
 whitelist /usr/share/mpv
 

--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -64,7 +64,6 @@ whitelist ${HOME}/.local/state/mpv
 whitelist ${HOME}/.netrc
 whitelist ${HOME}/yt-dlp.conf
 whitelist ${HOME}/yt-dlp.conf.txt
-whitelist /usr/share/lua
 whitelist /usr/share/lua*
 whitelist /usr/share/mpv
 include whitelist-common.inc

--- a/etc/profile-m-z/rhythmbox.profile
+++ b/etc/profile-m-z/rhythmbox.profile
@@ -26,7 +26,7 @@ include disable-shell.inc
 include disable-xdg.inc
 
 whitelist /usr/share/rhythmbox
-whitelist /usr/share/lua
+whitelist /usr/share/lua*
 whitelist /usr/share/libquvi-scripts
 whitelist /usr/share/tracker
 include whitelist-runuser-common.inc


### PR DESCRIPTION
To ensure that it includes luajit paths as well:

* /usr/share/lua
* /usr/share/luajit-2.1

And remove all entries of the same path without the wildcard, to avoid
redundancy.

Misc: The wildcard entries were added on commit 56b60dfd0 ("additional
Lua blacklisting (#3246)", 2020-02-24) and the entries without the
wildcard were partially removed on commit 721a984a5 ("Fix Lua in
disable-interpreters.inc", 2020-02-24).

This is a follow-up to #6128.

Reported-by: @pirate486743186