### PR TITLE
build: reduce hardcoding and inconsistencies

### DIFF
--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -48,12 +48,10 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: >
-          archive.ubuntu.com:80
           azure.archive.ubuntu.com:80
           github.com:443
           packages.microsoft.com:443
           ppa.launchpadcontent.net:443
-          security.ubuntu.com:80
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
     - name: update package information
       run: sudo apt-get update -qy

--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -73,4 +73,4 @@ jobs:
     - name: make install
       run: sudo make install
     - name: print version
-      run: command -V firejail && firejail --version
+      run: make print-version

--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -63,8 +63,9 @@ jobs:
       run: ./ci/printenv.sh
     - name: configure
       run: >
-        CC=clang-14 ./configure --enable-fatal-warnings --enable-apparmor
-        --enable-selinux
+        ./configure CC=clang-14
+        --prefix=/usr --enable-fatal-warnings
+        --enable-apparmor --enable-selinux
         || (cat config.log; exit 1)
     - name: make
       run: make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,8 +79,9 @@ jobs:
       run: ./ci/printenv.sh
     - name: configure
       run: >
-        CC=gcc-12 ./configure --prefix=/usr --enable-fatal-warnings
-        --enable-analyzer --enable-apparmor --enable-selinux
+        ./configure CC=gcc-12
+        --prefix=/usr --enable-fatal-warnings --enable-analyzer
+        --enable-apparmor --enable-selinux
         || (cat config.log; exit 1)
     - name: make
       run: make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,5 +87,5 @@ jobs:
       run: make
     - name: make install
       run: sudo make install
-    - name: print firejail version
-      run: command -V firejail && firejail --version
+    - name: print version
+      run: make print-version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,8 +74,7 @@ jobs:
     - name: install dependencies
       run: >
         sudo apt-get install -qy
-        gcc-12 libapparmor-dev libselinux1-dev expect xzdec whois
-        bridge-utils
+        gcc-12 libapparmor-dev libselinux1-dev
     - name: print env
       run: ./ci/printenv.sh
     - name: configure

--- a/.github/workflows/check-c.yml
+++ b/.github/workflows/check-c.yml
@@ -8,9 +8,9 @@ on:
     branches-ignore:
       - 'dependabot/**'
     paths:
+      - '**.c'
+      - '**.h'
       - 'm4/**'
-      - 'src/**.c'
-      - 'src/**.h'
       - 'src/**.mk'
       - 'src/**Makefile'
       - .github/workflows/check-c.yml
@@ -22,9 +22,9 @@ on:
       - configure.ac
   pull_request:
     paths:
+      - '**.c'
+      - '**.h'
       - 'm4/**'
-      - 'src/**.c'
-      - 'src/**.h'
       - 'src/**.mk'
       - 'src/**Makefile'
       - .github/workflows/check-c.yml

--- a/.github/workflows/check-c.yml
+++ b/.github/workflows/check-c.yml
@@ -68,7 +68,8 @@ jobs:
     - name: configure
       run: >
         ./configure CC=clang-14 SCAN_BUILD=scan-build-14
-        --enable-fatal-warnings --enable-apparmor --enable-selinux
+        --prefix=/usr --enable-fatal-warnings
+        --enable-apparmor --enable-selinux
         || (cat config.log; exit 1)
     - name: scan-build
       run: make scan-build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,8 +80,8 @@ jobs:
       run: make -j "$(nproc)"
     - name: make install
       run: sudo make install
-    - name: print firejail version
-      run: command -V firejail && firejail --version
+    - name: print version
+      run: make print-version
     - run: make lab-setup
     - run: make test-seccomp-extra
     - run: make test-firecfg
@@ -128,8 +128,8 @@ jobs:
       run: make -j "$(nproc)"
     - name: make install
       run: sudo make install
-    - name: print firejail version
-      run: command -V firejail && firejail --version
+    - name: print version
+      run: make print-version
     - run: make lab-setup
     - run: make test-private-etc
     - run: make test-fs
@@ -167,8 +167,8 @@ jobs:
       run: make -j "$(nproc)"
     - name: make install
       run: sudo make install
-    - name: print firejail version
-      run: command -V firejail && firejail --version
+    - name: print version
+      run: make print-version
     - run: make lab-setup
     - run: make test-environment
     - run: make test-profiles
@@ -209,8 +209,8 @@ jobs:
       run: make -j "$(nproc)"
     - name: make install
       run: sudo make install
