### PR TITLE
build: rename print-version target to installcheck

### DIFF
--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -71,5 +71,5 @@ jobs:
       run: make
     - name: make install
       run: sudo make install
-    - name: print version
-      run: make print-version
+    - name: make installcheck
+      run: make installcheck

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,5 +87,5 @@ jobs:
       run: make
     - name: make install
       run: sudo make install
-    - name: print version
-      run: make print-version
+    - name: make installcheck
+      run: make installcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,8 +81,8 @@ jobs:
       run: make -j "$(nproc)"
     - name: make install
       run: sudo make install
-    - name: print version
-      run: make print-version
+    - name: make installcheck
+      run: make installcheck
     - run: make lab-setup
     - run: make test-seccomp-extra
     - run: make test-firecfg
@@ -130,8 +130,8 @@ jobs:
       run: make -j "$(nproc)"
     - name: make install
       run: sudo make install
-    - name: print version
-      run: make print-version
+    - name: make installcheck
+      run: make installcheck
     - run: make lab-setup
     - run: make test-private-etc
     - run: make test-fs
@@ -170,8 +170,8 @@ jobs:
       run: make -j "$(nproc)"
     - name: make install
       run: sudo make install
-    - name: print version
-      run: make print-version
+    - name: make installcheck
+      run: make installcheck
     - run: make lab-setup
     - run: make test-environment
     - run: make test-profiles
@@ -213,8 +213,8 @@ jobs:
       run: make -j "$(nproc)"
     - name: make install
       run: sudo make install
-    - name: print version
-      run: make print-version
+    - name: make installcheck
+      run: make installcheck
     - run: make lab-setup
     - run: make test-utils
 
@@ -260,8 +260,8 @@ jobs:
       run: make -j "$(nproc)"
     - name: make install
       run: sudo make install
-    - name: print version
-      run: make print-version
+    - name: make installcheck
+      run: make installcheck
     - run: make lab-setup
     - run: make test-fnetfilter
     - run: make test-sysutils

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ build_ubuntu_package:
         - make dist
         - ./mkdeb.sh --enable-fatal-warnings
         - dpkg -i ./*.deb
-        - make print-version
+        - make installcheck
 
 build_debian_package:
     image: debian:buster
@@ -43,7 +43,7 @@ build_debian_package:
         - make dist
         - ./mkdeb.sh --enable-fatal-warnings
         - dpkg -i ./*.deb
-        - make print-version
+        - make installcheck
 
 build_no_apparmor:
     image: ubuntu:latest
@@ -63,8 +63,8 @@ build_no_apparmor:
             ./mkdeb.sh --enable-fatal-warnings
             --disable-apparmor
         - dpkg -i ./*.deb
-        - make print-version
-        - make print-version | grep -F 'AppArmor support is disabled'
+        - make installcheck
+        - make installcheck | grep -F 'AppArmor support is disabled'
 
 build_redhat_package:
     image: almalinux:latest
@@ -77,7 +77,7 @@ build_redhat_package:
         - make dist
         - ./platform/rpm/mkrpm.sh --enable-fatal-warnings
         - rpm -i ./*.rpm
-        - make print-version
+        - make installcheck
 
 build_fedora_package:
     image: fedora:latest
@@ -90,7 +90,7 @@ build_fedora_package:
         - make dist
         - ./platform/rpm/mkrpm.sh --enable-fatal-warnings
         - rpm -i ./*.rpm
-        - make print-version
+        - make installcheck
 
 # FIXME: Cannot build src/libtrace with musl (see #6610).
 #build_src_package:
@@ -108,7 +108,7 @@ build_fedora_package:
 #            || (cat config.log; exit 1)
 #        - make
 #        - make install-strip
-#        - make print-version
+#        - make installcheck
 
 debian_ci:
     image: registry.salsa.debian.org/salsa-ci-team/ci-image-git-buildpackage:latest

--- a/Makefile
+++ b/Makefile
@@ -400,8 +400,8 @@ codespell:
 print-env:
 	./ci/printenv.sh
 
-.PHONY: print-version
-print-version: config.mk
+.PHONY: installcheck
+installcheck: config.mk
 	command -V $(TARNAME) && $(TARNAME) --version
 
 #

--- a/gcov.sh
+++ b/gcov.sh
@@ -27,7 +27,7 @@ make -j "$(nproc)" &&
 sudo make install
 
 rm -fr gcov-dir gcov-file
-make print-version
+make installcheck
 gcov_generate
 
 make test-firecfg | grep TESTING


### PR DESCRIPTION
To make it consistent with the standard GNU make targets.

From the manual of GNU Make (version 4.4.1-2):

> 'installcheck'
>      Perform installation tests (if any).  The user must build and
>      install the program before running the tests.  You should not
>      assume that '$(bindir)' is in the search path.

Commands used to search and replace:

    $ git grep -Ilz print-version |
      xargs -0 -I '{}' sh -c "printf '%s\n' \"\$(sed \
        's/print-version/installcheck/g' '{}')\" >'{}'"
    $ git grep -Ilz 'print version' .github/workflows |
      xargs -0 -I '{}' sh -c "printf '%s\n' \"\$(sed \
        's/print version/make installcheck/g' '{}')\" >'{}'"

Added on commit c9531d95e ("build: add print-version target and use in
CI", 2024-02-22) / #6230.