### PR TITLE
profiles: firefox-common: fix private-etc in includers

### DIFF
--- a/etc/profile-a-l/abrowser.profile
+++ b/etc/profile-a-l/abrowser.profile
@@ -14,8 +14,7 @@ whitelist ${HOME}/.cache/mozilla/abrowser
 whitelist ${HOME}/.mozilla
 whitelist /usr/share/abrowser
 
-# private-etc must first be enabled in firefox-common.profile
-#private-etc abrowser
+private-etc abrowser
 
 # Redirect
 include firefox-common.profile

--- a/etc/profile-a-l/basilisk.profile
+++ b/etc/profile-a-l/basilisk.profile
@@ -19,8 +19,7 @@ seccomp
 ignore seccomp
 
 #private-bin basilisk
-# private-etc must first be enabled in firefox-common.profile
-#private-etc basilisk
+private-etc basilisk
 #private-opt basilisk
 
 restrict-namespaces

--- a/etc/profile-a-l/cachy-browser.profile
+++ b/etc/profile-a-l/cachy-browser.profile
@@ -26,9 +26,7 @@ whitelist /usr/share/cachy-browser
 
 # Add the next line to your cachy-browser.local to enable private-bin (Arch Linux).
 #private-bin dbus-launch,dbus-send,cachy-browser,sh
-# Add the next line to your cachy-browser.local to enable private-etc.
-# Note: private-etc must first be enabled in firefox-common.local.
-#private-etc cachy-browser
+private-etc cachy-browser
 
 dbus-user filter
 dbus-user.own org.mozilla.cachybrowser.*

--- a/etc/profile-a-l/cliqz.profile
+++ b/etc/profile-a-l/cliqz.profile
@@ -17,8 +17,7 @@ whitelist ${HOME}/.cliqz
 whitelist ${HOME}/.config/cliqz
 whitelist /usr/share/cliqz
 
-# private-etc must first be enabled in firefox-common.profile
-#private-etc cliqz
+private-etc cliqz
 
 # Redirect
 include firefox-common.profile

--- a/etc/profile-a-l/cyberfox.profile
+++ b/etc/profile-a-l/cyberfox.profile
@@ -16,8 +16,7 @@ whitelist /usr/share/8pecxstudios
 whitelist /usr/share/cyberfox
 
 #private-bin cyberfox,dbus-launch,dbus-send,env,sh,which
-# private-etc must first be enabled in firefox-common.profile
-#private-etc cyberfox
+private-etc cyberfox
 
 # Redirect
 include firefox-common.profile

--- a/etc/profile-a-l/firefox-common-addons.profile
+++ b/etc/profile-a-l/firefox-common-addons.profile
@@ -92,8 +92,7 @@ include allow-python3.inc
 #private-bin keepassxc-proxy
 
 # Flash plugin
-# private-etc must first be enabled in firefox-common.profile and in profiles including it.
-#private-etc adobe
+private-etc adobe
 
 # ff2mpv
 #ignore noexec ${HOME}

--- a/etc/profile-a-l/icecat.profile
+++ b/etc/profile-a-l/icecat.profile
@@ -14,8 +14,7 @@ whitelist ${HOME}/.cache/mozilla/icecat
 whitelist ${HOME}/.mozilla
 whitelist /usr/share/icecat
 
-# private-etc must first be enabled in firefox-common.profile
-#private-etc icecat
+private-etc icecat
 
 # Redirect
 include firefox-common.profile

--- a/etc/profile-a-l/iceweasel.profile
+++ b/etc/profile-a-l/iceweasel.profile
@@ -6,8 +6,7 @@ include iceweasel.local
 # added by included profile
 #include globals.local
 
-# private-etc must first be enabled in firefox-common.profile
-#private-etc iceweasel
+private-etc iceweasel
 
 # Redirect
 include firefox.profile

--- a/etc/profile-a-l/librewolf.profile
+++ b/etc/profile-a-l/librewolf.profile
@@ -27,9 +27,7 @@ whitelist /usr/share/librewolf
 
 # Add the next line to your librewolf.local to enable private-bin (Arch Linux).
 #private-bin dbus-launch,dbus-send,librewolf,sh
-# Add the next line to your librewolf.local to enable private-etc.
-# Note: private-etc must first be enabled in firefox-common.local.
-#private-etc librewolf
+private-etc librewolf
 
 dbus-user filter
 dbus-user.own io.gitlab.librewolf.*

--- a/etc/profile-m-z/palemoon.profile
+++ b/etc/profile-m-z/palemoon.profile
@@ -21,8 +21,7 @@ seccomp
 ignore seccomp
 
 #private-bin palemoon
-# private-etc must first be enabled in firefox-common.profile
-#private-etc palemoon
+private-etc palemoon
 
 restrict-namespaces
 ignore restrict-namespaces

--- a/etc/profile-m-z/waterfox.profile
+++ b/etc/profile-m-z/waterfox.profile
@@ -21,9 +21,7 @@ whitelist /usr/share/waterfox
 # waterfox requires a shell to launch on Arch. We can possibly remove sh though.
 # Add the next line to your waterfox.local to enable private-bin.
 #private-bin bash,dbus-launch,dbus-send,env,sh,waterfox,waterfox-classic,waterfox-current,which
-# Add the next line to your waterfox.local to enable private-etc. Note that private-etc must first be
-# enabled in your firefox-common.local.
-#private-etc waterfox
+private-etc waterfox
 
 # Redirect
 include firefox-common.profile


### PR DESCRIPTION
It was enabled in firefox-common.inc on commit 34d004892 ("private-etc:
corss-distro test for curl, gimp, inkscape, firefox, warzone2100",
2023-01-28), but not in the profiles that include it.

Enable it in the including profiles as well.

Note: This was already done for firefox.profile on commit 76249284f
("firefox: fix private-etc firefox", 2023-06-02) / PR #5844.

Relates to #6400.