### PR TITLE
firecfg: use ignorelist also for .profile/.desktop files

### DIFF
--- a/src/firecfg/desktop_files.c
+++ b/src/firecfg/desktop_files.c
@@ -163,7 +163,8 @@ void fix_desktop_files(const char *homedir) {
 	// copy
 	struct dirent *entry;
 	while ((entry = readdir(dir)) != NULL) {
-		if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+		const char *filename = entry->d_name;
+		if (strcmp(filename, ".") == 0 || strcmp(filename, "..") == 0)
 			continue;
 
 		// skip if not regular file or link
@@ -172,10 +173,8 @@ void fix_desktop_files(const char *homedir) {
 			continue;
 
 		// skip if not .desktop file
-		if (strstr(entry->d_name,".desktop") != (entry->d_name+strlen(entry->d_name)-8))
+		if (strstr(filename, ".desktop") != (filename + strlen(filename) - 8))
 			continue;
-
-		char *filename = entry->d_name;
 
 		// skip links - Discord on Arch #4235 seems to be a symlink to /opt directory
 //		if (is_link(filename))

--- a/src/firecfg/firecfg.h
+++ b/src/firecfg/firecfg.h
@@ -50,6 +50,8 @@
 
 // main.c
 extern int arg_debug;
+int in_ignorelist(const char *const str);
+void parse_config_all(int do_symlink);
 
 // util.c
 int which(const char *program);

--- a/src/firecfg/main.c
+++ b/src/firecfg/main.c
@@ -314,17 +314,19 @@ static void set_links_homedir(const char *homedir) {
 		if (!exec)
 			errExit("strdup");
 		char *ptr = strrchr(exec, '.');
-		if (!ptr) {
-			free(exec);
-			continue;
-		}
-		if (strcmp(ptr, ".profile") != 0) {
-			free(exec);
-			continue;
-		}
+		if (!ptr)
+			goto next;
+		if (strcmp(ptr, ".profile") != 0)
+			goto next;
 
 		*ptr = '\0';
+		if (in_ignorelist(exec)) {
+			printf("   %s ignored\n", exec);
+			goto next;
+		}
+
 		set_file(exec, FIREJAIL_EXEC);
+next:
 		free(exec);
 	}
 	closedir(dir);

--- a/src/man/firecfg.1.in
+++ b/src/man/firecfg.1.in
@@ -168,7 +168,7 @@ Configuration file syntax:
 A line that starts with \fB#\fR is considered a comment.
 .br
 A line that starts with \fB!PROGRAM\fR means to ignore "PROGRAM" when creating
-symlinks.
+symlinks and fixing .desktop files.
 .br
 A line that starts with anything else is considered to be the name of an
 executable and firecfg will attempt to create a symlink for it.


### PR DESCRIPTION
Currently it is only used when parsing the configuration files:

* /etc/firecfg.d/*.conf
* /etc/firecfg.config

Use it when searching for .profile and .desktop files as well:

* ~/.config/firejail/*.profile
* /usr/share/applications/*.desktop

Closes #5245.

Relates to #5876.
