### PR TITLE
profiles: loupe: harden and disable apparmor

### DIFF
--- a/etc/profile-a-l/loupe.profile
+++ b/etc/profile-a-l/loupe.profile
@@ -10,7 +10,9 @@ noblacklist ${HOME}/.local/share/Trash
 noblacklist ${HOME}/.Steam
 noblacklist ${HOME}/.steam
 
-#include disable-common.inc
+noblacklist ${PATH}/bwrap
+
+include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
@@ -22,7 +24,7 @@ include whitelist-runuser-common.inc
 #include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
-apparmor
+#apparmor
 caps.drop all
 ipc-namespace
 machine-id
@@ -44,7 +46,13 @@ protocol unix,netlink
 seccomp.block-secondary
 tracelog
 
+private-bin bwrap,loupe
 private-cache
 private-dev
 private-etc @x11
 private-tmp
+
+dbus-user none
+dbus-system none
+
+#read-only ${HOME} # breaks "Move to trash" and "Set as background"


### PR DESCRIPTION
The profile currently does not include disable-common nor makes
`${HOME}` read-only, so the program can simply write to ~/.bashrc
directly[1].

disable-common.inc was commented due to it apparently breaking bwrap.
As discovered by @glitsj16, it seems that allowing the bwrap binary is
enough to make it work (and that apparmor breaks loupe)[2].

So disable apparmor, allow bwrap and include disable-common.inc, plus
other hardening by @glitsj16.

This amends commit 9a0db13e1 ("profiles: add loupe", 2024-04-30) /
PR #6327.

[1] https://github.com/netblue30/firejail/pull/6327#pullrequestreview-2033860865
[2] https://github.com/netblue30/firejail/pull/6333#issuecomment-2099805480