-    - name: print firejail version
-      run: command -V firejail && firejail --version
+    - name: print version
+      run: make print-version
     - run: make lab-setup
     - run: make test-utils
 
@@ -255,8 +255,8 @@ jobs:
       run: make -j "$(nproc)"
     - name: make install
       run: sudo make install
-    - name: print firejail version
-      run: command -V firejail && firejail --version
+    - name: print version
+      run: make print-version
     - run: make lab-setup
     - run: make test-fnetfilter
     - run: make test-sysutils

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,8 +73,9 @@ jobs:
       run: ./ci/printenv.sh
     - name: configure
       run: >
-        CC=gcc-12 ./configure --prefix=/usr --enable-fatal-warnings
-        --enable-analyzer --enable-apparmor --enable-selinux
+        ./configure CC=gcc-12
+        --prefix=/usr --enable-fatal-warnings --enable-analyzer
+        --enable-apparmor --enable-selinux
         || (cat config.log; exit 1)
     - name: make
       run: make -j "$(nproc)"
@@ -121,8 +122,9 @@ jobs:
       run: ./ci/printenv.sh
     - name: configure
       run: >
-        CC=gcc-12 ./configure --prefix=/usr --enable-fatal-warnings
-        --enable-analyzer --enable-apparmor --enable-selinux
+        ./configure CC=gcc-12
+        --prefix=/usr --enable-fatal-warnings --enable-analyzer
+        --enable-apparmor --enable-selinux
         || (cat config.log; exit 1)
     - name: make
       run: make -j "$(nproc)"
@@ -160,8 +162,9 @@ jobs:
       run: ./ci/printenv.sh
     - name: configure
       run: >
-        CC=gcc-12 ./configure --prefix=/usr --enable-fatal-warnings
-        --enable-analyzer --enable-apparmor --enable-selinux
+        ./configure CC=gcc-12
+        --prefix=/usr --enable-fatal-warnings --enable-analyzer
+        --enable-apparmor --enable-selinux
         || (cat config.log; exit 1)
     - name: make
       run: make -j "$(nproc)"
@@ -202,8 +205,9 @@ jobs:
       run: ./ci/printenv.sh
     - name: configure
       run: >
-        CC=gcc-12 ./configure --prefix=/usr --enable-fatal-warnings
-        --enable-analyzer --enable-apparmor --enable-selinux
+        ./configure CC=gcc-12
+        --prefix=/usr --enable-fatal-warnings --enable-analyzer
+        --enable-apparmor --enable-selinux
         || (cat config.log; exit 1)
     - name: make
       run: make -j "$(nproc)"
@@ -248,8 +252,9 @@ jobs:
       run: ./ci/printenv.sh
     - name: configure
       run: >
-        CC=gcc-12 ./configure --prefix=/usr --enable-fatal-warnings
-        --enable-analyzer --enable-apparmor --enable-selinux
+        ./configure CC=gcc-12
+        --prefix=/usr --enable-fatal-warnings --enable-analyzer
+        --enable-apparmor --enable-selinux
         || (cat config.log; exit 1)
     - name: make
       run: make -j "$(nproc)"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,8 @@ build_ubuntu_package:
             | grep -Ev '^(Selecting|Preparing to unpack|Unpacking)'
         - ./ci/printenv.sh
         - ./configure || (cat config.log; exit 1)
