### PR TITLE
docs: man: sort commands (firejail.1)

### DIFF
--- a/src/man/firejail-profile.5.in
+++ b/src/man/firejail-profile.5.in
@@ -668,20 +668,20 @@ Enable filtered access to the system DBus. Filters can be specified with the dbu
 \fBdbus-system none
 Disable access to the system DBus. Once access is disabled, it cannot be relaxed to filtering.
 .TP
-\fBdbus-system.own org.gnome.ghex.*
-Allow the application to own the name org.gnome.ghex and all names underneath in on the system DBus.
-.TP
-\fBdbus-system.talk org.freedesktop.Notifications
-Allow the application to talk to the name org.freedesktop.Notifications on the system DBus.
-.TP
-\fBdbus-system.see org.freedesktop.Notifications
-Allow the application to see but not talk to the name org.freedesktop.Notifications on the system DBus.
+\fBdbus-system.broadcast org.freedesktop.Notifications=org.freedesktop.Notifications.*@/org/freedesktop/Notifications
+Allow the application to receive broadcast signals from the interface org.freedesktop.Notifications of the object exposed at the path /org/freedesktop/Notifications by the client owning the bus name org.freedesktop.Notifications on the system DBus.
 .TP
 \fBdbus-system.call org.freedesktop.Notifications=org.freedesktop.Notifications.*@/org/freedesktop/Notifications
 Allow the application to call methods of the interface org.freedesktop.Notifications of the object exposed at the path /org/freedesktop/Notifications by the client owning the bus name org.freedesktop.Notifications on the system DBus.
 .TP
-\fBdbus-system.broadcast org.freedesktop.Notifications=org.freedesktop.Notifications.*@/org/freedesktop/Notifications
-Allow the application to receive broadcast signals from the interface org.freedesktop.Notifications of the object exposed at the path /org/freedesktop/Notifications by the client owning the bus name org.freedesktop.Notifications on the system DBus.
+\fBdbus-system.own org.gnome.ghex.*
+Allow the application to own the name org.gnome.ghex and all names underneath in on the system DBus.
+.TP
+\fBdbus-system.see org.freedesktop.Notifications
+Allow the application to see but not talk to the name org.freedesktop.Notifications on the system DBus.
+.TP
+\fBdbus-system.talk org.freedesktop.Notifications
+Allow the application to talk to the name org.freedesktop.Notifications on the system DBus.
 .TP
 \fBdbus-user filter
 Enable filtered access to the session DBus. Filters can be specified with the dbus-user.talk and dbus-user.own commands.
@@ -689,20 +689,20 @@ Enable filtered access to the session DBus. Filters can be specified with the db
 \fBdbus-user none
 Disable access to the session DBus. Once access is disabled, it cannot be relaxed to filtering.
 .TP
-\fBdbus-user.own org.gnome.ghex.*
-Allow the application to own the name org.gnome.ghex and all names underneath in on the session DBus.
-.TP
-\fBdbus-user.talk org.freedesktop.Notifications
-Allow the application to talk to the name org.freedesktop.Notifications on the session DBus.
-.TP
-\fBdbus-user.see org.freedesktop.Notifications
-Allow the application to see but not talk to the name org.freedesktop.Notifications on the session DBus.
+\fBdbus-user.broadcast org.freedesktop.Notifications=org.freedesktop.Notifications.*@/org/freedesktop/Notifications
+Allow the application to receive broadcast signals from the the interface org.freedesktop.Notifications of the object exposed at the path /org/freedesktop/Notifications by the client owning the bus name org.freedesktop.Notifications on the session DBus.
 .TP
 \fBdbus-user.call org.freedesktop.Notifications=org.freedesktop.Notifications.*@/org/freedesktop/Notifications
 Allow the application to call methods of the interface org.freedesktop.Notifications of the object exposed at the path /org/freedesktop/Notifications by the client owning the bus name org.freedesktop.Notifications on the session DBus.
 .TP
-\fBdbus-user.broadcast org.freedesktop.Notifications=org.freedesktop.Notifications.*@/org/freedesktop/Notifications
-Allow the application to receive broadcast signals from the the interface org.freedesktop.Notifications of the object exposed at the path /org/freedesktop/Notifications by the client owning the bus name org.freedesktop.Notifications on the session DBus.
+\fBdbus-user.own org.gnome.ghex.*
+Allow the application to own the name org.gnome.ghex and all names underneath in on the session DBus.
+.TP
+\fBdbus-user.see org.freedesktop.Notifications
+Allow the application to see but not talk to the name org.freedesktop.Notifications on the session DBus.
+.TP
+\fBdbus-user.talk org.freedesktop.Notifications
+Allow the application to talk to the name org.freedesktop.Notifications on the session DBus.
 .TP
 \fBnodbus \fR(deprecated)
 Disable D-Bus access (both system and session buses). Equivalent to dbus-system none and dbus-user none.
