### PR TITLE
modif: remove --noautopulse from --help and zsh comp

### DIFF
--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -189,7 +189,6 @@ static const char *const usage_str =
 	"    --noroot - install a user namespace with only the current user.\n"
 #endif
 	"    --nosound - disable sound system.\n"
-	"    --noautopulse - disable automatic ~/.config/pulse init.\n"
 	"    --novideo - disable video devices.\n"
 	"    --notpm - disable TPM devices.\n"
 	"    --nou2f - disable U2F devices.\n"

--- a/src/zsh_completion/_firejail.in
+++ b/src/zsh_completion/_firejail.in
@@ -124,7 +124,6 @@ _firejail_args=(
     # many would enjoy getting a list from -20..20
     '--nice=-[set nice value]: :(1 10 15 20)'
     '--no3d[disable 3D hardware acceleration]'
-    '--noautopulse[disable automatic ~/.config/pulse init]'
     '--noblacklist=-[disable blacklist for file or directory]: :_files'
     '--nodbus[disable D-Bus access]'
     '--nodvd[disable DVD and audio CD devices]'


### PR DESCRIPTION
This command is deprecated and may be confused for a hardening option.

This amends commit 5a612029b ("rename noautopulse to keep-config-pulse",
2021-05-13) / PR #4278.

This is a follow-up to #6390.