### PR TITLE
profiles: clamav: add /etc/clamav

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -1260,6 +1260,7 @@ blacklist ${RUNUSER}/akonadi
 blacklist ${RUNUSER}/i3
 blacklist ${RUNUSER}/psd/*firefox*
 blacklist ${RUNUSER}/qutebrowser
+blacklist /etc/clamav
 blacklist /etc/ssmtp
 blacklist /tmp/.wine-*
 blacklist /tmp/akonadi-*

--- a/etc/profile-a-l/clamav.profile
+++ b/etc/profile-a-l/clamav.profile
@@ -7,6 +7,8 @@ include clamav.local
 # Persistent global definitions
 include globals.local
 
+noblacklist /etc/clamav
+
 blacklist ${RUNUSER}/wayland-*
 
 include disable-exec.inc

--- a/etc/profile-a-l/email-common.profile
+++ b/etc/profile-a-l/email-common.profile
@@ -14,6 +14,7 @@ noblacklist ${HOME}/.signature
 # when storing mail outside the default ${HOME}/Mail path, 'noblacklist' the custom path in your email-common.local
 # and 'blacklist' it in your disable-common.local too so it is kept hidden from other applications
 noblacklist ${HOME}/Mail
+noblacklist /etc/clamav
 noblacklist /var/lib/clamav
 noblacklist /var/mail
 noblacklist /var/spool/mail
@@ -82,7 +83,7 @@ tracelog
 #disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca,@x11,bogofilter,bogofilter.cf,gnupg,hosts.conf,mailname,timezone
+private-etc @tls-ca,@x11,bogofilter,bogofilter.cf,clamav,gnupg,hosts.conf,mailname,timezone
 private-tmp
 # encrypting and signing email
 writable-run-user


### PR DESCRIPTION
See also commit 2453f0ecf ("email-common.profile: allow clamav plugin
for claws-mail", 2023-03-07) / PR #5719.