### PR TITLE
ci: make dependabot updates monthly and bump PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,5 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 2
+      interval: "monthly"
+    open-pull-requests-limit: 4


### PR DESCRIPTION
It is currently only used for GitHub Actions.  The ones used in this
project rarely ever contain notable changes in their changelogs (in a
way that would cause a noticeable difference in our CI).

Also, there are weeks when most/all of the PR/commit activity is from
dependabot PRs being opened/merged.  For example, see the output of the
following command:

    git log --no-decorate --oneline 9a0db13e12..bef085035

So change the checks from weekly to monthly to reduce the noise.

Additionally, bump `open-pull-requests-limit` to 4, as it seems that we
only have 4 dependencies:

    $ git grep 'uses:' -- .github/ | sed -E 's/.*(uses: .*)@.*/\1/' |
      LC_ALL=C sort -u
    uses: actions/checkout
    uses: github/codeql-action/analyze
    uses: github/codeql-action/init
    uses: step-security/harden-runner

This should ensure that PRs can be opened against all of them when the
dependabot check is run.