### PR TITLE
profiles: replace x11 socket blacklist with disable-X11.inc

### DIFF
--- a/etc/profile-a-l/agetpkg.profile
+++ b/etc/profile-a-l/agetpkg.profile
@@ -7,7 +7,6 @@ include agetpkg.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 # Allow python (blacklisted by disable-interpreters.inc)
@@ -20,6 +19,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 whitelist ${DOWNLOADS}

--- a/etc/profile-a-l/alpine.profile
+++ b/etc/profile-a-l/alpine.profile
@@ -30,7 +30,6 @@ noblacklist ${HOME}/.pinercex
 noblacklist ${HOME}/.signature
 noblacklist ${HOME}/mail
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
@@ -39,6 +38,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 #whitelist ${DOCUMENTS}

--- a/etc/profile-a-l/aria2c.profile
+++ b/etc/profile-a-l/aria2c.profile
@@ -11,7 +11,6 @@ noblacklist ${HOME}/.cache/winetricks # XXX: See #5238
 noblacklist ${HOME}/.config/aria2
 noblacklist ${HOME}/.netrc
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
@@ -19,6 +18,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
+include disable-X11.inc
 
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc

--- a/etc/profile-a-l/bpftop.profile
+++ b/etc/profile-a-l/bpftop.profile
@@ -7,7 +7,6 @@ include bpftop.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist /usr/libexec
 blacklist ${RUNUSER}
 
@@ -18,6 +17,7 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 include whitelist-common.inc

--- a/etc/profile-a-l/cloneit.profile
+++ b/etc/profile-a-l/cloneit.profile
@@ -7,7 +7,6 @@ include cloneit.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist /usr/libexec
 blacklist ${RUNUSER}
 
@@ -18,6 +17,7 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 include whitelist-run-common.inc

--- a/etc/profile-a-l/curl.profile
+++ b/etc/profile-a-l/curl.profile
@@ -16,7 +16,6 @@ noblacklist ${HOME}/.config/curlrc # since curl 7.73.0
 noblacklist ${HOME}/.curl-hsts
 noblacklist ${HOME}/.curlrc
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
 
 # If you use nvm, add the below lines to your curl.local
@@ -26,6 +25,7 @@ blacklist ${RUNUSER}
 include disable-common.inc
 include disable-exec.inc
 include disable-programs.inc
+include disable-X11.inc
 # Depending on workflow you can add 'include disable-xdg.inc' to your curl.local.
 #include disable-xdg.inc
 

--- a/etc/profile-a-l/dbus-send.profile
+++ b/etc/profile-a-l/dbus-send.profile
@@ -7,7 +7,6 @@ include dbus-send.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
@@ -17,6 +16,7 @@ include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
 include disable-write-mnt.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 #include whitelist-common.inc # see #903

--- a/etc/profile-a-l/deadlink.profile
+++ b/etc/profile-a-l/deadlink.profile
@@ -6,7 +6,6 @@ include deadlink.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist /usr/libexec
 blacklist ${RUNUSER}
 
@@ -23,6 +22,7 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 include whitelist-run-common.inc

--- a/etc/profile-a-l/dexios.profile
+++ b/etc/profile-a-l/dexios.profile
@@ -7,7 +7,6 @@ include dexios.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist /usr/libexec
 blacklist ${RUNUSER}
 
@@ -18,6 +17,7 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 whitelist ${DOWNLOADS}

--- a/etc/profile-a-l/dig.profile
+++ b/etc/profile-a-l/dig.profile
@@ -10,7 +10,6 @@ include globals.local
 noblacklist ${HOME}/.digrc
 noblacklist ${PATH}/dig
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
 
 include disable-common.inc
@@ -18,6 +17,7 @@ include disable-common.inc
 include disable-exec.inc
 #include disable-interpreters.inc
 include disable-programs.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 #mkfile ${HOME}/.digrc # see #903

--- a/etc/profile-a-l/dnscrypt-proxy.profile
+++ b/etc/profile-a-l/dnscrypt-proxy.profile
@@ -7,7 +7,6 @@ include dnscrypt-proxy.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 noblacklist /sbin
@@ -18,6 +17,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 whitelist /usr/share/dnscrypt-proxy

--- a/etc/profile-a-l/dnsmasq.profile
+++ b/etc/profile-a-l/dnsmasq.profile
@@ -11,13 +11,13 @@ noblacklist /sbin
 noblacklist /usr/sbin
 noblacklist /var/lib/libvirt
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
 
 include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc
 include disable-programs.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 whitelist /var/lib/libvirt/dnsmasq

