### PR TITLE
profiles: ensure allow-lua where mpv is allowed

### DIFF
--- a/etc/profile-a-l/firefox-common-addons.profile
+++ b/etc/profile-a-l/firefox-common-addons.profile
@@ -37,6 +37,9 @@ noblacklist ${HOME}/.local/share/qpdfview
 noblacklist ${HOME}/.local/state/mpv
 noblacklist ${HOME}/.netrc
 
+# Allow lua (blacklisted by disable-interpreters.inc)
+include allow-lua.inc
+
 whitelist ${HOME}/.cache/gnome-mplayer/plugin
 whitelist ${HOME}/.cache/mpv
 whitelist ${HOME}/.cache/youtube-dl/youtube-sigfuncs

--- a/etc/profile-m-z/QMediathekView.profile
+++ b/etc/profile-m-z/QMediathekView.profile
@@ -21,6 +21,9 @@ noblacklist ${HOME}/.local/state/mpv
 noblacklist ${HOME}/.mplayer
 noblacklist ${VIDEOS}
 
+# Allow lua (blacklisted by disable-interpreters.inc)
+include allow-lua.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/profile-m-z/mediathekview.profile
+++ b/etc/profile-m-z/mediathekview.profile
@@ -24,6 +24,9 @@ ignore noexec /tmp
 # Allow java (blacklisted by disable-devel.inc)
 include allow-java.inc
 
+# Allow lua (blacklisted by disable-interpreters.inc)
+include allow-lua.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/profile-m-z/rtv-addons.profile
+++ b/etc/profile-m-z/rtv-addons.profile
@@ -18,6 +18,9 @@ noblacklist ${HOME}/.mailcap
 noblacklist ${HOME}/.netrc
 noblacklist ${HOME}/.w3m
 
+# Allow lua (blacklisted by disable-interpreters.inc)
+include allow-lua.inc
+
 whitelist ${HOME}/.cache/mpv
 whitelist ${HOME}/.cache/youtube-dl/youtube-sigfuncs
 whitelist ${HOME}/.config/mpv

--- a/etc/profile-m-z/smtube.profile
+++ b/etc/profile-m-z/smtube.profile
@@ -17,6 +17,9 @@ noblacklist ${HOME}/.mplayer
 noblacklist ${MUSIC}
 noblacklist ${VIDEOS}
 
+# Allow lua (blacklisted by disable-interpreters.inc)
+include allow-lua.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc


### PR DESCRIPTION
mpv crashes if luajit is blocked:

    $ firejail --quiet --noprofile \
      --include=/etc/firejail/disable-interpreters.inc /usr/bin/mpv
    /usr/bin/mpv: error while loading shared libraries: libluajit-5.1.so.2: cannot open shared object file: Permission denied

So make sure that allow-lua.inc is always included when mpv paths (such
as ~/.config/mpv) are allowed.

Environment: luajit 2.1.1727870382-1, mpv 1:0.39.0-3 on Artix Linux.

Related commits:

* db2bdaadd ("add lua support for mpv (#3243)", 2020-02-24) /
  PR #3243
* d6a6fb905 ("Allow Lua for mpv in dolphin.profile", 2020-04-18) /
  issue #3363
* f3585e539 ("fixes, closes, enhances, improvements, and so on",
  2020-11-09) /
  issue #3686
* 3ec523f11 ("profiles: anki: allow lua", 2024-11-14) /
  PR #6545