### PR TITLE
profiles: rename disable-X11.inc to disable-x11.inc

### DIFF
--- a/etc/inc/disable-X11.inc
+++ b/etc/inc/disable-X11.inc
@@ -2,14 +2,7 @@
 # Persistent customizations should go in a .local file.
 include disable-X11.local
 
-blacklist /tmp/.X11-unix
-blacklist ${HOME}/.Xauthority
-blacklist ${RUNUSER}/gdm/Xauthority
-blacklist ${RUNUSER}/.mutter-Xwaylandauth*
-blacklist ${RUNUSER}/xauth_*
-#blacklist ${RUNUSER}/[[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]]-[[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]]-[[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]]-[[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]]-[[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]]
-blacklist /tmp/xauth*
-blacklist /tmp/.ICE-unix
-blacklist ${RUNUSER}/ICEauthority
-rmenv DISPLAY
-rmenv XAUTHORITY
+# Warning: This file is deprecated; use disable-x11.inc (lowercase) instead.
+
+# Redirect
+include disable-x11.inc

--- a/etc/inc/disable-x11.inc
+++ b/etc/inc/disable-x11.inc
@@ -1,0 +1,15 @@
+# This file is overwritten during software install.
+# Persistent customizations should go in a .local file.
+include disable-x11.local
+
+blacklist /tmp/.X11-unix
+blacklist ${HOME}/.Xauthority
+blacklist ${RUNUSER}/gdm/Xauthority
+blacklist ${RUNUSER}/.mutter-Xwaylandauth*
+blacklist ${RUNUSER}/xauth_*
+#blacklist ${RUNUSER}/[[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]]-[[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]]-[[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]]-[[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]]-[[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]][[:xdigit:]]
+blacklist /tmp/xauth*
+blacklist /tmp/.ICE-unix
+blacklist ${RUNUSER}/ICEauthority
+rmenv DISPLAY
+rmenv XAUTHORITY

--- a/etc/profile-a-l/agetpkg.profile
+++ b/etc/profile-a-l/agetpkg.profile
@@ -19,7 +19,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 whitelist ${DOWNLOADS}

--- a/etc/profile-a-l/alpine.profile
+++ b/etc/profile-a-l/alpine.profile
@@ -38,7 +38,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 #whitelist ${DOCUMENTS}

--- a/etc/profile-a-l/aria2c.profile
+++ b/etc/profile-a-l/aria2c.profile
@@ -18,7 +18,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc

--- a/etc/profile-a-l/bpftop.profile
+++ b/etc/profile-a-l/bpftop.profile
@@ -17,7 +17,7 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 include whitelist-common.inc

--- a/etc/profile-a-l/build-systems-common.profile
+++ b/etc/profile-a-l/build-systems-common.profile
@@ -25,7 +25,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 #whitelist ${HOME}/Projects

--- a/etc/profile-a-l/clac.profile
+++ b/etc/profile-a-l/clac.profile
@@ -16,7 +16,7 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
-#include disable-X11.inc # x11 none
+#include disable-x11.inc # x11 none
 include disable-xdg.inc
 
 #include whitelist-common.inc # see #903

--- a/etc/profile-a-l/cloneit.profile
+++ b/etc/profile-a-l/cloneit.profile
@@ -17,7 +17,7 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 include whitelist-run-common.inc

--- a/etc/profile-a-l/cointop.profile
+++ b/etc/profile-a-l/cointop.profile
@@ -17,7 +17,7 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.config/cointop

--- a/etc/profile-a-l/curl.profile
+++ b/etc/profile-a-l/curl.profile
@@ -25,7 +25,7 @@ blacklist ${RUNUSER}
 include disable-common.inc
 include disable-exec.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 # Depending on workflow you can add 'include disable-xdg.inc' to your curl.local.
 #include disable-xdg.inc
 

--- a/etc/profile-a-l/daisy.profile
+++ b/etc/profile-a-l/daisy.profile
@@ -15,7 +15,7 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
-#include disable-X11.inc # x11 none
+#include disable-x11.inc # x11 none
 include disable-xdg.inc
 
 include whitelist-common.inc

--- a/etc/profile-a-l/dbus-send.profile
+++ b/etc/profile-a-l/dbus-send.profile
@@ -16,7 +16,7 @@ include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
 include disable-write-mnt.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 #include whitelist-common.inc # see #903