--- a/etc/profile-a-l/drill.profile
+++ b/etc/profile-a-l/drill.profile
@@ -9,7 +9,6 @@ include globals.local
 
 noblacklist ${PATH}/drill
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
 
 include disable-common.inc
@@ -17,6 +16,7 @@ include disable-common.inc
 include disable-exec.inc
 #include disable-interpreters.inc
 include disable-programs.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 #include whitelist-common.inc # see #903

--- a/etc/profile-a-l/editorconfiger.profile
+++ b/etc/profile-a-l/editorconfiger.profile
@@ -6,7 +6,6 @@ include editorconfiger.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist /usr/libexec
 blacklist ${RUNUSER}
 
@@ -17,6 +16,7 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 apparmor

--- a/etc/profile-a-l/erd.profile
+++ b/etc/profile-a-l/erd.profile
@@ -7,9 +7,8 @@ include erd.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
-
 include disable-exec.inc
+#include disable-X11.inc # x11 none
 
 apparmor
 caps.drop all

--- a/etc/profile-a-l/fdns.profile
+++ b/etc/profile-a-l/fdns.profile
@@ -8,7 +8,6 @@ include globals.local
 noblacklist /sbin
 noblacklist /usr/sbin
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
@@ -16,6 +15,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 #include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/gget.profile
+++ b/etc/profile-a-l/gget.profile
@@ -7,7 +7,6 @@ include gget.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
 
 include disable-common.inc
@@ -16,6 +15,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 whitelist ${DOWNLOADS}

--- a/etc/profile-a-l/gist.profile
+++ b/etc/profile-a-l/gist.profile
@@ -7,7 +7,6 @@ include gist.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 noblacklist ${HOME}/.gist
@@ -20,6 +19,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.gist

--- a/etc/profile-a-l/git.profile
+++ b/etc/profile-a-l/git.profile
@@ -28,12 +28,12 @@ ignore rmenv GITHUB_ENTERPRISE_TOKEN
 # Allow ssh (blacklisted by disable-common.inc)
 include allow-ssh.inc
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-exec.inc
 include disable-programs.inc
+include disable-X11.inc
 
 whitelist /usr/share/git
 whitelist /usr/share/git-core

--- a/etc/profile-a-l/gnome-keyring-daemon.profile
+++ b/etc/profile-a-l/gnome-keyring-daemon.profile
@@ -7,7 +7,6 @@ include gnome-keyring-daemon.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
@@ -16,6 +15,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 #include disable-X11.inc # x11 none
+include disable-X11.inc
 include disable-xdg.inc
 
 whitelist ${RUNUSER}/gnupg

--- a/etc/profile-a-l/googler-common.profile
+++ b/etc/profile-a-l/googler-common.profile
@@ -7,7 +7,6 @@ include googler-common.local
 # added by caller profile
 #include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
 
 noblacklist ${HOME}/.w3m
@@ -23,6 +22,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 whitelist ${HOME}/.w3m

--- a/etc/profile-a-l/gpg-agent.profile
+++ b/etc/profile-a-l/gpg-agent.profile
@@ -9,13 +9,13 @@ include globals.local
 
 noblacklist ${HOME}/.gnupg
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc
 include disable-programs.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.gnupg

--- a/etc/profile-a-l/gpg.profile
+++ b/etc/profile-a-l/gpg.profile
@@ -9,13 +9,13 @@ include globals.local
 
 noblacklist ${HOME}/.gnupg
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc
 include disable-programs.inc
+include disable-X11.inc
 
 whitelist ${RUNUSER}/gnupg
 whitelist ${RUNUSER}/keyring

--- a/etc/profile-a-l/links-common.profile
+++ b/etc/profile-a-l/links-common.profile
@@ -4,7 +4,6 @@ include links-common.local
 
 # common profile for links browsers
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
@@ -14,6 +13,7 @@ include disable-interpreters.inc
 # Additional noblacklist files/directories (blacklisted in disable-programs.inc)
 # used as associated programs can be added in your links-common.local.
 include disable-programs.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 whitelist ${DOWNLOADS}

--- a/etc/profile-a-l/lynx.profile
+++ b/etc/profile-a-l/lynx.profile
@@ -7,13 +7,13 @@ include lynx.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc
 include disable-programs.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 include whitelist-runuser-common.inc

--- a/etc/profile-m-z/makepkg.profile
+++ b/etc/profile-m-z/makepkg.profile
@@ -7,7 +7,6 @@ include makepkg.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 # Note: see this Arch forum discussion https://bbs.archlinux.org/viewtopic.php?pid=1743138
@@ -33,6 +32,7 @@ noblacklist /var/lib/pacman
 include disable-common.inc
 include disable-exec.inc
 include disable-programs.inc
