### PR TITLE
profiles: thunderbird: fix access to wayland socket

### DIFF
--- a/etc/profile-m-z/thunderbird.profile
+++ b/etc/profile-m-z/thunderbird.profile
@@ -6,8 +6,6 @@ include thunderbird.local
 # Persistent global definitions
 include globals.local
 
-ignore include whitelist-runuser-common.inc
-
 # TB stopped supporting enigmail in 2020 (v78) - let's harden D-Bus
 # https://support.mozilla.org/en-US/kb/openpgp-thunderbird-howto-and-faq
 ignore dbus-user none


### PR DESCRIPTION
Denying access to `${RUNUSER}` (`/run/user/$(id -u)`) denies access to
Wayland socket which results in thunderbird running under X11.

whitelist-runuser-common.inc is included in firefox-common.profile, which is
included by firefox.profile, which is in turn included by
thunderbird.profile. But it is ignored by the thunderbird.profile.
This patch removes the ignore whitelist-runuser-common.inc to allow
thunderbird to access wayland sockets.
