### PR TITLE
profiles: streamline Firefox URL opening support

### DIFF
--- a/etc/profile-a-l/electron-mail.profile
+++ b/etc/profile-a-l/electron-mail.profile
@@ -35,7 +35,7 @@ dbus-user filter
 dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.freedesktop.secrets
 dbus-user.talk org.gnome.keyring.SystemPrompter
-# allow D-Bus communication with firefox for opening links
+# Allow D-Bus communication with Firefox for opening links
 dbus-user.talk org.mozilla.*
 
 # Redirect

--- a/etc/profile-a-l/email-common.profile
+++ b/etc/profile-a-l/email-common.profile
@@ -10,7 +10,6 @@ include email-common.local
 noblacklist ${HOME}/.bogofilter
 noblacklist ${HOME}/.bsfilter
 noblacklist ${HOME}/.gnupg
-noblacklist ${HOME}/.mozilla
 noblacklist ${HOME}/.signature
 # when storing mail outside the default ${HOME}/Mail path, 'noblacklist' the custom path in your email-common.local
 # and 'blacklist' it in your disable-common.local too so it is kept hidden from other applications
@@ -31,6 +30,12 @@ include disable-interpreters.inc
 include disable-programs.inc
 include disable-xdg.inc
 
+# The lines below are needed to find the default Firefox profile name, to allow
+# opening links in an existing instance of Firefox (note that it still fails if
+# there isn't a Firefox instance running with the default profile; see #5352)
+noblacklist ${HOME}/.mozilla
+whitelist ${HOME}/.mozilla/firefox/profiles.ini
+
 mkdir ${HOME}/.gnupg
 mkfile ${HOME}/.config/mimeapps.list
 mkfile ${HOME}/.signature
@@ -38,7 +43,6 @@ whitelist ${HOME}/.bogofilter
 whitelist ${HOME}/.bsfilter
 whitelist ${HOME}/.config/mimeapps.list
 whitelist ${HOME}/.gnupg
-whitelist ${HOME}/.mozilla/firefox/profiles.ini
 whitelist ${HOME}/.signature
 whitelist ${DOCUMENTS}
 whitelist ${DOWNLOADS}
@@ -90,6 +94,7 @@ dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.freedesktop.secrets
 dbus-user.talk org.gnome.keyring.*
 dbus-user.talk org.gnome.seahorse.*
+# Allow D-Bus communication with Firefox for opening links
 dbus-user.talk org.mozilla.*
 dbus-system none
 

--- a/etc/profile-a-l/fluffychat.profile
+++ b/etc/profile-a-l/fluffychat.profile
@@ -64,7 +64,7 @@ private-tmp
 
 dbus-user filter
 dbus-user.talk org.freedesktop.secrets
-# allow D-Bus communication with firefox for opening links
+# Allow D-Bus communication with Firefox for opening links
 dbus-user.talk org.mozilla.*
 dbus-system filter
 dbus-system.talk org.freedesktop.NetworkManager

--- a/etc/profile-a-l/geary.profile
+++ b/etc/profile-a-l/geary.profile
@@ -14,9 +14,9 @@ noblacklist ${HOME}/.config/geary
 noblacklist ${HOME}/.local/share/evolution
 noblacklist ${HOME}/.local/share/geary
 noblacklist ${HOME}/.local/share/pki
-noblacklist ${HOME}/.mozilla
 noblacklist ${HOME}/.pki
 
+# sh is needed to allow Firefox to open links
 include allow-bin-sh.inc
 
 include disable-common.inc
@@ -26,6 +26,12 @@ include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
 include disable-xdg.inc
+
+# The lines below are needed to find the default Firefox profile name, to allow
+# opening links in an existing instance of Firefox (note that it still fails if
+# there isn't a Firefox instance running with the default profile; see #5352)
+noblacklist ${HOME}/.mozilla
+whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 mkdir ${HOME}/.cache/evolution
 mkdir ${HOME}/.cache/folks
@@ -43,7 +49,6 @@ whitelist ${HOME}/.config/geary
 whitelist ${HOME}/.local/share/evolution
 whitelist ${HOME}/.local/share/geary
 whitelist ${HOME}/.local/share/pki
