### PR TITLE
docs: github: streamline environment in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -47,10 +47,11 @@ _Any other detail that may help to understand/debug the problem_
 
 ### Environment
 
-- Linux distribution and version (e.g. "Ubuntu 20.04" or "Arch Linux")
-- Firejail version (`firejail --version`).
+- Name/version/arch of the Linux kernel (`uname -srm`):
+- Name/version of the Linux distribution (e.g. "Ubuntu 20.04" or "Arch Linux"):
+- Version of Firejail (`firejail --version`):
 - If you use a development version of firejail, also the commit from which it
-  was compiled (`git rev-parse HEAD`).
+  was compiled (`git rev-parse HEAD`):
 
 ### Checklist
 

--- a/.github/ISSUE_TEMPLATE/build_issue.md
+++ b/.github/ISSUE_TEMPLATE/build_issue.md
@@ -64,9 +64,9 @@ _(Optional) Any other detail that may help to understand/debug the problem_
 
 ### Environment
 
-- Name/version/arch of the Linux kernel (e.g. the output of `uname -srm`)
-- Name/version of the Linux distribution (e.g. "Ubuntu 20.04" or "Arch Linux")
-- Name/version of the C compiler (e.g. "gcc 14.1.1-1")
-- Name/version of the libc (e.g. "glibc 2.40-1")
-- Version of the Linux API headers (e.g. "linux-api-headers 6.10-1" on Arch Linux)
-- Version of the source code being built (e.g. the output of `git rev-parse HEAD`)
+- Name/version/arch of the Linux kernel (`uname -srm`):
+- Name/version of the Linux distribution (e.g. "Ubuntu 20.04" or "Arch Linux"):
+- Name/version of the C compiler (e.g. "gcc 14.1.1-1"):
+- Name/version of the libc (e.g. "glibc 2.40-1"):
+- Version of the Linux API headers (e.g. "linux-api-headers 6.10-1" on Arch Linux):
+- Version of the source code being built (`git rev-parse HEAD`):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -22,3 +22,11 @@ _A clear and concise description of any alternative solutions or features you've
 ### Additional context
 
 _Add any other context or screenshots about the feature request here._
+
+### Environment
+
+- Name/version/arch of the Linux kernel (`uname -srm`):
+- Name/version of the Linux distribution (e.g. "Ubuntu 20.04" or "Arch Linux"):
+- Version of Firejail (`firejail --version`):
+- If you use a development version of firejail, also the commit from which it:
+  was compiled (`git rev-parse HEAD`):


### PR DESCRIPTION
Changes:

* Sync bug_report.md with build_issue.md (reword items and add Linux
  kernel item)
* Add a colon to the end of every item (to clarify where to add the
  information)
* Add the Environment section to feature_request.md

The last item is intended as a basic sanity check, as users using an
outdated version of firejail may request something that was already
implemented (for example, see #6461).

Relates to #4515 #6423.