-        - make deb
+        - make dist
+        - ./mkdeb.sh --enable-fatal-warnings
         - dpkg -i ./*.deb
         - make print-version
 
@@ -39,7 +40,8 @@ build_debian_package:
             | grep -Ev '^(Selecting|Preparing to unpack|Unpacking)'
         - ./ci/printenv.sh
         - ./configure || (cat config.log; exit 1)
-        - make deb
+        - make dist
+        - ./mkdeb.sh --enable-fatal-warnings
         - dpkg -i ./*.deb
         - make print-version
 
@@ -57,7 +59,9 @@ build_no_apparmor:
         - ./ci/printenv.sh
         - ./configure || (cat config.log; exit 1)
         - make dist
-        - ./mkdeb.sh --disable-apparmor
+        - >
+            ./mkdeb.sh --enable-fatal-warnings
+            --disable-apparmor
         - dpkg -i ./*.deb
         - make print-version
         - make print-version | grep -F 'AppArmor support is disabled'
@@ -70,7 +74,8 @@ build_redhat_package:
         - dnf install -y rpm-build gcc make
         - ./ci/printenv.sh
         - ./configure || (cat config.log; exit 1)
-        - make rpms
+        - make dist
+        - ./platform/rpm/mkrpm.sh --enable-fatal-warnings
         - rpm -i ./*.rpm
         - make print-version
 
@@ -82,7 +87,8 @@ build_fedora_package:
         - dnf install -y rpm-build gcc make
         - ./ci/printenv.sh
         - ./configure || (cat config.log; exit 1)
-        - make rpms
+        - make dist
+        - ./platform/rpm/mkrpm.sh --enable-fatal-warnings
         - rpm -i ./*.rpm
         - make print-version
 
@@ -94,7 +100,11 @@ build_src_package:
         - apk upgrade
         - apk add build-base linux-headers gawk
         - ./ci/printenv.sh
-        - ./configure --prefix=/usr || (cat config.log; exit 1)
+        # Note: Do not use ` --enable-fatal-warnings` because the build
+        # currently produces warnings on Alpine (see #6224).
+        - >
+            ./configure --prefix=/usr
+            || (cat config.log; exit 1)
         - make
         - make install-strip
         - make print-version

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,13 @@
-# Basic notes: builds firejail on 5 different systems for 2 package systems:
-# 1. Debian-based systems. Use debian:jessie to ensure reasonable backwards
-# compat and ubuntu:rolling for new setups
-# 2. Redhat-based systems. Use centos:latest for reasonable backwards compat
-# and fedora:latest for new setups
-# 3. Alpine for installing directly from source
-# Also builds apparmor package for Ubuntu LTS
+# Builds on multiple systems using different package managers:
+#
+# - Debian-based systems: Use oldest working/supported debian image for
+# reasonable backwards compatibility and ubuntu:rolling for new setups.
+# Additionally, ensure that the package works without apparmor.
+#
+# - Redhat-based systems: Use a centos-like distribution for reasonable
+# backwards compatibility and fedora:latest for new setups.
+#
+# - Alpine: Use it for installing directly from source.
 
 build_ubuntu_package:
     image: ubuntu:rolling

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,6 +103,7 @@ debian_ci:
         DEBFULLNAME: "$GITLAB_USER_NAME"
         DEBEMAIL: "$GITLAB_USER_EMAIL"
         DEBIAN_FRONTEND: noninteractive
+        PKGNAME: firejail
     before_script:
         - git checkout -B ci_build "$CI_COMMIT_SHA"
         - gitlab-ci-enable-sid
@@ -117,17 +118,17 @@ debian_ci:
         - git config user.email "$DEBEMAIL"
         - |
             cd "$CI_PROJECT_DIR/.."
-            apt-get source --download-only -t experimental firejail ||
-            apt-get source --download-only firejail
+            apt-get source --download-only -t experimental "$PKGNAME" ||
+            apt-get source --download-only "$PKGNAME"
         - |
             cd "$CI_PROJECT_DIR"
-            tar xf ../firejail_*.debian.tar.*
+            tar xf "../${PKGNAME}"_*.debian.tar.*
         - rm -rf debian/patches/
         - |
             VERSION="$(grep ^PACKAGE_VERSION= configure | cut -d "'" -f 2)"
             dch -v "${VERSION}-0.1~ci" 'Non-maintainer upload.'
-            git archive -o "../firejail_${VERSION}.orig.tar.gz" HEAD
-            pristine-tar commit "../firejail_${VERSION}.orig.tar.gz" ci_build
+            git archive -o "../${PKGNAME}_${VERSION}.orig.tar.gz" HEAD
+            pristine-tar commit "../${PKGNAME}_${VERSION}.orig.tar.gz" ci_build
             git branch -m pristine-tar origin/pristine-tar
         - git add debian
         - git commit -m 'add debian/'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,6 +40,25 @@ build_debian_package:
         - dpkg -i ./*.deb
         - make print-version
 
+build_no_apparmor:
+    image: ubuntu:latest
+    timeout: 10 minutes
+    variables:
+        DEBIAN_FRONTEND: noninteractive
+    script:
+        - apt-get update -qy
+        - >
+            apt-get install --no-install-recommends -qy
+            build-essential fakeroot lintian pkg-config gawk
+            | grep -Ev '^(Selecting|Preparing to unpack|Unpacking)'
+        - ./ci/printenv.sh
+        - ./configure || (cat config.log; exit 1)
+        - make dist
+        - ./mkdeb.sh --disable-apparmor
+        - dpkg -i ./*.deb
+        - make print-version
+        - make print-version | grep -F 'AppArmor support is disabled'
+
 build_redhat_package:
     image: almalinux:latest
     timeout: 10 minutes
@@ -76,25 +95,6 @@ build_src_package:
         - make
         - make install-strip
         - make print-version
-
-build_no_apparmor:
-    image: ubuntu:latest
-    timeout: 10 minutes
-    variables:
-        DEBIAN_FRONTEND: noninteractive
-    script:
-        - apt-get update -qy
-        - >
-            apt-get install --no-install-recommends -qy
-            build-essential fakeroot lintian pkg-config gawk
-            | grep -Ev '^(Selecting|Preparing to unpack|Unpacking)'
-        - ./ci/printenv.sh
-        - ./configure || (cat config.log; exit 1)
-        - make dist
-        - ./mkdeb.sh --disable-apparmor
-        - dpkg -i ./*.deb
-        - make print-version
-        - make print-version | grep -F 'AppArmor support is disabled'
 
 debian_ci:
     image: registry.salsa.debian.org/salsa-ci-team/ci-image-git-buildpackage:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ build_ubuntu_package:
         - ./configure || (cat config.log; exit 1)
         - make deb
         - dpkg -i ./*.deb
-        - command -V firejail && firejail --version
+        - make print-version
 
 build_debian_package:
     image: debian:buster
@@ -38,7 +38,7 @@ build_debian_package:
         - ./configure || (cat config.log; exit 1)
         - make deb
         - dpkg -i ./*.deb
-        - command -V firejail && firejail --version
+        - make print-version
 
 build_redhat_package:
     image: almalinux:latest
@@ -50,7 +50,7 @@ build_redhat_package:
         - ./configure || (cat config.log; exit 1)
         - make rpms
         - rpm -i ./*.rpm
-        - command -V firejail && firejail --version
+        - make print-version
 
 build_fedora_package:
     image: fedora:latest
@@ -62,7 +62,7 @@ build_fedora_package:
         - ./configure || (cat config.log; exit 1)
         - make rpms
         - rpm -i ./*.rpm
-        - command -V firejail && firejail --version
+        - make print-version
 
 build_src_package:
     image: alpine:latest
@@ -75,7 +75,7 @@ build_src_package:
         - ./configure --prefix=/usr || (cat config.log; exit 1)
         - make
         - make install-strip
-        - command -V firejail && firejail --version
+        - make print-version
 
 build_no_apparmor:
     image: ubuntu:latest
@@ -93,8 +93,8 @@ build_no_apparmor:
         - make dist
         - ./mkdeb.sh --disable-apparmor
         - dpkg -i ./*.deb
-        - command -V firejail && firejail --version
-        - firejail --version | grep -F 'AppArmor support is disabled'
+        - make print-version
+        - make print-version | grep -F 'AppArmor support is disabled'
 
 debian_ci:
     image: registry.salsa.debian.org/salsa-ci-team/ci-image-git-buildpackage:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ build_ubuntu_package:
         - ./ci/printenv.sh
         - ./configure || (cat config.log; exit 1)
         - make deb
-        - dpkg -i firejail*.deb
+        - dpkg -i ./*.deb
         - command -V firejail && firejail --version
 
 build_debian_package:
@@ -37,7 +37,7 @@ build_debian_package:
         - ./ci/printenv.sh
         - ./configure || (cat config.log; exit 1)
         - make deb
-        - dpkg -i firejail*.deb
+        - dpkg -i ./*.deb
         - command -V firejail && firejail --version
 
 build_redhat_package:
@@ -49,7 +49,7 @@ build_redhat_package:
         - ./ci/printenv.sh
         - ./configure || (cat config.log; exit 1)
         - make rpms
-        - rpm -i firejail*.rpm
+        - rpm -i ./*.rpm
         - command -V firejail && firejail --version
 
 build_fedora_package:
@@ -61,7 +61,7 @@ build_fedora_package:
         - ./ci/printenv.sh
         - ./configure || (cat config.log; exit 1)
         - make rpms
-        - rpm -i firejail*.rpm
+        - rpm -i ./*.rpm
         - command -V firejail && firejail --version
 
 build_src_package:
@@ -92,7 +92,7 @@ build_no_apparmor:
         - ./configure || (cat config.log; exit 1)
         - make dist
         - ./mkdeb.sh --disable-apparmor
-        - dpkg -i firejail*.deb
+        - dpkg -i ./*.deb
         - command -V firejail && firejail --version
         - firejail --version | grep -F 'AppArmor support is disabled'
 

--- a/Makefile
+++ b/Makefile
@@ -391,6 +391,10 @@ codespell:
 print-env:
 	./ci/printenv.sh
 
+.PHONY: print-version
+print-version: config.mk
+	command -V $(TARNAME) && $(TARNAME) --version
+
 #
 # make test
 #

--- a/contrib/update_deb.sh
+++ b/contrib/update_deb.sh
@@ -16,7 +16,7 @@ sed -i "s/# restricted-network .*/restricted-network yes/" \
     etc/firejail.config
 
 make deb