-whitelist ${HOME}/.mozilla/firefox/profiles.ini
 whitelist ${HOME}/.pki
 whitelist /usr/share/geary
 include whitelist-common.inc
@@ -88,6 +93,7 @@ dbus-user.talk org.gnome.OnlineAccounts
 dbus-user.talk org.gnome.evolution.dataserver.AddressBook10
 dbus-user.talk org.gnome.evolution.dataserver.Sources5
 ?ALLOW_TRAY: dbus-user.talk org.kde.StatusNotifierWatcher
+# Allow D-Bus communication with Firefox for opening links
 dbus-user.talk org.mozilla.*
 dbus-system none
 

--- a/etc/profile-a-l/gtk-youtube-viewers-common.profile
+++ b/etc/profile-a-l/gtk-youtube-viewers-common.profile
@@ -18,5 +18,5 @@ whitelist ${HOME}/.mozilla/firefox/profiles.ini
 private-bin firefox,xterm
 
 dbus-user filter
-# allow D-Bus communication with firefox for opening links
+# Allow D-Bus communication with Firefox for opening links
 dbus-user.talk org.mozilla.*

--- a/etc/profile-a-l/kube.profile
+++ b/etc/profile-a-l/kube.profile
@@ -13,6 +13,9 @@ noblacklist ${HOME}/.gnupg
 noblacklist ${HOME}/.local/share/kube
 noblacklist ${HOME}/.local/share/sink
 
+# sh is needed to allow Firefox to open links
+include allow-bin-sh.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
@@ -78,7 +81,7 @@ dbus-user filter
 dbus-user.talk ca.desrt.dconf
 dbus-user.talk org.freedesktop.secrets
 dbus-user.talk org.freedesktop.Notifications
-# allow D-Bus communication with firefox for opening links
+# Allow D-Bus communication with Firefox for opening links
 dbus-user.talk org.mozilla.*
 dbus-system none
 

--- a/etc/profile-a-l/lettura.profile
+++ b/etc/profile-a-l/lettura.profile
@@ -11,6 +11,9 @@ noblacklist ${HOME}/.config/com.lettura.dev
 noblacklist ${HOME}/.lettura
 noblacklist ${HOME}/.local/share/com.lettura.dev
 
+# sh is needed to allow Firefox to open links
+include allow-bin-sh.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
@@ -69,7 +72,7 @@ private-tmp
 dbus-user filter
 dbus-user.talk org.freedesktop.Notifications
 ?ALLOW_TRAY: dbus-user.talk org.kde.StatusNotifierWatcher
-# allow D-Bus communication with firefox for opening links
+# Allow D-Bus communication with Firefox for opening links
 dbus-user.talk org.mozilla.*
 dbus-system none
 

--- a/etc/profile-a-l/linuxqq.profile
+++ b/etc/profile-a-l/linuxqq.profile
@@ -7,15 +7,20 @@ include linuxqq.local
 include globals.local
 
 noblacklist ${HOME}/.config/QQ
-noblacklist ${HOME}/.mozilla
 
+# sh is needed to allow Firefox to open links
 include allow-bin-sh.inc
 
 include disable-shell.inc
 
+# The lines below are needed to find the default Firefox profile name, to allow
+# opening links in an existing instance of Firefox (note that it still fails if
+# there isn't a Firefox instance running with the default profile; see #5352)
+noblacklist ${HOME}/.mozilla
+whitelist ${HOME}/.mozilla/firefox/profiles.ini
+
 mkdir ${HOME}/.config/QQ
 whitelist ${HOME}/.config/QQ
-whitelist ${HOME}/.mozilla/firefox/profiles.ini
 whitelist ${DESKTOP}
 whitelist /opt/QQ
 
@@ -34,6 +39,7 @@ dbus-user.talk org.freedesktop.portal.IBus
 dbus-user.talk org.freedesktop.ScreenSaver
 dbus-user.talk org.gnome.Mutter.IdleMonitor
 ?ALLOW_TRAY: dbus-user.talk org.kde.StatusNotifierWatcher
+# Allow D-Bus communication with Firefox for opening links
 dbus-user.talk org.mozilla.*
 ignore dbus-user none
 

