### PR TITLE
landlock: use "landlock.fs." prefix in filesystem commands

### DIFF
--- a/contrib/syntax/lists/profile_commands_arg1.list
+++ b/contrib/syntax/lists/profile_commands_arg1.list
@@ -29,11 +29,11 @@ ip6
 iprange
 join-or-start
 keep-fd
-landlock.execute
-landlock.makedev
-landlock.makeipc
-landlock.read
-landlock.write
+landlock.fs.execute
+landlock.fs.makedev
+landlock.fs.makeipc
+landlock.fs.read
+landlock.fs.write
 mac
 mkdir
 mkfile

--- a/etc/inc/landlock-common.inc
+++ b/etc/inc/landlock-common.inc
@@ -2,38 +2,38 @@
 # Persistent customizations should go in a .local file.
 include landlock-common.local
 
-landlock.read /          # whole system read
-landlock.read /proc
-landlock.makeipc /       # sockets etc.
+landlock.fs.read /          # whole system read
+landlock.fs.read /proc
+landlock.fs.makeipc /       # sockets etc.
 
 # write access
-landlock.write ${HOME}
-landlock.write ${RUNUSER}
-landlock.write /dev
-landlock.write /proc
-landlock.write /run/shm
-landlock.write /tmp
+landlock.fs.write ${HOME}
+landlock.fs.write ${RUNUSER}
+landlock.fs.write /dev
+landlock.fs.write /proc
+landlock.fs.write /run/shm
+landlock.fs.write /tmp
 
 # exec access
 ## misc
-landlock.execute /opt
-landlock.execute /run/firejail # appimage and various firejail features
+landlock.fs.execute /opt
+landlock.fs.execute /run/firejail # appimage and various firejail features
 ## bin
-landlock.execute /bin
-landlock.execute /sbin
-landlock.execute /usr/bin
-landlock.execute /usr/sbin
-landlock.execute /usr/games
-landlock.execute /usr/local/bin
-landlock.execute /usr/local/sbin
-landlock.execute /usr/local/games
+landlock.fs.execute /bin
+landlock.fs.execute /sbin
+landlock.fs.execute /usr/bin
+landlock.fs.execute /usr/sbin
+landlock.fs.execute /usr/games
+landlock.fs.execute /usr/local/bin
+landlock.fs.execute /usr/local/sbin
+landlock.fs.execute /usr/local/games
 ## lib
-landlock.execute /lib
-landlock.execute /lib32
-landlock.execute /libx32
-landlock.execute /lib64
-landlock.execute /usr/lib
-landlock.execute /usr/lib32
-landlock.execute /usr/libx32
-landlock.execute /usr/lib64
-landlock.execute /usr/local/lib
+landlock.fs.execute /lib
+landlock.fs.execute /lib32
+landlock.fs.execute /libx32
+landlock.fs.execute /lib64
+landlock.fs.execute /usr/lib
+landlock.fs.execute /usr/lib32
+landlock.fs.execute /usr/libx32
+landlock.fs.execute /usr/lib64
+landlock.fs.execute /usr/local/lib

--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -138,11 +138,11 @@ include globals.local
 #include whitelist-var-common.inc
 
 # Landlock commands
-##landlock.read PATH
-##landlock.write PATH
-##landlock.makeipc PATH
-##landlock.makedev PATH
-##landlock.execute PATH
+##landlock.fs.read PATH
+##landlock.fs.write PATH
+##landlock.fs.makeipc PATH
+##landlock.fs.makedev PATH
+##landlock.fs.execute PATH
 #include landlock-common.inc
 
 ##allusers

--- a/src/bash_completion/firejail.bash_completion.in
+++ b/src/bash_completion/firejail.bash_completion.in
@@ -45,23 +45,23 @@ _firejail()
         --landlock.enforce)
             return 0
             ;;
-        --landlock.read)
+        --landlock.fs.read)
             _filedir
             return 0
             ;;
-        --landlock.write)
+        --landlock.fs.write)
             _filedir
             return 0
             ;;
-        --landlock.makeipc)
+        --landlock.fs.makeipc)
             _filedir
             return 0
             ;;
-        --landlock.makedev)
+        --landlock.fs.makedev)
             _filedir
             return 0
             ;;