--- a/etc/profile-a-l/deadlink.profile
+++ b/etc/profile-a-l/deadlink.profile
@@ -22,7 +22,7 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 include whitelist-run-common.inc

--- a/etc/profile-a-l/dexios.profile
+++ b/etc/profile-a-l/dexios.profile
@@ -17,7 +17,7 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 whitelist ${DOWNLOADS}

--- a/etc/profile-a-l/dig.profile
+++ b/etc/profile-a-l/dig.profile
@@ -17,7 +17,7 @@ include disable-common.inc
 include disable-exec.inc
 #include disable-interpreters.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 #mkfile ${HOME}/.digrc # see #903

--- a/etc/profile-a-l/dnscrypt-proxy.profile
+++ b/etc/profile-a-l/dnscrypt-proxy.profile
@@ -17,7 +17,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 whitelist /usr/share/dnscrypt-proxy

--- a/etc/profile-a-l/dnsmasq.profile
+++ b/etc/profile-a-l/dnsmasq.profile
@@ -17,7 +17,7 @@ include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 whitelist /var/lib/libvirt/dnsmasq

--- a/etc/profile-a-l/drill.profile
+++ b/etc/profile-a-l/drill.profile
@@ -16,7 +16,7 @@ include disable-common.inc
 include disable-exec.inc
 #include disable-interpreters.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 #include whitelist-common.inc # see #903

--- a/etc/profile-a-l/editorconfiger.profile
+++ b/etc/profile-a-l/editorconfiger.profile
@@ -16,7 +16,7 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 apparmor

--- a/etc/profile-a-l/erd.profile
+++ b/etc/profile-a-l/erd.profile
@@ -8,7 +8,7 @@ include erd.local
 include globals.local
 
 include disable-exec.inc
-#include disable-X11.inc # x11 none
+#include disable-x11.inc # x11 none
 
 apparmor
 caps.drop all

--- a/etc/profile-a-l/fdns.profile
+++ b/etc/profile-a-l/fdns.profile
@@ -15,7 +15,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 #include whitelist-usr-share-common.inc

--- a/etc/profile-a-l/ftp.profile
+++ b/etc/profile-a-l/ftp.profile
@@ -17,7 +17,7 @@ include disable-proc.inc
 include disable-programs.inc
 #include disable-shell.inc
 include disable-write-mnt.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 apparmor

--- a/etc/profile-a-l/gget.profile
+++ b/etc/profile-a-l/gget.profile
@@ -15,7 +15,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 whitelist ${DOWNLOADS}

--- a/etc/profile-a-l/gist.profile
+++ b/etc/profile-a-l/gist.profile
@@ -19,7 +19,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.gist

--- a/etc/profile-a-l/git.profile
+++ b/etc/profile-a-l/git.profile
@@ -33,7 +33,7 @@ blacklist ${RUNUSER}/wayland-*
 include disable-common.inc
 include disable-exec.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 
 whitelist /usr/share/git
 whitelist /usr/share/git-core

--- a/etc/profile-a-l/gnome-keyring-daemon.profile
+++ b/etc/profile-a-l/gnome-keyring-daemon.profile
@@ -14,8 +14,8 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
-#include disable-X11.inc # x11 none
-include disable-X11.inc
+#include disable-x11.inc # x11 none
+include disable-x11.inc
 include disable-xdg.inc
 
 whitelist ${RUNUSER}/gnupg

--- a/etc/profile-a-l/googler-common.profile
+++ b/etc/profile-a-l/googler-common.profile
@@ -22,7 +22,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 whitelist ${HOME}/.w3m

--- a/etc/profile-a-l/gpg-agent.profile
+++ b/etc/profile-a-l/gpg-agent.profile
@@ -15,7 +15,7 @@ include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.gnupg

--- a/etc/profile-a-l/gpg.profile
+++ b/etc/profile-a-l/gpg.profile
@@ -15,7 +15,7 @@ include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 
 whitelist ${RUNUSER}/gnupg
 whitelist ${RUNUSER}/keyring

