### PR TITLE
profiles: seahorse: add redirect org.gnome.seahorse.Application

### DIFF
--- a/etc/profile-m-z/org.gnome.seahorse.Application.profile
+++ b/etc/profile-m-z/org.gnome.seahorse.Application.profile
@@ -1,0 +1,11 @@
+# Firejail profile alias for seahorse
+# This file is overwritten after every install/update
+# Persistent local customizations
+include org.gnome.seahorse.Application.local
+# Persistent global definitions
+# added by included profile
+#include globals.local
+
+# Temporary fix for https://github.com/netblue30/firejail/issues/2624
+# Redirect
+include seahorse.profile

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -698,6 +698,7 @@ opera
 opera-beta
 opera-developer
 orage
+org.gnome.seahorse.Application
 ostrichriders
 otter-browser
 out123


### PR DESCRIPTION
Apparently the .desktop file for `seahorse` is located in the following
path:

* `/usr/share/applications/org.gnome.seahorse.Application.desktop`

Which ends in `Application.desktop` instead of `seahorse.desktop`,
leading to it not being automatically detected by firecfg.

So add a redirect profile and an entry in firecfg.config.

See also commit 8f69e9841 ("bugfix: firecfg: check full filename in
check_profile() (#6674)", 2025-03-04).

Fixes #6658.

Reported-by: @ginto37
Reported-by: @rusty-snake
