### PR TITLE
ci: check-c: run all checks in parallel mode

### DIFF
--- a/.github/workflows/check-c.yml
+++ b/.github/workflows/check-c.yml
@@ -72,7 +72,7 @@ jobs:
         --enable-apparmor --enable-selinux
         || (cat config.log; exit 1)
     - name: scan-build
-      run: make scan-build
+      run: make -j "$(nproc)" scan-build
 
   cppcheck:
     runs-on: ubuntu-22.04
@@ -96,7 +96,7 @@ jobs:
       run: sudo apt-get install -qy cppcheck
     - name: configure
       run: >
-        ./configure CPPCHECK='cppcheck -q'
+        ./configure CPPCHECK="cppcheck -q -j '$(nproc)'"
         || (cat config.log; exit 1)
     - run: cppcheck --version
     - name: cppcheck
@@ -127,7 +127,7 @@ jobs:
       run: sudo apt-get install -qy cppcheck
     - name: configure
       run: >
-        ./configure CPPCHECK='cppcheck -q'
+        ./configure CPPCHECK="cppcheck -q -j '$(nproc)'"
         || (cat config.log; exit 1)
     - run: cppcheck --version
     - name: cppcheck-old


### PR DESCRIPTION
This considerably speeds up the execution of the relevant steps, most
noticeably on scan-build:

* scan-build:  121s to 55s (-54.5%)
* cppcheck:     51s to 30s (-41.2%)
* cppcheck-old: 21s to 11s (-47.6%)

Note: The above uses the average time of 3 runs on master (commit
bd946e359 ("Merge pull request #6624 from
powerjungle/chore/update-security-md", 2025-01-21)) [1] [2] [3] and 3
runs on this commit[4] [5] [6].

Note: This considers only the steps themselves, as the total time of
each job varies a lot between runs, mostly due to the apt-get
update/install steps.  For example, the same `apt-get install` command
took 3 seconds on one scan-build job run[7] and 132 seconds on another
scan-build job run[8].

Related commits:

* 500d8f2d6 ("ci: run make in parallel where applicable", 2023-08-14) /
  PR #5960
* 5b1bd33c7 ("build: use full paths on compile/link targets",
  2023-07-02) /
  PR #6158

[1] https://github.com/netblue30/firejail/actions/runs/12928036246
[2] https://github.com/netblue30/firejail/actions/runs/12928180264
[3] https://github.com/netblue30/firejail/actions/runs/12928238010
[4] https://github.com/netblue30/firejail/actions/runs/12927984482/attempts/2
[5] https://github.com/netblue30/firejail/actions/runs/12927984482/attempts/3
[6] https://github.com/netblue30/firejail/actions/runs/12927984482/attempts/4
[7] https://github.com/netblue30/firejail/actions/runs/12928180264/job/36054893393
[8] https://github.com/netblue30/firejail/actions/runs/12881736117/job/35912783635