### PR TITLE
profiles: firecfg.config: disable spectacle

### DIFF
--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -824,7 +824,7 @@ soffice
 sol
 sound-juicer
 soundconverter
-spectacle
+#spectacle # may be broken on wayland (see #5127)
 spectral
 spotify
 sqlitebrowser


### PR DESCRIPTION
There are various reports in #5127 that the current profile is broken on
wayland (and at least one report that it is broken on xorg as well).

Relates to #6268.