-sudo dpkg -i firejail*.deb
+sudo dpkg -i ./*.deb
 echo "Firejail updated."
 cd ..
 rm -rf firejail

--- a/gcov.sh
+++ b/gcov.sh
@@ -23,7 +23,7 @@ gcov_generate() {
 make distclean &&
 ./configure --prefix=/usr --enable-fatal-warnings \
   --enable-apparmor --enable-gcov &&
-make -j4 &&
+make -j "$(nproc)" &&
 sudo make install
 
 rm -fr gcov-dir gcov-file

--- a/gcov.sh
+++ b/gcov.sh
@@ -19,7 +19,7 @@ gcov_generate() {
 
 make distclean && ./configure --prefix=/usr --enable-apparmor --enable-gcov --enable-fatal-warnings && make -j4 && sudo make install
 rm -fr gcov-dir gcov-file
-firejail --version
+make print-version
 gcov_generate
 
 make test-firecfg | grep TESTING

--- a/gcov.sh
+++ b/gcov.sh
@@ -12,12 +12,20 @@
 gcov_generate() {
 	USER="$(whoami)"
 	find . -exec sudo chown "$USER:$USER" '{}' +
-	lcov -q --capture -d src/firejail -d src/lib -d src/firecfg -d src/firemon \
-		-d src/fnet -d src/fnetfilter -d src/fcopy -d src/fseccomp --output-file gcov-file
+	lcov -q --capture \
+		-d src/firejail -d src/lib -d src/firecfg -d src/firemon \
+		-d src/fnet -d src/fnetfilter -d src/fcopy \
+		-d src/fseccomp --output-file gcov-file
+
 	genhtml -q gcov-file --output-directory gcov-dir
 }
 
-make distclean && ./configure --prefix=/usr --enable-apparmor --enable-gcov --enable-fatal-warnings && make -j4 && sudo make install
+make distclean &&
+./configure --prefix=/usr --enable-fatal-warnings \
+  --enable-apparmor --enable-gcov &&
+make -j4 &&
+sudo make install
+
 rm -fr gcov-dir gcov-file
 make print-version
 gcov_generate

--- a/mkdeb.sh
+++ b/mkdeb.sh
@@ -26,7 +26,7 @@ tar -xJvf "$CODE_ARCHIVE"
 #mkdir -p "$INSTALL_DIR"
 cd "$CODE_DIR"
 ./configure --prefix=/usr --enable-apparmor "$@"
-make -j2
+make -j "$(nproc)"
 mkdir debian
 DESTDIR=debian make install-strip
 

--- a/platform/rpm/mkrpm.sh
+++ b/platform/rpm/mkrpm.sh
@@ -16,6 +16,8 @@ set -e
 name="$TARNAME"
 # Strip any trailing prefix from the version like -rc1 etc
 version="$(printf '%s\n' "$VERSION" | sed 's/\-.*//g')"
