### PR TITLE
tesseract.profile: add quiet

### DIFF
--- a/etc/profile-m-z/tesseract.profile
+++ b/etc/profile-m-z/tesseract.profile
@@ -1,6 +1,7 @@
 # Firejail profile for tesseract
 # Description: An OCR program
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include tesseract.local
 # Persistent global definitions


### PR DESCRIPTION
Tesseract is a CLI program and its output may be parsed by other
programs (such as `ocrmypdf`).  Including messages from firejail in the
output may break the parsing, so remove them.

Fixes #6171.

Reported-by: @kmille