--- a/etc/profile-a-l/links-common.profile
+++ b/etc/profile-a-l/links-common.profile
@@ -13,7 +13,7 @@ include disable-interpreters.inc
 # Additional noblacklist files/directories (blacklisted in disable-programs.inc)
 # used as associated programs can be added in your links-common.local.
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 whitelist ${DOWNLOADS}

--- a/etc/profile-a-l/lynx.profile
+++ b/etc/profile-a-l/lynx.profile
@@ -13,7 +13,7 @@ include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 include whitelist-runuser-common.inc

--- a/etc/profile-m-z/makepkg.profile
+++ b/etc/profile-m-z/makepkg.profile
@@ -32,7 +32,7 @@ noblacklist /var/lib/pacman
 include disable-common.inc
 include disable-exec.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 
 caps.drop all
 ipc-namespace

--- a/etc/profile-m-z/mimetype.profile
+++ b/etc/profile-m-z/mimetype.profile
@@ -11,7 +11,7 @@ blacklist ${RUNUSER}/wayland-*
 
 include disable-exec.inc
 include disable-proc.inc
-include disable-X11.inc
+include disable-x11.inc
 
 apparmor
 caps.drop all

--- a/etc/profile-m-z/mocp.profile
+++ b/etc/profile-m-z/mocp.profile
@@ -18,7 +18,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.moc

--- a/etc/profile-m-z/mutt.profile
+++ b/etc/profile-m-z/mutt.profile
@@ -50,7 +50,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.Mail

--- a/etc/profile-m-z/neomutt.profile
+++ b/etc/profile-m-z/neomutt.profile
@@ -48,7 +48,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.Mail

--- a/etc/profile-m-z/nodejs-common.profile
+++ b/etc/profile-m-z/nodejs-common.profile
@@ -39,7 +39,7 @@ include disable-common.inc
 include disable-exec.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 # If you want whitelisting, change ${HOME}/Projects below to your node projects directory

--- a/etc/profile-m-z/nslookup.profile
+++ b/etc/profile-m-z/nslookup.profile
@@ -16,7 +16,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 whitelist ${HOME}/.nslookuprc

--- a/etc/profile-m-z/ping.profile
+++ b/etc/profile-m-z/ping.profile
@@ -15,7 +15,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 #include whitelist-common.inc # see #903

--- a/etc/profile-m-z/qpdf.profile
+++ b/etc/profile-m-z/qpdf.profile
@@ -18,7 +18,7 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 whitelist ${DOCUMENTS}

--- a/etc/profile-m-z/rsync-download_only.profile
+++ b/etc/profile-m-z/rsync-download_only.profile
@@ -19,7 +19,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 # Add the next line to your rsync-download_only.local to enable extra hardening.

--- a/etc/profile-m-z/rtv.profile
+++ b/etc/profile-m-z/rtv.profile
@@ -27,7 +27,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.config/rtv

--- a/etc/profile-m-z/seahorse-daemon.profile
+++ b/etc/profile-m-z/seahorse-daemon.profile
@@ -9,7 +9,7 @@ include seahorse-daemon.local
 #include globals.local
 
 blacklist ${RUNUSER}/wayland-*
-include disable-X11.inc
+include disable-x11.inc
 
 memory-deny-write-execute
 

--- a/etc/profile-m-z/server.profile
+++ b/etc/profile-m-z/server.profile
@@ -44,7 +44,7 @@ include disable-common.inc
 #include disable-interpreters.inc
 include disable-programs.inc
 include disable-write-mnt.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 #include whitelist-runuser-common.inc

--- a/etc/profile-m-z/signal-cli.profile
+++ b/etc/profile-m-z/signal-cli.profile
@@ -17,7 +17,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.local/share/signal-cli

--- a/etc/profile-m-z/ssh-agent.profile
+++ b/etc/profile-m-z/ssh-agent.profile
@@ -13,7 +13,7 @@ blacklist ${RUNUSER}/wayland-*
 
 include disable-common.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 
 include whitelist-usr-share-common.inc
 

--- a/etc/profile-m-z/ssmtp.profile
+++ b/etc/profile-m-z/ssmtp.profile
@@ -24,7 +24,7 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 mkfile ${HOME}/dead.letter

--- a/etc/profile-m-z/statusof.profile
+++ b/etc/profile-m-z/statusof.profile
@@ -20,7 +20,7 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 include whitelist-common.inc