+
+# Note: rpmbuild itself already passes --prefix=/usr to ./configure
 config_opt="--disable-userns --disable-contrib-install $*"
 
 if [[ ! -f "platform/rpm/${name}.spec" ]]; then

--- a/src/tools/mkcoverit.sh
+++ b/src/tools/mkcoverit.sh
@@ -44,5 +44,5 @@ mv $DIRFIRETOOLS $DIRFIREJAIL/extras/firetools
 
 # build
 cd $DIRFIREJAIL
-cov-build --dir cov-int make -j 4 extras
+cov-build --dir cov-int make -j "$(nproc)" extras
 tar czvf myproject.tgz cov-int

--- a/test/compile/compile.sh
+++ b/test/compile/compile.sh
@@ -81,7 +81,9 @@ tar -xJvf ../../"$DIST.tar.xz"
 mv "$DIST" firejail
 
 cd firejail || exit 1
-./configure --prefix=/usr --enable-fatal-warnings 2>&1 | tee ../output-configure
+./configure --prefix=/usr --enable-fatal-warnings \
+  2>&1 | tee ../output-configure
+
 make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test1
@@ -98,7 +100,10 @@ rm output-configure output-make
 print_title "${arr[2]}"
 cd firejail || exit 1
 make distclean
-./configure --prefix=/usr --disable-dbusproxy --enable-fatal-warnings 2>&1 | tee ../output-configure
+./configure --prefix=/usr --enable-fatal-warnings \
+  --disable-dbusproxy \
+  2>&1 | tee ../output-configure
+
 make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test2
