### PR TITLE
profiles: ssh: allow gpgagent socket for custom homedir

### DIFF
--- a/etc/profile-m-z/ssh.profile
+++ b/etc/profile-m-z/ssh.profile
@@ -19,7 +19,8 @@ include disable-exec.inc
 include disable-programs.inc
 
 whitelist ${RUNUSER}/gcr/ssh
-whitelist ${RUNUSER}/gnupg/S.gpg-agent.ssh
+whitelist ${RUNUSER}/gnupg/S.gpg-agent.ssh # default gpg homedir setup
+whitelist ${RUNUSER}/gnupg/*/S.gpg-agent.ssh # custom gpg homedir setup
 whitelist ${RUNUSER}/keyring/ssh
 include whitelist-usr-share-common.inc
 include whitelist-runuser-common.inc


### PR DESCRIPTION
If a custom GPG homedir is used, a hash of its path is used in the path
of the gpg agent socket[1].

For example, when running:

    gpgconf --list-dirs agent-ssh-socket

With a custom homedir it returns:

    /run/user/1000/gnupg/<hashed homedir>/S.gpg-agent.ssh

Environment: gnupg 2.4.5-4 on Arch Linux.

[1] https://github.com/gpg/gnupg/blob/91532dc3f40599b74fff489cb021c0cd3344ae60/common/homedir.c#L1342