### PR TITLE
bugfix: fix possible memory leak in fs_home.c

### DIFF
--- a/src/firejail/fs_home.c
+++ b/src/firejail/fs_home.c
@@ -194,6 +194,7 @@ static int store_asoundrc(void) {
 	if (stat(src, &s) == 0) {
 		if (s.st_uid != getuid()) {
 			fwarning(".asoundrc is not owned by the current user, skipping...\n");
+			free(src);
 			return 0;
 		}
 


### PR DESCRIPTION
The pointer returned by ```asprintf()``` should be passed to free() to release the allocated storage when it is no longer needed.
There was one exit point without previous freeing ```src```.