### PR TITLE
profiles: element-desktop: allow /usr/share/element

### DIFF
--- a/etc/profile-a-l/element-desktop.profile
+++ b/etc/profile-a-l/element-desktop.profile
@@ -14,6 +14,7 @@ noblacklist ${HOME}/.config/Element
 mkdir ${HOME}/.config/Element
 whitelist ${HOME}/.config/Element
 whitelist /opt/Element
+whitelist /usr/share/element
 
 dbus-user filter
 dbus-user.talk org.freedesktop.Notifications


### PR DESCRIPTION
This path is apparently needed on openSUSE Tumbleweed[1]:

    $ LC_ALL=C firejail /usr/bin/element-desktop
    [...]
    Error launching app
    Unable to find Electron app at /usr/share/element/app

    Cannot find module '/usr/share/element/app'

    Parent is shutting down, bye...

Fixes #6421.

[1] https://software.opensuse.org/package/element-desktop

Reported-by: @leukimi