@@ -115,7 +120,10 @@ rm output-configure output-make
 print_title "${arr[3]}"
 cd firejail || exit 1
 make distclean
-./configure --prefix=/usr --disable-chroot --enable-fatal-warnings 2>&1 | tee ../output-configure
+./configure --prefix=/usr --enable-fatal-warnings \
+  --disable-chroot \
+  2>&1 | tee ../output-configure
+
 make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test3
@@ -132,7 +140,10 @@ rm output-configure output-make
 print_title "${arr[4]}"
 cd firejail || exit 1
 make distclean
-./configure --prefix=/usr --disable-firetunnel --enable-fatal-warnings 2>&1 | tee ../output-configure
+./configure --prefix=/usr --enable-fatal-warnings \
+  --disable-firetunnel \
+  2>&1 | tee ../output-configure
+
 make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test4
@@ -149,7 +160,10 @@ rm output-configure output-make
 print_title "${arr[5]}"
 cd firejail || exit 1
 make distclean
-./configure --prefix=/usr --disable-userns --enable-fatal-warnings 2>&1 | tee ../output-configure
+./configure --prefix=/usr --enable-fatal-warnings \
+  --disable-userns \
+  2>&1 | tee ../output-configure
+
 make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test5
@@ -167,7 +181,10 @@ rm output-configure output-make
 print_title "${arr[6]}"
 cd firejail || exit 1
 make distclean
-./configure --prefix=/usr --disable-network --enable-fatal-warnings 2>&1 | tee ../output-configure
+./configure --prefix=/usr --enable-fatal-warnings \
+  --disable-network \
+  2>&1 | tee ../output-configure
+
 make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test6
@@ -184,7 +201,10 @@ rm output-configure output-make
 print_title "${arr[7]}"
 cd firejail || exit 1
 make distclean
-./configure --prefix=/usr --disable-x11 --enable-fatal-warnings 2>&1 | tee ../output-configure
+./configure --prefix=/usr --enable-fatal-warnings \
+  --disable-x11 \
+  2>&1 | tee ../output-configure
+
 make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test7
@@ -201,7 +221,10 @@ rm output-configure output-make
 print_title "${arr[8]}"
 cd firejail || exit 1
 make distclean
-./configure --prefix=/usr --enable-selinux --enable-fatal-warnings 2>&1 | tee ../output-configure
+./configure --prefix=/usr --enable-fatal-warnings \
+  --enable-selinux \
+  2>&1 | tee ../output-configure
+
 make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test8
@@ -218,7 +241,10 @@ rm output-configure output-make
 print_title "${arr[9]}"
 cd firejail || exit 1
 make distclean
-./configure --prefix=/usr --disable-file-transfer --enable-fatal-warnings 2>&1 | tee ../output-configure
+./configure --prefix=/usr --enable-fatal-warnings \
+  --disable-file-transfer \
+  2>&1 | tee ../output-configure
+
 make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test9
@@ -235,7 +261,10 @@ rm output-configure output-make
 print_title "${arr[10]}"
 cd firejail || exit 1
 make distclean
-./configure --prefix=/usr --disable-whitelist --enable-fatal-warnings 2>&1 | tee ../output-configure
+./configure --prefix=/usr --enable-fatal-warnings \
+  --disable-whitelist \
+  2>&1 | tee ../output-configure
+
 make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test10
@@ -252,7 +281,10 @@ rm output-configure output-make
 print_title "${arr[11]}"
 cd firejail || exit 1
 make distclean
-./configure --prefix=/usr --disable-globalcfg --enable-fatal-warnings 2>&1 | tee ../output-configure
+./configure --prefix=/usr --enable-fatal-warnings \
+  --disable-globalcfg \
+  2>&1 | tee ../output-configure
+
 make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test11
@@ -269,7 +301,10 @@ rm output-configure output-make
 print_title "${arr[12]}"
 cd firejail || exit 1
 make distclean
