### PR TITLE
profiles: claws-mail: add ~/.cache/claws-mail 

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -100,6 +100,7 @@ blacklist ${HOME}/.cache/cantata
 blacklist ${HOME}/.cache/champlain
 blacklist ${HOME}/.cache/chromium
 blacklist ${HOME}/.cache/chromium-dev
+blacklist ${HOME}/.cache/claws-mail
 blacklist ${HOME}/.cache/cliqz
 blacklist ${HOME}/.cache/com.github.johnfactotum.Foliate
 blacklist ${HOME}/.cache/darktable

--- a/etc/profile-a-l/claws-mail.profile
+++ b/etc/profile-a-l/claws-mail.profile
@@ -11,9 +11,12 @@ include globals.local
 # adding the following line to claws-mail.local:
 #ignore no3d
 
+noblacklist ${HOME}/.cache/claws-mail
 noblacklist ${HOME}/.claws-mail
 
+mkdir ${HOME}/.cache/claws-mail
 mkdir ${HOME}/.claws-mail
+whitelist ${HOME}/.cache/claws-mail
 whitelist ${HOME}/.claws-mail
 
 # Add the below lines to your claws-mail.local if you use python-based plugins.


### PR DESCRIPTION
It is apparently used by the (widely used) "Fancy" plugin, which
"Renders HTML e-mail using the WebKit library".

https://www.claws-mail.org/plugins.php

Relates to #6377.

Note: etc/profile-a-l/email-common.profile contains `private-cache`.