### PR TITLE
crawl.profile: allow lua

### DIFF
--- a/etc/profile-a-l/crawl.profile
+++ b/etc/profile-a-l/crawl.profile
@@ -8,6 +8,9 @@ include globals.local
 
 noblacklist ${HOME}/.crawl
 
+# Allow lua (blacklisted by disable-interpreters.inc)
+include allow-lua.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc


### PR DESCRIPTION
Add common Lua include to crawl.profile (Dungeon Crawl Stone Soup) to allow Lua libraries, as both the ncurses and tiles executables are dynamically linked to Lua.