### PR TITLE
docs: clarify to run "sudo firecfg" as a normal (desktop) user

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ $ firejail --list
 
 ## Desktop integration
 
+Note: Desktop integration is only applied to the user running firecfg, so make
+sure to run `sudo firecfg` as a normal (desktop) user, not as root.
+
 Integrate your sandbox into your desktop by running the following two commands:
 
 ```sh
@@ -227,6 +230,8 @@ number goes up with every new release.
 We keep the application list in
 [src/firecfg/firecfg.config](src/firecfg/firecfg.config)
 (/etc/firejail/firecfg.config when installed).
+
+See `man firecfg` for details.
 
 ## Security profiles
 

--- a/src/man/firecfg.1.in
+++ b/src/man/firecfg.1.in
@@ -26,6 +26,11 @@ desktop managers are supported in this moment
 .PP
 Note: The examples use \fBsudo\fR, but \fBdoas\fR is also supported.
 .PP
+Note: Changes inside the user home (such as for desktop integration) are only
+made for the user running firecfg, so make sure to run "sudo firecfg" as a
+normal (desktop) user, not as root.
+See \fB\-\-fix\fR for details.
+.PP
 To set it up, run "sudo firecfg" after installing Firejail software.
 The same command should also be run after
 installing new programs. If the program is supported by Firejail, the symbolic link in /usr/local/bin


### PR DESCRIPTION
End users following the steps for desktop integration may end up running
`sudo firecfg` as root (or as a similar account) rather than as a normal
desktop user.

In that case, programs opened through a desktop launcher would still not
be running under firejail, which might surprise users.

So clarify that `sudo firecfg` should be executed as a normal (desktop)
user for desktop integration.

Relates to #6657.

Kind of relates to #5812.

Reported-by: @ginto37