### PR TITLE
build: allow overriding certain tools & sync targets with CI

### DIFF
--- a/.github/workflows/check-c.yml
+++ b/.github/workflows/check-c.yml
@@ -67,11 +67,11 @@ jobs:
       run: ./ci/printenv.sh
     - name: configure
       run: >
-        CC=clang-14 ./configure --enable-fatal-warnings --enable-apparmor
-        --enable-selinux
+        ./configure CC=clang-14 SCAN_BUILD=scan-build-14
+        --enable-fatal-warnings --enable-apparmor --enable-selinux
         || (cat config.log; exit 1)
     - name: scan-build
-      run: scan-build-14 --status-bugs make
+      run: make scan-build
 
   cppcheck:
     runs-on: ubuntu-22.04

--- a/.github/workflows/check-c.yml
+++ b/.github/workflows/check-c.yml
@@ -93,11 +93,13 @@ jobs:
       run: sudo apt-get update -qy
     - name: install cppcheck
       run: sudo apt-get install -qy cppcheck
+    - name: configure
+      run: >
+        ./configure CPPCHECK='cppcheck -q'
+        || (cat config.log; exit 1)
     - run: cppcheck --version
     - name: cppcheck
-      run: >
-        cppcheck -q --force --error-exitcode=1 --enable=warning,performance
-        -i src/firejail/checkcfg.c -i src/firejail/main.c .
+      run: make cppcheck
 
   # new cppcheck version currently chokes on checkcfg.c and main.c, therefore
   # scan all files also with older cppcheck version from ubuntu 20.04.
@@ -122,9 +124,13 @@ jobs:
       run: sudo apt-get update -qy
     - name: install cppcheck
       run: sudo apt-get install -qy cppcheck
+    - name: configure
+      run: >
+        ./configure CPPCHECK='cppcheck -q'
+        || (cat config.log; exit 1)
     - run: cppcheck --version
-    - name: cppcheck
-      run: cppcheck -q --force --error-exitcode=1 --enable=warning,performance .
+    - name: cppcheck-old
+      run: make cppcheck-old
 
   codeql-cpp:
     permissions:

--- a/Makefile
+++ b/Makefile
@@ -364,6 +364,12 @@ extras: all
 
 .PHONY: cppcheck
 cppcheck: clean
+	$(CPPCHECK) --force --error-exitcode=1 --enable=warning,performance \
+	  -i src/firejail/checkcfg.c -i src/firejail/main.c .
+
+# For cppcheck 1.x; see .github/workflows/check-c.yml
+.PHONY: cppcheck-old
+cppcheck-old: clean
 	$(CPPCHECK) --force --error-exitcode=1 --enable=warning,performance .
 
 .PHONY: scan-build

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,13 @@
 ROOT = .
 -include config.mk
 
+# Default programs
+CC ?= cc
+CODESPELL ?= codespell
+CPPCHECK ?= cppcheck
+GAWK ?= gawk
+SCAN_BUILD ?= scan-build
+
 ifneq ($(HAVE_MAN),no)
 MAN_TARGET = man
 endif
@@ -357,18 +364,18 @@ extras: all
 
 .PHONY: cppcheck
 cppcheck: clean
-	cppcheck --force --error-exitcode=1 --enable=warning,performance .
+	$(CPPCHECK) --force --error-exitcode=1 --enable=warning,performance .
 
 .PHONY: scan-build
 scan-build: clean
-	scan-build $(MAKE)
+	$(SCAN_BUILD) $(MAKE)
 
 # TODO: Old codespell versions (such as v2.1.0 in CI) have issues with
 # contrib/syscalls.sh
 .PHONY: codespell
 codespell:
 	@printf 'Running %s...\n' $@
-	@codespell --ignore-regex 'Manuel|UE|als|chage|creat|doas|ether|isplay|readby|[Ss]hotcut' \
+	@$(CODESPELL) --ignore-regex 'Manuel|UE|als|chage|creat|doas|ether|isplay|readby|[Ss]hotcut' \
 	  -S *.d,*.gz,*.o,*.so \
 	  -S COPYING,m4 \
 	  -S ./contrib/syscalls.sh \

--- a/Makefile
+++ b/Makefile
@@ -374,7 +374,7 @@ cppcheck-old: clean
 
 .PHONY: scan-build
 scan-build: clean
