### PR TITLE
torbrowser-launcher fixes

### DIFF
--- a/etc/apparmor/firejail-local
+++ b/etc/apparmor/firejail-local
@@ -24,4 +24,4 @@
 #owner @{HOME}/.local/share/mullvad-browser/** ix,
 
 # Uncomment to opt-in to apparmor for torbrowser-launcher
-#owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/** ix,
+#owner @{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser*/Browser/** ix,

--- a/etc/profile-m-z/torbrowser-launcher.profile
+++ b/etc/profile-m-z/torbrowser-launcher.profile
@@ -59,7 +59,7 @@ seccomp.block-secondary
 #tracelog # may cause issues, see #1930
 
 disable-mnt
-private-bin bash,cat,cp,cut,dirname,env,expr,file,gpg,grep,gxmessage,id,kdialog,ln,mkdir,mv,python*,rm,sed,sh,tail,tar,tclsh,test,tor-browser,tor-browser-en,torbrowser-launcher,update-desktop-database,xmessage,xz,zenity
+private-bin bash,cat,cp,cut,dirname,env,execdesktop,expr,file,gpg,grep,gxmessage,id,kdialog,ln,mkdir,mv,python*,rm,sed,sh,tail,tar,tclsh,test,tor-browser,tor-browser-en,torbrowser-launcher,update-desktop-database,xmessage,xz,zenity
 private-dev
 private-etc @tls-ca
 private-tmp


### PR DESCRIPTION
Apparently Tor Browser 13.0.11 (based on Mozilla Firefox 115.8.0esr)
changed a few things. The former versions installed under
`${HOME}/.local/share/torbrowser/tbb/x86_64/tor-browser_en-US/Browser`
and now under
`${HOME}/.local/share/torbrowser/tbb/x86_64/tor-browser/Browser`.

All of our tor-browser-foo.profile profiles redirect to
torbrowser-launcher.profile and are covered by the fixes.

torbrowser.profile was not tested. It redirects to
firefox-common.profile and seems to be Gentoo-specific.

Fixes #6269.