### PR TITLE
profiles: remove blacklisting of qt5ct/qt6ct paths

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -614,8 +614,6 @@ blacklist ${HOME}/.config/qBittorrent
 blacklist ${HOME}/.config/qBittorrentrc
 blacklist ${HOME}/.config/qnapi.ini
 blacklist ${HOME}/.config/qpdfview
-blacklist ${HOME}/.config/qt5ct
-blacklist ${HOME}/.config/qt6ct
 blacklist ${HOME}/.config/quodlibet
 blacklist ${HOME}/.config/qupzilla
 blacklist ${HOME}/.config/qutebrowser
@@ -1030,8 +1028,6 @@ blacklist ${HOME}/.local/share/psi
 blacklist ${HOME}/.local/share/psi+
 blacklist ${HOME}/.local/share/qBittorrent
 blacklist ${HOME}/.local/share/qpdfview
-blacklist ${HOME}/.local/share/qt5ct
-blacklist ${HOME}/.local/share/qt6ct
 blacklist ${HOME}/.local/share/quadrapassel
 blacklist ${HOME}/.local/share/qutebrowser
 blacklist ${HOME}/.local/share/remmina

--- a/etc/profile-m-z/qt5ct.profile
+++ b/etc/profile-m-z/qt5ct.profile
@@ -8,9 +8,6 @@ include globals.local
 
 blacklist /usr/libexec
 
-noblacklist ${HOME}/.config/qt5ct
-noblacklist ${HOME}/.local/share/qt5ct
-
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/profile-m-z/qt6ct.profile
+++ b/etc/profile-m-z/qt6ct.profile
@@ -8,9 +8,6 @@ include globals.local
 
 blacklist /usr/libexec
 
-noblacklist ${HOME}/.config/qt6ct
-noblacklist ${HOME}/.local/share/qt6ct
-
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc


### PR DESCRIPTION
Blacklisting qt5ct/qt6ct configuration and data paths breaks styling in all apps that use them. This was working as expected before #6249 and #6250, let's restore this for both apps.