-	$(SCAN_BUILD) $(MAKE)
+	$(SCAN_BUILD) --status-bugs $(MAKE)
 
 # TODO: Old codespell versions (such as v2.1.0 in CI) have issues with
 # contrib/syscalls.sh

--- a/config.mk.in
+++ b/config.mk.in
@@ -75,6 +75,11 @@ MANFLAGS = \
 # the user building the package); see the following for details:
 # https://www.gnu.org/software/automake/manual/1.16.5/html_node/User-Variables.html
 CC=@CC@
+CODESPELL=@CODESPELL@
+CPPCHECK=@CPPCHECK@
+GAWK=@GAWK@
+SCAN_BUILD=@SCAN_BUILD@
+
 CFLAGS=@CFLAGS@
 CPPFLAGS=@CPPFLAGS@
 LDFLAGS=@LDFLAGS@

--- a/configure
+++ b/configure
@@ -665,7 +665,6 @@ HAVE_GLOBALCFG
 HAVE_CHROOT
 HAVE_PRIVATE_LIB
 HAVE_PRIVATE_HOME
-HAVE_GAWK
 HAVE_MAN
 HAVE_USERTMPFS
 HAVE_OUTPUT
@@ -683,6 +682,10 @@ PKG_CONFIG
 HAVE_APPARMOR
 HAVE_IDS
 DEPS_CFLAGS
+SCAN_BUILD
+GAWK
+CPPCHECK
+CODESPELL
 OBJEXT
 EXEEXT
 ac_ct_CC
@@ -3270,6 +3273,194 @@ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
+for ac_prog in codespell
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_prog_CODESPELL+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  if test -n "$CODESPELL"; then
+  ac_cv_prog_CODESPELL="$CODESPELL" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_prog_CODESPELL="$ac_prog"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+CODESPELL=$ac_cv_prog_CODESPELL
+if test -n "$CODESPELL"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CODESPELL" >&5
+printf "%s\n" "$CODESPELL" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+
+  test -n "$CODESPELL" && break
+done
+
+for ac_prog in cppcheck
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_prog_CPPCHECK+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  if test -n "$CPPCHECK"; then
+  ac_cv_prog_CPPCHECK="$CPPCHECK" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_prog_CPPCHECK="$ac_prog"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+CPPCHECK=$ac_cv_prog_CPPCHECK
+if test -n "$CPPCHECK"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CPPCHECK" >&5
+printf "%s\n" "$CPPCHECK" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+
+  test -n "$CPPCHECK" && break
+done
+
+for ac_prog in gawk
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_prog_GAWK+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  if test -n "$GAWK"; then
+  ac_cv_prog_GAWK="$GAWK" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_prog_GAWK="$ac_prog"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+GAWK=$ac_cv_prog_GAWK
+if test -n "$GAWK"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $GAWK" >&5
+printf "%s\n" "$GAWK" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+
+  test -n "$GAWK" && break
+done
+
+for ac_prog in scan-build
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_prog_SCAN_BUILD+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  if test -n "$SCAN_BUILD"; then
+  ac_cv_prog_SCAN_BUILD="$SCAN_BUILD" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_prog_SCAN_BUILD="$ac_prog"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+SCAN_BUILD=$ac_cv_prog_SCAN_BUILD
+if test -n "$SCAN_BUILD"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $SCAN_BUILD" >&5
+printf "%s\n" "$SCAN_BUILD" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+
+  test -n "$SCAN_BUILD" && break
+done
+
 
 DEPS_CFLAGS=""
 
@@ -3901,50 +4092,7 @@ if test "x$enable_man" != "xno"
 then :
 
 	HAVE_MAN="-DHAVE_MAN"
-	# Extract the first word of "gawk", so it can be a program name with args.
-set dummy gawk; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_HAVE_GAWK+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  if test -n "$HAVE_GAWK"; then
-  ac_cv_prog_HAVE_GAWK="$HAVE_GAWK" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    ac_cv_prog_HAVE_GAWK="yes"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-  test -z "$ac_cv_prog_HAVE_GAWK" && ac_cv_prog_HAVE_GAWK="no"
-fi
-fi
-HAVE_GAWK=$ac_cv_prog_HAVE_GAWK
-if test -n "$HAVE_GAWK"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $HAVE_GAWK" >&5
-printf "%s\n" "$HAVE_GAWK" >&6; }
-else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-fi
-
-
-	if test "x$HAVE_GAWK" != "xyes"
+	if test "x$GAWK" = "x"
 then :
   as_fn_error $? "*** gawk not found ***" "$LINENO" 5
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,10 @@ AC_CONFIG_SRCDIR([src/firejail/main.c])
 AC_CONFIG_MACRO_DIR([m4])
 
 AC_PROG_CC
