### PR TITLE
geeqie.profile: allow lua interpreter

### DIFF
--- a/etc/profile-a-l/geeqie.profile
+++ b/etc/profile-a-l/geeqie.profile
@@ -10,6 +10,9 @@ noblacklist ${HOME}/.cache/geeqie
 noblacklist ${HOME}/.config/geeqie
 noblacklist ${HOME}/.local/share/geeqie
 
+# Allow lua (blacklisted by disable-interpreters.inc)
+include allow-lua.inc
+
 # Allow perl (blacklisted by disable-interpreters.inc)
 include allow-perl.inc
 


### PR DESCRIPTION
Recent versions of [geeqie](https://www.geeqie.org/) use a LUA interpreter, like the one in Arch Linux (2.2).

Without this fix it fails with:

```
/usr/bin/geeqie: error while loading shared libraries: liblua.so.5.4: cannot open shared object file: Permission denied
```