### PR TITLE
profiles: wget: unify wget2 into wget profile

### DIFF
--- a/etc/profile-m-z/wget.profile
+++ b/etc/profile-m-z/wget.profile
@@ -7,6 +7,7 @@ include wget.local
 # Persistent global definitions
 include globals.local
 
+noblacklist ${HOME}/.config/wget
 noblacklist ${HOME}/.local/share/wget
 noblacklist ${HOME}/.netrc
 noblacklist ${HOME}/.wget-hsts
@@ -55,7 +56,7 @@ private-bin wget
 private-cache
 private-dev
 # Depending on workflow you can add the next line to your wget.local.
-#private-etc alternatives,ca-certificates,crypto-policies,pki,resolv.conf,ssl,wgetrc
+#private-etc alternatives,ca-certificates,crypto-policies,pki,resolv.conf,ssl,wget2rc,wgetrc
 #private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/wget2.profile
+++ b/etc/profile-m-z/wget2.profile
@@ -8,12 +8,7 @@ include wget2.local
 # added by included profile
 #include globals.local
 
-noblacklist ${HOME}/.config/wget
-ignore noblacklist ${HOME}/.wgetrc
-
 private-bin wget2
-# Depending on workflow you can add the next line to your wget2.local.
-#private-etc wget2rc
 
 # Redirect
 include wget.profile


### PR DESCRIPTION
According to @rusty-snake[1]:

> Distributions started to replace wget with wget2 (I.e. `wget` and
> `wget2` are the same binary where one of them is a symlink to the
> other).

So move all custom entries (other than `private-bin`) from wget2.profile
into wget.profile and turn wget2.profile into more of a redirect to
wget.profile.

[1] https://github.com/netblue30/firejail/pull/6542#pullrequestreview-2426287045