### PR TITLE
profiles: floorp: add profile sync daemon paths

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -1277,9 +1277,11 @@ blacklist ${HOME}/wallet.dat
 blacklist ${HOME}/yt-dlp.conf
 blacklist ${HOME}/yt-dlp.conf.txt
 blacklist ${RUNUSER}/*firefox*
+blacklist ${RUNUSER}/*floorp*
 blacklist ${RUNUSER}/akonadi
 blacklist ${RUNUSER}/i3
 blacklist ${RUNUSER}/psd/*firefox*
+blacklist ${RUNUSER}/psd/*floorp*
 blacklist ${RUNUSER}/qutebrowser
 blacklist /etc/clamav
 blacklist /etc/ssmtp

--- a/etc/profile-a-l/floorp.profile
+++ b/etc/profile-a-l/floorp.profile
@@ -1,5 +1,5 @@
 # Firejail profile for floorp
-# Description: A customisable Firefox fork with excellent privacy protection
+# Description: A customizable Firefox fork with excellent privacy protection
 # This file is overwritten after every install/update
 # Persistent local customizations
 include floorp.local
@@ -8,11 +8,15 @@ include globals.local
 
 noblacklist ${HOME}/.cache/floorp
 noblacklist ${HOME}/.floorp
+noblacklist ${RUNUSER}/*floorp*
+noblacklist ${RUNUSER}/psd/*floorp*
 
 mkdir ${HOME}/.cache/floorp
 mkdir ${HOME}/.floorp
 whitelist ${HOME}/.cache/floorp
 whitelist ${HOME}/.floorp
+whitelist ${RUNUSER}/*floorp*
+whitelist ${RUNUSER}/psd/*floorp*
 
 dbus-user filter
 dbus-user.own org.mozilla.floorp.*


### PR DESCRIPTION
Fix typo.

Denying read-write access to ${HOME}/.local/share/applications prevents Floorp from creating shortcuts to the application launcher, which breaks the (experimental) PWA feature on Linux.

Additionally i whitelisted the directories `${RUNUSER}/*floorp* `and
whitelist `${RUNUSER}/psd/*floorp* `to enable profile-sync-daemon support.

Since this is my first time doing a PR, I may have missed something, feel free to edit if needed.