### PR TITLE
docs: bug_report.md: use absolute path in 'steps to reproduce'

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ _Describe the bug_
 
 _Steps to reproduce the behavior_
 
-1. Run in bash `LC_ALL=C firejail PROGRAM` (`LC_ALL=C` to get a consistent
+1. Run in bash `LC_ALL=C firejail /path/to/program` (`LC_ALL=C` to get a consistent
    output in English that can be understood by everybody)
 2. Click on '....'
 3. Scroll down to '....'


### PR DESCRIPTION
We still see lots of issue reports where the user runs `firejail foo` and ends up running foo's sandbox twice (due to firecfg's symlink precedence). Try to improve the situation by explicitly using absolute paths in the 'steps to reproduce' section.