### PR TITLE
modif: private-dev: keep /dev/kfd unless no3d is used

### DIFF
--- a/src/firejail/fs_dev.c
+++ b/src/firejail/fs_dev.c
@@ -52,7 +52,8 @@ typedef struct {
 
 static DevEntry dev[] = {
 	{"/dev/snd", RUN_DEV_DIR "/snd", DEV_SOUND},	// sound device
-	{"/dev/dri", RUN_DEV_DIR "/dri", DEV_3D},		// 3d device
+	{"/dev/dri", RUN_DEV_DIR "/dri", DEV_3D},		// 3d devices
+	{"/dev/kfd", RUN_DEV_DIR "/kfd", DEV_3D},
 	{"/dev/nvidia0", RUN_DEV_DIR "/nvidia0", DEV_3D},
 	{"/dev/nvidia1", RUN_DEV_DIR "/nvidia1", DEV_3D},
 	{"/dev/nvidia2", RUN_DEV_DIR "/nvidia2", DEV_3D},


### PR DESCRIPTION
Apparently hashcat needs access to this device for hardware acceleration
on AMD gpus and `private-dev` currently breaks that (see #6364).

It seems to be used by the "amdgpu" and "amdkfd" Linux kernel drivers
and as with /dev/dri/renderD128, this file is owned by the "render"
group.

Relevant udev rules from /usr/lib/udev/rules.d/50-udev-default.rules:

    SUBSYSTEM=="drm", KERNEL=="renderD*", GROUP="render", MODE="0666"
    SUBSYSTEM=="kfd", GROUP="render", MODE="0666"
    SUBSYSTEM=="accel", GROUP="render", MODE="0666"

Environment: udev 255.6-1 on Artix Linux.

Reported-by: @schrotthaufen