--- a/etc/profile-m-z/signal-desktop.profile
+++ b/etc/profile-m-z/signal-desktop.profile
@@ -5,6 +5,9 @@ include signal-desktop.local
 # Persistent global definitions
 include globals.local
 
+# sh is needed to allow Firefox to open links
+include allow-bin-sh.inc
+
 ignore novideo
 
 ignore noexec /tmp
@@ -25,7 +28,7 @@ private-etc @tls-ca
 dbus-user filter
 # allow D-Bus notifications
 dbus-user.talk org.freedesktop.Notifications
-# allow D-Bus communication with firefox for opening links
+# Allow D-Bus communication with Firefox for opening links
 dbus-user.talk org.mozilla.*
 
 ignore dbus-user none

--- a/etc/profile-m-z/thunderbird.profile
+++ b/etc/profile-m-z/thunderbird.profile
@@ -15,7 +15,7 @@ dbus-user filter
 dbus-user.own org.mozilla.thunderbird.*
 dbus-user.talk ca.desrt.dconf
 dbus-user.talk org.freedesktop.Notifications
-# allow D-Bus communication with firefox for opening links
+# Allow D-Bus communication with Firefox for opening links
 dbus-user.talk org.mozilla.*
 # e2ee email needs writable-run-user
 # https://support.mozilla.org/en-US/kb/introduction-to-e2e-encryption

--- a/etc/profile-m-z/trojita.profile
+++ b/etc/profile-m-z/trojita.profile
@@ -10,6 +10,9 @@ noblacklist ${HOME}/.abook
 noblacklist ${HOME}/.cache/flaska.net/trojita
 noblacklist ${HOME}/.config/flaska.net
 
+# sh is needed to allow Firefox to open links
+include allow-bin-sh.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
@@ -61,7 +64,7 @@ private-tmp
 
 dbus-user filter
 dbus-user.talk org.freedesktop.secrets
-# allow D-Bus communication with firefox for opening links
+# Allow D-Bus communication with Firefox for opening links
 dbus-user.talk org.mozilla.*
 dbus-system none
 

--- a/etc/profile-m-z/tutanota-desktop.profile
+++ b/etc/profile-m-z/tutanota-desktop.profile
@@ -40,7 +40,7 @@ dbus-user filter
 dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.freedesktop.secrets
 dbus-user.talk org.gnome.keyring.SystemPrompter
-# allow D-Bus communication with firefox for opening links
+# Allow D-Bus communication with Firefox for opening links
 dbus-user.talk org.mozilla.*
 
 # Redirect

--- a/etc/profile-m-z/zeal.profile
+++ b/etc/profile-m-z/zeal.profile
@@ -10,6 +10,9 @@ noblacklist ${HOME}/.cache/Zeal
 noblacklist ${HOME}/.config/Zeal
 noblacklist ${HOME}/.local/share/Zeal
 
+# sh is needed to allow Firefox to open links
+include allow-bin-sh.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
@@ -19,8 +22,9 @@ include disable-programs.inc
 include disable-shell.inc
 include disable-xdg.inc
 
-# Allow zeal to open links in Firefox browsers.
-# This also requires dbus-user filtering (see below).
+# The lines below are needed to find the default Firefox profile name, to allow
+# opening links in an existing instance of Firefox (note that it still fails if
+# there isn't a Firefox instance running with the default profile; see #5352)
 noblacklist ${HOME}/.mozilla
 whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
@@ -63,8 +67,9 @@ private-etc @tls-ca,@x11,host.conf,mime.types,rpc,services
 private-tmp
 
 dbus-user filter
-dbus-user.talk org.mozilla.*
 ?ALLOW_TRAY: dbus-user.talk org.kde.StatusNotifierWatcher
+# Allow D-Bus communication with Firefox for opening links
+dbus-user.talk org.mozilla.*
 dbus-system none
 
 #memory-deny-write-execute # breaks on Arch


### PR DESCRIPTION
Changes:

* Improve Firefox D-Bus comment
* Add missing/standardize related comments
* Include allow-bin-sh.inc in relevant profiles
* Use Firefox URL open section in relevant profiles