### PR TITLE
profiles: wget: allow ~/.local/share/wget

### DIFF
--- a/etc/profile-m-z/wget.profile
+++ b/etc/profile-m-z/wget.profile
@@ -7,6 +7,7 @@ include wget.local
 # Persistent global definitions
 include globals.local
 
+noblacklist ${HOME}/.local/share/wget
 noblacklist ${HOME}/.netrc
 noblacklist ${HOME}/.wget-hsts
 noblacklist ${HOME}/.wgetrc

--- a/etc/profile-m-z/wget2.profile
+++ b/etc/profile-m-z/wget2.profile
@@ -9,7 +9,6 @@ include wget2.local
 #include globals.local
 
 noblacklist ${HOME}/.config/wget
-noblacklist ${HOME}/.local/share/wget
 ignore noblacklist ${HOME}/.wgetrc
 
 private-bin wget2


### PR DESCRIPTION
wget appears to require access to this directory for HSTS & HPKP.

Without access to this directory, I get the following error when running wget:

```sh
Failed to read HSTS data
Failed to read HPKP data
Failed to write HSTS file
```

This fixes it.