### PR TITLE
profiles: anki: fix opening, allow media & add to firecfg

### DIFF
--- a/etc/profile-a-l/anki.profile
+++ b/etc/profile-a-l/anki.profile
@@ -9,6 +9,8 @@ include globals.local
 # Add the following to anki.local if you don't need media playing/recording
 # (lua is needed by mpv):
 #ignore include allow-lua.inc
+#machine-id
+#nosound
 
 noblacklist ${DOCUMENTS}
 noblacklist ${HOME}/.config/mpv
@@ -40,7 +42,7 @@ include whitelist-var-common.inc
 
 apparmor
 caps.drop all
-machine-id
+#machine-id
 netfilter
 no3d
 nodvd
@@ -48,7 +50,7 @@ nogroups
 noinput
 nonewprivs
 noroot
-nosound
+#nosound
 notv
 nou2f
 novideo

--- a/etc/profile-a-l/anki.profile
+++ b/etc/profile-a-l/anki.profile
@@ -7,7 +7,9 @@ include anki.local
 include globals.local
 
 noblacklist ${DOCUMENTS}
+noblacklist ${HOME}/.config/mpv
 noblacklist ${HOME}/.local/share/Anki2
+noblacklist ${HOME}/.mplayer
 
 # Allow python (blacklisted by disable-interpreters.inc)
 include allow-python2.inc
@@ -23,7 +25,9 @@ include disable-xdg.inc
 
 mkdir ${HOME}/.local/share/Anki2
 whitelist ${DOCUMENTS}
+whitelist ${HOME}/.config/mpv
 whitelist ${HOME}/.local/share/Anki2
+whitelist ${HOME}/.mplayer
 include whitelist-common.inc
 include whitelist-var-common.inc
 

--- a/etc/profile-a-l/anki.profile
+++ b/etc/profile-a-l/anki.profile
@@ -46,7 +46,7 @@ protocol unix,inet,inet6
 seccomp !chroot
 
 disable-mnt
-private-bin anki,python*
+private-bin anki,mplayer,mpv,python*
 private-cache
 private-dev
 private-etc @tls-ca,@x11

--- a/etc/profile-a-l/anki.profile
+++ b/etc/profile-a-l/anki.profile
@@ -6,10 +6,17 @@ include anki.local
 # Persistent global definitions
 include globals.local
 
+# Add the following to anki.local if you don't need media playing/recording
+# (lua is needed by mpv):
+#ignore include allow-lua.inc
+
 noblacklist ${DOCUMENTS}
 noblacklist ${HOME}/.config/mpv
 noblacklist ${HOME}/.local/share/Anki2
 noblacklist ${HOME}/.mplayer
+
+# Allow lua (blacklisted by disable-interpreters.inc)
+include allow-lua.inc
 
 # Allow python (blacklisted by disable-interpreters.inc)
 include allow-python2.inc

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -51,6 +51,7 @@ amule
 amuled
 android-studio
 ani-cli
+anki
 anydesk
 apktool
 apostrophe


### PR DESCRIPTION
Anki relies on mpv and mplayer for playing audio and video files.

If mpv is present in the system but not allowed in firejail then Anki fails to start because mpv permissions won't allow for execution.

Fixes #6544.