### PR TITLE
profiles: steam: update novideo comment for webcam motion trackers

### DIFF
--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -159,7 +159,8 @@ nonewprivs
 noroot
 notv
 nou2f
-# For VR support add 'ignore novideo' to your steam.local.
+# To allow VR and camera-based motion tracking, add 'ignore novideo' to your
+# steam.local.
 novideo
 protocol unix,inet,inet6,netlink
 # seccomp sometimes causes issues (see #2951, #3267).


### PR DESCRIPTION
Update comment to account for camera-based motion trackers.

Fixes an issue with https://github.com/markx86/opentrack-launcher, where
video input devices won't show up unless novideo is removed.