### PR TITLE
bugfix: firemon: skip coredump if unsupported

### DIFF
--- a/src/firemon/procevent.c
+++ b/src/firemon/procevent.c
@@ -396,6 +396,8 @@ static void __attribute__((noreturn)) procevent_monitor(const int sock, pid_t my
 					sprintf(lineptr, " sid ");
 					break;
 
+// Note: PROC_EVENT_COREDUMP only exists since Linux 3.10 (see #6414).
+#ifdef PROC_EVENT_COREDUMP
 				case PROC_EVENT_COREDUMP:
 					pid = proc_ev->event_data.coredump.process_tgid;
 #ifdef DEBUG_PRCTL
@@ -403,6 +405,7 @@ static void __attribute__((noreturn)) procevent_monitor(const int sock, pid_t my
 #endif
 					sprintf(lineptr, " coredump ");
 					break;
+#endif /* PROC_EVENT_COREDUMP */
 
 				case PROC_EVENT_COMM:
 					pid = proc_ev->event_data.comm.process_tgid;


### PR DESCRIPTION
The coredump-related code fails to build on Linux kernel version 3.8 as
apparently it only exists on Linux since version 3.10:

    docker run --platform linux/386 --rm -it satmandu/crewbuild:386
    [...]
    ./configure && make
    [...]
    gcc -ggdb -O2 -DVERSION='"0.9.73"' [...] -march=i686  -c ../../src/firemon/procevent.c -o ../../src/firemon/procevent.o
    ../../src/firemon/procevent.c: In function ‘procevent_monitor’:
    ../../src/firemon/procevent.c:399:38: error: ‘PROC_EVENT_COREDUMP’ undeclared (first use in this function); did you mean ‘PROC_EVENT_COMM’?
      399 |                                 case PROC_EVENT_COREDUMP:
          |                                      ^~~~~~~~~~~~~~~~~~~
          |                                      PROC_EVENT_COMM
    ../../src/firemon/procevent.c:399:38: note: each undeclared identifier is reported only once for each function it appears in
    ../../src/firemon/procevent.c:400:66: error: ‘union <anonymous>’ has no member named ‘coredump’
      400 |                                         pid = proc_ev->event_data.coredump.process_tgid;
          |                                                                  ^
    make[1]: *** [../../src/prog.mk:25: ../../src/firemon/procevent.o] Error 1
    make[1]: Leaving directory '/home/chronos/user/firejail/src/firemon'
    make: *** [Makefile:72: src/firemon/firemon] Error 2

Environment: gcc 14.1.0, glibc 2.23 and linuxheaders 3.8 on ChromeOS
M58.

Misc: @Zopolis4 also reports that "All i686 chromebooks have a kernel
version of 3.8".

This amends commit e11949a71 ("add support for comm, coredump, and prctl
procevents in firemon", 2024-04-30).

Fixes #6414.

Reported-by: @Zopolis4