@@ -867,20 +867,6 @@ net eth0
 ip 10.10.20.56
 
 .TP
-\fBip none
-No IP address and no default gateway are configured for the last interface
-defined by a net command. Use this option
-in case you intend to start an external DHCP client in the sandbox.
-.br
-
-.br
-Example:
-.br
-net eth0
-.br
-ip none
-
-.TP
 \fBip dhcp
 Acquire an IP address and default gateway for the last interface defined by a
 net command, as well as set the DNS servers according to the DHCP response.
@@ -906,6 +892,20 @@ The DHCP client will NOT release the DHCP lease when the sandbox terminates.
 If your DHCP server requires leases to be explicitly released, consider running
 a DHCP client and releasing the lease manually in conjunction with the
 net none command.
+
+.TP
+\fBip none
+No IP address and no default gateway are configured for the last interface
+defined by a net command. Use this option
+in case you intend to start an external DHCP client in the sandbox.
+.br
+
+.br
+Example:
+.br
+net eth0
+.br
+ip none
 
 .TP
 \fBip6 address

--- a/src/man/firejail.1.in
+++ b/src/man/firejail.1.in
@@ -611,21 +611,6 @@ Example:
 $ firejail --dbus-user=filter --dbus-user.own=org.gnome.ghex.*
 
 .TP
-\fB\-\-dbus-user.talk=name
-Allows the application to talk to the specified well-known name on the session DBus.
-The name may have a .* suffix to match all names underneath it, including itself
-(e.g. "foo.bar.*" matches "foo.bar", "foo.bar.baz" and "foo.bar.baz.quux", but
-not "foobar").
-.br
-
-.br
-Example:
-.br
-$ firejail --dbus-user=filter --dbus-user.talk=\\
-.br
-org.freedesktop.Notifications
-
-.TP
 \fB\-\-dbus-user.see=name
 Allows the application to see, but not talk to the specified well-known name on
 the session DBus.
@@ -638,6 +623,21 @@ not "foobar").
 Example:
 .br
 $ firejail --dbus-user=filter --dbus-user.see=\\
+.br
+org.freedesktop.Notifications
+
+.TP
+\fB\-\-dbus-user.talk=name
+Allows the application to talk to the specified well-known name on the session DBus.
+The name may have a .* suffix to match all names underneath it, including itself
+(e.g. "foo.bar.*" matches "foo.bar", "foo.bar.baz" and "foo.bar.baz.quux", but
+not "foobar").
+.br
+
+.br
+Example:
+.br
+$ firejail --dbus-user=filter --dbus-user.talk=\\
 .br
 org.freedesktop.Notifications
 #endif
@@ -888,6 +888,32 @@ Example:
 .br
 $ firejail \-\-hosts-file=~/myhosts firefox
 
+.TP
+\fB\-\-icmptrace[=name|pid]
+Monitor ICMP traffic. The sandbox can be specified by name or pid. Only networked sandboxes
+created with \-\-net are supported. This option is only available when running the sandbox as root.
+.br
+
+.br
+Without a name/pid, Firejail will monitor the main system network namespace.
+.br
+
+.br
+Example
+.br
+$ sudo firejail --icmptrace
+.br
+20:53:54  192.168.1.60 -> 142.250.65.174 - 98 bytes - Echo request/0
+.br
+20:53:54  142.250.65.174 -> 192.168.1.60 - 98 bytes - Echo reply/0
+.br
+20:53:55  192.168.1.60 -> 142.250.65.174 - 98 bytes - Echo request/0
+.br
+20:53:55  142.250.65.174 -> 192.168.1.60 - 98 bytes - Echo reply/0
+.br
+20:53:55  192.168.1.60 -> 1.1.1.1 - 154 bytes - Destination unreachable/Port unreachable
+.br
+
 #ifdef HAVE_IDS
 .TP
 \fB\-\-ids-check
@@ -925,32 +951,6 @@ $ firejail \-\-ignore="net eth0" firefox
 #endif
 
 .TP
-\fB\-\-icmptrace[=name|pid]
-Monitor ICMP traffic. The sandbox can be specified by name or pid. Only networked sandboxes
-created with \-\-net are supported. This option is only available when running the sandbox as root.
-.br
-
-.br
-Without a name/pid, Firejail will monitor the main system network namespace.
-.br
-
-.br
-Example
-.br
-$ sudo firejail --icmptrace
-.br
-20:53:54  192.168.1.60 -> 142.250.65.174 - 98 bytes - Echo request/0
-.br
-20:53:54  142.250.65.174 -> 192.168.1.60 - 98 bytes - Echo reply/0
-.br
-20:53:55  192.168.1.60 -> 142.250.65.174 - 98 bytes - Echo request/0
-.br
-20:53:55  142.250.65.174 -> 192.168.1.60 - 98 bytes - Echo reply/0
-.br
-20:53:55  192.168.1.60 -> 1.1.1.1 - 154 bytes - Destination unreachable/Port unreachable
-.br
-
-.TP
 \fB\-\-\include=file.profile
 Include a profile file before the regular profiles are used.
 .br
