### PR TITLE
bugfix: parse --debug before using it

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1110,6 +1110,12 @@ int main(int argc, char **argv, char **envp) {
 	if (check_arg(argc, argv, "--quiet", 1) || (env_quiet && strcmp(env_quiet, "yes") == 0))
 		arg_quiet = 1;
 
+	// process --debug
+	if (check_arg(argc, argv, "--debug", 1)) {
+		arg_debug = 1;
+		arg_quiet = 0;
+	}
+
 	// check if the user is allowed to use firejail
 	init_cfg(argc, argv);
 


### PR DESCRIPTION
The `arg_debug` flag is set after some functions check for it.
https://github.com/netblue30/firejail/blob/f27775c5a810729b7dc8f144f522c5e79ec4ee55/src/firejail/main.c#L1347
An example of a function in this situation is `check_kernel_procs()`.
https://github.com/netblue30/firejail/blob/f27775c5a810729b7dc8f144f522c5e79ec4ee55/src/firejail/main.c#L1129
https://github.com/netblue30/firejail/blob/f27775c5a810729b7dc8f144f522c5e79ec4ee55/src/firejail/no_sandbox.c#L102