### PR TITLE
profiles: thunderbird: allow /etc/thunderbird

### DIFF
--- a/etc/profile-m-z/thunderbird.profile
+++ b/etc/profile-m-z/thunderbird.profile
@@ -61,6 +61,8 @@ whitelist /usr/share/thunderbird
 #machine-id
 novideo
 
+private-etc thunderbird
+
 # We need the real /tmp for data exchange when xdg-open handles email attachments on KDE
 ignore private-tmp
 


### PR DESCRIPTION
This fixes access to Thunderbird system policies, which can be set
system-wide via `/etc/thunderbird/policies/policies.json`.

Users can also use this directory to set different default preferences.

Relates to #6400 #6435.