### PR TITLE
profiles: nextcloud: fix access to ~/Nextcloud

### DIFF
--- a/etc/profile-m-z/QOwnNotes.profile
+++ b/etc/profile-m-z/QOwnNotes.profile
@@ -9,6 +9,7 @@ include globals.local
 noblacklist ${DOCUMENTS}
 noblacklist ${HOME}/.config/PBE
 noblacklist ${HOME}/.local/share/PBE
+noblacklist ${HOME}/Nextcloud
 noblacklist ${HOME}/Nextcloud/Notes
 
 include disable-common.inc

--- a/etc/profile-m-z/nextcloud.profile
+++ b/etc/profile-m-z/nextcloud.profile
@@ -9,6 +9,7 @@ include globals.local
 noblacklist ${HOME}/.config/Nextcloud
 noblacklist ${HOME}/.local/share/Nextcloud
 noblacklist ${HOME}/Nextcloud
+noblacklist ${HOME}/Nextcloud/Notes
 # Add the next lines to your nextcloud.local to allow sync in more directories.
 #noblacklist ${DOCUMENTS}
 #noblacklist ${MUSIC}


### PR DESCRIPTION
Related commits:

* 7c481eb43 ("Add QOwnNotes profile", 2018-10-20)
* 49a381c70 ("Add nextcloud-desktop", 2021-02-20) / PR #3997

Fixes #5877.

Reported-by: @Sadoon-AlBader
