### PR TITLE
build: remove cppcheck-old target/job

### DIFF
--- a/.github/workflows/check-c.yml
+++ b/.github/workflows/check-c.yml
@@ -102,37 +102,6 @@ jobs:
     - name: cppcheck
       run: make cppcheck
 
-  # new cppcheck version currently chokes on checkcfg.c and main.c, therefore
-  # scan all files also with older cppcheck version from ubuntu 20.04.
-  cppcheck_old:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 10
-    steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481
-      with:
-        egress-policy: block
-        allowed-endpoints: >
-          archive.ubuntu.com:80
-          azure.archive.ubuntu.com:80
-          github.com:443
-          packages.microsoft.com:443
-          ppa.launchpad.net:80
-          ppa.launchpadcontent.net:443
-          security.ubuntu.com:80
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-    - name: update package information
-      run: sudo apt-get update -qy
-    - name: install cppcheck
-      run: sudo apt-get install -qy cppcheck
-    - name: configure
-      run: >
-        ./configure CPPCHECK="cppcheck -q -j '$(nproc)'"
-        || (cat config.log; exit 1)
-    - run: cppcheck --version
-    - name: cppcheck-old
-      run: make cppcheck-old
-
   codeql-cpp:
     permissions:
       actions: read

--- a/Makefile
+++ b/Makefile
@@ -376,11 +376,6 @@ cppcheck:
 	$(CPPCHECK) --force --error-exitcode=1 --enable=warning,performance \
 	  -i src/firejail/checkcfg.c -i src/firejail/main.c .
 
-# For cppcheck 1.x; see .github/workflows/check-c.yml
-.PHONY: cppcheck-old
-cppcheck-old:
-	$(CPPCHECK) --force --error-exitcode=1 --enable=warning,performance .
-
 .PHONY: scan-build
 scan-build: clean
 	$(SCAN_BUILD) --status-bugs $(MAKE)


### PR DESCRIPTION
To avoid CI failures.

From the first run of `cppcheck_old` on commit 8f69e9841 ("bugfix:
firecfg: check full filename in check_profile() (#6674)", 2025-03-04)
[1]:

> This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner
> will be removed on 2025-04-01. For more details, see
> https://github.com/actions/runner-images/issues/11101

The target depends on the cppcheck version from Ubuntu 20.04 in order to
work properly and this distribution will become EOL next month (April
2025), so just remove the target.

Added on commit 53f0b3950 ("CI: keep old cppcheck job and ignore two
files in new job that take too long to check", 2022-07-26).

[1] https://github.com/netblue30/firejail/actions/runs/13658953453/job/38185280665