### PR TITLE
profiles: godot: ignore noexec in home to fix addons

### DIFF
--- a/etc/profile-a-l/godot.profile
+++ b/etc/profile-a-l/godot.profile
@@ -12,7 +12,6 @@ noblacklist ${HOME}/.local/share/godot
 
 include disable-common.inc
 include disable-devel.inc
-include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-xdg.inc

--- a/etc/profile-a-l/godot.profile
+++ b/etc/profile-a-l/godot.profile
@@ -6,12 +6,16 @@ include godot.local
 # Persistent global definitions
 include globals.local
 
+# Needed for loading addons
+ignore noexec ${HOME}
+
 noblacklist ${HOME}/.cache/godot
 noblacklist ${HOME}/.config/godot
 noblacklist ${HOME}/.local/share/godot
 
 include disable-common.inc
 include disable-devel.inc
+include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-xdg.inc


### PR DESCRIPTION
I had weird errors when working on a godot project:

    addons/godot-sqlite/bin/libgdsqlite.linux.template_debug.x86_64.so: failed to map segment from shared object.
    ERROR: Can't open GDExtension dynamic library: 'res://addons/godot-sqlite/gdsqlite.gdextension'.

These addons are executable files. Addons like these are common enough
and `noexec` breaks them. I confirmed that the change fixes this error
and allows loading addons.
