### PR TITLE
profiles: librewolf: add new dbus name (io.gitlab.firefox)

### DIFF
--- a/etc/profile-a-l/librewolf.profile
+++ b/etc/profile-a-l/librewolf.profile
@@ -30,6 +30,7 @@ whitelist /usr/share/librewolf
 private-etc librewolf
 
 dbus-user filter
+dbus-user.own io.gitlab.firefox.*
 dbus-user.own io.gitlab.librewolf.*
 dbus-user.own org.mozilla.librewolf.*
 # Add the next line to your librewolf.local to enable native notifications.


### PR DESCRIPTION
It appears that LibreWolf 129 uses `io.gitlab.firefox.*` as the dbus
name.

Commands used to check the dbus name:

    $ busctl --user --no-legend | grep -v '^:' | grep librewolf |
      sed -E 's/(^[^ ]+\.)[^. ]+ .*/\1/'
    io.gitlab.firefox.

Commands used to test dbus communication:

    # Open a new browser instance:
    $ firejail --name=lwtest --ignore=name --ignore='dbus-user none' \
      --dbus-user=filter --dbus-user.own='io.gitlab.firefox.*' \
      --private --net=none --ignore=net /usr/bin/librewolf
    # In another shell, try to open a new tab:
    $ firejail --join=lwtest /usr/bin/librewolf --new-tab about:blank
    # Check that the new tab was opened

Related commits:

* c3f299620 ("Let programs outside librewolf sandbox open new tabs in
  librewolf (#4546)", 2021-09-19)
* a8ad9cad1 ("Update librewolf.profile: use new message bus",
  2022-02-03) / PR #4897
* 4211ee323 ("merges", 2022-02-04)

Fixes #6413.

Misc: This was noticed on #6444.

Reported-by: @Lonniebiz