### PR TITLE
profiles: deny access to ~/.config/autostart

### DIFF
--- a/etc/profile-a-l/dropbox.profile
+++ b/etc/profile-a-l/dropbox.profile
@@ -5,7 +5,12 @@ include dropbox.local
 # Persistent global definitions
 include globals.local
 
-noblacklist ${HOME}/.config/autostart
+# To allow the program to autostart, add the following to dropbox.local:
+# Warning: This allows the program to easily escape the sandbox.
+#noblacklist ${HOME}/.config/autostart
+#mkfile ${HOME}/.config/autostart/dropbox.desktop
+#whitelist ${HOME}/.config/autostart/dropbox.desktop
+
 noblacklist ${HOME}/.dropbox
 noblacklist ${HOME}/.dropbox-dist
 
@@ -20,8 +25,6 @@ include disable-programs.inc
 mkdir ${HOME}/.dropbox
 mkdir ${HOME}/.dropbox-dist
 mkdir ${HOME}/Dropbox
-mkfile ${HOME}/.config/autostart/dropbox.desktop
-whitelist ${HOME}/.config/autostart/dropbox.desktop
 whitelist ${HOME}/.dropbox
 whitelist ${HOME}/.dropbox-dist
 whitelist ${HOME}/Dropbox

--- a/etc/profile-a-l/gitter.profile
+++ b/etc/profile-a-l/gitter.profile
@@ -5,7 +5,11 @@ include gitter.local
 # Persistent global definitions
 include globals.local
 
-noblacklist ${HOME}/.config/autostart
+# To allow the program to autostart, add the following to gitter.local:
+# Warning: This allows the program to easily escape the sandbox.
+#noblacklist ${HOME}/.config/autostart
+#whitelist ${HOME}/.config/autostart
+
 noblacklist ${HOME}/.config/Gitter
 
 include disable-common.inc
@@ -16,7 +20,6 @@ include disable-programs.inc
 
 mkdir ${HOME}/.config/Gitter
 whitelist ${DOWNLOADS}
-whitelist ${HOME}/.config/autostart
 whitelist ${HOME}/.config/Gitter
 whitelist /opt/Gitter
 include whitelist-var-common.inc

--- a/etc/profile-m-z/meteo-qt.profile
+++ b/etc/profile-m-z/meteo-qt.profile
@@ -6,7 +6,11 @@ include meteo-qt.local
 # Persistent global definitions
 include globals.local
 
-noblacklist ${HOME}/.config/autostart
+# To allow the program to autostart, add the following to meteo-qt.local:
+# Warning: This allows the program to easily escape the sandbox.
+#noblacklist ${HOME}/.config/autostart
+#whitelist ${HOME}/.config/autostart
+
 noblacklist ${HOME}/.config/meteo-qt
 
 # Allow python (blacklisted by disable-interpreters.inc)
@@ -21,7 +25,6 @@ include disable-shell.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.config/meteo-qt
-whitelist ${HOME}/.config/autostart
 whitelist ${HOME}/.config/meteo-qt
 include whitelist-common.inc
 include whitelist-var-common.inc


### PR DESCRIPTION
The files in this directory are intended to be automatically executed
when the user logs in.

In which case, granting write access to this directory allows the
program to easily escape the sandbox (by autostarting itself outside of
firejail, for example).

Misc: This was noticed on #6244.