### PR TITLE
feature: create the link only if its endpoint is available

### DIFF
--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -121,6 +121,8 @@ static void disable_file(OPERATION op, const char *filename) {
 
 	// modify the file
 	if (op == BLACKLIST_FILE || op == BLACKLIST_NOLOG) {
+		remove_blacklisted_delayed_links(fname, false);
+
 		// some distros put all executables under /usr/bin and make /bin a symbolic link
 		if ((strcmp(fname, "/bin") == 0 || strcmp(fname, "/usr/bin") == 0) &&
 		    is_link(filename) &&

--- a/src/firejail/fs_whitelist.c
+++ b/src/firejail/fs_whitelist.c
@@ -341,6 +341,11 @@ static void tmpfs_topdirs(const TopDir * const topdirs) {
 			continue;
 		}
 
+		// Check whether bind mount of tmpfs on topdirs[i].path will affect delayed links
+		// Bind mount of tmpfs on topdirs[i].path has the same meaning that blacklisting topdirs[i].path)
+		// exсept that whitelisted entries will be restored inside topdirs[i].path later.
+		remove_blacklisted_delayed_links(topdirs[i].path, true);
+
 		// special case /run
 		// open /run/firejail, so it can be restored right after mounting the tmpfs
 		int fd = -1;


### PR DESCRIPTION
This PR is intended to discuss the operation of the `--private-etc` option. Right now, for most files, a copy of the resolved file ((resolved path) is created in /etc. But this is not always a good way, as for example with the hardcoded value of `/etc/mtab`. But there are also files that in theory can be changed while the process is running in the sandbox. The process will not know about these changes until the sandbox is restarted, e.g. `localtime`, `resolv.conf`. If the time zone changes, localtime will change.

localtime without sandbox on my machine:

```sh
lrwxrwxrwx   1 root root       33 Jan 31  2024 localtime -> /usr/share/zoneinfo/Europe/Moscow
```

localtime in sandbox on my machine:

```sh
ilya@pankrat:/etc$ firejail --private-etc=localtime
-rw-r--r--  1 nobody nogroup   1535 Oct 10 13:11 localtime
```

Moreover, it is intuitively unexpected and seems unsafe that a link file in /etc/ is created if some intermediate link or resolved file is not available in the sandbox. I would expect firejail to send at least a warning or not just create a file in /etc/ in such a case. Example with localtime linked to /usr/share/zoneinfo/Europe/Moscow, /usr/share/zoneinfo is blacklisted and /etc/localtime is available:

```sh
ilya@pankrat:/etc$ firejail --private-etc=localtime --blacklist=/usr/share/zoneinfo
ilya@pankrat:/etc$ ls -la | grep localtime
-rw-r--r--  1 nobody nogroup   1535 Oct 10 13:14 localtime
ilya@pankrat:/etc$ ls /usr/share/zoneinfo
ls: cannot open directory '/usr/share/zoneinfo': Permission denied
```

The PR offers a solution to two problems:
1. Creates links for files from /etc
2. Does not create files for /etc links if any of the intermediate paths are unavailable

I haven't fixed the tests yet. Let's discuss what you think about it.