### PR TITLE
build: improve reliability/portability of date command usage

### DIFF
--- a/src/man/mkman.sh
+++ b/src/man/mkman.sh
@@ -5,8 +5,15 @@
 
 set -e
 
-MONTH="$(LC_ALL=C date -u --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%b)"
-YEAR="$(LC_ALL=C date -u --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y)"
+test -z "$SOURCE_DATE_EPOCH" && SOURCE_DATE_EPOCH="$(date +%s)"
+
+format='+%b %Y'
+date="$(LC_ALL=C date -u -d "@$SOURCE_DATE_EPOCH" "$format" 2>/dev/null ||
+	LC_ALL=C date -u -r "$SOURCE_DATE_EPOCH" "$format" 2>/dev/null ||
+	LC_ALL=C date -u "$format")"
+
+MONTH="$(printf '%s\n' "$date" | cut -f 1 -d ' ')"
+YEAR="$(printf '%s\n' "$date" | cut -f 2 -d ' ')"
 
 sed \
   -e "s/VERSION/$1/g" \


### PR DESCRIPTION
Changes:

* Use the exact same source date string for all `date` invocations
* Use `-d` instead of `--date=`
* Fallback to `-r` and then to no argument

Some `date` implementations only support BSD `-r` instead of GNU `-d` /
`--date=` and others may not support any of them since neither option is
in POSIX.

For example, if zoneinfo is installed by chromebrew on ChromeOS, it
provides a date program that only supports `-r` and overrides the system
one (which supports `-d`) [1]:

    ./mkman.sh 0.9.72 src/man/firejail.man firejail.1
    date: invalid option -- '-'
    date: usage: date [-u] [-c] [-r seconds] [+format]
    make: *** [Makefile:42: firejail.1] Error 1

Environment: zoneinfo 2024a on ChromeOS M125.

Note: The changes are based on what is suggested by
reproducible-builds.org [2].

Relates to #193.

Fixes #6403.

[1] https://github.com/netblue30/firejail/issues/6403#issue-2402292506
[2] https://reproducible-builds.org/docs/source-date-epoch/

Reported-by: @Zopolis4
Cc: @reinerh (from #193)