--- a/etc/profile-m-z/telnet.profile
+++ b/etc/profile-m-z/telnet.profile
@@ -17,7 +17,7 @@ include disable-proc.inc
 include disable-programs.inc
 #include disable-shell.inc
 include disable-write-mnt.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 apparmor

--- a/etc/profile-m-z/termshark.profile
+++ b/etc/profile-m-z/termshark.profile
@@ -10,7 +10,7 @@ include termshark.local
 
 blacklist ${RUNUSER}
 
-include disable-X11.inc
+include disable-x11.inc
 
 # Redirect
 include wireshark.profile

--- a/etc/profile-m-z/tin.profile
+++ b/etc/profile-m-z/tin.profile
@@ -18,7 +18,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.tin

--- a/etc/profile-m-z/tmux.profile
+++ b/etc/profile-m-z/tmux.profile
@@ -15,7 +15,7 @@ noblacklist /tmp/tmux-*
 #include disable-devel.inc
 #include disable-exec.inc
 #include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 
 caps.drop all
 ipc-namespace

--- a/etc/profile-m-z/tracker.profile
+++ b/etc/profile-m-z/tracker.profile
@@ -15,7 +15,7 @@ include disable-devel.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 
 include whitelist-runuser-common.inc
 

--- a/etc/profile-m-z/tshark.profile
+++ b/etc/profile-m-z/tshark.profile
@@ -9,7 +9,7 @@ include tshark.local
 
 blacklist ${RUNUSER}
 
-include disable-X11.inc
+include disable-x11.inc
 
 # Redirect
 include wireshark.profile

--- a/etc/profile-m-z/tvnamer.profile
+++ b/etc/profile-m-z/tvnamer.profile
@@ -23,7 +23,7 @@ include disable-interpreters.inc
 include disable-programs.inc
 include disable-proc.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.config/tvnamer

--- a/etc/profile-m-z/unbound.profile
+++ b/etc/profile-m-z/unbound.profile
@@ -16,7 +16,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 whitelist /usr/share/dns

--- a/etc/profile-m-z/w3m.profile
+++ b/etc/profile-m-z/w3m.profile
@@ -28,7 +28,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.w3m

--- a/etc/profile-m-z/wget.profile
+++ b/etc/profile-m-z/wget.profile
@@ -23,7 +23,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 # Depending on workflow you can add the next line to your wget.local.
 #include disable-xdg.inc
 

--- a/etc/profile-m-z/whois.profile
+++ b/etc/profile-m-z/whois.profile
@@ -14,7 +14,7 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 include whitelist-usr-share-common.inc

--- a/etc/profile-m-z/yt-dlp.profile
+++ b/etc/profile-m-z/yt-dlp.profile
@@ -37,7 +37,7 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 include whitelist-usr-share-common.inc

--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -120,7 +120,7 @@ include globals.local
 #include disable-programs.inc
 #include disable-shell.inc
 #include disable-write-mnt.inc
-#include disable-X11.inc
+#include disable-x11.inc
 #include disable-xdg.inc
 
 # This section often mirrors noblacklist section above. The idea is
@@ -181,7 +181,7 @@ include globals.local
 #seccomp.block-secondary
 ##seccomp-error-action log (only for debugging seccomp issues)
 #tracelog
-# Prefer 'x11 none' instead of 'disable-X11.inc' if 'net none' is set
+# Prefer 'x11 none' instead of 'disable-x11.inc' if 'net none' is set
 ##x11 none
 
 #disable-mnt


### PR DESCRIPTION
That is, make "X11" lowercase so that the order of the includes in the
disable- section remain the same when sorted with `LC_ALL=C`, as is the
case for most of the other sections.  That is also likely to be the
default in text editors (such as in vim on Arch), so this should make
the disable- section more consistent and easier to sort when editing the
profile.

Also, keep the old include as a redirect to the new one for now to avoid
breakage.

Commands used to search and replace:

    git mv etc/inc/disable-X11.inc etc/inc/disable-x11.inc
    git grep -Ilz 'disable-X11' -- etc | xargs -0 \
      perl -pi -e 's/disable-X11/disable-x11/'

Relates to #4462 #4854 #6070 #6289.

This is a follow-up to #6286.