+include disable-X11.inc
 
 caps.drop all
 ipc-namespace

--- a/etc/profile-m-z/mimetype.profile
+++ b/etc/profile-m-z/mimetype.profile
@@ -7,11 +7,11 @@ include mimetype.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 include disable-exec.inc
 include disable-proc.inc
+include disable-X11.inc
 
 apparmor
 caps.drop all

--- a/etc/profile-m-z/mocp.profile
+++ b/etc/profile-m-z/mocp.profile
@@ -10,7 +10,6 @@ include globals.local
 noblacklist ${HOME}/.moc
 noblacklist ${MUSIC}
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
@@ -19,6 +18,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.moc

--- a/etc/profile-m-z/mutt.profile
+++ b/etc/profile-m-z/mutt.profile
@@ -38,7 +38,6 @@ noblacklist ${HOME}/postponed
 noblacklist ${HOME}/sent
 noblacklist /etc/msmtprc
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 # Add the next lines to your mutt.local for oauth.py,S/MIME support.
@@ -51,6 +50,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.Mail

--- a/etc/profile-m-z/neomutt.profile
+++ b/etc/profile-m-z/neomutt.profile
@@ -39,7 +39,6 @@ noblacklist /etc/msmtprc
 noblacklist /var/mail
 noblacklist /var/spool/mail
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 include allow-lua.inc
@@ -49,6 +48,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.Mail

--- a/etc/profile-m-z/nslookup.profile
+++ b/etc/profile-m-z/nslookup.profile
@@ -7,7 +7,6 @@ include nslookup.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
 
 noblacklist ${PATH}/nslookup
@@ -17,6 +16,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 whitelist ${HOME}/.nslookuprc

--- a/etc/profile-m-z/rsync-download_only.profile
+++ b/etc/profile-m-z/rsync-download_only.profile
@@ -11,7 +11,6 @@ include globals.local
 # not as a daemon (rsync --daemon) nor to create backups.
 # Usage: firejail --profile=rsync-download_only rsync
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
 
 include disable-common.inc
@@ -20,6 +19,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 # Add the next line to your rsync-download_only.local to enable extra hardening.

--- a/etc/profile-m-z/rtv.profile
+++ b/etc/profile-m-z/rtv.profile
@@ -6,7 +6,6 @@ include rtv.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 noblacklist ${HOME}/.config/rtv
@@ -28,6 +27,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.config/rtv

--- a/etc/profile-m-z/server.profile
+++ b/etc/profile-m-z/server.profile
@@ -36,7 +36,6 @@ noblacklist /usr/sbin
 noblacklist /etc/init.d
 #noblacklist /var/opt
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
@@ -45,6 +44,7 @@ include disable-common.inc
 #include disable-interpreters.inc
 include disable-programs.inc
 include disable-write-mnt.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 #include whitelist-runuser-common.inc

--- a/etc/profile-m-z/signal-cli.profile
+++ b/etc/profile-m-z/signal-cli.profile
@@ -6,7 +6,6 @@ include signal-cli.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 noblacklist ${HOME}/.local/share/signal-cli
@@ -18,6 +17,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.local/share/signal-cli

--- a/etc/profile-m-z/ssh-agent.profile
+++ b/etc/profile-m-z/ssh-agent.profile
@@ -9,11 +9,11 @@ include globals.local
 # Allow ssh (blacklisted by disable-common.inc)
 include allow-ssh.inc
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-programs.inc
+include disable-X11.inc
 
 include whitelist-usr-share-common.inc
 

--- a/etc/profile-m-z/ssmtp.profile
+++ b/etc/profile-m-z/ssmtp.profile
@@ -24,8 +24,8 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-xdg.inc
 include disable-X11.inc
+include disable-xdg.inc
 
 mkfile ${HOME}/dead.letter
 whitelist ${HOME}/dead.letter

--- a/etc/profile-m-z/statusof.profile
+++ b/etc/profile-m-z/statusof.profile
@@ -7,7 +7,6 @@ include statusof.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist /usr/libexec
 blacklist ${RUNUSER}
 
@@ -21,6 +20,7 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 include whitelist-common.inc

--- a/etc/profile-m-z/termshark.profile
+++ b/etc/profile-m-z/termshark.profile
@@ -8,8 +8,9 @@ include termshark.local
 # added by included profile
 #include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
+
+include disable-X11.inc
 
 # Redirect
 include wireshark.profile

--- a/etc/profile-m-z/tin.profile
+++ b/etc/profile-m-z/tin.profile
@@ -9,7 +9,6 @@ include globals.local
 noblacklist ${HOME}/.newsrc
 noblacklist ${HOME}/.tin
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
 blacklist /usr/libexec
 
