### PR TITLE
build: use full paths on compile/link targets

### DIFF
--- a/config.mk.in
+++ b/config.mk.in
@@ -81,7 +81,7 @@ LDFLAGS=@LDFLAGS@
 # Project variables
 EXTRA_CFLAGS  =@EXTRA_CFLAGS@
 COMMON_CFLAGS = \
-	-ggdb -O2 -DVERSION='"$(VERSION)"' -DMOD_DIR='"$(MOD_DIR)"' \
+	-ggdb -O2 -DVERSION='"$(VERSION)"' \
 	-Wall -Wextra $(HAVE_FATAL_WARNINGS) \
 	-Wformat -Wformat-security \
 	-fstack-protector-all -D_FORTIFY_SOURCE=2 \

--- a/src/etc-cleanup/Makefile
+++ b/src/etc-cleanup/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/etc-cleanup
-PROG = etc-cleanup
+MOD = etc-cleanup
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 EXTRA_HDRS = ../include/etc_groups.h

--- a/src/fbuilder/Makefile
+++ b/src/fbuilder/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/fbuilder
-PROG = fbuilder
+MOD = fbuilder
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 EXTRA_HDRS = ../include/common.h ../include/syscall.h

--- a/src/fcopy/Makefile
+++ b/src/fcopy/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/fcopy
-PROG = fcopy
+MOD = fcopy
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 EXTRA_HDRS = ../include/common.h ../include/syscall.h

--- a/src/fids/Makefile
+++ b/src/fids/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/fids
-PROG = fids
+MOD = fids
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 EXTRA_HDRS = ../include/common.h

--- a/src/firecfg/Makefile
+++ b/src/firecfg/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/firecfg
-PROG = firecfg
+MOD = firecfg
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 EXTRA_HDRS = \

--- a/src/firejail/Makefile
+++ b/src/firejail/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/firejail
-PROG = firejail
+MOD = firejail
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 EXTRA_HDRS = \

--- a/src/firemon/Makefile
+++ b/src/firemon/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/firemon
-PROG = firemon
+MOD = firemon
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 EXTRA_HDRS = ../include/common.h ../include/pid.h

--- a/src/fldd/Makefile
+++ b/src/fldd/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/fldd
-PROG = fldd
+MOD = fldd
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 EXTRA_HDRS = ../include/common.h ../include/syscall.h ../include/ldd_utils.h

--- a/src/fnet/Makefile
+++ b/src/fnet/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/fnet
-PROG = fnet
+MOD = fnet
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 EXTRA_HDRS = ../include/common.h ../include/libnetlink.h

--- a/src/fnetfilter/Makefile
+++ b/src/fnetfilter/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/fnetfilter
-PROG = fnetfilter
+MOD = fnetfilter
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 EXTRA_HDRS = ../include/common.h ../include/syscall.h

--- a/src/fnetlock/Makefile
+++ b/src/fnetlock/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/fnetlock
-PROG = fnetlock
+MOD = fnetlock
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 include $(ROOT)/src/prog.mk

--- a/src/fnettrace-dns/Makefile
+++ b/src/fnettrace-dns/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/fnettrace-dns
-PROG = fnettrace-dns
+MOD = fnettrace-dns
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 include $(ROOT)/src/prog.mk

--- a/src/fnettrace-icmp/Makefile
+++ b/src/fnettrace-icmp/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/fnettrace-icmp
-PROG = fnettrace-icmp
+MOD = fnettrace-icmp
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 include $(ROOT)/src/prog.mk

--- a/src/fnettrace-sni/Makefile
+++ b/src/fnettrace-sni/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/fnettrace-sni
-PROG = fnettrace-sni
+MOD = fnettrace-sni
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 include $(ROOT)/src/prog.mk

--- a/src/fnettrace/Makefile
+++ b/src/fnettrace/Makefile
@@ -2,12 +2,13 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/fnettrace
-PROG = fnettrace
+MOD = fnettrace
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 include $(ROOT)/src/prog.mk
 
 all: $(TARGET) static-ip-map
-static-ip-map: static-ip-map.txt fnettrace
-	./fnettrace --squash-map=static-ip-map.txt > static-ip-map
+static-ip-map: static-ip-map.txt $(PROG)
+	./$(PROG) --squash-map=static-ip-map.txt > static-ip-map

--- a/src/fsec-optimize/Makefile
+++ b/src/fsec-optimize/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/fsec-optimize
-PROG = fsec-optimize
+MOD = fsec-optimize
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 EXTRA_HDRS = ../include/common.h ../include/seccomp.h ../include/syscall.h

--- a/src/fsec-print/Makefile
+++ b/src/fsec-print/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/fsec-print
-PROG = fsec-print
+MOD = fsec-print
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 EXTRA_HDRS = ../include/common.h ../include/seccomp.h ../include/syscall.h

--- a/src/fseccomp/Makefile
+++ b/src/fseccomp/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/fseccomp
-PROG = fseccomp
+MOD = fseccomp
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 EXTRA_HDRS = ../include/common.h ../include/syscall.h

--- a/src/ftee/Makefile
+++ b/src/ftee/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/ftee
-PROG = ftee
+MOD = ftee
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 include $(ROOT)/src/prog.mk

--- a/src/fzenity/Makefile
+++ b/src/fzenity/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/fzenity
-PROG = fzenity
+MOD = fzenity
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 EXTRA_HDRS = ../include/common.h

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -41,8 +41,8 @@
 
 #define errExit(msg) do { \
 	char msgout[500]; \
