### PR TITLE
profiles: ssh: add ${RUNUSER}/gvfsd-sftp

### DIFF
--- a/etc/profile-m-z/ssh.profile
+++ b/etc/profile-m-z/ssh.profile
@@ -21,6 +21,7 @@ include disable-programs.inc
 whitelist ${RUNUSER}/gcr/ssh
 whitelist ${RUNUSER}/gnupg/*/S.gpg-agent.ssh # custom gpg homedir setup
 whitelist ${RUNUSER}/gnupg/S.gpg-agent.ssh # default gpg homedir setup
+whitelist ${RUNUSER}/gvfsd-sftp
 whitelist ${RUNUSER}/keyring/ssh
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc


### PR DESCRIPTION
Based on the report by @Saren-Arterius[1]:

Since GNOME gvfs 1.53+, the ssh client options `ControlMaster=auto` and
`ControlPath=/run/user/$UID/gvfsd-sftp/%C` are used to mount sftp.

Since `/run/user/$UID/gvfsd-sftp` is not whitelisted, gvfs sftp mount
with nautilus will fail with a meaningless error message shown in the
UI.

Steps to reproduce[1]:

Prepare ssh server or localhost, then run:

    ssh -o"ForwardX11 no" -o"ForwardAgent no" \
        -o"PermitLocalCommand no" -o"ClearAllForwardings yes" \
        -o"NoHostAuthenticationForLocalhost yes" \
        -o"ControlMaster auto" \
        -o"ControlPath=/run/user/${UID}/gvfsd-sftp/test" \
        -s {SSH_HOST} sftp

stderr shows:

    unix_listener: cannot bind to path /run/user/$UID/gvfsd-sftp/test.{RANDOM_STRING}: No such file or directory

And ssh exits with error code 255.

Fixes #5816.

[1] https://github.com/netblue30/firejail/issues/5816#issue-1695295931

Reported-by: @Saren-Arterius
Suggested-by: @Saren-Arterius
Reported-by: @Alex-Farol
Reported-by: @mirko
