### PR TITLE
profiles: firecfg.config: disable dnsmasq

### DIFF
--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -219,7 +219,7 @@ display
 display-im6.q16
 dnox
 dnscrypt-proxy
-dnsmasq
+#dnsmasq # server; problems with libvirt on Arch (see #6121)
 dolphin-emu
 dooble
 dooble-qt4


### PR DESCRIPTION
There are multiple reports in #6121 that dnsmasq does not work when
called by libvirt:

    $ sudo virsh net-start default
    error: Failed to start network default
    error: internal error: Child process (VIR_BRIDGE_NAME=virbr0 /usr/local/bin/dnsmasq [...]) unexpected exit status 1: Error: PATH environment variable not set

Also, note that this is a server program, so it might be better to
disable it by default anyway.

Reported-by: @marek22k