### PR TITLE
security: fix sscanf rv checks (CodeQL)

### DIFF
--- a/src/firejail/restrict_users.c
+++ b/src/firejail/restrict_users.c
@@ -210,9 +210,9 @@ static void sanitize_passwd(void) {
 			goto errout;
 
 		// process uid
-		int uid;
+		int uid = -1;
 		int rv = sscanf(ptr, "%d:", &uid);
-		if (rv == 0 || uid < 0)
+		if (rv != 1 || uid < 0)
 			goto errout;
 		assert(uid_min);
 		if (uid < uid_min || uid == 65534) { // on Debian platforms user nobody is 65534
@@ -349,9 +349,9 @@ static void sanitize_group(void) {
 			goto errout;
 
 		// process uid
-		int gid;
+		int gid = -1;
 		int rv = sscanf(ptr, "%d:", &gid);
-		if (rv == 0 || gid < 0)
+		if (rv != 1 || gid < 0)
 			goto errout;
 		assert(gid_min);
 		if (gid < gid_min || gid == 65534) { // on Debian platforms 65534 is group nogroup


### PR DESCRIPTION
Fix the following CodeQL warning (CWE-253)[1]:

> Rule ID: cpp/incorrectly-checked-scanf

> The result of scanf is only checked against 0, but it can also return
> EOF.

> Functions in the scanf family return either EOF (a negative value) in
> case of IO failure, or the number of items successfully read from the
> input.  Consequently, a simple check that the return value is nonzero
> is not enough.
>
> Recommendation
>
> Ensure that all uses of scanf check the return value against the
> expected number of arguments rather than just against zero.

Note: The affected code portions attempt to read values from /etc/passwd
and /etc/group, so invalid input seems unlikely to be the case.  Either
way, the changes make the checks in question more consistent with
similar sscanf return value checks in the rest of the code.

Added on commit 4f003daec ("prevent leaking user information by
modifying /home directory, /etc/passwd and /etc/group", 2015-11-19).

[1] https://github.com/netblue30/firejail/security/code-scanning/32