### PR TITLE
build: sort.py: fix whitespace in entire profile

### DIFF
--- a/.github/workflows/check-profiles.yml
+++ b/.github/workflows/check-profiles.yml
@@ -48,7 +48,9 @@ jobs:
     - name: sort.py
       run: >
         ./ci/check/profiles/sort.py
-        etc/inc/*.inc etc/{profile-a-l,profile-m-z}/*.profile
+        etc/inc/*.inc etc/{profile-a-l,profile-m-z}/*.profile;
+        echo;
+        git diff --exit-code
 # Currently broken (see #5610)
 #   - name: private-etc-always-required.sh
 #     run: >

--- a/contrib/sort.py
+++ b/contrib/sort.py
@@ -99,11 +99,20 @@ def check_profile(filename, overwrite):
                 )
             fixed_profile.append(line)
 
+        fixed_profile_str = "\n".join(fixed_profile)
+        stripped_profile_str = fixed_profile_str.strip() + "\n"
+        while "\n\n\n" in stripped_profile_str:
+            stripped_profile_str = stripped_profile_str.replace("\n\n\n", "\n\n")
+
+        if stripped_profile_str != fixed_profile_str:
+            was_fixed = True
+            print(f"{filename}:(fixed whitespace)")
+
         if was_fixed:
             if overwrite:
                 profile.seek(0)
                 profile.truncate()
-                profile.write("\n".join(fixed_profile))
+                profile.write(stripped_profile_str)
                 profile.flush()
                 print(f"[ Fixed ] {filename}")
             return 101

--- a/etc/profile-a-l/devhelp.profile
+++ b/etc/profile-a-l/devhelp.profile
@@ -6,7 +6,6 @@ include devhelp.local
 # Persistent global definitions
 include globals.local
 
-
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/profile-a-l/display-im6.q16.profile
+++ b/etc/profile-a-l/display-im6.q16.profile
@@ -5,6 +5,5 @@ include display-im6.q16.local
 # Persistent global definitions
 include globals.local
 
-
 # Redirect
 include display.profile

--- a/etc/profile-a-l/empathy.profile
+++ b/etc/profile-a-l/empathy.profile
@@ -6,7 +6,6 @@ include empathy.local
 # Persistent global definitions
 include globals.local
 
-
 include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc

--- a/etc/profile-a-l/gnome-font-viewer.profile
+++ b/etc/profile-a-l/gnome-font-viewer.profile
@@ -6,7 +6,6 @@ include gnome-font-viewer.local
 # Persistent global definitions
 include globals.local
 
-
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc

--- a/etc/profile-a-l/gnome-recipes.profile
+++ b/etc/profile-a-l/gnome-recipes.profile
@@ -6,7 +6,6 @@ include gnome-recipes.local
 # Persistent global definitions
 include globals.local
 
-
 noblacklist ${HOME}/.cache/gnome-recipes
 noblacklist ${HOME}/.local/share/gnome-recipes
 

--- a/etc/profile-a-l/godot.profile
+++ b/etc/profile-a-l/godot.profile
@@ -33,7 +33,6 @@ protocol unix,inet,inet6,netlink
 seccomp
 tracelog
 
-
 #private-bin godot
 private-cache
 private-dev

--- a/etc/profile-m-z/quassel.profile
+++ b/etc/profile-m-z/quassel.profile
@@ -6,7 +6,6 @@ include quassel.local
 # Persistent global definitions
 include globals.local
 
-
 include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc

--- a/etc/profile-m-z/rtorrent.profile
+++ b/etc/profile-m-z/rtorrent.profile
@@ -6,7 +6,6 @@ include rtorrent.local
 # Persistent global definitions
 include globals.local
 
-
 include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc

--- a/etc/profile-m-z/silentarmy.profile
+++ b/etc/profile-m-z/silentarmy.profile
@@ -5,7 +5,6 @@ include silentarmy.local
 # Persistent global definitions
 include globals.local
 
-
 include disable-common.inc
 #include disable-devel.inc
 include disable-exec.inc


### PR DESCRIPTION
Changes:

* Strip whitespace at the beginning
* Strip whitespace at the end
* Ensure exactly one newline at the end
* Strip extraneous newlines

Also, for clarity print the git diff in the sort.py ci job, since the
specific lines changed are not printed by the sort.py script in this
case (as whitespace is fixed in the entire profile at once).

Command used to search and replace:

    ./contrib/sort.py etc/inc/*.inc etc/profile*/*.profile

This is a follow-up to #6556.