### PR TITLE
gnome-keyring: harden and add gnome-keyring-daemon.profile

### DIFF
--- a/etc/profile-a-l/gnome-keyring-daemon.profile
+++ b/etc/profile-a-l/gnome-keyring-daemon.profile
@@ -1,0 +1,62 @@
+# Firejail profile for gnome-keyring-daemon
+# Description: Stores passwords and encryption keys
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include gnome-keyring-daemon.local
+# Persistent global definitions
+include globals.local
+
+blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-programs.inc
+#include disable-X11.inc # x11 none
+include disable-xdg.inc
+
+whitelist ${RUNUSER}/gnupg
+whitelist ${RUNUSER}/keyring
+whitelist /usr/share/gnupg
+whitelist /usr/share/gnupg2
+include whitelist-common.inc
+include whitelist-runuser-common.inc
+include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
+
+apparmor
+caps.drop all
+ipc-namespace
+machine-id
+netfilter
+no3d
+nodvd
+nogroups
+noinput
+nonewprivs
+noroot
+nosound
+notv
+nou2f
+novideo
+protocol unix,inet,inet6
+seccomp
+seccomp.block-secondary
+tracelog
+x11 none
+
+disable-mnt
+#private-bin gnome-keyrin*,secret-tool
+private-cache
+private-dev
+#private-lib alternatives,gnome-keyring,libsecret-1.so.*,pkcs11,security
+private-tmp
+
+#dbus-user none
+dbus-system none
+
+memory-deny-write-execute
+restrict-namespaces

--- a/etc/profile-a-l/gnome-keyring.profile
+++ b/etc/profile-a-l/gnome-keyring.profile
@@ -1,7 +1,6 @@
 # Firejail profile for gnome-keyring
 # Description: Stores passwords and encryption keys
 # This file is overwritten after every install/update
-quiet
 # Persistent local customizations
 include gnome-keyring.local
 # Persistent global definitions
@@ -9,11 +8,15 @@ include globals.local
 
 noblacklist ${HOME}/.gnupg
 
+blacklist /tmp/.X11-unix
+blacklist ${RUNUSER}/wayland-*
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
+#include disable-X11.inc # x11 none
 include disable-xdg.inc
 
 mkdir ${HOME}/.gnupg
@@ -47,6 +50,7 @@ protocol unix,inet,inet6
 seccomp
 seccomp.block-secondary
 tracelog
+x11 none
 
 disable-mnt
 #private-bin gnome-keyrin*,secret-tool

--- a/etc/profile-a-l/gnome-keyring.profile
+++ b/etc/profile-a-l/gnome-keyring.profile
@@ -4,63 +4,14 @@
 # Persistent local customizations
 include gnome-keyring.local
 # Persistent global definitions
-include globals.local
+# added by included profile
+#include globals.local
 
 noblacklist ${HOME}/.gnupg
-
-blacklist /tmp/.X11-unix
-blacklist ${RUNUSER}/wayland-*
-
-include disable-common.inc
-include disable-devel.inc
-include disable-exec.inc
-include disable-interpreters.inc
-include disable-programs.inc
-#include disable-X11.inc # x11 none
-include disable-xdg.inc
 
 mkdir ${HOME}/.gnupg
 whitelist ${HOME}/.gnupg
 whitelist ${DOWNLOADS}
-whitelist ${RUNUSER}/gnupg
-whitelist ${RUNUSER}/keyring
-whitelist /usr/share/gnupg
-whitelist /usr/share/gnupg2
-include whitelist-common.inc
-include whitelist-runuser-common.inc
-include whitelist-usr-share-common.inc
-include whitelist-var-common.inc
 
-apparmor
-caps.drop all
-ipc-namespace
-machine-id
-netfilter
-no3d
-nodvd
-nogroups
-noinput
-nonewprivs
-noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix,inet,inet6
-seccomp
-seccomp.block-secondary
-tracelog
-x11 none
-
-disable-mnt
-#private-bin gnome-keyrin*,secret-tool
-private-cache
-private-dev
-#private-lib alternatives,gnome-keyring,libsecret-1.so.*,pkcs11,security
-private-tmp
-
-#dbus-user none
-dbus-system none
-
-memory-deny-write-execute
-restrict-namespaces
+# Redirect
+include gnome-keyring-daemon.profile

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -342,6 +342,9 @@ gnome-contacts
 gnome-documents
 gnome-font-viewer
 gnome-hexgl
+gnome-keyring
+gnome-keyring-3
+gnome-keyring-daemon
 gnome-klotski
 gnome-latex
 gnome-logs


### PR DESCRIPTION
We were missing a profile for gnome-keyring-daemon. Let's bring that in.
Also slightly hardened gnome-keyring.profile.