### PR TITLE
profiles: bijiben: update webkit var and disable in firecfg

### DIFF
--- a/etc/profile-a-l/bijiben.profile
+++ b/etc/profile-a-l/bijiben.profile
@@ -59,5 +59,8 @@ dbus-user.talk ca.desrt.dconf
 dbus-user.talk org.freedesktop.Tracker1
 dbus-system none
 
-env WEBKIT_FORCE_SANDBOX=0
+# Warning: Disabling the webkit sandbox may be needed to make firejail work
+# with webkit2gtk, but this is not recommended (see #2995).
+# Add the following line to bijiben.local at your own risk:
+#env WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
 restrict-namespaces

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -97,7 +97,7 @@ basilisk
 bcompare
 beaker
 bibletime
-bijiben
+#bijiben # webkit2gtk-4.x requires bwrap (see #3647)
 bitcoin-qt
 bitlbee
 bitwarden


### PR DESCRIPTION
The current `bijiben.profile` sets an environment variable to disable
its internal webkit/bubblewrap sandbox but now a different variable
needs to be set[1]:

    WEBKIT_FORCE_SANDBOX no longer allows disabling the sandbox. Use WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1 instead.

This may be needed to make the profile work, but disabling the sandbox
affects the security in webkit[2], so update the variable and disable
bijiben by default in firecfg.config.

Note: Upstream replaced bijiben by gnome-notes[3] [4].

Relates to #2995.

[1] https://github.com/WebKit/WebKit/blob/0678a98c864ee36f0114ea4e7d303fd07788a822/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp#L117
[2] https://github.com/netblue30/firejail/issues/2995
[3] https://archlinux.org/packages/extra/x86_64/gnome-notes/
[4] https://wiki.gnome.org/Apps/Notes