@@ -19,6 +18,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.tin

--- a/etc/profile-m-z/tmux.profile
+++ b/etc/profile-m-z/tmux.profile
@@ -7,7 +7,6 @@ include tmux.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
 
 noblacklist /tmp/tmux-*
@@ -16,6 +15,7 @@ noblacklist /tmp/tmux-*
 #include disable-devel.inc
 #include disable-exec.inc
 #include disable-programs.inc
+include disable-X11.inc
 
 caps.drop all
 ipc-namespace

--- a/etc/profile-m-z/tracker.profile
+++ b/etc/profile-m-z/tracker.profile
@@ -8,7 +8,6 @@ include globals.local
 
 # Tracker is started by systemd on most systems. Therefore it is not firejailed by default
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
@@ -16,6 +15,7 @@ include disable-devel.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
+include disable-X11.inc
 
 include whitelist-runuser-common.inc
 

--- a/etc/profile-m-z/tshark.profile
+++ b/etc/profile-m-z/tshark.profile
@@ -7,8 +7,9 @@ include tshark.local
 # added by included profile
 #include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
+
+include disable-X11.inc
 
 # Redirect
 include wireshark.profile

--- a/etc/profile-m-z/tvnamer.profile
+++ b/etc/profile-m-z/tvnamer.profile
@@ -6,7 +6,6 @@ include tvnamer.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist /usr/libexec
 blacklist ${RUNUSER}
 
@@ -24,6 +23,7 @@ include disable-interpreters.inc
 include disable-programs.inc
 include disable-proc.inc
 include disable-shell.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.config/tvnamer

--- a/etc/profile-m-z/unbound.profile
+++ b/etc/profile-m-z/unbound.profile
@@ -9,7 +9,6 @@ include globals.local
 noblacklist /sbin
 noblacklist /usr/sbin
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
 
 include disable-common.inc
@@ -17,6 +16,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 whitelist /usr/share/dns

--- a/etc/profile-m-z/w3m.profile
+++ b/etc/profile-m-z/w3m.profile
@@ -14,7 +14,6 @@ include globals.local
 
 noblacklist ${HOME}/.w3m
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}/wayland-*
 
 # Allow /bin/sh (blacklisted by disable-shell.inc)
@@ -29,6 +28,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.w3m

--- a/etc/profile-m-z/wget.profile
+++ b/etc/profile-m-z/wget.profile
@@ -15,7 +15,6 @@ noblacklist ${HOME}/.wgetrc
 #ignore read-only ${HOME}/.nvm
 #noblacklist ${HOME}/.nvm
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
 
 include disable-common.inc
@@ -24,6 +23,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
+include disable-X11.inc
 # Depending on workflow you can add the next line to your wget.local.
 #include disable-xdg.inc
 

--- a/etc/profile-m-z/whois.profile
+++ b/etc/profile-m-z/whois.profile
@@ -7,7 +7,6 @@ include whois.local
 # Persistent global definitions
 include globals.local
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
 
 include disable-common.inc
@@ -15,6 +14,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 include whitelist-usr-share-common.inc

--- a/etc/profile-m-z/yt-dlp.profile
+++ b/etc/profile-m-z/yt-dlp.profile
@@ -29,7 +29,6 @@ noblacklist ${VIDEOS}
 # Allow python (blacklisted by disable-interpreters.inc)
 include allow-python3.inc
 
-blacklist /tmp/.X11-unix
 blacklist ${RUNUSER}
 
 include disable-common.inc
@@ -38,6 +37,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 include whitelist-usr-share-common.inc


### PR DESCRIPTION
Replace all occurrences of `blacklist /tmp/.X11-unix` with
`include disable-X11.inc`, which blacklists more X11-related files.

Commands used to search and replace:

    $ git grep -Ilz '^blacklist /tmp/.X11-unix' -- \
      etc/profile*/*.profile | xargs -0 perl -0 -pi -e '\
        s/\nblacklist \/tmp\/.X11-unix\n/\n/; \
        s/(\ninclude disable-xdg.inc\n)/\ninclude disable-X11.inc$1/; \
        s/(\ninclude disable-[^Xx\n]+\n)(\n|# )/$1include disable-X11.inc\n$2/'

Note: The following files were also edited manually:

* etc/profile-a-l/erd.profile
* etc/profile-a-l/links-common.profile
* etc/profile-m-z/termshark.profile
* etc/profile-m-z/tmux.profile
* etc/profile-m-z/tshark.profile

Relates to #4462 #4854 #5544.