@@ -984,23 +984,6 @@ Example:
 $ firejail \-\-net=eth0 \-\-ip=10.10.20.56 firefox
 
 .TP
-\fB\-\-ip=none
-No IP address and no default gateway are configured for the last interface
-defined by a \-\-net option. Use this option
-in case you intend to start an external DHCP client in the sandbox.
-.br
-
-.br
-Example:
-.br
-$ firejail \-\-net=eth0 \-\-\ip=none
-.br
-
-.br
-If the corresponding interface doesn't have an IP address configured, this
-option is enabled by default.
-
-.TP
 \fB\-\-ip=dhcp
 Acquire an IP address and default gateway for the last interface defined by a
 \-\-net option, as well as set the DNS servers according to the DHCP response.
@@ -1024,6 +1007,23 @@ The DHCP client will NOT release the DHCP lease when the sandbox terminates.
 If your DHCP server requires leases to be explicitly released, consider running
 a DHCP client and releasing the lease manually in conjunction with the
 \-\-net=none option.
+
+.TP
+\fB\-\-ip=none
+No IP address and no default gateway are configured for the last interface
+defined by a \-\-net option. Use this option
+in case you intend to start an external DHCP client in the sandbox.
+.br
+
+.br
+Example:
+.br
+$ firejail \-\-net=eth0 \-\-\ip=none
+.br
+
+.br
+If the corresponding interface doesn't have an IP address configured, this
+option is enabled by default.
 
 .TP
 \fB\-\-ip6=address
@@ -1324,6 +1324,21 @@ Example:
 $ firejail \-\-machine-id
 
 .TP
+\fB\-\-memory-deny-write-execute
+Install a seccomp filter to block attempts to create memory mappings
+that are both writable and executable, to change mappings to be
+executable, or to create executable shared memory. The filter examines
+the arguments of mmap, mmap2, mprotect, pkey_mprotect, memfd_create
+and shmat system calls and returns error EPERM to the process (or
+kills it or log the attempt, see \-\-seccomp-error-action below) if necessary.
+.br
+
+.br
+Note: shmat is not implemented
+as a system call on some platforms including i386, and it cannot be
+handled by seccomp-bpf.
+
+.TP
 \fB\-\-mkdir=dirname
 Create a directory in user home. Parent directories are created as needed.
 .br
@@ -1343,20 +1358,6 @@ Example:
 .br
 $ firejail --mkfile=~/work/project/readme
 
-.TP
-\fB\-\-memory-deny-write-execute
-Install a seccomp filter to block attempts to create memory mappings
-that are both writable and executable, to change mappings to be
-executable, or to create executable shared memory. The filter examines
-the arguments of mmap, mmap2, mprotect, pkey_mprotect, memfd_create
-and shmat system calls and returns error EPERM to the process (or
-kills it or log the attempt, see \-\-seccomp-error-action below) if necessary.
-.br
-
-.br
-Note: shmat is not implemented
-as a system call on some platforms including i386, and it cannot be
-handled by seccomp-bpf.
 #ifdef HAVE_NETWORK
 .TP
 \fB\-\-mtu=number
@@ -1792,15 +1793,6 @@ Example:
 .br
 $ firejail \-\-nodvd
 .TP
-\fB\-\-noinput
-Disable input devices.
-.br
-
-.br
-Example:
-.br
-$ firejail \-\-noinput
-.TP
 \fB\-\-noexec=dirname_or_filename
 Remount directory or file noexec, nodev and nosuid. File globbing is supported, see \fBFILE GLOBBING\fR section for more details.
 .br
@@ -1843,6 +1835,16 @@ $ id
 uid=1000(netblue) gid=1000(netblue) groups=1000(netblue)
 .br
 $
+
+.TP
+\fB\-\-noinput
+Disable input devices.
+.br
+
+.br
+Example:
+.br
+$ firejail \-\-noinput
 
 .TP
 \fB\-\-nonewprivs


### PR DESCRIPTION
Sort commands in firejail.1.in and sync the result with
firejail-profile.5.in.

* Commands: `--dbus-system.*`, `--dbus-user.*`, `--icmptrace`,
  `--ip=none`, `memory-deny-write-execute`, `--noinput`

Relates to #3190 #3406 #4209.