### PR TITLE
enchant-lsmod-2: redirect to enchant-2

### DIFF
--- a/etc/profile-a-l/enchant-lsmod-2.profile
+++ b/etc/profile-a-l/enchant-lsmod-2.profile
@@ -7,4 +7,4 @@ include enchant-lsmod-2.local
 #include globals.local
 
 # Redirect
-include enchant.profile
+include enchant-2.profile


### PR DESCRIPTION
Keep our include logic intact by redirecting to enchant-2.profile.