### PR TITLE
profiles: blacklist i3 IPC socket & dir except for i3 itself

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -167,6 +167,10 @@ blacklist ${RUNUSER}/gnome-session-leader-fifo
 blacklist ${RUNUSER}/gnome-shell
 blacklist ${RUNUSER}/gsconnect
 
+# i3 IPC socket (allows arbitrary shell script execution)
+blacklist ${RUNUSER}/i3/ipc-socket.*
+blacklist /tmp/i3-*/ipc-socket.*
+
 # systemd
 blacklist ${HOME}/.config/systemd
 blacklist ${HOME}/.local/share/systemd

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -1250,11 +1250,13 @@ blacklist ${HOME}/yt-dlp.conf
 blacklist ${HOME}/yt-dlp.conf.txt
 blacklist ${RUNUSER}/*firefox*
 blacklist ${RUNUSER}/akonadi
+blacklist ${RUNUSER}/i3
 blacklist ${RUNUSER}/psd/*firefox*
 blacklist ${RUNUSER}/qutebrowser
 blacklist /etc/ssmtp
 blacklist /tmp/.wine-*
 blacklist /tmp/akonadi-*
+blacklist /tmp/i3-*
 blacklist /tmp/lwjgl_*
 blacklist /var/games/nethack
 blacklist /var/games/slashem

--- a/etc/profile-a-l/i3.profile
+++ b/etc/profile-a-l/i3.profile
@@ -8,6 +8,10 @@ include globals.local
 
 # all applications started in i3 will run in this profile
 noblacklist ${HOME}/.config/i3
+noblacklist ${RUNUSER}/i3
+noblacklist ${RUNUSER}/i3/ipc-socket.*
+noblacklist /tmp/i3-*
+noblacklist /tmp/i3-*/ipc-socket.*
 include disable-common.inc
 
 caps.drop all


### PR DESCRIPTION
This closes the escape route discussed in https://github.com/netblue30/firejail/discussions/6357.

It's left open for i3's own profile, so that people who run i3 itself sandboxed still have the option to use IPC with it at all.

Reference for file paths: https://i3wm.org/docs/userguide.html#_interprocess_communication