### PR TITLE
build: sort.py: strip whitespace in profiles

### DIFF
--- a/contrib/sort.py
+++ b/contrib/sort.py
@@ -72,18 +72,17 @@ def check_profile(filename, overwrite):
         was_fixed = False
         fixed_profile = []
         for lineno, line in enumerate(lines, 1):
-            if line[:12] in ("private-bin ", "private-etc ", "private-lib "):
-                fixed_line = f"{line[:12]}{sort_alphabetical(line[12:])}"
-            elif line[:13] in ("seccomp.drop ", "seccomp.keep "):
-                fixed_line = f"{line[:13]}{sort_alphabetical(line[13:])}"
-            elif line[:10] in ("caps.drop ", "caps.keep "):
-                fixed_line = f"{line[:10]}{sort_alphabetical(line[10:])}"
-            elif line[:8] == "protocol":
-                fixed_line = f"protocol {sort_protocol(line[9:])}"
-            elif line[:8] == "seccomp ":
-                fixed_line = f"{line[:8]}{sort_alphabetical(line[8:])}"
-            else:
-                fixed_line = line
+            fixed_line = line
+            if fixed_line[:12] in ("private-bin ", "private-etc ", "private-lib "):
+                fixed_line = f"{fixed_line[:12]}{sort_alphabetical(fixed_line[12:])}"
+            elif fixed_line[:13] in ("seccomp.drop ", "seccomp.keep "):
+                fixed_line = f"{fixed_line[:13]}{sort_alphabetical(fixed_line[13:])}"
+            elif fixed_line[:10] in ("caps.drop ", "caps.keep "):
+                fixed_line = f"{fixed_line[:10]}{sort_alphabetical(fixed_line[10:])}"
+            elif fixed_line[:8] == "protocol":
+                fixed_line = f"protocol {sort_protocol(fixed_line[9:])}"
+            elif fixed_line[:8] == "seccomp ":
+                fixed_line = f"{fixed_line[:8]}{sort_alphabetical(fixed_line[8:])}"
             if fixed_line != line:
                 was_fixed = True
                 print(

--- a/contrib/sort.py
+++ b/contrib/sort.py
@@ -9,7 +9,7 @@ from os import path
 from sys import argv, exit as sys_exit, stderr
 
 __doc__ = f"""\
-Sort the arguments of commands in profiles.
+Strip whitespace and sort the arguments of commands in profiles.
 
 Usage: {path.basename(argv[0])} [-h] [-i] [-n] [--] [/path/to/profile ...]
 
@@ -19,6 +19,9 @@ The following commands are supported:
     seccomp.drop, seccomp.keep, protocol
 
 Note that this is only applicable to commands that support multiple arguments.
+
+Trailing whitespace is removed in all lines (that is, not just in lines
+containing supported commands).
 
 Options:
     -h  Print this message.
@@ -72,7 +75,7 @@ def check_profile(filename, overwrite):
         was_fixed = False
         fixed_profile = []
         for lineno, original_line in enumerate(lines, 1):
-            line = original_line
+            line = original_line.rstrip()
             if line[:12] in ("private-bin ", "private-etc ", "private-lib "):
                 line = f"{line[:12]}{sort_alphabetical(line[12:])}"
             elif line[:13] in ("seccomp.drop ", "seccomp.keep "):

--- a/contrib/sort.py
+++ b/contrib/sort.py
@@ -21,7 +21,8 @@ The following commands are supported:
 Note that this is only applicable to commands that support multiple arguments.
 
 Trailing whitespace is removed in all lines (that is, not just in lines
-containing supported commands).
+containing supported commands) and other whitespace is stripped depending on
+the command.
 
 Options:
     -h  Print this message.
@@ -45,7 +46,8 @@ Exit Codes:
 
 def sort_alphabetical(original_items):
     items = original_items.split(",")
-    items = filter(None, set(items))
+    items = set(map(str.strip, items))
+    items = filter(None, items)
     items = sorted(items)
     return ",".join(items)
 
@@ -56,6 +58,9 @@ def sort_protocol(original_protocols):
 
         unix,inet,inet6,netlink,packet,bluetooth
     """
+
+    # remove all whitespace
+    original_protocols = "".join(original_protocols.split())
 
     # shortcut for common protocol lines
     if original_protocols in ("unix", "unix,inet,inet6"):

--- a/contrib/sort.py
+++ b/contrib/sort.py
@@ -71,25 +71,25 @@ def check_profile(filename, overwrite):
         lines = profile.read().split("\n")
         was_fixed = False
         fixed_profile = []
-        for lineno, line in enumerate(lines, 1):
-            fixed_line = line
-            if fixed_line[:12] in ("private-bin ", "private-etc ", "private-lib "):
-                fixed_line = f"{fixed_line[:12]}{sort_alphabetical(fixed_line[12:])}"
-            elif fixed_line[:13] in ("seccomp.drop ", "seccomp.keep "):
-                fixed_line = f"{fixed_line[:13]}{sort_alphabetical(fixed_line[13:])}"
-            elif fixed_line[:10] in ("caps.drop ", "caps.keep "):
-                fixed_line = f"{fixed_line[:10]}{sort_alphabetical(fixed_line[10:])}"
-            elif fixed_line[:8] == "protocol":
-                fixed_line = f"protocol {sort_protocol(fixed_line[9:])}"
-            elif fixed_line[:8] == "seccomp ":
-                fixed_line = f"{fixed_line[:8]}{sort_alphabetical(fixed_line[8:])}"
-            if fixed_line != line:
+        for lineno, original_line in enumerate(lines, 1):
+            line = original_line
+            if line[:12] in ("private-bin ", "private-etc ", "private-lib "):
+                line = f"{line[:12]}{sort_alphabetical(line[12:])}"
+            elif line[:13] in ("seccomp.drop ", "seccomp.keep "):
+                line = f"{line[:13]}{sort_alphabetical(line[13:])}"
+            elif line[:10] in ("caps.drop ", "caps.keep "):
+                line = f"{line[:10]}{sort_alphabetical(line[10:])}"
+            elif line[:8] == "protocol":
+                line = f"protocol {sort_protocol(line[9:])}"
+            elif line[:8] == "seccomp ":
+                line = f"{line[:8]}{sort_alphabetical(line[8:])}"
+            if line != original_line:
                 was_fixed = True
                 print(
-                    f"{filename}:{lineno}:-{line}\n"
-                    f"{filename}:{lineno}:+{fixed_line}"
+                    f"{filename}:{lineno}:-{original_line}\n"
+                    f"{filename}:{lineno}:+{line}"
                 )
-            fixed_profile.append(fixed_line)
+            fixed_profile.append(line)
 
         if was_fixed:
             if overwrite:


### PR DESCRIPTION
build: sort.py: strip trailing whitespace in all lines

Currently the output is mangled if the last item on the line contains
trailing whitespace and is moved when sorting.

So remove trailing whitespace in all lines (that is, not just in lines
containing supported commands).

Leave leading whitespace as is for now since it could potentially be
used for indentation.

Before:

    $ printf '# hello world  \nprivate-bin a,b  \nprivate-bin b,a  \nprivate-bin  a,b\n' \
      >foo.profile
    $ ./contrib/sort.py -n foo.profile | tr ' ' .
    sort.py:.checking.1.profile(s)...
    foo.profile:3:-private-bin.b,a..
    foo.profile:3:+private-bin.a..,b

After:

    $ printf '# hello world  \nprivate-bin a,b  \nprivate-bin b,a  \n' \
      >foo.profile
    $ ./contrib/sort.py -n foo.profile | tr ' ' .
    sort.py:.checking.1.profile(s)...
    foo.profile:1:-#.hello.world..
    foo.profile:1:+#.hello.world
    foo.profile:2:-private-bin.a,b..
    foo.profile:2:+private-bin.a,b
    foo.profile:3:-private-bin.b,a..
    foo.profile:3:+private-bin.a,b

---

build: sort.py: strip whitespace in commands

Currently whitespace is left as is within an entry.

In a `protocol` entry, if there is whitespace between the command and
its argument or around an item, the item in question is dropped from the
output.

Changes:

* `protocol`: Strip all whitespace in the argument
* Other commands: Strip leading/trailing whitespace around each item,
  including any extra whitespace between a command and its argument

Note: Whitespace characters inside paths are left as is, as some paths
(such as `Foo Bar` may contain spaces.

Before:

    $ printf 'private-bin a,b\nprivate-bin  a,b\nprivate-bin  b,a\nprivate-bin  C,A  B\nprotocol  unix,net\nprotocol  inet,unix\n' \
      >foo.profile
    $ ./contrib/sort.py -n foo.profile
    sort.py: checking 1 profile(s)...
    foo.profile:5:-protocol  unix,net
    foo.profile:5:+protocol
    foo.profile:6:-protocol  inet,unix
    foo.profile:6:+protocol unix

After:

    $ printf 'private-bin a,b\nprivate-bin  a,b\nprivate-bin  b,a\nprivate-bin  C,A  B\nprotocol  unix,net\nprotocol  inet,unix\n' \
      >foo.profile
    $ ./contrib/sort.py -n foo.profile
    sort.py: checking 1 profile(s)...
    foo.profile:2:-private-bin  a,b
    foo.profile:2:+private-bin a,b
    foo.profile:3:-private-bin  b,a
    foo.profile:3:+private-bin a,b
    foo.profile:4:-private-bin  C,A  B
    foo.profile:4:+private-bin A  B,C
    foo.profile:5:-protocol  unix,net
    foo.profile:5:+protocol unix
    foo.profile:6:-protocol  inet,unix
    foo.profile:6:+protocol unix,inet
