### PR TITLE
profiles: clarify and add opengl-game to profile.template

### DIFF
--- a/etc/inc/allow-opengl-game.inc
+++ b/etc/inc/allow-opengl-game.inc
@@ -2,6 +2,12 @@
 # Persistent customizations should go in a .local file.
 include allow-opengl-game.local
 
+# Explanation: Fedora (and maybe others) install a .desktop file that uses
+# `Exec=foo-wrapper` instead of `Exec=foo`.  Each /usr/bin/foo-wrapper is a
+# symlink to /usr/bin/opengl-game-wrapper.sh, which checks hardware
+# acceleration and then starts the game or notifies the user that there is a
+# problem.
+
 noblacklist ${PATH}/bash
 whitelist /usr/share/opengl-games-utils/opengl-game-functions.sh
 private-bin basename,bash,cut,glxinfo,grep,head,sed,zenity

--- a/etc/profile-a-l/alienarena-wrapper.profile
+++ b/etc/profile-a-l/alienarena-wrapper.profile
@@ -6,6 +6,7 @@ include alienarena-wrapper.local
 # added by included profile
 #include globals.local
 
+# Allow opengl-game wrapper script (distribution-specific)
 include allow-opengl-game.inc
 
 private-bin alienarena-wrapper

--- a/etc/profile-a-l/ballbuster-wrapper.profile
+++ b/etc/profile-a-l/ballbuster-wrapper.profile
@@ -6,6 +6,7 @@ include ballbuster-wrapper.local
 # added by included profile
 #include globals.local
 
+# Allow opengl-game wrapper script (distribution-specific)
 include allow-opengl-game.inc
 
 private-bin ballbuster-wrapper

--- a/etc/profile-a-l/colorful-wrapper.profile
+++ b/etc/profile-a-l/colorful-wrapper.profile
@@ -6,6 +6,7 @@ include colorful-wrapper.local
 # added by included profile
 #include globals.local
 
+# Allow opengl-game wrapper script (distribution-specific)
 include allow-opengl-game.inc
 
 private-bin colorful-wrapper

--- a/etc/profile-a-l/etr-wrapper.profile
+++ b/etc/profile-a-l/etr-wrapper.profile
@@ -6,6 +6,7 @@ include etr-wrapper.local
 # added by included profile
 #include globals.local
 
+# Allow opengl-game wrapper script (distribution-specific)
 include allow-opengl-game.inc
 
 private-bin etr-wrapper

--- a/etc/profile-a-l/gl-117-wrapper.profile
+++ b/etc/profile-a-l/gl-117-wrapper.profile
@@ -6,6 +6,7 @@ include gl-117-wrapper.local
 # added by included profile
 #include globals.local
 
+# Allow opengl-game wrapper script (distribution-specific)
 include allow-opengl-game.inc
 
 private-bin gl-117-wrapper

--- a/etc/profile-a-l/glaxium-wrapper.profile
+++ b/etc/profile-a-l/glaxium-wrapper.profile
@@ -6,6 +6,7 @@ include glaxium-wrapper.local
 # added by included profile
 #include globals.local
 
+# Allow opengl-game wrapper script (distribution-specific)
 include allow-opengl-game.inc
 
 private-bin glaxium-wrapper

--- a/etc/profile-m-z/neverball-wrapper.profile
+++ b/etc/profile-m-z/neverball-wrapper.profile
@@ -6,6 +6,7 @@ include neverball-wrapper.local
 # added by included profile
 #include globals.local
 
+# Allow opengl-game wrapper script (distribution-specific)
 include allow-opengl-game.inc
 
 private-bin neverball-wrapper

--- a/etc/profile-m-z/neverputt-wrapper.profile
+++ b/etc/profile-m-z/neverputt-wrapper.profile
@@ -6,6 +6,7 @@ include neverputt-wrapper.local
 # added by included profile
 #include globals.local
 
+# Allow opengl-game wrapper script (distribution-specific)
 include allow-opengl-game.inc
 
 private-bin neverputt-wrapper

--- a/etc/profile-m-z/pinball-wrapper.profile
+++ b/etc/profile-m-z/pinball-wrapper.profile
@@ -6,6 +6,7 @@ include pinball-wrapper.local
 # added by included profile
 #include globals.local
 
+# Allow opengl-game wrapper script (distribution-specific)
 include allow-opengl-game.inc
 
 private-bin pinball-wrapper

--- a/etc/profile-m-z/scorched3d-wrapper.profile
+++ b/etc/profile-m-z/scorched3d-wrapper.profile
@@ -3,6 +3,7 @@
 # Persistent local customizations
 include scorched3d-wrapper.local
 
+# Allow opengl-game wrapper script (distribution-specific)
 include allow-opengl-game.inc
 
 private-bin scorched3d-wrapper

--- a/etc/profile-m-z/supertuxkart-wrapper.profile
+++ b/etc/profile-m-z/supertuxkart-wrapper.profile
@@ -6,6 +6,7 @@ include supertuxkart-wrapper.local
 # added by included profile
 #include globals.local
 
+# Allow opengl-game wrapper script (distribution-specific)
 include allow-opengl-game.inc
 
 private-bin supertuxkart-wrapper

--- a/etc/profile-m-z/xonotic.profile
+++ b/etc/profile-m-z/xonotic.profile
@@ -8,7 +8,10 @@ include globals.local
 
 noblacklist ${HOME}/.xonotic
 
+# Allow /bin/sh (blacklisted by disable-shell.inc)
 include allow-bin-sh.inc
+
+# Allow opengl-game wrapper script (distribution-specific)
 include allow-opengl-game.inc
 
 include disable-common.inc

--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -91,6 +91,9 @@ include globals.local
 # Allow nodejs (blacklisted by disable-interpreters.inc)
 #include allow-nodejs.inc
 
+# Allow opengl-game wrapper script (distribution-specific)
+#include allow-opengl-game.inc
+
 # Allow perl (blacklisted by disable-interpreters.inc)
 #include allow-perl.inc
 


### PR DESCRIPTION
To make it consistent with the other include profiles.

See etc/templates/profile.template.

With this, all `etc/inc/allow-*` files are listed in profile.template.

The explanation is based on a comment by @rusty-snake[1].

Relates to #4071.

This is a follow-up to #6299.

[1] https://github.com/netblue30/firejail/pull/4071#issuecomment-822003473
