### PR TITLE
profiles: tor: add memory-deny-write-execute

### DIFF
--- a/etc/profile-m-z/tor.profile
+++ b/etc/profile-m-z/tor.profile
@@ -49,4 +49,5 @@ private-etc @tls-ca,tor
 private-tmp
 writable-var
 
+memory-deny-write-execute
 restrict-namespaces


### PR DESCRIPTION
Add `memory-deny-write-execute` to tor profile. (Tested by running tor for more than 7 hour with continuous traffic.)

Note: not tested as relay. If it is expected that tor touches on this only as a relay, then it would benefit to await a second opinion.

Update: tor ran (as client) for 7+ hours continuously without issue.