### PR TITLE
feature: block /dev/ntsync & add keep-dev-ntsync command

### DIFF
--- a/contrib/syntax/lists/profile_commands_arg0.list
+++ b/contrib/syntax/lists/profile_commands_arg0.list
@@ -9,6 +9,7 @@ deterministic-shutdown
 disable-mnt
 ipc-namespace
 keep-config-pulse
+keep-dev-ntsync
 keep-dev-shm
 keep-shell-rc
 keep-var-tmp

--- a/etc/profile-a-l/lutris.profile
+++ b/etc/profile-a-l/lutris.profile
@@ -79,6 +79,7 @@ protocol unix,inet,inet6,netlink
 seccomp !clone3,!modify_ldt,!process_vm_readv,!ptrace
 seccomp.32 !modify_ldt
 
+keep-dev-ntsync
 # Add the next line to your lutris.local if you do not need controller support.
 #private-dev
 private-tmp

--- a/etc/profile-m-z/noprofile.profile
+++ b/etc/profile-m-z/noprofile.profile
@@ -21,6 +21,7 @@ ignore read-only /sys/module/nvidia*
 allow-debuggers
 allusers
 keep-config-pulse
+keep-dev-ntsync
 keep-dev-shm
 keep-fd all
 keep-var-tmp

--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -185,6 +185,7 @@ seccomp.32 !process_vm_readv
 # To view screenshots add the next line to your steam.local.
 #private-bin eog,eom,gthumb,pix,viewnior,xviewer
 
+keep-dev-ntsync
 private-dev
 # private-etc breaks a small selection of games on some systems. Add 'ignore private-etc'
 # to your steam.local to support those.

--- a/etc/profile-m-z/wine.profile
+++ b/etc/profile-m-z/wine.profile
@@ -39,6 +39,7 @@ notv
 #novideo
 seccomp
 
+keep-dev-ntsync
 private-dev
 
 restrict-namespaces

--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -195,6 +195,7 @@ include globals.local
 ##x11 none
 
 #disable-mnt
+##keep-dev-ntsync
 ##private
 # It's common practice to refer to the python executable(s) in private-bin with `python*`, which covers both v2 and v3
 #private-bin PROGRAMS

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -328,6 +328,7 @@ extern char *arg_netfilter6_file;	// netfilter file
 extern char *arg_netns;		// "ip netns"-created network namespace to use
 extern int arg_doubledash;	// double dash
 extern int arg_private_dev;	// private dev directory
+extern int arg_keep_dev_ntsync; // preserve /dev/ntsync
 extern int arg_keep_dev_shm;    // preserve /dev/shm
 extern int arg_private_etc;	// private etc directory
 extern int arg_private_opt;	// private opt directory
@@ -650,6 +651,7 @@ void fs_dev_disable_dvd(void);
 void fs_dev_disable_tpm(void);
 void fs_dev_disable_u2f(void);
 void fs_dev_disable_input(void);
+void fs_dev_disable_ntsync(void);
 
 // fs_home.c
 // private mode (--private)

--- a/src/firejail/fs_dev.c
+++ b/src/firejail/fs_dev.c
@@ -41,7 +41,8 @@ typedef enum {
 	DEV_DVD,
 	DEV_TPM,
 	DEV_U2F,
-	DEV_INPUT
+	DEV_INPUT,
+	DEV_NTSYNC
 } DEV_TYPE;
 
 
@@ -98,6 +99,7 @@ static DevEntry dev[] = {
 	{"/dev/hidraw9", RUN_DEV_DIR "/hidraw9", DEV_U2F},
 	{"/dev/usb", RUN_DEV_DIR "/usb", DEV_U2F},	// USB devices such as Yubikey, U2F
 	{"/dev/input", RUN_DEV_DIR "/input", DEV_INPUT},
+	{"/dev/ntsync", RUN_DEV_DIR "/ntsync", DEV_NTSYNC},
 	{NULL, NULL, DEV_NONE}
 };
 
