### PR TITLE
profiles: torbrowser-launcher: move path from dc to dp

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -734,8 +734,5 @@ blacklist ${RUNUSER}/inaccessible
 blacklist ${RUNUSER}/pk-debconf-socket
 blacklist ${RUNUSER}/update-notifier.pid
 
-# tor-browser
-blacklist ${HOME}/.local/opt/tor-browser
-
 # pass utility (pass package in Debian etc.)
 blacklist ${HOME}/.password-store

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -875,6 +875,7 @@ blacklist ${HOME}/.linphone-history.db
 blacklist ${HOME}/.linphonerc
 blacklist ${HOME}/.lmmsrc.xml
 blacklist ${HOME}/.local/lib/vivaldi
+blacklist ${HOME}/.local/opt/tor-browser
 blacklist ${HOME}/.local/share/0ad
 blacklist ${HOME}/.local/share/3909/PapersPlease
 blacklist ${HOME}/.local/share/Anki2


### PR DESCRIPTION
Added the path to tor-browser as used by torbrowser-launcher: `~/.local/share/torbrowser`.

Actualy, this original entry for `${HOME}/opt/torbrowser` seems to be oddly placed. There is an occurrence in `disable-programs.profile` for `${HOME}/.local/share/torbrowser` already. Should the old entry be removed (or moved) instead? Did you guys start using `disable-programs.profile` at a later time?