### PR TITLE
ci: add timeout limits

### DIFF
--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -41,6 +41,7 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
   build-clang:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,7 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
   build:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895

--- a/.github/workflows/check-c.yml
+++ b/.github/workflows/check-c.yml
@@ -43,6 +43,7 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
   scan-build:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895
@@ -74,6 +75,7 @@ jobs:
 
   cppcheck:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895
@@ -101,6 +103,7 @@ jobs:
   # scan all files also with older cppcheck version from ubuntu 20.04.
   cppcheck_old:
     runs-on: ubuntu-20.04
+    timeout-minutes: 10
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895
@@ -129,6 +132,7 @@ jobs:
       contents: read
       security-events: write
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
     - name: Harden Runner

--- a/.github/workflows/check-profiles.yml
+++ b/.github/workflows/check-profiles.yml
@@ -29,6 +29,8 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
   profile-checks:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895

--- a/.github/workflows/check-python.yml
+++ b/.github/workflows/check-python.yml
@@ -27,6 +27,7 @@ jobs:
       contents: read
       security-events: write
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
     - name: Harden Runner

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -21,6 +21,7 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
   codespell:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
   test-main:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     env:
       SHELL: /bin/bash
     steps:
@@ -96,6 +97,7 @@ jobs:
 
   test-fs:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     env:
       SHELL: /bin/bash
     steps:
@@ -134,6 +136,7 @@ jobs:
 
   test-environment:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     env:
       SHELL: /bin/bash
     steps:
@@ -172,6 +175,7 @@ jobs:
 
   test-utils:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     env:
       SHELL: /bin/bash
     steps:
@@ -212,6 +216,7 @@ jobs:
 
   test-network:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     env:
       SHELL: /bin/bash
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,7 @@
 
 build_ubuntu_package:
     image: ubuntu:rolling
+    timeout: 10 minutes
     variables:
         DEBIAN_FRONTEND: noninteractive
     script:
@@ -24,6 +25,7 @@ build_ubuntu_package:
 
 build_debian_package:
     image: debian:buster
+    timeout: 10 minutes
     variables:
         DEBIAN_FRONTEND: noninteractive
     script:
@@ -40,6 +42,7 @@ build_debian_package:
 
 build_redhat_package:
     image: almalinux:latest
+    timeout: 10 minutes
     script:
         - dnf update -y
         - dnf install -y rpm-build gcc make
@@ -51,6 +54,7 @@ build_redhat_package:
 
 build_fedora_package:
     image: fedora:latest
+    timeout: 10 minutes
     script:
         - dnf update -y
         - dnf install -y rpm-build gcc make
@@ -62,6 +66,7 @@ build_fedora_package:
 
 build_src_package:
     image: alpine:latest
+    timeout: 10 minutes
     script:
         - apk update
         - apk upgrade
@@ -74,6 +79,7 @@ build_src_package:
 
 build_no_apparmor:
     image: ubuntu:latest
+    timeout: 10 minutes
     variables:
         DEBIAN_FRONTEND: noninteractive
     script:
@@ -92,6 +98,7 @@ build_no_apparmor:
 
 debian_ci:
     image: registry.salsa.debian.org/salsa-ci-team/ci-image-git-buildpackage:latest
+    timeout: 10 minutes
     variables:
         DEBFULLNAME: "$GITLAB_USER_NAME"
         DEBEMAIL: "$GITLAB_USER_EMAIL"


### PR DESCRIPTION
So that they fail early instead of letting them run indefinitely when
there are problems with the CI infrastructure.

Use 5 minutes for the jobs that usually complete in under a minute
(check-profiles and codespell) and 10 minutes for the rest (most jobs
usually take 1-3 minutes).