### PR TITLE
firefox: Add org.kde.kdeconnect to plasma integration comment

### DIFF
--- a/etc/profile-a-l/firefox.profile
+++ b/etc/profile-a-l/firefox.profile
@@ -55,6 +55,7 @@ dbus-user.own org.mpris.MediaPlayer2.firefox.*
 # Add the next lines to your firefox.local for plasma browser integration.
 #dbus-user.own org.mpris.MediaPlayer2.plasma-browser-integration
 #dbus-user.talk org.kde.JobViewServer
+#dbus-user.talk org.kde.kdeconnect
 #dbus-user.talk org.kde.kuiserver
 # Add the next line to your firefox.local to allow screen sharing under wayland.
 #dbus-user.talk org.freedesktop.portal.Desktop


### PR DESCRIPTION
Turning this into a PR as per <https://github.com/netblue30/firejail/issues/1139#issuecomment-2014916426>.

I recently set up KDE connect and plasma-browser-integration for firefox (Linux Mint 21.2) and needed this line in addition to the ones mentioned in the profile. Found it via running `firejail --profile=/etc/firejail/firefox.profile --dbus-user.log firefox`, trying to send links to device, and seeing what events get logged.

(I also needed `ignore dbus-user none` in `firefox-common.local`, which is mentioned in a comment already. I'm not using `private-bin` for firefox.)

Ideally I'd want someone to test this and confirm they also require this line for plasma-browser-integration to work; possibly it's platform- or version-specific.