### PR TITLE
profiles: refactor dbus debugger profiles

### DIFF
--- a/etc/profile-a-l/d-feet.profile
+++ b/etc/profile-a-l/d-feet.profile
@@ -12,45 +12,16 @@ noblacklist ${HOME}/.config/d-feet
 include allow-python2.inc
 include allow-python3.inc
 
-include disable-common.inc
-include disable-devel.inc
-include disable-exec.inc
-include disable-interpreters.inc
-include disable-programs.inc
-include disable-shell.inc
-include disable-xdg.inc
-
 mkdir ${HOME}/.config/d-feet
 whitelist ${HOME}/.config/d-feet
 whitelist /usr/share/d-feet
-include whitelist-common.inc
-include whitelist-runuser-common.inc
-include whitelist-usr-share-common.inc
-include whitelist-var-common.inc
 
-apparmor
-caps.drop all
-ipc-namespace
-#net none # breaks on Ubuntu
-no3d
-nodvd
-nogroups
-noinput
-nonewprivs
-noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix
-seccomp
+# breaks on Ubuntu
+ignore net none
 
-disable-mnt
 private-bin d-feet,python*
-private-cache
-private-dev
-private-etc dbus-1
-private-tmp
 
 #memory-deny-write-execute # breaks on Arch (see issue #1803)
-restrict-namespaces
+
+# Redirect
+include dbus-debug-common.profile

--- a/etc/profile-a-l/d-spy.profile
+++ b/etc/profile-a-l/d-spy.profile
@@ -6,43 +6,7 @@ include d-spy.local
 # Persistent global definitions
 include globals.local
 
-include disable-common.inc
-include disable-devel.inc
-include disable-exec.inc
-include disable-interpreters.inc
-include disable-proc.inc
-include disable-programs.inc
-include disable-shell.inc
-include disable-xdg.inc
-
-include whitelist-common.inc
-include whitelist-runuser-common.inc
-include whitelist-usr-share-common.inc
-include whitelist-var-common.inc
-
-apparmor
-caps.drop all
-ipc-namespace
-net none
-no3d
-nodvd
-nogroups
-noinput
-nonewprivs
-noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix
-seccomp
-
-disable-mnt
 private-bin d-spy
-private-cache
-private-dev
-private-etc dbus-1
-private-tmp
 
-read-only ${HOME}
-restrict-namespaces
+# Redirect
+include dbus-debug-common.profile

--- a/etc/profile-a-l/dbus-debug-common.profile
+++ b/etc/profile-a-l/dbus-debug-common.profile
@@ -1,0 +1,49 @@
+# Firejail profile for dbus-debug-common
+# This file is overwritten after every install/update
+# Persistent local customizations
+include dbus-debug-common.local
+# Persistent global definitions
+# added by caller profile
+#include globals.local
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-proc.inc
+include disable-programs.inc
+include disable-shell.inc
+include disable-xdg.inc
+
+include whitelist-common.inc
+include whitelist-runuser-common.inc
+include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
+
+apparmor
+caps.drop all
+ipc-namespace
+net none
+no3d
+nodvd
+nogroups
+noinput
+nonewprivs
+noroot
+nosound
+notv
+nou2f
+novideo
+protocol unix
+seccomp
+seccomp.block-secondary
+tracelog
+
+disable-mnt
+private-cache
+private-dev
+private-etc dbus-1
+private-tmp
+
+read-only ${HOME}
+restrict-namespaces


### PR DESCRIPTION
There are a lot of common options in the `d-feet` and `d-spy` profiles.

Create a new common include file and refactor the existing profiles as
redirects.

Relates to #2492 #6328.