### PR TITLE
docs: man: fix bold in command TPs

### DIFF
--- a/src/man/firejail-profile.5.in
+++ b/src/man/firejail-profile.5.in
@@ -511,30 +511,30 @@ Blacklist all Linux capabilities.
 Whitelist given Linux capabilities.
 #ifdef HAVE_LANDLOCK
 .TP
-\fBlandlock.enforce (experimental)
+\fBlandlock.enforce\fR (experimental)
 Enforce the Landlock ruleset.
 .PP
 Without it, the other Landlock commands have no effect.
 .TP
-\fBlandlock.fs.read path (experimental)
+\fBlandlock.fs.read path\fR (experimental)
 Create a Landlock ruleset (if it doesn't already exist) and add a read access
 rule for path.
 .TP
-\fBlandlock.fs.write path (experimental)
+\fBlandlock.fs.write path\fR (experimental)
 Create a Landlock ruleset (if it doesn't already exist) and add a write access
 rule for path.
 .TP
-\fBlandlock.fs.makeipc path (experimental)
+\fBlandlock.fs.makeipc path\fR (experimental)
 Create a Landlock ruleset (if it doesn't already exist) and add a rule that
 allows the creation of named pipes (FIFOs) and Unix domain sockets beneath
 the given path.
 .TP
-\fBlandlock.fs.makedev path (experimental)
+\fBlandlock.fs.makedev path\fR (experimental)
 Create a Landlock ruleset (if it doesn't already exist) and add a rule that
 allows the creation of block devices and character devices beneath the given
 path.
 .TP
-\fBlandlock.fs.execute path (experimental)
+\fBlandlock.fs.execute path\fR (experimental)
 Create a Landlock ruleset (if it doesn't already exist) and add an execution
 permission rule for path.
 #endif
@@ -704,7 +704,7 @@ Allow the application to see but not talk to the name org.freedesktop.Notificati
 \fBdbus-user.talk org.freedesktop.Notifications
 Allow the application to talk to the name org.freedesktop.Notifications on the session DBus.
 .TP
-\fBnodbus \fR(deprecated)
+\fBnodbus\fR (deprecated)
 Disable D-Bus access (both system and session buses). Equivalent to dbus-system none and dbus-user none.
 .TP
 .br
@@ -804,7 +804,7 @@ name browser
 \fBno3d
 Disable 3D hardware acceleration.
 .TP
-\fBnoautopulse \fR(deprecated)
+\fBnoautopulse\fR (deprecated)
 See keep-config-pulse.
 .TP
 \fBnodvd

--- a/src/man/firejail.1.in
+++ b/src/man/firejail.1.in
@@ -1241,30 +1241,30 @@ $ firejail --keep-var-tmp
 
 #ifdef HAVE_LANDLOCK
 .TP
-\fB\-\-landlock.enforce (experimental)
+\fB\-\-landlock.enforce\fR (experimental)
 Enforce the Landlock ruleset.
 Without it, the other Landlock commands have no effect.
 See the \fBLANDLOCK\fR section for more information.
 .TP
-\fB\-\-landlock.fs.read=path (experimental)
+\fB\-\-landlock.fs.read=path\fR (experimental)
 Create a Landlock ruleset (if it doesn't already exist) and add a read access
 rule for path.
 .TP
-\fB\-\-landlock.fs.write=path (experimental)
+\fB\-\-landlock.fs.write=path\fR (experimental)
 Create a Landlock ruleset (if it doesn't already exist) and add a write access
 rule for path.
 .TP
-\fB\-\-landlock.fs.makeipc=path (experimental)
+\fB\-\-landlock.fs.makeipc=path\fR (experimental)
 Create a Landlock ruleset (if it doesn't already exist) and add a rule that
 allows the creation of named pipes (FIFOs) and Unix domain sockets beneath
 the given path.
 .TP
-\fB\-\-landlock.fs.makedev=path (experimental)
+\fB\-\-landlock.fs.makedev=path\fR (experimental)
 Create a Landlock ruleset (if it doesn't already exist) and add a rule that
 allows the creation of block devices and character devices beneath the given
 path.
 .TP
-\fB\-\-landlock.fs.execute=path (experimental)
+\fB\-\-landlock.fs.execute=path\fR (experimental)
 Create a Landlock ruleset (if it doesn't already exist) and add an execution
 permission rule for path.
 .br
@@ -1727,7 +1727,7 @@ Example:
 $ firejail --no3d firefox
 
 .TP
-\fB\-\-noautopulse \fR(deprecated)
+\fB\-\-noautopulse\fR (deprecated)
 See --keep-config-pulse.
 
 .TP
@@ -1773,7 +1773,7 @@ $ nc dict.org 2628
 220 pan.alephnull.com dictd 1.12.1/rf on Linux 3.14-1-amd64
 .br
 .TP
-\fB\-\-nodbus \fR(deprecated)
+\fB\-\-nodbus\fR (deprecated)
 #ifdef HAVE_DBUSPROXY
 Disable D-Bus access (both system and session buses). Equivalent to --dbus-system=none --dbus-user=none.
 .br


### PR DESCRIPTION
Reset the bold right after each command/argument.

Command used to check for issues:

    git grep -E ' \\fR' -- src/man/*.in

Related commits:

* e91b9ff0f ("Deprecate --nodbus option", 2020-04-07) /
  PR #3265
* 5a612029b ("rename noautopulse to keep-config-pulse", 2021-05-13) /
  PR #4278
* d79547ca9 ("docs: warn about limitations of landlock", 2024-03-31) /
  PR #6302

This is a follow-up to #6451.

Relates to #6078.