-        --landlock.execute)
+        --landlock.fs.execute)
             _filedir
             return 0
             ;;

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -152,11 +152,11 @@ typedef struct profile_entry_t {
 
 typedef struct landlock_entry_t {
 	struct landlock_entry_t *next;
-#define LL_READ 0
-#define LL_WRITE 1
-#define LL_MAKEIPC 2
-#define LL_MAKEDEV 3
-#define LL_EXEC 4
+#define LL_FS_READ 0
+#define LL_FS_WRITE 1
+#define LL_FS_MAKEIPC 2
+#define LL_FS_MAKEDEV 3
+#define LL_FS_EXEC 4
 #define LL_MAX 5
 	int type;
 	char *data;

--- a/src/firejail/landlock.c
+++ b/src/firejail/landlock.c
@@ -174,7 +174,7 @@ static void ll_fs(const char *allowed_path, const __u64 allowed_access,
 	free(expanded_path);
 }
 
-static void ll_read(const char *allowed_path) {
+static void ll_fs_read(const char *allowed_path) {
 	__u64 allowed_access =
 		LANDLOCK_ACCESS_FS_READ_DIR |
 		LANDLOCK_ACCESS_FS_READ_FILE;
@@ -182,7 +182,7 @@ static void ll_read(const char *allowed_path) {
 	ll_fs(allowed_path, allowed_access, __func__);
 }
 
-static void ll_write(const char *allowed_path) {
+static void ll_fs_write(const char *allowed_path) {
 	__u64 allowed_access =
 		LANDLOCK_ACCESS_FS_MAKE_DIR |
 		LANDLOCK_ACCESS_FS_MAKE_REG |
@@ -194,7 +194,7 @@ static void ll_write(const char *allowed_path) {
 	ll_fs(allowed_path, allowed_access, __func__);
 }
 
-static void ll_makeipc(const char *allowed_path) {
+static void ll_fs_makeipc(const char *allowed_path) {
 	__u64 allowed_access =
 		LANDLOCK_ACCESS_FS_MAKE_FIFO |
 		LANDLOCK_ACCESS_FS_MAKE_SOCK;
@@ -202,7 +202,7 @@ static void ll_makeipc(const char *allowed_path) {
 	ll_fs(allowed_path, allowed_access, __func__);
 }
 
-static void ll_makedev(const char *allowed_path) {
+static void ll_fs_makedev(const char *allowed_path) {
 	__u64 allowed_access =
 		LANDLOCK_ACCESS_FS_MAKE_BLOCK |
 		LANDLOCK_ACCESS_FS_MAKE_CHAR;
@@ -210,7 +210,7 @@ static void ll_makedev(const char *allowed_path) {
 	ll_fs(allowed_path, allowed_access, __func__);
 }
 
-static void ll_exec(const char *allowed_path) {
+static void ll_fs_exec(const char *allowed_path) {
 	__u64 allowed_access =
 		LANDLOCK_ACCESS_FS_EXECUTE;
 
@@ -227,11 +227,11 @@ int ll_restrict(uint32_t flags) {
 		fprintf(stderr, "%s: Starting Landlock restrict\n", __func__);
 
 	void (*fnc[])(const char *) = {
-		ll_read,
-		ll_write,
-		ll_makeipc,
-		ll_makedev,
-		ll_exec,
+		ll_fs_read,
+		ll_fs_write,
+		ll_fs_makeipc,
+		ll_fs_makedev,
+		ll_fs_exec,
 		NULL
 	};
 

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1505,16 +1505,16 @@ int main(int argc, char **argv, char **envp) {
 #ifdef HAVE_LANDLOCK
 		else if (strncmp(argv[i], "--landlock.enforce", 18) == 0)
 			arg_landlock_enforce = 1;
-		else if (strncmp(argv[i], "--landlock.read=", 16) == 0)
-			ll_add_profile(LL_FS_READ, argv[i] + 16);
-		else if (strncmp(argv[i], "--landlock.write=", 17) == 0)
-			ll_add_profile(LL_FS_WRITE, argv[i] + 17);
-		else if (strncmp(argv[i], "--landlock.makeipc=", 19) == 0)
-			ll_add_profile(LL_FS_MAKEIPC, argv[i] + 19);
-		else if (strncmp(argv[i], "--landlock.makedev=", 19) == 0)
-			ll_add_profile(LL_FS_MAKEDEV, argv[i] + 19);
-		else if (strncmp(argv[i], "--landlock.execute=", 19) == 0)
-			ll_add_profile(LL_FS_EXEC, argv[i] + 19);
+		else if (strncmp(argv[i], "--landlock.fs.read=", 19) == 0)
+			ll_add_profile(LL_FS_READ, argv[i] + 19);
+		else if (strncmp(argv[i], "--landlock.fs.write=", 20) == 0)
+			ll_add_profile(LL_FS_WRITE, argv[i] + 20);
+		else if (strncmp(argv[i], "--landlock.fs.makeipc=", 22) == 0)
+			ll_add_profile(LL_FS_MAKEIPC, argv[i] + 22);
+		else if (strncmp(argv[i], "--landlock.fs.makedev=", 22) == 0)
+			ll_add_profile(LL_FS_MAKEDEV, argv[i] + 22);
+		else if (strncmp(argv[i], "--landlock.fs.execute=", 22) == 0)
+			ll_add_profile(LL_FS_EXEC, argv[i] + 22);
 #endif
 		else if (strcmp(argv[i], "--memory-deny-write-execute") == 0) {
 			if (checkcfg(CFG_SECCOMP))

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1506,15 +1506,15 @@ int main(int argc, char **argv, char **envp) {
 		else if (strncmp(argv[i], "--landlock.enforce", 18) == 0)
 			arg_landlock_enforce = 1;
 		else if (strncmp(argv[i], "--landlock.read=", 16) == 0)
-			ll_add_profile(LL_READ, argv[i] + 16);
+			ll_add_profile(LL_FS_READ, argv[i] + 16);
 		else if (strncmp(argv[i], "--landlock.write=", 17) == 0)
-			ll_add_profile(LL_WRITE, argv[i] + 17);
+			ll_add_profile(LL_FS_WRITE, argv[i] + 17);
 		else if (strncmp(argv[i], "--landlock.makeipc=", 19) == 0)
-			ll_add_profile(LL_MAKEIPC, argv[i] + 19);
+			ll_add_profile(LL_FS_MAKEIPC, argv[i] + 19);
 		else if (strncmp(argv[i], "--landlock.makedev=", 19) == 0)
-			ll_add_profile(LL_MAKEDEV, argv[i] + 19);
+			ll_add_profile(LL_FS_MAKEDEV, argv[i] + 19);
 		else if (strncmp(argv[i], "--landlock.execute=", 19) == 0)
-			ll_add_profile(LL_EXEC, argv[i] + 19);
+			ll_add_profile(LL_FS_EXEC, argv[i] + 19);
 #endif
 		else if (strcmp(argv[i], "--memory-deny-write-execute") == 0) {
 			if (checkcfg(CFG_SECCOMP))

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -1079,23 +1079,23 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		return 0;
 	}
 	if (strncmp(ptr, "landlock.read ", 14) == 0) {
-		ll_add_profile(LL_READ, ptr + 14);
+		ll_add_profile(LL_FS_READ, ptr + 14);
 		return 0;
 	}
 	if (strncmp(ptr, "landlock.write ", 15) == 0) {
-		ll_add_profile(LL_WRITE, ptr + 15);
+		ll_add_profile(LL_FS_WRITE, ptr + 15);
 		return 0;
 	}
 	if (strncmp(ptr, "landlock.makeipc ", 17) == 0) {
-		ll_add_profile(LL_MAKEIPC, ptr + 17);
+		ll_add_profile(LL_FS_MAKEIPC, ptr + 17);
 		return 0;
 	}
 	if (strncmp(ptr, "landlock.makedev ", 17) == 0) {
-		ll_add_profile(LL_MAKEDEV, ptr + 17);
+		ll_add_profile(LL_FS_MAKEDEV, ptr + 17);
 		return 0;
 	}
 	if (strncmp(ptr, "landlock.execute ", 17) == 0) {
-		ll_add_profile(LL_EXEC, ptr + 17);
+		ll_add_profile(LL_FS_EXEC, ptr + 17);
 		return 0;
 	}
 #endif

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -1078,24 +1078,24 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		arg_landlock_enforce = 1;
 		return 0;
 	}
-	if (strncmp(ptr, "landlock.read ", 14) == 0) {
-		ll_add_profile(LL_FS_READ, ptr + 14);
+	if (strncmp(ptr, "landlock.fs.read ", 17) == 0) {
+		ll_add_profile(LL_FS_READ, ptr + 17);
 		return 0;
 	}
-	if (strncmp(ptr, "landlock.write ", 15) == 0) {
-		ll_add_profile(LL_FS_WRITE, ptr + 15);
+	if (strncmp(ptr, "landlock.fs.write ", 18) == 0) {
+		ll_add_profile(LL_FS_WRITE, ptr + 18);
 		return 0;
 	}
-	if (strncmp(ptr, "landlock.makeipc ", 17) == 0) {
-		ll_add_profile(LL_FS_MAKEIPC, ptr + 17);
+	if (strncmp(ptr, "landlock.fs.makeipc ", 20) == 0) {
+		ll_add_profile(LL_FS_MAKEIPC, ptr + 20);
 		return 0;
 	}
-	if (strncmp(ptr, "landlock.makedev ", 17) == 0) {
-		ll_add_profile(LL_FS_MAKEDEV, ptr + 17);
+	if (strncmp(ptr, "landlock.fs.makedev ", 20) == 0) {
+		ll_add_profile(LL_FS_MAKEDEV, ptr + 20);
 		return 0;
 	}
-	if (strncmp(ptr, "landlock.execute ", 17) == 0) {
-		ll_add_profile(LL_FS_EXEC, ptr + 17);
+	if (strncmp(ptr, "landlock.fs.execute ", 20) == 0) {
+		ll_add_profile(LL_FS_EXEC, ptr + 20);
 		return 0;
 	}
 #endif

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -135,11 +135,11 @@ static const char *const usage_str =
 	"    --keep-var-tmp - /var/tmp directory is untouched.\n"
 #ifdef HAVE_LANDLOCK
 	"    --landlock.enforce - enforce the Landlock ruleset.\n"
-	"    --landlock.read=path - add a read access rule for the path to the Landlock ruleset.\n"
-	"    --landlock.write=path - add a write access rule for the path to the Landlock ruleset.\n"
-	"    --landlock.makeipc=path - add an access rule for the path to the Landlock ruleset for creating named pipes and sockets.\n"
-	"    --landlock.makedev=path - add an access rule for the path to the Landlock ruleset for creating block/char devices.\n"
-	"    --landlock.execute=path - add an execute access rule for the path to the Landlock ruleset.\n"
+	"    --landlock.fs.read=path - add a read access rule for the path to the Landlock ruleset.\n"
+	"    --landlock.fs.write=path - add a write access rule for the path to the Landlock ruleset.\n"
+	"    --landlock.fs.makeipc=path - add an access rule for the path to the Landlock ruleset for creating named pipes and sockets.\n"
+	"    --landlock.fs.makedev=path - add an access rule for the path to the Landlock ruleset for creating block/char devices.\n"
+	"    --landlock.fs.execute=path - add an execute access rule for the path to the Landlock ruleset.\n"
 #endif
 	"    --list - list all sandboxes.\n"
 #ifdef HAVE_FILE_TRANSFER

--- a/src/man/firejail-profile.5.in
+++ b/src/man/firejail-profile.5.in
@@ -514,25 +514,25 @@ Enforce the Landlock ruleset.
 .PP
 Without it, the other Landlock commands have no effect.
 .TP
-\fBlandlock.read path
+\fBlandlock.fs.read path
 Create a Landlock ruleset (if it doesn't already exist) and add a read access
 rule for path.
 .TP
-\fBlandlock.write path
+\fBlandlock.fs.write path
 Create a Landlock ruleset (if it doesn't already exist) and add a write access
 rule for path.
 .TP
-\fBlandlock.makeipc path
+\fBlandlock.fs.makeipc path
 Create a Landlock ruleset (if it doesn't already exist) and add a rule that
 allows the creation of named pipes (FIFOs) and Unix domain sockets beneath
 the given path.
 .TP
-\fBlandlock.makedev path
+\fBlandlock.fs.makedev path
 Create a Landlock ruleset (if it doesn't already exist) and add a rule that
 allows the creation of block devices and character devices beneath the given
 path.
 .TP
-\fBlandlock.execute path
+\fBlandlock.fs.execute path
 Create a Landlock ruleset (if it doesn't already exist) and add an execution
 permission rule for path.
 #endif

--- a/src/man/firejail.1.in
+++ b/src/man/firejail.1.in
@@ -1241,25 +1241,25 @@ Enforce the Landlock ruleset.
 Without it, the other Landlock commands have no effect.
 See the \fBLANDLOCK\fR section for more information.
 .TP
-\fB\-\-landlock.read=path
+\fB\-\-landlock.fs.read=path
 Create a Landlock ruleset (if it doesn't already exist) and add a read access
 rule for path.
 .TP
-\fB\-\-landlock.write=path
+\fB\-\-landlock.fs.write=path
 Create a Landlock ruleset (if it doesn't already exist) and add a write access
 rule for path.
 .TP
-\fB\-\-landlock.makeipc=path
+\fB\-\-landlock.fs.makeipc=path
 Create a Landlock ruleset (if it doesn't already exist) and add a rule that
 allows the creation of named pipes (FIFOs) and Unix domain sockets beneath
 the given path.
 .TP
-\fB\-\-landlock.makedev=path
+\fB\-\-landlock.fs.makedev=path
 Create a Landlock ruleset (if it doesn't already exist) and add a rule that
 allows the creation of block devices and character devices beneath the given
 path.
 .TP
-\fB\-\-landlock.execute=path
+\fB\-\-landlock.fs.execute=path
 Create a Landlock ruleset (if it doesn't already exist) and add an execution
 permission rule for path.
 .br
@@ -1267,8 +1267,8 @@ permission rule for path.
 .br
 Example:
 .br
-$ firejail \-\-landlock.read=/ \-\-landlock.write=/home
-\-\-landlock.execute=/usr \-\-landlock.enforce
+$ firejail \-\-landlock.fs.read=/ \-\-landlock.fs.write=/home
+\-\-landlock.fs.execute=/usr \-\-landlock.enforce
 #endif
 .TP
 \fB\-\-list
@@ -3404,7 +3404,7 @@ features, pass \fB\-\-landlock.enforce\fR flag to Firejail command line.
 Without it, the other Landlock commands have no effect.
 Example:
 .PP
-$ firejail \-\-landlock.enforce \-\-landlock.read=/media mc
+$ firejail \-\-landlock.enforce \-\-landlock.fs.read=/media mc
 .PP
 To disable Landlock self-restriction, use \fB\-\-ignore=landlock.enforce\fR.
 #endif

--- a/src/zsh_completion/_firejail.in
+++ b/src/zsh_completion/_firejail.in
@@ -108,11 +108,11 @@ _firejail_args=(
     '--keep-var-tmp[/var/tmp directory is untouched]'
 #ifdef HAVE_LANDLOCK
     '--landlock.enforce[enforce the Landlock ruleset]'
-    '--landlock.read=-[add a read access rule for the path to the Landlock ruleset]: :_files'
-    '--landlock.write=-[add a write access rule for the path to the Landlock ruleset]: :_files'
-    '--landlock.makeipc=-[add an access rule for the path to the Landlock ruleset for creating named pipes and sockets]: :_files'
-    '--landlock.makedev=-[add an access rule for the path to the Landlock ruleset for creating block/char devices]: :_files'
-    '--landlock.execute=-[add an execute access rule for the path to the Landlock ruleset]: :_files'
+    '--landlock.fs.read=-[add a read access rule for the path to the Landlock ruleset]: :_files'
+    '--landlock.fs.write=-[add a write access rule for the path to the Landlock ruleset]: :_files'
+    '--landlock.fs.makeipc=-[add an access rule for the path to the Landlock ruleset for creating named pipes and sockets]: :_files'
+    '--landlock.fs.makedev=-[add an access rule for the path to the Landlock ruleset for creating block/char devices]: :_files'
+    '--landlock.fs.execute=-[add an execute access rule for the path to the Landlock ruleset]: :_files'
 #endif
     '--machine-id[spoof /etc/machine-id with a random id]'
     '--memory-deny-write-execute[seccomp filter to block attempts to create memory mappings that are both writable and executable]'


### PR DESCRIPTION
Since Landlock ABI v4 it is possible to restrict actions related to the
network and potentially more areas will be added in the future.

So use `landlock.fs.` as the prefix in the current filesystem-related
commands (and later `landlock.net.` for the network-related commands) to
keep them organized and to match what is used in the kernel.

Examples of filesystem and network access flags:

* `LANDLOCK_ACCESS_FS_EXECUTE`: Execute a file.
* `LANDLOCK_ACCESS_FS_READ_DIR`: Open a directory or list its content.
* `LANDLOCK_ACCESS_NET_BIND_TCP`: Bind a TCP socket to a local port.
* `LANDLOCK_ACCESS_NET_CONNECT_TCP`: Connect an active TCP socket to a
  remote port.

Relates to #6078.