+AC_CHECK_PROGS([CODESPELL], [codespell])
+AC_CHECK_PROGS([CPPCHECK], [cppcheck])
+AC_CHECK_PROGS([GAWK], [gawk])
+AC_CHECK_PROGS([SCAN_BUILD], [scan-build])
 
 DEPS_CFLAGS=""
 AC_SUBST([DEPS_CFLAGS])
@@ -139,8 +143,7 @@ AC_ARG_ENABLE([man],
     [AS_HELP_STRING([--disable-man], [disable man pages])])
 AS_IF([test "x$enable_man" != "xno"], [
 	HAVE_MAN="-DHAVE_MAN"
-	AC_CHECK_PROG([HAVE_GAWK], [gawk], [yes], [no])
-	AS_IF([test "x$HAVE_GAWK" != "xyes"], [AC_MSG_ERROR([*** gawk not found ***])])
+	AS_IF([test "x$GAWK" = "x"], [AC_MSG_ERROR([*** gawk not found ***])])
 ])
 
 HAVE_PRIVATE_HOME=""

--- a/src/bash_completion/Makefile
+++ b/src/bash_completion/Makefile
@@ -6,7 +6,7 @@ ROOT = ../..
 all: firejail.bash_completion
 
 firejail.bash_completion: firejail.bash_completion.in $(ROOT)/config.mk
-	gawk -f ../man/preproc.awk -- $(MANFLAGS) < $< > $@.tmp
+	$(GAWK) -f ../man/preproc.awk -- $(MANFLAGS) < $< > $@.tmp
 	sed "s|_SYSCONFDIR_|$(sysconfdir)|" < $@.tmp > $@
 	rm $@.tmp
 

--- a/src/man/Makefile
+++ b/src/man/Makefile
@@ -13,7 +13,7 @@ all: $(TARGET)
 # foo.1: foo.1.in
 $(MOD_DIR)/%: $(MOD_DIR)/%.in $(ROOT)/config.mk
 	@printf 'Generating %s from %s\n' $@ $<
-	@gawk -f $(MOD_DIR)/preproc.awk -- $(MANFLAGS) <$< | \
+	@$(GAWK) -f $(MOD_DIR)/preproc.awk -- $(MANFLAGS) <$< | \
 	  $(MOD_DIR)/mkman.sh $(VERSION) >$@
 
 # foo.1.gz: foo.1

--- a/src/zsh_completion/Makefile
+++ b/src/zsh_completion/Makefile
@@ -6,7 +6,7 @@ ROOT = ../..
 all: _firejail
 
 _firejail: _firejail.in $(ROOT)/config.mk
-	gawk -f ../man/preproc.awk -- $(MANFLAGS) < $< > $@.tmp
+	$(GAWK) -f ../man/preproc.awk -- $(MANFLAGS) < $< > $@.tmp
 	sed "s|_SYSCONFDIR_|$(sysconfdir)|" < $@.tmp > $@
 	rm $@.tmp
 


### PR DESCRIPTION
Allow overriding the following tools at configure-time and build-time:

* codespell
* cppcheck
* gawk
* scan-build

For example, instead of hardcoding `gawk`, enable overriding it at
configure-time with:

    ./configure GAWK=/path/to/gawk

To override it for a single `make` invocation:

    make GAWK=/path/to/gawk

Also, add default values for the programs that are not found (rather
than leaving the variables empty), to make error messages clearer when
trying to run them:

    $ make CPPCHECK= cppcheck-old
    [...]
    force --error-exitcode=1 --enable=warning,performance .
    make: force: No such file or directory
    $ make CPPCHECK=cppcheck cppcheck-old
    [...]
    cppcheck --force --error-exitcode=1 --enable=warning,performance .
    make: cppcheck: No such file or directory