### PR TITLE
firecfg.config: add floorp

### DIFF
--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -274,6 +274,7 @@ fix-qdf
 flacsplt
 flameshot
 flashpeak-slimjet
+floorp
 flowblade
 fluffychat
 font-manager


### PR DESCRIPTION
Floorp Browser is already having a profile (floorp.profile) but the firecfg.config doesn't have a entry for floorp. As a result `sudo firecfg` was not creating firejail symlinks for floorp.