### PR TITLE
WIP: feature: add support for wayland-security-context-v1

### DIFF
--- a/src/firejail/checkcfg.c
+++ b/src/firejail/checkcfg.c
@@ -425,6 +425,12 @@ static const char *const compiletime_support =
 #else
 		"disabled"
 #endif
+	"\n\t- wayland security context support is "
+#ifdef HAVE_WAYLAND_SECURITY_CONTEXT
+		"enabled"
+#else
+		"disabled"
+#endif
 	"\n";
 
 void print_compiletime_support(void) {

--- a/src/firejail/env.c
+++ b/src/firejail/env.c
@@ -261,7 +261,8 @@ static const char * const env_whitelist[] = {
 	"LANGUAGE",
 	"LC_MESSAGES",
 	// "PATH",
-	"DISPLAY"	// required by X11
+	"DISPLAY",	// required by X11
+	"WAYLAND_DISPLAY"	// required by wayland
 };
 
 static const char * const env_whitelist_sbox[] = {

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -376,6 +376,7 @@ extern int arg_deterministic_shutdown;	// shut down the sandbox if first child d
 extern int arg_keep_fd_all;	// inherit all file descriptors to sandbox
 extern int arg_netlock;	// netlocker
 extern int arg_restrict_namespaces;
+extern int arg_wayland;	// filter wayland socket
 
 typedef enum {
 	DBUS_POLICY_ALLOW,	// Allow unrestricted access to the bus

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -171,6 +171,7 @@ int login_shell = 0;
 int just_run_the_shell = 0;
 int arg_netlock = 0;
 int arg_restrict_namespaces = 0;
+int arg_wayland = 0;
 
 int parent_to_child_fds[2];
 int child_to_parent_fds[2];
@@ -1646,6 +1647,11 @@ int main(int argc, char **argv, char **envp) {
 				cfg.nice = 0;
 			arg_nice = 1;
 		}
+#ifdef HAVE_WAYLAND_SECURITY_CONTEXT
+		else if (strcmp(argv[1], "--wayland") == 0) {
+			arg_wayland = 1;
+		}
+#endif
 
 		//*************************************
 		// filesystem

--- a/src/firejail/wayland.c
+++ b/src/firejail/wayland.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2014-2024 Firejail Authors
+ *
+ * This file is part of firejail project
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+ #include "firejail.h"
+
+ 


### PR DESCRIPTION
Add support for limiting access to privileged wayland protocols via [security-context-v1](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/tree/main/staging/security-context)

To do this firejail needs to create a new wayland socket and attach a security context to it, which it then passes to the sandboxed application.

See also: [flatpak#4920](https://github.com/flatpak/flatpak/pull/4920)

Todo:
 - [ ] build: 
   - [ ] add wayland-protocols and wayland-scanner as build dependencies when building with `HAVE_WAYLAND_SECURITY_CONTEXT`
 - [ ] profiles:
    - [ ] check which programs can run natively under wayland. Start by looking for programs whitelisting the wayland socket and go from there.
 - [ ] src:
    - [ ] man: document changes
    - [ ] firemon: list which wayland display is in use and information about the attached security context
    - [ ] bash_completion, zsh_completion: add `--wayland` cli flag
    - [ ] jailcheck: test for presence of `security-context` global and creating a security context for an application
    - [ ] firejail:
      - [ ] implement wayland filter (either `wayland` for using a security context, or `wayland none` to disable access to wayland)
      - [ ] create wayland security context and attach it to a process. Should be pretty simple, I already wrote a small program that does it [here](https://github.com/FelixPehla/run_with_wayland_security_context_v1).

Open Questions:
 - what to do with `WAYLAND_SOCKET`, see [flatpak#5614](https://github.com/flatpak/flatpak/issues/5614):
   - unset it by default and add a global setting to allow it, which can be done on DEs which use them (KDE)
   - unset it by default and use a special filter option and enable it in profiles that commonly use this feature (check on flathub for apps which enable it). (this is the one that I find the most sensible)
   - don't unset it by default
 - `sandbox_engine` to use. Flatpak uses `org.flatpak`, use `com.wordpress.firejail`, thanks @rusty-snake
 - `app_id` to use. Flatpak uses the flatpak application ID (e.g. `org.signal.Signal` for the Signal messenger app), maybe use the name of the profile in use?
 - `instance_id` to use. Has to be unique to the currently running sandbox and should never be reused. Just use a (secure) random identifier from `/dev/urandom` or similar?