### PR TITLE
gnome-boxes: deny access to /usr/libexec

### DIFF
--- a/etc/profile-a-l/gnome-boxes.profile
+++ b/etc/profile-a-l/gnome-boxes.profile
@@ -6,9 +6,7 @@ include gnome-boxes.local
 # Persistent global definitions
 include globals.local
 
-noblacklist /usr/libexec/gnome-boxes-search-provider
-noblacklist /usr/libexec/spice-client-glib-usb-acl-helper
-blacklist /usr/libexec/*
+blacklist /usr/libexec
 
 noblacklist ${HOME}/.cache/gnome-boxes
 noblacklist ${HOME}/.config/gnome-boxes

--- a/etc/profile-a-l/gnome-boxes.profile
+++ b/etc/profile-a-l/gnome-boxes.profile
@@ -6,6 +6,10 @@ include gnome-boxes.local
 # Persistent global definitions
 include globals.local
 
+noblacklist /usr/libexec/gnome-boxes-search-provider
+noblacklist /usr/libexec/spice-client-glib-usb-acl-helper
+blacklist /usr/libexec/*
+
 noblacklist ${HOME}/.cache/gnome-boxes
 noblacklist ${HOME}/.config/gnome-boxes
 noblacklist ${HOME}/.local/share/gnome-boxes


### PR DESCRIPTION
Restrict access to /usr/libexec.