### PR TITLE
ssh: whitelist gcr-ssh-agent unix socket

### DIFF
--- a/etc/profile-m-z/ssh.profile
+++ b/etc/profile-m-z/ssh.profile
@@ -18,9 +18,9 @@ include disable-common.inc
 include disable-exec.inc
 include disable-programs.inc
 
+whitelist ${RUNUSER}/gcr/ssh
 whitelist ${RUNUSER}/gnupg/S.gpg-agent.ssh
 whitelist ${RUNUSER}/keyring/ssh
-whitelist ${RUNUSER}/gcr/ssh
 include whitelist-usr-share-common.inc
 include whitelist-runuser-common.inc
 

--- a/etc/profile-m-z/ssh.profile
+++ b/etc/profile-m-z/ssh.profile
@@ -20,6 +20,7 @@ include disable-programs.inc
 
 whitelist ${RUNUSER}/gnupg/S.gpg-agent.ssh
 whitelist ${RUNUSER}/keyring/ssh
+whitelist ${RUNUSER}/gcr/ssh
 include whitelist-usr-share-common.inc
 include whitelist-runuser-common.inc
 


### PR DESCRIPTION
Since gnome-keyring 1.46 the ssh-agent functionality has been removed and gcr-ssh-agent is the recommended alternative.

Source:
  - https://gitlab.gnome.org/GNOME/gcr/-/merge_requests/67
  - https://wiki.archlinux.org/title/GNOME/Keyring#SSH_keys

NOTE: @glitsj16 suggested to put the whitelist statement inside `whitelist-runuser-common.inc`, but since `whitelist-runuser-common.inc` is in this file, I think it makes more sense to leave it right after it.