-	snprintf(msgout, 500, "Error %s/%s:%d: %s: %s", \
-	         MOD_DIR, __FILE__, __LINE__, __func__, msg); \
+	snprintf(msgout, 500, "Error %s:%d: %s: %s", \
+	         __FILE__, __LINE__, __func__, msg); \
 	perror(msgout); \
 	exit(1); \
 } while (0)

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -41,7 +41,7 @@
 
 #define errExit(msg) do { \
 	char msgout[500]; \
-	snprintf(msgout, 500, "Error %s/%s:%d %s(): %s", \
+	snprintf(msgout, 500, "Error %s/%s:%d: %s: %s", \
 	         MOD_DIR, __FILE__, __LINE__, __func__, msg); \
 	perror(msgout); \
 	exit(1); \

--- a/src/jailcheck/Makefile
+++ b/src/jailcheck/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/jailcheck
-PROG = jailcheck
+MOD = jailcheck
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 EXTRA_HDRS = ../include/common.h ../include/pid.h

--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -2,7 +2,8 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/lib
+MOD = lib
+MOD_DIR = $(ROOT)/src/$(MOD)
 TARGET = lib
 
 include $(ROOT)/src/prog.mk

--- a/src/libpostexecseccomp/Makefile
+++ b/src/libpostexecseccomp/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/libpostexecseccomp
-SO = libpostexecseccomp.so
+MOD = libpostexecseccomp
+MOD_DIR = $(ROOT)/src/$(MOD)
+SO = $(MOD_DIR)/$(MOD).so
 TARGET = $(SO)
 
 EXTRA_HDRS = ../include/seccomp.h ../include/rundefs.h

--- a/src/libtrace/Makefile
+++ b/src/libtrace/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/libtrace
-SO = libtrace.so
+MOD = libtrace
+MOD_DIR = $(ROOT)/src/$(MOD)
+SO = $(MOD_DIR)/$(MOD).so
 TARGET = $(SO)
 
 include $(ROOT)/src/so.mk

--- a/src/libtracelog/Makefile
+++ b/src/libtracelog/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/libtracelog
-SO = libtracelog.so
+MOD = libtracelog
+MOD_DIR = $(ROOT)/src/$(MOD)
+SO = $(MOD_DIR)/$(MOD).so
 TARGET = $(SO)
 
 EXTRA_HDRS = ../include/rundefs.h

--- a/src/profstats/Makefile
+++ b/src/profstats/Makefile
@@ -2,8 +2,9 @@
 ROOT = ../..
 -include $(ROOT)/config.mk
 
-MOD_DIR = src/profstats
-PROG = profstats
+MOD = profstats
+MOD_DIR = $(ROOT)/src/$(MOD)
+PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
 EXTRA_HDRS = ../include/common.h

--- a/src/prog.mk
+++ b/src/prog.mk
@@ -5,8 +5,8 @@
 # The includer should probably define PROG and TARGET and may also want to
 # define EXTRA_HDRS and EXTRA_OBJS and extend CLEANFILES.
 
-HDRS := $(sort $(wildcard *.h)) $(EXTRA_HDRS)
-SRCS := $(sort $(wildcard *.c))
+HDRS := $(sort $(wildcard $(MOD_DIR)/*.h)) $(EXTRA_HDRS)
+SRCS := $(sort $(wildcard $(MOD_DIR)/*.c))
 OBJS := $(SRCS:.c=.o) $(EXTRA_OBJS)
 
 .PHONY: all

--- a/src/so.mk
+++ b/src/so.mk
@@ -5,8 +5,8 @@
 # The includer should probably define SO and TARGET and may also want to define
 # EXTRA_HDRS and EXTRA_OBJS and extend CLEANFILES.
 
-HDRS := $(sort $(wildcard *.h)) $(EXTRA_HDRS)
-SRCS := $(sort $(wildcard *.c))
+HDRS := $(sort $(wildcard $(MOD_DIR)/*.h)) $(EXTRA_HDRS)
+SRCS := $(sort $(wildcard $(MOD_DIR)/*.c))
 OBJS := $(SRCS:.c=.o) $(EXTRA_OBJS)
 
 .PHONY: all


### PR DESCRIPTION
This makes the compile commands clearer when building in parallel (with
`make -j`) and ensures that `__FILE__` includes the full build-time path
(relative to the root of the repository) whenever it is referenced, such
as in failed assert() messages (currently the full path is only shown in
errExit() messages).  Example:

Before:

    firejail: main.c:100: main: Assertion `1 == 2' failed.
    Error src/firecfg/main.c:100: main: malloc: Cannot allocate memory

After:

    firejail: ../../src/firejail/main.c:100: main: Assertion `1 == 2' failed.
    Error ../../src/firecfg/main.c:100: main: malloc: Cannot allocate memory

Commands used to search and replace:

    $ git grep -Ilz '^MOD_DIR =' -- '*Makefile' | xargs -0 -I '{}' \
      sh -c "printf '%s\n' \"\$(sed -E \
        -e 's|^MOD_DIR = src/(.*)|MOD = \\1\\nMOD_DIR = \$(ROOT)/src/\$(MOD)|' \
        -e 's:^(PROG|SO) = [^.]+(\.so)?$:\\1 = \$(MOD_DIR)/\$(MOD)\2:' \
        '{}')\" >'{}'"
    $ git grep -Ilz '^HDRS :=' -- '*.mk' | xargs -0 -I '{}' \
      sh -c "printf '%s\n' \"\$(sed -E \
        -e 's|wildcard (\*\..)|wildcard \$(MOD_DIR)/\\1|' '{}')\" >'{}'"

Note: config.mk.in, src/fnettrace/Makefile and src/include/common.h were
edited manually.

This is a follow-up to #5871.