### PR TITLE
profiles: blacklist sway IPC socket

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -171,6 +171,10 @@ blacklist ${RUNUSER}/gsconnect
 blacklist ${RUNUSER}/i3/ipc-socket.*
 blacklist /tmp/i3-*/ipc-socket.*
 
+# sway IPC socket (allows arbitrary shell script execution)
+blacklist ${RUNUSER}/sway-ipc.*
+blacklist /tmp/sway-ipc.*
+
 # systemd
 blacklist ${HOME}/.config/systemd
 blacklist ${HOME}/.local/share/systemd

--- a/etc/profile-m-z/sway.profile
+++ b/etc/profile-m-z/sway.profile
@@ -10,6 +10,10 @@ include globals.local
 noblacklist ${HOME}/.config/sway
 # sway uses ~/.config/i3 as fallback if there is no ~/.config/sway
 noblacklist ${HOME}/.config/i3
+# allow creation of IPC socket
+noblacklist ${RUNUSER}/sway-ipc.*
+noblacklist /tmp/sway-ipc.*
+
 include disable-common.inc
 
 caps.drop all


### PR DESCRIPTION
Much like the i3 IPC socket (#6361), the sway IPC socket also allows arbitrary code execution via the `exec` subcommand (i.e. `swaymsg exec 'echo test > ~/test'`) . Access should only be permitted to sway itself by default.

The location of the IPC socket is set in [sway/ipc-server.c](https://github.com/swaywm/sway/blob/7e74a4914261cf32c45017521960adf7ff6dac8f/sway/ipc-server.c#L126):

```
	const char *dir = getenv("XDG_RUNTIME_DIR");
	if (!dir) {
		dir = "/tmp";
	}
	if (path_size <= snprintf(ipc_sockaddr->sun_path, path_size,
			"%s/sway-ipc.%u.%i.sock", dir, getuid(), getpid())) {
		sway_abort("Socket path won't fit into ipc_sockaddr->sun_path");
	}
```