### PR TITLE
profiles: evolution: add /tmp/evolution-* & disable private-tmp

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -1261,6 +1261,7 @@ blacklist ${RUNUSER}/qutebrowser
 blacklist /etc/ssmtp
 blacklist /tmp/.wine-*
 blacklist /tmp/akonadi-*
+blacklist /tmp/evolution-*
 blacklist /tmp/i3-*
 blacklist /tmp/lwjgl_*
 blacklist /var/games/nethack

--- a/etc/profile-a-l/evolution.profile
+++ b/etc/profile-a-l/evolution.profile
@@ -6,6 +6,7 @@ include evolution.local
 # Persistent global definitions
 include globals.local
 
+noblacklist /tmp/evolution-*
 noblacklist /var/mail
 noblacklist /var/spool/mail
 noblacklist ${HOME}/.bogofilter
@@ -41,7 +42,7 @@ protocol unix,inet,inet6
 seccomp
 
 private-dev
-private-tmp
+#private-tmp
 writable-var
 
 restrict-namespaces


### PR DESCRIPTION
These paths are apparently used for attachments.

Disable private-tmp to make it easier to open attachments with external
programs.

Relates to #5101.

Reported-by: @githlp
Suggested-by: @rusty-snake