### PR TITLE
build: fix undeclared AUDIT_ARCH_AARCH64 on Linux <3.17

### DIFF
--- a/src/include/seccomp.h
+++ b/src/include/seccomp.h
@@ -101,6 +101,11 @@
 #define SECCOMP_RET_LOG		0x7ffc0000U
 #endif
 
+// Note: AUDIT_ARCH_AARCH64 only exists since Linux 3.17; see #6440 and
+// https://github.com/torvalds/linux/commit/875cbf3e4614cfdcc7f65033e25292aec80f09c0
+#ifndef AUDIT_ARCH_AARCH64
+#define AUDIT_ARCH_AARCH64	(EM_AARCH64|__AUDIT_ARCH_64BIT|__AUDIT_ARCH_LE)
+#endif
 
 #if defined(__i386__)
 # define ARCH_NR	AUDIT_ARCH_I386


### PR DESCRIPTION

It apparently only exists since Linux kernel version 3.17 (in
linux/audit.h)[1].

Partial build log:

    ../include/seccomp.h:114:25: error: 'AUDIT_ARCH_AARCH64' undeclared (first use in this function); did you mean 'AUDIT_ARCH_SPARC64'?
      114 | # define ARCH_NR        AUDIT_ARCH_AARCH64
          |                         ^~~~~~~~~~~~~~~~~~
    ../include/seccomp.h:198:38: note: in expansion of macro 'ARCH_NR'
      198 |      BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, ARCH_NR, 1, 0), \
          |                                      ^~~~~~~
    sbox.c:113:25: note: in expansion of macro 'VALIDATE_ARCHITECTURE'
      113 |                         VALIDATE_ARCHITECTURE,
          |                         ^~~~~~~~~~~~~~~~~~~~~
    ../include/seccomp.h:114:25: note: each undeclared identifier is reported only once for each function it appears in
      114 | # define ARCH_NR        AUDIT_ARCH_AARCH64
          |                         ^~~~~~~~~~~~~~~~~~
    ../include/seccomp.h:198:38: note: in expansion of macro 'ARCH_NR'
      198 |      BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, ARCH_NR, 1, 0), \
          |                                      ^~~~~~~
    sbox.c:113:25: note: in expansion of macro 'VALIDATE_ARCHITECTURE'
      113 |                         VALIDATE_ARCHITECTURE,
          |                         ^~~~~~~~~~~~~~~~~~~~~

Environment: Linux kernel/headers 3.10 / CentOS 7 / arm64.

Fixes #6440.

[1] https://github.com/torvalds/linux/commit/875cbf3e4614cfdcc7f65033e25292aec80f09c0

Reported-by: @snakethatlovesstaticlibs
