### PR TITLE
modif: keep plugdev group unless nou2f is used

### DIFF
--- a/RELNOTES
+++ b/RELNOTES
@@ -41,6 +41,7 @@ firejail (0.9.73) baseline; urgency=low
   * modif: private-dev: keep /dev/kfd unless no3d is used (#6380)
   * modif: keep /sys/module/nvidia* if prop driver and no no3d (#6372 #6387)
   * modif: clarify error messages in profile.c (#6605)
+  * modif: keep plugdev group unless nou2f is used (#6664)
   * removal: firemon: remove --interface option (it duplicates the firejail
     --net.print= option) (0e48f9933)
   * removal: remove support for LTS and firetunnel (db09546f2)

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -3234,6 +3234,15 @@ int main(int argc, char **argv, char **envp) {
 					ptr += strlen(ptr);
 				}
 			}
+
+			// add plugdev group
+			if (!arg_nou2f) {
+				g = get_group_id("plugdev");
+				if (g) {
+					sprintf(ptr, "%d %d 1\n", g, g);
+					ptr += strlen(ptr);
+				}
+			}
 		}
 
 		if (!arg_nogroups) {

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -240,6 +240,11 @@ static void clean_supplementary_groups(gid_t gid) {
 		                  new_groups, &new_ngroups, MAX_GROUPS);
 	}
 
+	if (!arg_nou2f) {
+		copy_group_ifcont("plugdev", groups, ngroups,
+				  new_groups, &new_ngroups, MAX_GROUPS);
+	}
+
 	if (new_ngroups) {
 		rv = setgroups(new_ngroups, new_groups);
 		if (rv)

--- a/test/seccomp-extra/noroot.exp
+++ b/test/seccomp-extra/noroot.exp
@@ -72,7 +72,7 @@ expect {
 send -- "cat /proc/self/gid_map | wc -l\r"
 expect {
 	timeout {puts "TESTING ERROR 12\n";exit}
-	"9"
+	"10"
 }
 
 
@@ -104,7 +104,7 @@ expect {
 send -- "cat /proc/self/gid_map | wc -l\r"
 expect {
 	timeout {puts "TESTING ERROR 17\n";exit}
-	"9"
+	"10"
 }
 
 # check seccomp disabled and all caps enabled


### PR DESCRIPTION
To make hardware tokens available for ordinary users, some distributions include a udev rule to make the corresponding entry in /dev/... available for users belonging to a specific group.

The options `noroot` and `nogroups` currently break this behavior.

This PR implements a fix that checks whether `browser-disable-u2f` is set to `no`  in order to disable these two options.