### PR TITLE
profiles: add allow-nodejs.inc to profile.template

### DIFF
--- a/etc/profile-m-z/rssguard.profile
+++ b/etc/profile-m-z/rssguard.profile
@@ -8,6 +8,7 @@ include globals.local
 
 noblacklist ${HOME}/.config/RSS Guard 4
 
+# Allow nodejs (blacklisted by disable-interpreters.inc)
 include allow-nodejs.inc
 
 include disable-common.inc

--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -88,6 +88,9 @@ include globals.local
 # Allow lua (blacklisted by disable-interpreters.inc)
 #include allow-lua.inc
 
+# Allow nodejs (blacklisted by disable-interpreters.inc)
+#include allow-nodejs.inc
+
 # Allow perl (blacklisted by disable-interpreters.inc)
 #include allow-perl.inc
 


### PR DESCRIPTION
To make it consistent with the other include profiles.

See etc/templates/profile.template.

Relates to #3866 #5881.
