### PR TITLE
profiles: firefox-common: allow org.freedesktop.portal.Documents

### DIFF
--- a/etc/profile-a-l/firefox-common.profile
+++ b/etc/profile-a-l/firefox-common.profile
@@ -96,6 +96,8 @@ private-tmp
 dbus-user none
 dbus-system none
 
+# Allow drag and drop
+dbus-user.talk org.freedesktop.portal.Documents
 # Add the next line to firefox-common.local to enable native notifications.
 #dbus-user.talk org.freedesktop.Notifications
 # Add the next line to firefox-common.local to allow inhibiting screensavers.


### PR DESCRIPTION
This fixes drag and drop for at least Dolphin.

Fixes #6444.

Reported-by: @Utini2000
Suggested-by: @rusty-snake