### PR TITLE
build: sort.py: filter empty and duplicate items

### DIFF
--- a/contrib/sort.py
+++ b/contrib/sort.py
@@ -38,7 +38,8 @@ Exit Codes:
 
 def sort_alphabetical(original_items):
     items = original_items.split(",")
-    items.sort()
+    items = filter(None, set(items))
+    items = sorted(items)
     return ",".join(items)
 
 

--- a/etc/profile-a-l/dnscrypt-proxy.profile
+++ b/etc/profile-a-l/dnscrypt-proxy.profile
@@ -38,7 +38,7 @@ notv
 nou2f
 novideo
 protocol inet,inet6
-seccomp.drop _sysctl,acct,add_key,adjtimex,clock_adjtime,delete_module,fanotify_init,finit_module,get_mempolicy,init_module,io_cancel,io_destroy,io_getevents,io_setup,io_submit,ioperm,iopl,kcmp,kexec_file_load,kexec_load,keyctl,lookup_dcookie,mbind,migrate_pages,modify_ldt,mount,move_pages,open_by_handle_at,perf_event_open,perf_event_open,pivot_root,process_vm_readv,process_vm_writev,ptrace,remap_file_pages,request_key,set_mempolicy,swapoff,swapon,sysfs,syslog,umount2,uselib,vmsplice
+seccomp.drop _sysctl,acct,add_key,adjtimex,clock_adjtime,delete_module,fanotify_init,finit_module,get_mempolicy,init_module,io_cancel,io_destroy,io_getevents,io_setup,io_submit,ioperm,iopl,kcmp,kexec_file_load,kexec_load,keyctl,lookup_dcookie,mbind,migrate_pages,modify_ldt,mount,move_pages,open_by_handle_at,perf_event_open,pivot_root,process_vm_readv,process_vm_writev,ptrace,remap_file_pages,request_key,set_mempolicy,swapoff,swapon,sysfs,syslog,umount2,uselib,vmsplice
 tracelog
 
 disable-mnt


### PR DESCRIPTION
Note: This seems to already be done for `protocol` lines.

Before:

    $ ./contrib/sort.py test.profile
    sort.py: checking 1 profile(s)...
    test.profile:1:-private-etc ,,bar,,foo,,bar,,,
    test.profile:1:+private-etc ,,,,,,,bar,bar,foo
    test.profile:2:-protocol ,,unix,,bluetooth,,unix,,inet,,,
    test.profile:2:+protocol unix,inet,bluetooth
    [ Fixed ] test.profile

After:

    $ ./contrib/sort.py test.profile
    sort.py: checking 1 profile(s)...
    test.profile:1:-private-etc ,,bar,,foo,,bar,,,
    test.profile:1:+private-etc bar,foo
    test.profile:2:-protocol ,,unix,,bluetooth,,unix,,inet,,,
    test.profile:2:+protocol unix,inet,bluetooth
    [ Fixed ] test.profile