### PR TITLE
profiles: ytmdesktop: add redirect & whitelist /opt/ytmdesktop 

### DIFF
--- a/etc/profile-m-z/youtube-music-desktop-app.profile
+++ b/etc/profile-m-z/youtube-music-desktop-app.profile
@@ -1,0 +1,11 @@
+# Firejail profile for youtube-music-desktop-app
+# Description: Unofficial electron based desktop wrapper for YouTube Music
+# This file is overwritten after every install/update
+# Persistent local customizations
+include youtube-music-desktop-app
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+# Redirect
+include ytmdesktop.profile

--- a/etc/profile-m-z/ytmdesktop.profile
+++ b/etc/profile-m-z/ytmdesktop.profile
@@ -13,7 +13,7 @@ noblacklist ${HOME}/.config/youtube-music-desktop-app
 mkdir ${HOME}/.config/youtube-music-desktop-app
 whitelist ${HOME}/.config/youtube-music-desktop-app
 
-#private-bin env,ytmdesktop
+#private-bin env,youtube-music-desktop-app,ytmdesktop
 private-etc @tls-ca,@x11,bumblebee,host.conf,mime.types
 #private-opt
 

--- a/etc/profile-m-z/ytmdesktop.profile
+++ b/etc/profile-m-z/ytmdesktop.profile
@@ -12,10 +12,10 @@ noblacklist ${HOME}/.config/youtube-music-desktop-app
 
 mkdir ${HOME}/.config/youtube-music-desktop-app
 whitelist ${HOME}/.config/youtube-music-desktop-app
+whitelist /opt/ytmdesktop
 
 #private-bin env,youtube-music-desktop-app,ytmdesktop
 private-etc @tls-ca,@x11,bumblebee,host.conf,mime.types
-#private-opt
 
 # Redirect
 include electron-common.profile

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -1033,6 +1033,7 @@ yelp
 youtube
 youtube-dl
 youtube-dl-gui
+youtube-music-desktop-app
 youtube-viewer
 youtube-viewer-gtk
 youtubemusic-nativefier


### PR DESCRIPTION
Apparently the main binary has been renamed from `ytmdesktop` to
`youtube-music-desktop-app`[1]:

    $ pacman -Qlq ytmdesktop
    [...]
    /opt/ytmdesktop/youtube-music-desktop-app
    /usr/bin/youtube-music-desktop-app
    /usr/share/applications/ytmdesktop.desktop

So add a redirect for it.

Fixes #6662.

[1] https://github.com/netblue30/firejail/issues/6662#issuecomment-2681532969

Reported-by: @Dieterbe

---

ytmdesktop: whitelist /opt/ytmdesktop

See also commit 175905530 ("profiles: exchange private-opt with a
whitelist (#6021)", 2023-10-18).
