### PR TITLE
profiles: drop paths already in wusc

### DIFF
--- a/etc/profile-a-l/alacarte.profile
+++ b/etc/profile-a-l/alacarte.profile
@@ -21,7 +21,6 @@ include disable-xdg.inc
 whitelist /usr/share/alacarte
 whitelist /usr/share/app-info
 whitelist /usr/share/desktop-directories
-whitelist /usr/share/icons
 whitelist /var/lib/app-info/icons
 whitelist /var/lib/flatpak/exports/share/applications
 whitelist /var/lib/flatpak/exports/share/icons

--- a/etc/profile-a-l/apostrophe.profile
+++ b/etc/profile-a-l/apostrophe.profile
@@ -32,7 +32,6 @@ include disable-xdg.inc
 
 whitelist /usr/libexec/webkit2gtk-4.0
 whitelist /usr/share/apostrophe
-whitelist /usr/share/texlive
 whitelist /usr/share/texmf
 whitelist /usr/share/pandoc-*
 include whitelist-runuser-common.inc

--- a/etc/profile-a-l/equalx.profile
+++ b/etc/profile-a-l/equalx.profile
@@ -23,7 +23,6 @@ whitelist ${HOME}/.config/equalx
 whitelist ${HOME}/.equalx
 whitelist /usr/share/poppler
 whitelist /usr/share/ghostscript
-whitelist /usr/share/texlive
 whitelist /usr/share/equalx
 whitelist /var/lib/texmf
 include whitelist-common.inc

--- a/etc/profile-a-l/ghostwriter.profile
+++ b/etc/profile-a-l/ghostwriter.profile
@@ -23,7 +23,6 @@ include disable-xdg.inc
 
 whitelist /usr/share/ghostwriter
 whitelist /usr/share/mozilla-dicts
-whitelist /usr/share/texlive
 whitelist /usr/share/pandoc*
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/gnome-latex.profile
+++ b/etc/profile-a-l/gnome-latex.profile
@@ -19,7 +19,6 @@ include disable-interpreters.inc
 include disable-programs.inc
 
 whitelist /usr/share/gnome-latex
-whitelist /usr/share/texlive
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 # May cause issues.

--- a/etc/profile-a-l/impressive.profile
+++ b/etc/profile-a-l/impressive.profile
@@ -23,7 +23,6 @@ include disable-xdg.inc
 
 mkdir ${HOME}/.cache/mesa_shader_cache
 whitelist /usr/share/opengl-games-utils
-whitelist /usr/share/zenity
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 

--- a/etc/profile-a-l/lyx.profile
+++ b/etc/profile-a-l/lyx.profile
@@ -23,7 +23,6 @@ include allow-python3.inc
 
 whitelist /usr/share/lyx
 whitelist /usr/share/texinfo
-whitelist /usr/share/texlive
 whitelist /usr/share/texmf-dist
 whitelist /usr/share/tlpkg
 include whitelist-usr-share-common.inc

--- a/etc/profile-m-z/menulibre.profile
+++ b/etc/profile-m-z/menulibre.profile
@@ -20,7 +20,6 @@ include disable-xdg.inc
 # Whitelist your system icon directory,varies by distro
 whitelist /usr/share/app-info
 whitelist /usr/share/desktop-directories
-whitelist /usr/share/icons
 whitelist /usr/share/menulibre
 whitelist /var/lib/app-info/icons
 whitelist /var/lib/flatpak/exports/share/applications

--- a/etc/profile-m-z/okular.profile
+++ b/etc/profile-m-z/okular.profile
@@ -33,7 +33,6 @@ whitelist /usr/share/config.kcfg/okular.kcfg
 whitelist /usr/share/config.kcfg/okular_core.kcfg
 whitelist /usr/share/ghostscript
 whitelist /usr/share/kconf_update/okular.upd
-whitelist /usr/share/kxmlgui5/okular
 whitelist /usr/share/okular
 whitelist /usr/share/poppler
 include whitelist-run-common.inc


### PR DESCRIPTION
Detected a few profiles that include wusc yet still reference paths that are present in that file. This PR drops the 'double' whitelisting from the relevant profiles.