### PR TITLE
landlock: use PATH macro in landlock-common.inc

### DIFF
--- a/etc/inc/landlock-common.inc
+++ b/etc/inc/landlock-common.inc
@@ -16,17 +16,9 @@ landlock.fs.write /tmp
 
 # exec access
 ## misc
+landlock.fs.execute ${PATH}
 landlock.fs.execute /opt
 landlock.fs.execute /run/firejail # appimage and various firejail features
-## bin
-landlock.fs.execute /bin
-landlock.fs.execute /sbin
-landlock.fs.execute /usr/bin
-landlock.fs.execute /usr/sbin
-landlock.fs.execute /usr/games
-landlock.fs.execute /usr/local/bin
-landlock.fs.execute /usr/local/sbin
-landlock.fs.execute /usr/local/games
 ## lib
 landlock.fs.execute /lib
 landlock.fs.execute /lib32


### PR DESCRIPTION
To reduce duplication.

Support for it was added on commit bf5a99360 ("landlock: add support for
PATH macro", 2023-12-22).

See also commit 19e108248 ("landlock: expand simple macros in commands",
2023-11-11) / PR #6125.

Relates to #6078.