### PR TITLE
profiles: keepassxc: add new socket location

### DIFF
--- a/etc/profile-a-l/chromium-common.profile
+++ b/etc/profile-a-l/chromium-common.profile
@@ -13,6 +13,8 @@ include chromium-common.local
 # chromium-common.local.
 # Note: Start KeePassXC before the web browser and keep it open to allow
 # communication between them.
+#noblacklist ${RUNUSER}/app
+#whitelist ${RUNUSER}/app/org.keepassxc.KeePassXC
 #whitelist ${RUNUSER}/kpxc_server
 #whitelist ${RUNUSER}/org.keepassxc.KeePassXC.BrowserServer
 

--- a/etc/profile-a-l/firefox-common-addons.profile
+++ b/etc/profile-a-l/firefox-common-addons.profile
@@ -4,6 +4,7 @@ include firefox-common-addons.local
 
 # Prevent whitelisting in ${RUNUSER}
 ignore whitelist ${RUNUSER}/*firefox*
+ignore whitelist ${RUNUSER}/app/org.keepassxc.KeePassXC
 ignore whitelist ${RUNUSER}/psd/*firefox*
 ignore whitelist ${RUNUSER}/kpxc_server
 ignore whitelist ${RUNUSER}/org.keepassxc.KeePassXC.BrowserServer

--- a/etc/profile-a-l/firefox-common.profile
+++ b/etc/profile-a-l/firefox-common.profile
@@ -20,6 +20,8 @@ include firefox-common.local
 # firefox-common.local.
 # Note: Start KeePassXC before the web browser and keep it open to allow
 # communication between them.
+#noblacklist ${RUNUSER}/app
+#whitelist ${RUNUSER}/app/org.keepassxc.KeePassXC
 #whitelist ${RUNUSER}/kpxc_server
 #whitelist ${RUNUSER}/org.keepassxc.KeePassXC.BrowserServer
 

--- a/etc/profile-a-l/keepassxc.profile
+++ b/etc/profile-a-l/keepassxc.profile
@@ -13,6 +13,7 @@ noblacklist ${HOME}/.config/keepassxc
 noblacklist ${HOME}/.config/KeePassXCrc
 noblacklist ${HOME}/.keepassxc
 noblacklist ${DOCUMENTS}
+noblacklist ${RUNUSER}/app
 
 # Allow browser profiles, required for browser integration.
 noblacklist ${HOME}/.config/BraveSoftware
@@ -62,8 +63,11 @@ include disable-xdg.inc
 #whitelist ${HOME}/.config/KeePassXCrc
 #include whitelist-common.inc
 
+mkdir ${RUNUSER}/app/org.keepassxc.KeePassXC
+whitelist ${RUNUSER}/app/org.keepassxc.KeePassXC
 whitelist /usr/share/keepassxc
 include whitelist-run-common.inc
+include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 


### PR DESCRIPTION
KeePassXC browser extension look for KeePassXC socket in the /run/user/app directory (https://github.com/keepassxreboot/keepassxc/blob/6b1ab1a5edd66ac10706a2fb5af34ec9458a901d/src/browser/BrowserShared.cpp#L41).

Unfortunately, /run/user/app seems to be blacklisted in disable-common.inc under the flatpak section (https://github.com/netblue30/firejail/blob/b89ec818926b4bcd3a58bb4e2a67b68a8090ba1c/etc/inc/disable-common.inc#L667), as a result, KeePassXC extension cannot find a socket.
    
Fixes #5447.

Relates to:

* #3952
* #3984
* #4213