### PR TITLE
profiles: game-launchers: disable nou2f

### DIFF
--- a/etc/profile-a-l/lutris.profile
+++ b/etc/profile-a-l/lutris.profile
@@ -68,7 +68,7 @@ nogroups
 nonewprivs
 noroot
 notv
-nou2f
+#nou2f # may break gamepads in certain games (see #6523)
 novideo
 protocol unix,inet,inet6,netlink
 seccomp !clone3,!modify_ldt,!process_vm_readv,!ptrace

--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -161,7 +161,7 @@ nogroups
 nonewprivs
 noroot
 notv
-nou2f
+#nou2f # may break gamepads in certain games (see #6523)
 # To allow VR and camera-based motion tracking, add 'ignore novideo' to your
 # steam.local.
 novideo


### PR DESCRIPTION

While gamepads apparently work fine in the Steam client itself, `nou2f`
appears to make gamepads unresponsive inside certain games while using
"Steam Input" (possibly due to `nou2f` blocking access to `/dev/hidraw*`
devices).

This issue reportedly affects at least the following games on Steam:
"Undertale", "Persona 4 Golden" and "Persona 5 Royal".

Disable nou2f to ensure that gamepads can be used.

Relates to #6523.

Reported-by: @opqriu