### PR TITLE
profiles: wesnoth: allow lua

### DIFF
--- a/etc/profile-m-z/wesnoth.profile
+++ b/etc/profile-m-z/wesnoth.profile
@@ -10,6 +10,9 @@ noblacklist ${HOME}/.cache/wesnoth
 noblacklist ${HOME}/.config/wesnoth
 noblacklist ${HOME}/.local/share/wesnoth
 
+# Allow lua (blacklisted by disable-interpreters.inc)
+include allow-lua.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc


### PR DESCRIPTION
Fixes the following error:

    $ LC_ALL=C firejail /usr/bin/wesnoth
    [...]
    /usr/bin/wesnoth: error while loading shared libraries: liblua++.so.5.4: cannot open shared object file: Permission denied

Environment: lua 5.4.7-1, wesnoth 1:1.18.2-2 on Arch Linux.

Fixes #6475.

Reported-by: @marek22k
