### PR TITLE
build: move errExit macro into inline function

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -39,13 +39,15 @@
 // dbus proxy path used by firejail and firemon
 #define XDG_DBUS_PROXY_PATH "/usr/bin/xdg-dbus-proxy"
 
-#define errExit(msg) do { \
-	char msgout[500]; \
-	snprintf(msgout, 500, "Error %s:%d: %s: %s", \
-	         __FILE__, __LINE__, __func__, msg); \
-	perror(msgout); \
-	exit(1); \
-} while (0)
+#define errExit(msg) _errExit(__FILE__, __LINE__, __func__, msg)
+
+static inline void __attribute__((noreturn))
+_errExit(const char *fname, int lineno, const char *func, const char *msg) {
+	char msgout[500];
+	snprintf(msgout, 500, "Error %s:%d: %s: %s", fname, lineno, func, msg);
+	perror(msgout);
+	exit(1);
+}
 
 // macro to print ip addresses in a printf statement
 #define PRINT_IP(A) \


### PR DESCRIPTION

Move most of the `errExit` macro into a new `_errExit` inline function
and use the former just to forward arguments to the latter.

This reduces the noise in the build output when using `-fanalyzer`, as
it causes the `errExit` macro to stop being expanded.

For example, the complete output of the following warning in
src/firejail/dbus.c is reduced from 243 lines to 141 lines (a ~41%
reduction):

    $ pacman -Q gcc
    gcc 13.2.1-5
    $ ./configure --enable-apparmor --enable-analyzer >/dev/null &&
      make clean >/dev/null && make >/dev/null
    [...]
    ../../src/firejail/dbus.c: In function ‘dbus_proxy_start’:
    ../../src/firejail/dbus.c:311:36: warning: leak of file descriptor ‘dup2(output_fd, 1)’ [CWE-775] [-Wanalyzer-fd-leak]
      311 |                                 if (dup2(output_fd, STDOUT_FILENO) != STDOUT_FILENO)
    [...]
             ‘dbus_create_user_dir’: event 5
               |
               |../../src/firejail/../include/common.h:42:25:
               |   42 | #define errExit(msg) do { \
               |      |                         ^
               |      |                         |
               |      |                         (5) ...to here
    ../../src/firejail/dbus.c:239:17: note: in expansion of macro ‘errExit’
               |  239 |                 errExit("asprintf");
               |      |                 ^~~~~~~
    [...]

Relates to #6190.