### PR TITLE
profiles: signal-desktop - Add access to D-Bus freedesktop.org secret API

### DIFF
--- a/etc/profile-m-z/signal-desktop.profile
+++ b/etc/profile-m-z/signal-desktop.profile
@@ -30,6 +30,8 @@ dbus-user filter
 dbus-user.talk org.freedesktop.Notifications
 # Allow D-Bus communication with Firefox for opening links
 dbus-user.talk org.mozilla.*
+# Allow D-Bus communication with Freedesktop.org secrets API to decrypt local key
+dbus-user.talk org.freedesktop.secrets
 
 ignore dbus-user none
 


### PR DESCRIPTION
Signal recently started storing a local key in the freedesktop.org secret API so allow access in the profile

Also see https://github.com/signalapp/Signal-Desktop/issues/6970