### PR TITLE
profiles: add allow-php.inc to profile.template

### DIFF
--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -94,6 +94,9 @@ include globals.local
 # Allow perl (blacklisted by disable-interpreters.inc)
 #include allow-perl.inc
 
+# Allow php (blacklisted by disable-interpreters.inc)
+#include allow-php.inc
+
 # Allow python (blacklisted by disable-interpreters.inc)
 #include allow-python2.inc
 #include allow-python3.inc


### PR DESCRIPTION
To make it consistent with the other include profiles.

See etc/templates/profile.template.

Note: It is not currently included in any profile.

Added on commit 89f30f1f2 ("Create allow-php.inc", 2020-01-25).

This is a follow-up to #6298.
