### PR TITLE
qt6ct: add dbus-filtering rules

### DIFF
--- a/etc/profile-m-z/qt6ct.profile
+++ b/etc/profile-m-z/qt6ct.profile
@@ -55,7 +55,9 @@ private-dev
 private-etc dbus-1,machine-id
 private-tmp
 
-dbus-user none
+dbus-user filter
+dbus-user.talk org.freedesktop.portal.Desktop
+dbus-user.talk org.freedesktop.portal.Settings
 dbus-system none
 
 memory-deny-write-execute


### PR DESCRIPTION
Add support for qt6ct packages that use XDG desktop portal.

https://github.com/MikeWalrus/qt6ct#branch=colorscheme-portal
https://aur.archlinux.org/packages/qt6ct-xdg-colorscheme-git