### PR TITLE
keepassxc: allow access to ssh-agent socket

### DIFF
--- a/etc/profile-a-l/keepassxc.profile
+++ b/etc/profile-a-l/keepassxc.profile
@@ -14,6 +14,7 @@ noblacklist ${HOME}/.config/KeePassXCrc
 noblacklist ${HOME}/.keepassxc
 noblacklist ${DOCUMENTS}
 noblacklist ${RUNUSER}/app
+noblacklist /tmp/ssh-*
 
 # Allow browser profiles, required for browser integration.
 noblacklist ${HOME}/.config/BraveSoftware
@@ -65,6 +66,7 @@ include disable-xdg.inc
 
 mkdir ${RUNUSER}/app/org.keepassxc.KeePassXC
 whitelist ${RUNUSER}/app/org.keepassxc.KeePassXC
+whitelist /tmp/ssh-*
 whitelist /usr/share/keepassxc
 include whitelist-run-common.inc
 include whitelist-runuser-common.inc


### PR DESCRIPTION
Fixes #3314.

Relates to #6529.
