### PR TITLE
modif: keep /sys/module/nvidia* if prop driver and no no3d

### DIFF
--- a/etc/profile-m-z/noprofile.profile
+++ b/etc/profile-m-z/noprofile.profile
@@ -15,6 +15,8 @@
 
 noblacklist /sys/fs
 noblacklist /sys/module
+nowhitelist /sys/module/nvidia*
+ignore read-only /sys/module/nvidia*
 
 allow-debuggers
 allusers

--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -743,10 +743,20 @@ void fs_proc_sys_dev_boot(void) {
 
 	disable_file(BLACKLIST_FILE, "/sys/firmware");
 	disable_file(BLACKLIST_FILE, "/sys/hypervisor");
-	{ // allow user access to some directories in /sys/ by specifying 'noblacklist' option
-		profile_add("blacklist /sys/fs");
+
+	// Soft-block some paths in /sys/ (can be undone in profiles).
+	profile_add("blacklist /sys/fs");
+
+	// Hardware acceleration with the nvidia proprietary driver may fail
+	// without access to these paths (see #6372).
+	if (access("/dev/nvidiactl", R_OK) == 0 && arg_no3d == 0) {
+		profile_add("whitelist /sys/module/nvidia*");
+		profile_add("read-only /sys/module/nvidia*");
+	}
+	else {
 		profile_add("blacklist /sys/module");
 	}
+
 	disable_file(BLACKLIST_FILE, "/sys/power");
 	disable_file(BLACKLIST_FILE, "/sys/kernel/debug");
 	disable_file(BLACKLIST_FILE, "/sys/kernel/vmcoreinfo");


### PR DESCRIPTION
It has been reported in #6372 that after upgrading the nvidia
proprietary driver from version 550.78 to 550.90.07, programs using
hardware acceleration fail unless paths in `/sys/module/nvidia*` are
accessible.  Example:

    $ firejail --noprofile prime-run /bin/glxdemo
    [...]
    X Error of failed request:  BadValue (integer parameter out of range for operation)
      Major opcode of failed request:  150 (GLX)
      Minor opcode of failed request:  3 (X_GLXCreateContext)
      Value in failed request:  0x0
      Serial number of failed request:  22
      Current serial number in output stream:  23
    [...]

Meanwhile, the AMD proprietary driver (AMDGPU Pro) seems to depend on
`/sys/module/amdgpu` for OpenCL (though it is unclear how to detect that
driver).  See commit 95c8e284d ("Allow accessing /sys/module directory",
2018-05-08) and commit 9dd581d25 ("Allow AMD GPU usage by Blender",
2018-05-08) from PR #1932.

So whitelist `/sys/module/nvidia*` by default if the nvidia proprietary
driver is detected and `no3d` is not used.

Note: The driver check is copied from src/firejail/util.c (see #841).

To keep the current behavior (that is, block all modules), add
`blacklist /sys/module` to globals.local.

Fixes #6372.

Reported-by: @GreatBigWhiteWorld
Reported-by: @orzogc
Reported-by: @krop
Reported-by: @michelesr
Suggested-by: @glitsj16
Tested-by: @flyxyz123
