### PR TITLE
feature: add notpm command & keep tpm devices in private-dev

### DIFF
--- a/contrib/syntax/lists/profile_commands_arg0.list
+++ b/contrib/syntax/lists/profile_commands_arg0.list
@@ -27,6 +27,7 @@ nonewprivs
 noprinters
 noroot
 nosound
+notpm
 notv
 nou2f
 novideo

--- a/etc/profile-a-l/default.profile
+++ b/etc/profile-a-l/default.profile
@@ -37,6 +37,7 @@ noinput
 nonewprivs
 noroot
 #nosound
+#notpm
 notv
 #nou2f
 novideo

--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -175,6 +175,7 @@ include globals.local
 #noprinters
 #noroot
 #nosound
+#notpm
 #notv
 #nou2f
 #novideo

--- a/src/fbuilder/build_profile.c
+++ b/src/fbuilder/build_profile.c
@@ -138,6 +138,7 @@ void build_profile(int argc, char **argv, int index, FILE *fp) {
 		fprintf(fp, "#noinput\t# disable input devices\n");
 		fprintf(fp, "nonewprivs\n");
 		fprintf(fp, "noroot\n");
+		fprintf(fp, "#notpm\t# disable TPM devices\n");
 		fprintf(fp, "#notv\t# disable DVB TV devices\n");
 		fprintf(fp, "#nou2f\t# disable U2F devices\n");
 		fprintf(fp, "#novideo\t# disable video capture devices\n");

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -368,6 +368,7 @@ extern int arg_noprofile;	// use default.profile if none other found/specified
 extern int arg_memory_deny_write_execute;	// block writable and executable memory
 extern int arg_notv;	// --notv
 extern int arg_nodvd;	// --nodvd
+extern int arg_notpm;	// --notpm
 extern int arg_nou2f;	// --nou2f
 extern int arg_noinput;	// --noinput
 extern int arg_deterministic_exit_code;	// always exit with first child's exit status
@@ -646,6 +647,7 @@ void fs_dev_disable_3d(void);
 void fs_dev_disable_video(void);
 void fs_dev_disable_tv(void);
 void fs_dev_disable_dvd(void);
+void fs_dev_disable_tpm(void);
 void fs_dev_disable_u2f(void);
 void fs_dev_disable_input(void);
 

--- a/src/firejail/fs_dev.c
+++ b/src/firejail/fs_dev.c
@@ -39,6 +39,7 @@ typedef enum {
 	DEV_VIDEO,
 	DEV_TV,
 	DEV_DVD,
+	DEV_TPM,
 	DEV_U2F,
 	DEV_INPUT
 } DEV_TYPE;
@@ -79,6 +80,12 @@ static DevEntry dev[] = {
 	{"/dev/video9", RUN_DEV_DIR "/video9", DEV_VIDEO},
 	{"/dev/dvb", RUN_DEV_DIR "/dvb", DEV_TV}, // DVB (Digital Video Broadcasting) - TV device
 	{"/dev/sr0", RUN_DEV_DIR "/sr0", DEV_DVD}, // for DVD and audio CD players
+	{"/dev/tpm0", RUN_DEV_DIR "/tpm0", DEV_TPM}, // TPM (Trusted Platform Module) devices
+	{"/dev/tpm1", RUN_DEV_DIR "/tpm1", DEV_TPM},
+	{"/dev/tpm2", RUN_DEV_DIR "/tpm2", DEV_TPM},
+	{"/dev/tpm3", RUN_DEV_DIR "/tpm3", DEV_TPM},
+	{"/dev/tpm4", RUN_DEV_DIR "/tpm4", DEV_TPM},
+	{"/dev/tpm5", RUN_DEV_DIR "/tpm5", DEV_TPM},
 	{"/dev/hidraw0", RUN_DEV_DIR "/hidraw0", DEV_U2F},
 	{"/dev/hidraw1", RUN_DEV_DIR "/hidraw1", DEV_U2F},
 	{"/dev/hidraw2", RUN_DEV_DIR "/hidraw2", DEV_U2F},
@@ -105,6 +112,7 @@ static void deventry_mount(void) {
 			    (dev[i].type == DEV_VIDEO && arg_novideo == 0) ||
 			    (dev[i].type == DEV_TV && arg_notv == 0) ||
 			    (dev[i].type == DEV_DVD && arg_nodvd == 0) ||
+			    (dev[i].type == DEV_TPM && arg_notpm == 0) ||
 			    (dev[i].type == DEV_U2F && arg_nou2f == 0) ||
 			    (dev[i].type == DEV_INPUT && arg_noinput == 0)) {
 
@@ -379,6 +387,15 @@ void fs_dev_disable_dvd(void) {
 	int i = 0;
 	while (dev[i].dev_fname != NULL) {
 		if (dev[i].type == DEV_DVD)
+			disable_file_or_dir(dev[i].dev_fname);
+		i++;
+	}
+}
+
+void fs_dev_disable_tpm(void) {
+	int i = 0;
+	while (dev[i].dev_fname != NULL) {
+		if (dev[i].type == DEV_TPM)
 			disable_file_or_dir(dev[i].dev_fname);
 		i++;
 	}

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -155,6 +155,7 @@ int arg_noprofile = 0; // use default.profile if none other found/specified
 int arg_memory_deny_write_execute = 0;		// block writable and executable memory
 int arg_notv = 0;	// --notv
 int arg_nodvd = 0; // --nodvd
+int arg_notpm = 0; // --notpm
 int arg_nou2f = 0; // --nou2f
 int arg_noinput = 0; // --noinput
 int arg_deterministic_exit_code = 0;	// always exit with first child's exit status
@@ -2209,6 +2210,8 @@ int main(int argc, char **argv, char **envp) {
 			arg_notv = 1;
 		else if (strcmp(argv[i], "--nodvd") == 0)
 			arg_nodvd = 1;
+		else if (strcmp(argv[i], "--notpm") == 0)
+			arg_notpm = 1;
 		else if (strcmp(argv[i], "--nou2f") == 0)
 			arg_nou2f = 1;
 		else if (strcmp(argv[i], "--noinput") == 0)

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -618,6 +618,10 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 #endif
 		return 1;
 	}
+	else if (strcmp(ptr, "notpm") == 0) {
+		arg_notpm = 1;
+		return 0;
+	}
 	else if (strcmp(ptr, "nou2f") == 0) {
 		arg_nou2f = 1;
 		return 0;

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -1101,6 +1101,9 @@ int sandbox(void* sandbox_arg) {
 	if (arg_nodvd)
 		fs_dev_disable_dvd();
 
+	if (arg_notpm)
+		fs_dev_disable_tpm();
+
 	if (arg_nou2f)
 		fs_dev_disable_u2f();
 

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -191,6 +191,7 @@ static const char *const usage_str =
 	"    --nosound - disable sound system.\n"
 	"    --noautopulse - disable automatic ~/.config/pulse init.\n"
 	"    --novideo - disable video devices.\n"
+	"    --notpm - disable TPM devices.\n"
 	"    --nou2f - disable U2F devices.\n"
 	"    --nowhitelist=filename - disable whitelist for file or directory.\n"
 	"    --oom=value - configure OutOfMemory killer for the sandbox\n"

--- a/src/man/firejail-profile.5.in
+++ b/src/man/firejail-profile.5.in
@@ -383,10 +383,10 @@ Set working directory inside the jail. Full directory path is required. Symbolic
 .TP
 \fBprivate-dev
 Create a new /dev directory.
-Only disc, dri, dvb, full, hidraw, log, null, ptmx, pts, random, shm, snd, tty,
-urandom, usb, video and zero devices are available.
-Use the options no3d, nodvd, nosound, notv, nou2f and novideo for additional
-restrictions.
+Only disc, dri, dvb, full, hidraw, log, null, ptmx, pts, random, shm, snd, tpm,
+tty, urandom, usb, video and zero devices are available.
+Use the options no3d, nodvd, nosound, notpm, notv, nou2f and novideo for
+additional restrictions.
 
 .TP
 \fBprivate-etc file,directory
@@ -818,6 +818,9 @@ Disable input devices.
 .TP
 \fBnosound
 Disable sound system.
+.TP
+\fBnotpm
+Disable Trusted Platform Module (TPM) devices.
 .TP
 \fBnotv
 Disable DVB (Digital Video Broadcasting) TV devices.

--- a/src/man/firejail.1.in
+++ b/src/man/firejail.1.in
@@ -1919,6 +1919,16 @@ Example:
 $ firejail \-\-nosound firefox
 
 .TP
+\fB\-\-notpm
+Disable Trusted Platform Module (TPM) devices.
+.br
+
+.br
+Example:
+.br
+$ firejail \-\-notpm
+
+.TP
 \fB\-\-notv
 Disable DVB (Digital Video Broadcasting) TV devices.
 .br
@@ -2173,10 +2183,10 @@ $ pwd
 .TP
 \fB\-\-private-dev
 Create a new /dev directory.
-Only disc, dri, dvb, full, hidraw, log, null, ptmx, pts, random, shm, snd, tty,
-urandom, usb, video and zero devices are available.
-Use the options \-\-no3d, \-\-nodvd, \-\-nosound, \-\-notv, \-\-nou2f and
-\-\-novideo for additional restrictions.
+Only disc, dri, dvb, full, hidraw, log, null, ptmx, pts, random, shm, snd, tpm,
+tty, urandom, usb, video and zero devices are available.
+Use the options \-\-no3d, \-\-nodvd, \-\-nosound, \-\-notpm, \-\-notv,
+\-\-nou2f and \-\-novideo for additional restrictions.
 .br
 
 .br

--- a/src/zsh_completion/_firejail.in
+++ b/src/zsh_completion/_firejail.in
@@ -134,6 +134,7 @@ _firejail_args=(
     '--nonewprivs[sets the NO_NEW_PRIVS prctl]'
     '--noprinters[disable printers]'
     '--nosound[disable sound system]'
+    '--notpm[disable TPM devices]'
     '--nou2f[disable U2F devices]'
     '--novideo[disable video devices]'
     '--private[temporary home directory]'


### PR DESCRIPTION
An ssh private key may be stored in a Trusted Platform Module (TPM)
device and `private-dev` in ssh.profile currently breaks this use-case,
as it does not keep tpm devices (see #6379).

So add a new `notpm` command and keep tpm devices in /dev by default
with `private-dev` unless `notpm` is used.

Tested locally with:

```
❯ /usr/local/bin/firejail --private-dev --noprofile stat /dev/tpm0
firejail version 0.9.73

Parent pid 34059, child pid 34060
Base filesystem installed in 0.03 ms
Child process initialized in 13.23 ms
  File: /dev/tpm0
  Size: 0         	Blocks: 0          IO Block: 4096   character special file
Device: 0,6	Inode: 150         Links: 1     Device type: 10,224
Access: (0600/crw-------)  Uid: (  973/     tss)   Gid: (  973/     tss)
Access: 2024-06-22 11:20:44.017230197 +0200
Modify: 2024-06-22 11:20:44.017230197 +0200
Change: 2024-06-22 11:20:44.017230197 +0200
 Birth: 2024-06-22 11:20:10.406666659 +0200

Parent is shutting down, bye...
```

Fixes #6379.