### PR TITLE
landlock: fix struct initialization

### DIFF
--- a/src/firejail/landlock.c
+++ b/src/firejail/landlock.c
@@ -83,7 +83,7 @@ out:
 }
 
 static int ll_create_full_ruleset(void) {
-	struct landlock_ruleset_attr attr;
+	struct landlock_ruleset_attr attr = {0};
 	attr.handled_access_fs =
 		LANDLOCK_ACCESS_FS_EXECUTE |
 		LANDLOCK_ACCESS_FS_MAKE_BLOCK |
@@ -133,7 +133,7 @@ static void _ll_fs(const char *allowed_path, const __u64 allowed_access,
 		return;
 	}
 
-	struct landlock_path_beneath_attr target;
+	struct landlock_path_beneath_attr target = {0};
 	target.parent_fd = allowed_fd;
 	target.allowed_access = allowed_access;
 	int error = landlock_add_rule(ll_ruleset_fd, LANDLOCK_RULE_PATH_BENEATH,


### PR DESCRIPTION
Recently (as of Landlock ABI 4), the `handled_access_net` field was
added to the `landlock_ruleset_attr` struct in the Linux kernel (in
linux/landlock.h).  In src/firejail/landlock.c, that field is not being
set in the struct (as we currently do not use it) before passing it to
the `landlock_create_full_ruleset` syscall, so it is likely to contain
random garbage when used, resulting in the syscall returning EINVAL:

    $ firejail --debug --profile=/etc/firejail/landlock-common.inc \
      --landlock.enforce true
    [...]
    ll_is_supported: Detected Landlock ABI version 4
    ll_restrict: Starting Landlock restrict
    ll_create_full_ruleset: Creating Landlock ruleset (abi=4 fs=1fff)
    Error: ll_create_full_ruleset: failed to create Landlock ruleset (abi=4 fs=1fff): Invalid argument
    ll_read: Adding Landlock rule (abi=4 fs=c) for /
    Error: ll_read: failed to add Landlock rule (abi=4 fs=c) for /: Bad file descriptor
    [...]
    Not enforcing Landlock

So ensure that all structs in src/firejail/landlock.c are initialized to
0 before using them.

Note: Arch has recently (2024-01-31) updated the linux-api-headers
package from version 6.4-1 to 6.7-1[1].  The former version is not affected
(as it does not contain the extra struct field in linux/landlock.h),
while the latter is.

Fixes #6195.

Relates to #6078.

[1] https://gitlab.archlinux.org/archlinux/packaging/packages/linux-api-headers/-/commit/b4223b0c2bfba54c26acc4dc289415b81b15989f

Reported-by: @curiosityseeker