### PR TITLE
docs: firecfg: note different .desktop naming schemes

### DIFF
--- a/src/man/firecfg.1.in
+++ b/src/man/firecfg.1.in
@@ -186,6 +186,20 @@ could be added to /etc/firejail/firecfg.d/10-my.conf:
 .br
 myprog
 .RE
+.PP
+Note that certain programs may use different naming schemes for their .desktop
+file compared to the main executable.
+To ensure that both files are handled in the same manner, it is recommended to
+list both names in the configuration.
+For example, if Spectacle has its main executable at /usr/bin/spectacle and its
+\&.desktop file at /usr/share/applications/org.kde.spectacle.desktop, then the
+following lines can to be used to ignore both:
+.PP
+.RS
+!org.kde.spectacle
+.br
+!spectacle
+.RE
 .SH LICENSE
 This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
 .PP


### PR DESCRIPTION
Based on the discussion at #5063.

Misc: The `\&` is used to escape the dot in `.desktop` (see roff(7)).

This amends commit a9c851ee4 ("firecfg: use ignorelist also for .desktop
files", 2024-01-08) / PR #6153.