### PR TITLE
landlock: amend empty functions and comments

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -966,10 +966,8 @@ void run_ids(int argc, char **argv);
 void oom_set(const char *oom_string);
 
 // landlock.c
-#ifdef HAVE_LANDLOCK
 int ll_get_fd(void);
 int ll_restrict(uint32_t flags);
 void ll_add_profile(int type, const char *data);
-#endif /* HAVE_LANDLOCK */
 
 #endif

--- a/src/firejail/landlock.c
+++ b/src/firejail/landlock.c
@@ -18,7 +18,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifdef HAVE_LANDLOCK
 #include "firejail.h"
 #include <linux/landlock.h>
 #include <sys/prctl.h>
@@ -26,6 +25,8 @@
 #include <sys/types.h>
 #include <errno.h>
 #include <fcntl.h>
+
+#ifdef HAVE_LANDLOCK
 
 static int ll_ruleset_fd = -1;
 static int ll_abi = -1;
@@ -295,6 +296,17 @@ void ll_add_profile(int type, const char *data) {
 }
 
 #else
+
+int ll_get_fd(void) {
+	return -1;
+}
+
+int ll_restrict(uint32_t flags) {
+	(void) flags;
+
+	return 0;
+}
+
 void ll_add_profile(int type, const char *data) {
 	(void) type;
 	(void) data;

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -1074,8 +1074,10 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 	}
 
 //#ifdef HAVE_LANDLOCK
-// landlock_connon.inc included by derfault in landlock.profile
-// all landlcok functions are empty in case landlock is not available in the kernel
+// landlock-common.inc is included by default.profile, so the entries of the
+// former should be processed or ignored instead of aborting.
+// Note that all landlock functions are empty when building without landlock
+// support.
 	if (strncmp(ptr, "landlock.enforce", 16) == 0) {
 		arg_landlock_enforce = 1;
 		return 0;


### PR DESCRIPTION
Changes:

* Always declare public landlock functions, regardless of
  `HAVE_LANDLOCK`
* Make the other public landlock functions (besides `ll_add_profile`)
  also be empty when `HAVE_LANDLOCK` is not defined
* Clarify related comments

This amends commit 8259f66e1 ("landlock fix for old kernel versions",
2024-04-06).

For clarity, landlock-common.inc is included by default.profile and the
issue that the aforementioned commit fixes is that if profile.c is built
without the part that parses landlock commands (that is, when
`HAVE_LANDLOCK` is not defined), using default.profile would cause
firejail to abort due to "invalid lines".

Note that the issue would only occur when firejail is built with an
older kernel (or with --disable-landlock), not when simply running on an
older kernel.

See also commit b02a7a337 ("landlock: remove empty functions",
2023-12-07).

Relates to #6078.