### PR TITLE
build: add strip target and simplify install targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,8 +193,8 @@ clean:
 distclean: clean
 	rm -fr autom4te.cache config.log config.mk config.sh config.status
 
-.PHONY: realinstall
-realinstall: config.mk
+.PHONY: install
+install: all config.mk
 	# firejail executable
 	install -m 0755 -d $(DESTDIR)$(bindir)
 	install -m 0755 src/firejail/firejail $(DESTDIR)$(bindir)
@@ -272,13 +272,8 @@ endif
 	install -m 0755 -d $(DESTDIR)$(datarootdir)/zsh/site-functions
 	install -m 0644 src/zsh_completion/_firejail $(DESTDIR)$(datarootdir)/zsh/site-functions/
 
-.PHONY: install
-install: all
-	$(MAKE) realinstall
-
 .PHONY: install-strip
-install-strip: strip
-	$(MAKE) realinstall
+install-strip: strip install
 
 .PHONY: uninstall
 uninstall: config.mk

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ mydirs: $(MYDIRS)
 $(MYDIRS):
 	$(MAKE) -C $@
 
+.PHONY: strip
+strip: all
+	strip $(ALL_ITEMS)
+
 .PHONY: filters
 filters: $(SECCOMP_FILTERS)
 seccomp: src/fseccomp/fseccomp src/fsec-optimize/fsec-optimize Makefile
@@ -273,8 +277,7 @@ install: all
 	$(MAKE) realinstall
 
 .PHONY: install-strip
-install-strip: all
-	strip $(ALL_ITEMS)
+install-strip: strip
 	$(MAKE) realinstall
 
 .PHONY: uninstall


### PR DESCRIPTION
* build: add a standalone strip target

Move the strip invocation into its own target to allow stripping
binaries without having to run the "realinstall" target.

* build: remove redundant realinstall target

Leave just the "install" and "install-strip" targets.

See commit 099925e18 ("added install-strip, make install now without
strip.", 2015-09-10) / PR #60 and commit 0215cbc02 ("make install, make
install-strip", 2015-09-11).
