### PR TITLE
profiles: video-players: add missing /usr/share paths

### DIFF
--- a/etc/profile-a-l/chatterino.profile
+++ b/etc/profile-a-l/chatterino.profile
@@ -44,7 +44,9 @@ whitelist-ro ${HOME}/.config/mpv
 whitelist-ro ${HOME}/.config/pulse
 whitelist-ro ${HOME}/.config/vlc
 whitelist-ro ${HOME}/.local/share/vlc
+whitelist-ro /usr/share/lua*
 whitelist-ro /usr/share/mpv
+whitelist-ro /usr/share/vlc
 include whitelist-common.inc
 include whitelist-run-common.inc
 include whitelist-runuser-common.inc

--- a/etc/profile-m-z/QMediathekView.profile
+++ b/etc/profile-m-z/QMediathekView.profile
@@ -50,8 +50,11 @@ whitelist ${HOME}/.local/share/totem
 whitelist ${HOME}/.local/share/xplayer
 whitelist ${HOME}/.local/state/mpv
 whitelist ${HOME}/.mplayer
+whitelist /usr/share/lua*
 whitelist /usr/share/mpv
 whitelist /usr/share/qtchooser
+whitelist /usr/share/smplayer
+whitelist /usr/share/vlc
 include whitelist-common.inc
 include whitelist-run-common.inc
 include whitelist-runuser-common.inc

--- a/etc/profile-m-z/smtube.profile
+++ b/etc/profile-m-z/smtube.profile
@@ -27,8 +27,11 @@ include disable-interpreters.inc
 include disable-programs.inc
 include disable-xdg.inc
 
+whitelist /usr/share/lua*
+whitelist /usr/share/mpv
 whitelist /usr/share/smplayer
 whitelist /usr/share/smtube
+whitelist /usr/share/vlc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 

--- a/etc/profile-m-z/youtube-viewers-common.profile
+++ b/etc/profile-m-z/youtube-viewers-common.profile
@@ -32,6 +32,8 @@ include disable-xdg.inc
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.cache/youtube-dl/youtube-sigfuncs
 whitelist ${HOME}/.config/mpv
+whitelist /usr/share/lua*
+whitelist /usr/share/mpv
 include whitelist-common.inc
 include whitelist-run-common.inc
 include whitelist-runuser-common.inc


### PR DESCRIPTION
Add missing paths for:

* lua (for mpv)
* mplayer
* mpv
* smplayer
* vlc

Apparently mpv plugins may break without the lua path; see commit
ccff014de ("fix Lua in mpv.profile", 2020-07-28) / issue #3554.

Command used to search for relevant profiles:

    $ git grep -IE -l '/\.?(s?mplayer|mpv|vlc)' -- etc

This is a follow-up to commit e4ebbfafe ("profiles: ensure allow-lua
where mpv is allowed (#6555)", 2024-11-29).