### PR TITLE
k3b.profile: fix dvd drive detection (private-dev)

### DIFF
--- a/etc/profile-a-l/k3b.profile
+++ b/etc/profile-a-l/k3b.profile
@@ -24,6 +24,7 @@ caps.keep chown,dac_override,ipc_lock,net_bind_service,sys_admin,sys_nice,sys_ra
 #net none
 netfilter
 no3d
+#nodvd
 #nonewprivs # breaks privileged helpers
 noinput
 #noroot # breaks privileged helpers
@@ -33,7 +34,7 @@ novideo
 #protocol unix # breaks privileged helpers
 #seccomp # breaks privileged helpers
 
-private-dev
+#private-dev # breaks detection of dvd drives (see #6279)
 #private-tmp
 
 #restrict-namespaces # breaks privileged helpers


### PR DESCRIPTION
@hedgehog29 commented[1]:

> It prevents k3b from detecting all dvd drives, incudling USB ones, and
> it seems that also SATA.

Fixes #6279.

[1] https://github.com/netblue30/firejail/issues/6279#issue-2191392448