@@ -114,7 +116,8 @@ static void deventry_mount(void) {
 			    (dev[i].type == DEV_DVD && arg_nodvd == 0) ||
 			    (dev[i].type == DEV_TPM && arg_notpm == 0) ||
 			    (dev[i].type == DEV_U2F && arg_nou2f == 0) ||
-			    (dev[i].type == DEV_INPUT && arg_noinput == 0)) {
+			    (dev[i].type == DEV_INPUT && arg_noinput == 0) ||
+			    (dev[i].type == DEV_NTSYNC && arg_keep_dev_ntsync == 1)) {
 
 				int dir = is_dir(dev[i].run_fname);
 				if (arg_debug)
@@ -414,6 +417,15 @@ void fs_dev_disable_input(void) {
 	int i = 0;
 	while (dev[i].dev_fname != NULL) {
 		if (dev[i].type == DEV_INPUT)
+			disable_file_or_dir(dev[i].dev_fname);
+		i++;
+	}
+}
+
+void fs_dev_disable_ntsync(void) {
+	int i = 0;
+	while (dev[i].dev_fname != NULL) {
+		if (dev[i].type == DEV_NTSYNC)
 			disable_file_or_dir(dev[i].dev_fname);
 		i++;
 	}

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -114,6 +114,7 @@ char *arg_netfilter6_file = NULL;		// netfilter6 file
 char *arg_netns = NULL;			// "ip netns"-created network namespace to use
 int arg_doubledash = 0;			// double dash
 int arg_private_dev = 0;			// private dev directory
+int arg_keep_dev_ntsync = 0;			// preserve /dev/ntsync
 int arg_keep_dev_shm = 0;			// preserve /dev/shm
 int arg_private_etc = 0;			// private etc directory
 int arg_private_opt = 0;			// private opt directory
@@ -2032,6 +2033,9 @@ int main(int argc, char **argv, char **envp) {
 #endif
 		else if (strcmp(argv[i], "--private-dev") == 0) {
 			arg_private_dev = 1;
+		}
+		else if (strcmp(argv[i], "--keep-dev-ntsync") == 0) {
+			arg_keep_dev_ntsync = 1;
 		}
 		else if (strcmp(argv[i], "--keep-dev-shm") == 0) {
 			arg_keep_dev_shm = 1;

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -431,6 +431,10 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		arg_private_dev = 1;
 		return 0;
 	}
+	else if (strcmp(ptr, "keep-dev-ntsync") == 0) {
+		arg_keep_dev_ntsync = 1;
+		return 0;
+	}
 	else if (strcmp(ptr, "keep-dev-shm") == 0) {
 		arg_keep_dev_shm = 1;
 		return 0;

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -1113,6 +1113,9 @@ int sandbox(void* sandbox_arg) {
 	if (arg_noinput)
 		fs_dev_disable_input();
 
+	if (!arg_keep_dev_ntsync)
+		fs_dev_disable_ntsync();
+
 	//****************************
 	// set DNS
 	//****************************

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -129,6 +129,7 @@ static const char *const usage_str =
 #endif
 	"    --join-or-start=name|pid - join the sandbox or start a new one.\n"
 	"    --keep-config-pulse - disable automatic ~/.config/pulse init.\n"
+	"    --keep-dev-ntsync - /dev/ntsync character device is untouched (even with --private-dev).\n"
 	"    --keep-dev-shm - /dev/shm directory is untouched (even with --private-dev).\n"
 	"    --keep-fd - inherit open file descriptors to sandbox.\n"
 	"    --keep-shell-rc - do not copy shell rc files from /etc/skel\n"

--- a/src/man/firejail-profile.5.in
+++ b/src/man/firejail-profile.5.in
@@ -299,6 +299,12 @@ Disable /mnt, /media, /run/mount and /run/media access.
 Disable automatic ~/.config/pulse init, for complex setups such as remote
 pulse servers or non-standard socket paths.
 .TP
+\fBkeep-dev-ntsync
+Allow access to the /dev/ntsync character device (even with \fBprivate-dev\fR),
+which is blocked by default.
+This device is mostly intended to increase performance and compatibility when
+running certain programs through Wine.
+.TP
 \fBkeep-dev-shm
 /dev/shm directory is untouched (even with private-dev).
 .TP

--- a/src/man/firejail.1.in
+++ b/src/man/firejail.1.in
@@ -1219,6 +1219,19 @@ Example:
 $ firejail \-\-keep-config-pulse firefox
 
 .TP
+\fB\-\-keep-dev-ntsync
+Allow access to the /dev/ntsync character device (even with
+\fB\-\-private-dev\fR), which is blocked by default.
+This device is mostly intended to increase performance and compatibility when
+running certain programs through Wine.
+.br
+
+.br
+Example:
+.br
+$ firejail --keep-dev-ntsync --private-dev
+
+.TP
 \fB\-\-keep-dev-shm
 /dev/shm directory is untouched (even with --private-dev)
 .br

--- a/src/zsh_completion/_firejail.in
+++ b/src/zsh_completion/_firejail.in
@@ -102,6 +102,7 @@ _firejail_args=(
     '--ipc-namespace[enable a new IPC namespace]'
     '--join-or-start=-[join the sandbox or start a new one name|pid]: :_all_firejails'
     '--keep-config-pulse[disable automatic ~/.config/pulse init]'
+    '--keep-dev-ntsync[/dev/ntsync character device is untouched (even with --private-dev)]'
     '--keep-dev-shm[/dev/shm directory is untouched (even with --private-dev)]'
     '--keep-fd[inherit open file descriptors to sandbox]: :'
     '--keep-shell-rc[do not copy shell rc files from /etc/skel]'


### PR DESCRIPTION
Changes:

* Block access to /dev/ntsync by default
* Add the `keep-dev-ntsync` command to allow access to /dev/ntsync (even
  if `private-dev` is used)
* Add `keep-dev-ntsync` to wine.profile and similar profiles

Closes #6655.