### PR TITLE
New profile: remmina-file-wrapper

### DIFF
--- a/etc/profile-m-z/remmina-file-wrapper.profile
+++ b/etc/profile-m-z/remmina-file-wrapper.profile
@@ -1,0 +1,10 @@
+# Firejail profile for remmina-file-wrapper
+# This file is overwritten after every install/update
+# Persistent local customizations
+include remmina-file-wrapper.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+# Redirect
+include remmina.profile

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -776,6 +776,7 @@ rednotebook
 redshift
 regextester
 remmina
+remmina-file-wrapper
 retroarch
 rhythmbox
 rhythmbox-client


### PR DESCRIPTION
Remmina may install this wrapper binary on some distributions.

On Void Linux, this is the default binary launched via application
launchers (e.g. rofi):

    $ grep "Exec" /usr/share/applications/org.remmina.Remmina.desktop
    TryExec=remmina-file-wrapper
    Exec=remmina-file-wrapper %U
    [...]
