### PR TITLE
profiles: firecfg: disable text editors

### DIFF
--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -320,9 +320,9 @@ gcalccmd
 gcloud
 gconf-editor
 gdu
-geany
+#geany # text editor (see #6002)
 #geary # webkit2gtk-4.x requires bwrap (see #3647)
-gedit
+#gedit # text editor (see #6002)
 geekbench
 geeqie
 geki2
@@ -463,7 +463,7 @@ kaffeine
 kalgebra
 kalgebramobile
 karbon
-kate
+#kate # text editor (see #6002)
 kazam
 kcalc
 #kdeinit4
@@ -499,11 +499,11 @@ ktorrent
 ktouch
 kube
 #kwin_x11
-kwrite
+#kwrite # text editor (see #6002)
 lbreakouthd
 lbry-viewer
 lbry-viewer-gtk
-leafpad
+#leafpad # text editor (see #6002)
 #less # breaks man
 lettura
 librecad
@@ -588,7 +588,7 @@ minitube
 mirage
 mirrormagic
 mocp
-mousepad
+#mousepad # text editor (see #6002)
 mov-cli
 mp3splt
 mp3splt-gtk
@@ -722,7 +722,7 @@ pix
 planmaker18
 planmaker18free
 playonlinux
-pluma
+#pluma # text editor (see #6002)
 plv
 pngquant
 polari
@@ -992,7 +992,7 @@ x2goclient
 xbill
 xcalc
 xchat
-xed
+#xed # text editor (see #6002)
 xfburn
 xfce4-dict
 xfce4-mixer


### PR DESCRIPTION
Disable common general-purpose text editors.

They are likely to be the default OS text editor and users may want to
use them for editing most/all files, which could include common
sensitive files such as ~/.bashrc and profiles in ~/.config/firejail.

Fixes #6002.

Relates to #924 #941 #1154.

Reported-by: @ilikenwf