### PR TITLE
build: sort.py: quote diff lines

### DIFF
--- a/contrib/sort.py
+++ b/contrib/sort.py
@@ -94,8 +94,8 @@ def check_profile(filename, overwrite):
             if line != original_line:
                 was_fixed = True
                 print(
-                    f"{filename}:{lineno}:-{original_line}\n"
-                    f"{filename}:{lineno}:+{line}"
+                    f"{filename}:{lineno}:-'{original_line}'\n"
+                    f"{filename}:{lineno}:+'{line}'"
                 )
             fixed_profile.append(line)
 


### PR DESCRIPTION
To make it clearer when only whitespace was fixed on a given line.

Before:

    $ printf 'private-bin a,b \n' >foo.profile
    $ ./contrib/sort.py -n foo.profile
    sort.py: checking 1 profile(s)...
    foo.profile:1:-private-bin a,b
    foo.profile:1:+private-bin a,b

After:

    $ printf 'private-bin a,b \n' >foo.profile
    $ ./contrib/sort.py -n foo.profile
    sort.py: checking 1 profile(s)...
    foo.profile:1:-'private-bin a,b '
    foo.profile:1:+'private-bin a,b'

See commit 53ff8e0ad ("build: sort.py: strip trailing whitespace in all
lines", 2024-11-26) / PR #6556.