### PR TITLE
profiles: aria2p: disable x11 and clipboard managers

### DIFF
--- a/etc/profile-a-l/aria2p.profile
+++ b/etc/profile-a-l/aria2p.profile
@@ -20,8 +20,7 @@ include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
 #include disable-write-mnt.inc
-# xclip and xsel require X11.
-#include disable-X11.inc
+include disable-X11.inc
 include disable-xdg.inc
 
 include whitelist-common.inc
@@ -54,7 +53,7 @@ tracelog
 
 disable-mnt
 private
-private-bin aria2p,cat,python*,wl-copy,wl-paste,xclip,xsel
+private-bin aria2p,cat,python*
 private-dev
 private-tmp
 


### PR DESCRIPTION
aria2p is a command-line tool, so these should not be needed (and it's
unclear how/why they would be used by the program).

See also:
https://github.com/netblue30/firejail/pull/6583#discussion_r1912891807

Added on commit c869f11d5 ("New profile: aria2p/aria2rpc", 2024-12-27) /
PR #6583.

Cc: @amano-kenji