-./configure --prefix=/usr --enable-apparmor --enable-fatal-warnings 2>&1 | tee ../output-configure
+./configure --prefix=/usr --enable-fatal-warnings \
+  --enable-apparmor \
+  2>&1 | tee ../output-configure
+
 make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test12
@@ -286,7 +321,10 @@ rm output-configure output-make
 print_title "${arr[13]}"
 cd firejail || exit 1
 make distclean
-./configure --prefix=/usr --enable-busybox-workaround --enable-fatal-warnings 2>&1 | tee ../output-configure
+./configure --prefix=/usr --enable-fatal-warnings \
+  --enable-busybox-workaround \
+  2>&1 | tee ../output-configure
+
 make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test13
@@ -303,7 +341,10 @@ rm output-configure output-make
 print_title "${arr[14]}"
 cd firejail || exit 1
 make distclean
-./configure --prefix=/usr --disable-overlayfs --enable-fatal-warnings 2>&1 | tee ../output-configure
+./configure --prefix=/usr --enable-fatal-warnings \
+  --disable-overlayfs \
+  2>&1 | tee ../output-configure
+
 make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test14
@@ -320,7 +361,10 @@ rm output-configure output-make
 print_title "${arr[15]}"
 cd firejail || exit 1
 make distclean
-./configure --prefix=/usr --disable-private-home --enable-fatal-warnings 2>&1 | tee ../output-configure
+./configure --prefix=/usr --enable-fatal-warnings \
+  --disable-private-home \
+  2>&1 | tee ../output-configure
+
 make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test15
@@ -337,7 +381,10 @@ rm output-configure output-make
 print_title "${arr[16]}"
 cd firejail || exit 1
 make distclean
-./configure --prefix=/usr --disable-man --enable-fatal-warnings 2>&1 | tee ../output-configure
+./configure --prefix=/usr --enable-fatal-warnings \
+  --disable-man \
+  2>&1 | tee ../output-configure
+
 make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test16
@@ -354,7 +401,10 @@ rm output-configure output-make
 print_title "${arr[17]}"
 cd firejail || exit 1
 make distclean
-./configure --prefix=/usr --disable-usertmpfs --enable-fatal-warnings 2>&1 | tee ../output-configure
+./configure --prefix=/usr --enable-fatal-warnings \
+  --disable-usertmpfs \
+  2>&1 | tee ../output-configure
+
 make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test17
@@ -371,7 +421,10 @@ rm output-configure output-make
 print_title "${arr[18]}"
 cd firejail || exit 1
 make distclean
-./configure --prefix=/usr --disable-private-home --enable-fatal-warnings 2>&1 | tee ../output-configure
+./configure --prefix=/usr --enable-fatal-warnings \
+  --disable-private-home \
+  2>&1 | tee ../output-configure
+
 make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test18
@@ -388,7 +441,10 @@ rm output-configure output-make
 print_title "${arr[19]}"
 cd firejail || exit 1
 make distclean
-./configure --prefix=/usr --enable-ids --enable-fatal-warnings 2>&1 | tee ../output-configure
+./configure --prefix=/usr --enable-fatal-warnings \
+  --enable-ids \
+  2>&1 | tee ../output-configure
+
 make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test19

--- a/test/compile/compile.sh
+++ b/test/compile/compile.sh
@@ -82,7 +82,7 @@ mv "$DIST" firejail
 
 cd firejail || exit 1
 ./configure --prefix=/usr --enable-fatal-warnings 2>&1 | tee ../output-configure
-make -j4 2>&1 | tee ../output-make
+make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test1
 grep Error output-configure output-make >> ./report-test1
@@ -99,7 +99,7 @@ print_title "${arr[2]}"
 cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-dbusproxy --enable-fatal-warnings 2>&1 | tee ../output-configure
-make -j4 2>&1 | tee ../output-make
+make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test2
 grep Error output-configure output-make >> ./report-test2
@@ -116,7 +116,7 @@ print_title "${arr[3]}"
 cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-chroot --enable-fatal-warnings 2>&1 | tee ../output-configure
-make -j4 2>&1 | tee ../output-make
+make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test3
 grep Error output-configure output-make >> ./report-test3
@@ -133,7 +133,7 @@ print_title "${arr[4]}"
 cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-firetunnel --enable-fatal-warnings 2>&1 | tee ../output-configure
-make -j4 2>&1 | tee ../output-make
+make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test4
 grep Error output-configure output-make >> ./report-test4
@@ -150,7 +150,7 @@ print_title "${arr[5]}"
 cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-userns --enable-fatal-warnings 2>&1 | tee ../output-configure
