### PR TITLE
profiles: firefox-esr: allow /etc/firefox-esr

### DIFF
--- a/etc/profile-a-l/firefox-esr.profile
+++ b/etc/profile-a-l/firefox-esr.profile
@@ -8,5 +8,7 @@ include firefox-esr.local
 
 whitelist /usr/share/firefox-esr
 
+private-etc firefox-esr
+
 # Redirect
 include firefox.profile


### PR DESCRIPTION
This path is apparently used on Debian.

Relates to #5518 #6400 #6435.

Reported-by: @Boruch-Baum
