### PR TITLE
profiles: fractal: add ~/.local/share/fractal

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -950,6 +950,7 @@ blacklist ${HOME}/.local/share/feedreader
 blacklist ${HOME}/.local/share/feral-interactive
 blacklist ${HOME}/.local/share/five-or-more
 blacklist ${HOME}/.local/share/fluffychat
+blacklist ${HOME}/.local/share/fractal
 blacklist ${HOME}/.local/share/freecol
 blacklist ${HOME}/.local/share/gajim
 blacklist ${HOME}/.local/share/gdfuse

--- a/etc/profile-a-l/fractal.profile
+++ b/etc/profile-a-l/fractal.profile
@@ -7,6 +7,7 @@ include fractal.local
 include globals.local
 
 noblacklist ${HOME}/.cache/fractal
+noblacklist ${HOME}/.local/share/fractal
 
 # Allow python (blacklisted by disable-interpreters.inc)
 include allow-python2.inc
@@ -21,7 +22,9 @@ include disable-shell.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.cache/fractal
+mkdir ${HOME}/.local/share/fractal
 whitelist ${HOME}/.cache/fractal
+whitelist ${HOME}/.local/share/fractal
 whitelist ${DOWNLOADS}
 whitelist /usr/share/fractal
 include whitelist-common.inc


### PR DESCRIPTION
I'm on Arch using Fractal 7 and firejail 0.9.72. Even after fixing #6119, using Fractal with firejail would either not work (without Internet access) or show me "Crypto identity incomplete" when using it with, as it stores (encrypted) messages and key material in ~/.local/share/fractal.

This patch fixes that issue for me. Let me know if you'd like me to open an issue first to discuss the problem there before accepting a pull request, or if you have any advice or improvements.