### PR TITLE
multimc: instances not running, because of missing permissions

### DIFF
--- a/etc/profile-m-z/multimc5.profile
+++ b/etc/profile-m-z/multimc5.profile
@@ -8,10 +8,15 @@ include globals.local
 noblacklist ${HOME}/.local/share/multimc
 noblacklist ${HOME}/.local/share/multimc5
 noblacklist ${HOME}/.multimc5
+noblacklist ${HOME}/.cache/JNA
+noblacklist /tmp/lwjgl_*
 
 # Ignore noexec on ${HOME} as MultiMC installs LWJGL native
 # libraries in ${HOME}/.local/share/multimc
 ignore noexec ${HOME}
+
+# Ignore noexec on /tmp as LWJGL extracts libraries to /tmp
+ignore noexec /tmp
 
 # Allow java (blacklisted by disable-devel.inc)
 include allow-java.inc
@@ -25,9 +30,12 @@ include disable-programs.inc
 mkdir ${HOME}/.local/share/multimc
 mkdir ${HOME}/.local/share/multimc5
 mkdir ${HOME}/.multimc5
+mkdir ${HOME}/.cache/JNA
 whitelist ${HOME}/.local/share/multimc
 whitelist ${HOME}/.local/share/multimc5
 whitelist ${HOME}/.multimc5
+whitelist ${HOME}/.cache/JNA
+whitelist /tmp/lwjgl_*
 include whitelist-common.inc
 
 caps.drop all
@@ -48,5 +56,8 @@ disable-mnt
 #private-bin apt-file,awk,bash,chmod,dirname,dnf,grep,java,kdialog,ldd,mkdir,multimc5,pfl,pkgfile,readlink,sort,valgrind,which,yum,zenity,zypper
 private-dev
 private-tmp
+
+dbus-user none
+dbus-system none
 
 #restrict-namespaces


### PR DESCRIPTION
When starting an instance, in the logs, a failed attempt to load the lwjgl library is shown and the game doesn't run.
The library is in the /tmp directory. The reason for this appears to be, in the lwjgl source code, the shared library loading function, extracts in the temporary directory and continues from there. This is fixed by whitelisting.

The reason for adding "ignore noexec /tmp" as well, is that without it, the game can't run, even if the directory is whitelisted. It seems the library needs to be loaded from /tmp.

A second error for a failed attempt to access /home/user/.cache/JNA is also shown in the logs. This is also fixed by whitelisting.

The errors which inspired the commit:
```
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.UnsatisfiedLinkError: /home/user/.cache/JNA/temp/jna205883382989158645.tmp: /home/user/.cache/JNA/temp/jna205883382989158645.tmp: failed to map segment from shared object [in thread "main"]
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.UnsatisfiedLinkError: /tmp/lwjgl_user/3.3.2+13/x64/liblwjgl.so: /tmp/lwjgl_user/3.3.2+13/x64/liblwjgl.so: failed to map segment from shared object [in thread "Render thread"]
```

Links to the source code that should be responsible for the /tmp error:

https://github.com/LWJGL/lwjgl3/blob/56d09c39ff26ad49c74f6be6884d60ef3f597384/modules/lwjgl/core/src/main/java/org/lwjgl/system/SharedLibraryLoader.java#L51

https://github.com/LWJGL/lwjgl3/blob/56d09c39ff26ad49c74f6be6884d60ef3f597384/modules/lwjgl/core/src/main/java/org/lwjgl/system/SharedLibraryLoader.java#L137
