### PR TITLE
profiles: video: add ~/.dvdcss

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -728,6 +728,7 @@ blacklist ${HOME}/.dillo
 blacklist ${HOME}/.dooble
 blacklist ${HOME}/.dosbox
 blacklist ${HOME}/.dropbox*
+blacklist ${HOME}/.dvdcss
 blacklist ${HOME}/.easystroke
 blacklist ${HOME}/.electron-cache
 blacklist ${HOME}/.electron-cash

--- a/etc/profile-a-l/ffmpeg.profile
+++ b/etc/profile-a-l/ffmpeg.profile
@@ -9,6 +9,7 @@ include globals.local
 
 noblacklist ${MUSIC}
 noblacklist ${VIDEOS}
+noblacklist ${HOME}/.dvdcss
 
 include disable-common.inc
 include disable-devel.inc

--- a/etc/profile-a-l/handbrake.profile
+++ b/etc/profile-a-l/handbrake.profile
@@ -7,6 +7,7 @@ include handbrake.local
 include globals.local
 
 noblacklist ${HOME}/.config/ghb
+noblacklist ${HOME}/.dvdcss
 noblacklist ${MUSIC}
 noblacklist ${VIDEOS}
 

--- a/etc/profile-m-z/mplayer.profile
+++ b/etc/profile-m-z/mplayer.profile
@@ -6,6 +6,7 @@ include mplayer.local
 # Persistent global definitions
 include globals.local
 
+noblacklist ${HOME}/.dvdcss
 noblacklist ${HOME}/.mplayer
 
 include disable-common.inc
@@ -16,6 +17,7 @@ include disable-programs.inc
 
 read-only ${DESKTOP}
 mkdir ${HOME}/.mplayer
+whitelist ${HOME}/.dvdcss
 whitelist ${HOME}/.mplayer
 include whitelist-common.inc
 include whitelist-player-common.inc

--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -29,6 +29,7 @@ noblacklist ${HOME}/.config/mpv
 noblacklist ${HOME}/.config/youtube-dl
 noblacklist ${HOME}/.config/yt-dlp
 noblacklist ${HOME}/.config/yt-dlp.conf
+noblacklist ${HOME}/.dvdcss
 noblacklist ${HOME}/.local/state/mpv
 noblacklist ${HOME}/.netrc
 noblacklist ${HOME}/yt-dlp.conf
@@ -60,6 +61,7 @@ whitelist ${HOME}/.config/mpv
 whitelist ${HOME}/.config/youtube-dl
 whitelist ${HOME}/.config/yt-dlp
 whitelist ${HOME}/.config/yt-dlp.conf
+whitelist ${HOME}/.dvdcss
 whitelist ${HOME}/.local/state/mpv
 whitelist ${HOME}/.netrc
 whitelist ${HOME}/yt-dlp.conf

--- a/etc/profile-m-z/smplayer.profile
+++ b/etc/profile-m-z/smplayer.profile
@@ -8,6 +8,7 @@ include globals.local
 
 noblacklist ${HOME}/.config/smplayer
 noblacklist ${HOME}/.config/youtube-dl
+noblacklist ${HOME}/.dvdcss
 noblacklist ${HOME}/.mplayer
 
 # Allow lua (blacklisted by disable-interpreters.inc)

--- a/etc/profile-m-z/totem.profile
+++ b/etc/profile-m-z/totem.profile
@@ -14,6 +14,7 @@ include allow-lua.inc
 include allow-python3.inc
 
 noblacklist ${HOME}/.config/totem
+noblacklist ${HOME}/.dvdcss
 noblacklist ${HOME}/.local/share/totem
 
 include disable-common.inc
@@ -27,6 +28,7 @@ read-only ${DESKTOP}
 mkdir ${HOME}/.config/totem
 mkdir ${HOME}/.local/share/totem
 whitelist ${HOME}/.config/totem
+whitelist ${HOME}/.dvdcss
 whitelist ${HOME}/.local/share/totem
 whitelist /usr/share/totem
 include whitelist-common.inc

--- a/etc/profile-m-z/vlc.profile
+++ b/etc/profile-m-z/vlc.profile
@@ -9,6 +9,7 @@ include globals.local
 noblacklist ${HOME}/.cache/vlc
 noblacklist ${HOME}/.config/vlc
 noblacklist ${HOME}/.config/aacs
+noblacklist ${HOME}/.dvdcss
 noblacklist ${HOME}/.local/share/vlc
 
 include disable-common.inc
@@ -24,6 +25,7 @@ mkdir ${HOME}/.local/share/vlc
 whitelist ${HOME}/.cache/vlc
 whitelist ${HOME}/.config/vlc
 whitelist ${HOME}/.config/aacs
+whitelist ${HOME}/.dvdcss
 whitelist ${HOME}/.local/share/vlc
 include whitelist-common.inc
 include whitelist-player-common.inc


### PR DESCRIPTION
It's used by libdvdcss (which is used to play copy-restricted dvds).

It seems to be just a cache directory, so just allow without mkdir.

Relates to #5391.

Suggested-by: @reinerh
