### PR TITLE
bugfix: firecfg: check full filename in check_profile()

### DIFF
--- a/src/firecfg/desktop_files.c
+++ b/src/firecfg/desktop_files.c
@@ -67,8 +67,6 @@ static int have_profile(const char *filename, const char *homedir) {
 
 	// we get strange names here, such as .org.gnome.gedit.desktop, com.uploadedlobster.peek.desktop,
 	// or io.github.Pithos.desktop; extract the word before .desktop
-	// TODO: implement proper fix for #2624 (names like org.gnome.Logs.desktop fall thru
-	// the 'last word' logic and don't get installed to ~/.local/share/applications
 
 	char *tmpfname = strdup(filename);
 	if (!tmpfname)
@@ -84,7 +82,16 @@ static int have_profile(const char *filename, const char *homedir) {
 		free(tmpfname);
 		return 0;
 	}
+
+	// strip ".desktop"
 	tmpfname[len - 8] = '\0';
+
+	// check full filename (without .desktop)
+	int rv = check_profile(tmpfname, homedir);
+	if (rv) {
+		free(tmpfname);
+		return rv;
+	}
 
 	// extract last word
 	char *last_word = strrchr(tmpfname, '.');
@@ -95,7 +102,7 @@ static int have_profile(const char *filename, const char *homedir) {
 
 	// try lowercase
 	last_word[0] = tolower(last_word[0]);
-	int rv = check_profile(last_word, homedir);
+	rv = check_profile(last_word, homedir);
 	if (rv) {
 		free(tmpfname);
 		return rv;


### PR DESCRIPTION
Currently, firecfg only checks the last word in .desktop files when
trying to match them to an existing profile.  For example:

* `org.gnome.gedit.desktop` -> `gedit.desktop`
* `org.gnome.seahorse.Application.desktop` -> `Application.desktop`

This works in the former case where there is an exact match of the last
word on each side (`gedit.desktop` and `gedit.profile`), but not in the
latter case (`Application.desktop` and `seahorse.profile`).

So make firecfg also check the full filename of the .desktop file, to
make it easier to create redirect profiles that match the full name of
the .desktop files.  For example:

* `org.gnome.seahorse.Application.desktop` ->
  `org.gnome.seahorse.Application.profile` (which itself then redirects
  to `seahorse.profile`)

Related commits:

* a6341b904 ("disable DBus activation in firecfg", 2017-09-25)
* 3e69deba3 ("fix firecfg", 2017-09-25)
* bd9761508 ("Temp fix firecfg (#2634)", 2019-04-02)

Relates to #2624 #6658.