### PR TITLE
build: remove clean dependency from cppcheck targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,13 +363,13 @@ extras: all
 	$(MAKE) -C extras/firetools
 
 .PHONY: cppcheck
-cppcheck: clean
+cppcheck:
 	$(CPPCHECK) --force --error-exitcode=1 --enable=warning,performance \
 	  -i src/firejail/checkcfg.c -i src/firejail/main.c .
 
 # For cppcheck 1.x; see .github/workflows/check-c.yml
 .PHONY: cppcheck-old
-cppcheck-old: clean
+cppcheck-old:
 	$(CPPCHECK) --force --error-exitcode=1 --enable=warning,performance .
 
 .PHONY: scan-build


### PR DESCRIPTION
Cleaning does not appear to make a difference; the same amount of files
is checked with/without cleaning.

Environment: cppcheck 2.12.0-3 on Artix Linux.

Added on commit 4e22add64 ("llvm scan", 2015-11-29).

This is a follow-up to #6222.