-make -j4 2>&1 | tee ../output-make
+make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test5
 grep Error output-configure output-make >> ./report-test5
@@ -168,7 +168,7 @@ print_title "${arr[6]}"
 cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-network --enable-fatal-warnings 2>&1 | tee ../output-configure
-make -j4 2>&1 | tee ../output-make
+make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test6
 grep Error output-configure output-make >> ./report-test6
@@ -185,7 +185,7 @@ print_title "${arr[7]}"
 cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-x11 --enable-fatal-warnings 2>&1 | tee ../output-configure
-make -j4 2>&1 | tee ../output-make
+make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test7
 grep Error output-configure output-make >> ./report-test7
@@ -202,7 +202,7 @@ print_title "${arr[8]}"
 cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --enable-selinux --enable-fatal-warnings 2>&1 | tee ../output-configure
-make -j4 2>&1 | tee ../output-make
+make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test8
 grep Error output-configure output-make >> ./report-test8
@@ -219,7 +219,7 @@ print_title "${arr[9]}"
 cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-file-transfer --enable-fatal-warnings 2>&1 | tee ../output-configure
-make -j4 2>&1 | tee ../output-make
+make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test9
 grep Error output-configure output-make >> ./report-test9
@@ -236,7 +236,7 @@ print_title "${arr[10]}"
 cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-whitelist --enable-fatal-warnings 2>&1 | tee ../output-configure
-make -j4 2>&1 | tee ../output-make
+make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test10
 grep Error output-configure output-make >> ./report-test10
@@ -253,7 +253,7 @@ print_title "${arr[11]}"
 cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-globalcfg --enable-fatal-warnings 2>&1 | tee ../output-configure
-make -j4 2>&1 | tee ../output-make
+make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test11
 grep Error output-configure output-make >> ./report-test11
@@ -270,7 +270,7 @@ print_title "${arr[12]}"
 cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --enable-apparmor --enable-fatal-warnings 2>&1 | tee ../output-configure
-make -j4 2>&1 | tee ../output-make
+make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test12
 grep Error output-configure output-make >> ./report-test12
@@ -287,7 +287,7 @@ print_title "${arr[13]}"
 cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --enable-busybox-workaround --enable-fatal-warnings 2>&1 | tee ../output-configure
-make -j4 2>&1 | tee ../output-make
+make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test13
 grep Error output-configure output-make >> ./report-test13
@@ -304,7 +304,7 @@ print_title "${arr[14]}"
 cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-overlayfs --enable-fatal-warnings 2>&1 | tee ../output-configure
-make -j4 2>&1 | tee ../output-make
+make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test14
 grep Error output-configure output-make >> ./report-test14
@@ -321,7 +321,7 @@ print_title "${arr[15]}"
 cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-private-home --enable-fatal-warnings 2>&1 | tee ../output-configure
-make -j4 2>&1 | tee ../output-make
+make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test15
 grep Error output-configure output-make >> ./report-test15
@@ -338,7 +338,7 @@ print_title "${arr[16]}"
 cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-man --enable-fatal-warnings 2>&1 | tee ../output-configure
-make -j4 2>&1 | tee ../output-make
+make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test16
 grep Error output-configure output-make >> ./report-test16
@@ -355,7 +355,7 @@ print_title "${arr[17]}"
 cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-usertmpfs --enable-fatal-warnings 2>&1 | tee ../output-configure
-make -j4 2>&1 | tee ../output-make
+make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test17
 grep Error output-configure output-make >> ./report-test17
@@ -372,7 +372,7 @@ print_title "${arr[18]}"
 cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --disable-private-home --enable-fatal-warnings 2>&1 | tee ../output-configure
-make -j4 2>&1 | tee ../output-make
+make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test18
 grep Error output-configure output-make >> ./report-test18
@@ -389,7 +389,7 @@ print_title "${arr[19]}"
 cd firejail || exit 1
 make distclean
 ./configure --prefix=/usr --enable-ids --enable-fatal-warnings 2>&1 | tee ../output-configure
-make -j4 2>&1 | tee ../output-make
+make -j "$(nproc)" 2>&1 | tee ../output-make
 cd ..
 grep Warning output-configure output-make > ./report-test19
 grep Error output-configure output-make >> ./report-test19


### PR DESCRIPTION
Main changes:

* build: reduce TARNAME hardcoding
* build: standardize parallel make arguments
* build: standardize ./configure arguments

Relates to #5148 #5960 #6224.

This is a follow-up to #6222.
