### PR TITLE
profiles: split commands that increase/reduce access

### DIFF
--- a/etc/profile-a-l/alpine.profile
+++ b/etc/profile-a-l/alpine.profile
@@ -66,6 +66,9 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+writable-run-user
+writable-var
+
 apparmor
 caps.drop all
 ipc-namespace
@@ -92,8 +95,6 @@ private-cache
 private-dev
 private-etc @tls-ca,@x11,c-client.cf,host.conf,krb5.keytab,mailcap,mime.types,pine.conf,pinerc.fixed,rpc,services,terminfo
 private-tmp
-writable-run-user
-writable-var
 
 dbus-user none
 dbus-system none

--- a/etc/profile-a-l/audacity.profile
+++ b/etc/profile-a-l/audacity.profile
@@ -30,6 +30,7 @@ include whitelist-var-common.inc
 
 # Silence blacklist violation. See #5539.
 allow-debuggers
+
 ## Enabling App Armor appears to break some Fedora / Arch installs
 #apparmor
 caps.drop all

--- a/etc/profile-a-l/dnsmasq.profile
+++ b/etc/profile-a-l/dnsmasq.profile
@@ -23,6 +23,8 @@ include disable-xdg.inc
 whitelist /var/lib/libvirt/dnsmasq
 whitelist /var/run
 
+writable-var
+
 caps.keep net_admin,net_bind_service,net_raw,setgid,setuid
 no3d
 nodvd
@@ -39,6 +41,5 @@ disable-mnt
 private
 private-dev
 private-tmp
-writable-var
 
 restrict-namespaces

--- a/etc/profile-a-l/email-common.profile
+++ b/etc/profile-a-l/email-common.profile
@@ -61,6 +61,10 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+# encrypting and signing email
+writable-run-user
+writable-var
+
 apparmor
 caps.drop all
 machine-id
@@ -85,9 +89,6 @@ private-cache
 private-dev
 private-etc @tls-ca,@x11,bogofilter,bogofilter.cf,clamav,gnupg,hosts.conf,mailname,timezone
 private-tmp
-# encrypting and signing email
-writable-run-user
-writable-var
 
 dbus-user filter
 dbus-user.talk ca.desrt.dconf

--- a/etc/profile-a-l/evolution.profile
+++ b/etc/profile-a-l/evolution.profile
@@ -25,6 +25,8 @@ include disable-programs.inc
 
 include whitelist-runuser-common.inc
 
+writable-var
+
 caps.drop all
 netfilter
 # no3d breaks under wayland
@@ -43,6 +45,5 @@ seccomp
 
 private-dev
 #private-tmp
-writable-var
 
 restrict-namespaces

--- a/etc/profile-a-l/file-manager-common.profile
+++ b/etc/profile-a-l/file-manager-common.profile
@@ -29,6 +29,7 @@ include disable-interpreters.inc
 #include disable-programs.inc
 
 allusers
+
 #apparmor
 caps.drop all
 #net none

--- a/etc/profile-a-l/freshclam.profile
+++ b/etc/profile-a-l/freshclam.profile
@@ -8,6 +8,9 @@ include globals.local
 
 include disable-exec.inc
 
+writable-var
+writable-var-log
+
 caps.keep setgid,setuid
 ipc-namespace
 netfilter
@@ -29,8 +32,6 @@ private
 private-cache
 private-dev
 private-tmp
-writable-var
-writable-var-log
 
 memory-deny-write-execute
 restrict-namespaces

--- a/etc/profile-a-l/gajim.profile
+++ b/etc/profile-a-l/gajim.profile
@@ -41,6 +41,8 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+writable-run-user
+
 apparmor
 caps.drop all
 netfilter
@@ -61,7 +63,6 @@ private-cache
 private-dev
 private-etc @tls-ca,@x11
 private-tmp
-writable-run-user
 
 dbus-user filter
 dbus-user.own org.gajim.Gajim

--- a/etc/profile-a-l/geki2.profile
+++ b/etc/profile-a-l/geki2.profile
@@ -18,6 +18,8 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+writable-var # game scores are stored under /var/games
+
 apparmor
 caps.drop all
 ipc-namespace
@@ -40,7 +42,6 @@ private-bin geki2
 private-dev
 private-etc @games,@sound,@x11
 private-tmp
-writable-var # game scores are stored under /var/games
 
 dbus-user none
 dbus-system none

--- a/etc/profile-a-l/geki3.profile
+++ b/etc/profile-a-l/geki3.profile
@@ -18,6 +18,8 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+writable-var # game scores are stored under /var/games
+
 apparmor
 caps.drop all
 ipc-namespace
@@ -40,7 +42,6 @@ private-bin geki3
 private-dev
 private-etc @games,@sound,@x11
 private-tmp
-writable-var # game scores are stored under /var/games
 
 dbus-user none
 dbus-system none

--- a/etc/profile-a-l/git-cola.profile
+++ b/etc/profile-a-l/git-cola.profile
@@ -46,6 +46,8 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+writable-run-user
+
 apparmor
 caps.drop all
 machine-id
@@ -71,7 +73,6 @@ private-cache
 private-dev
 private-etc @tls-ca,@x11,gitconfig,host.conf,mime.types,ssh
 private-tmp
-writable-run-user
 
 # dbus-user filtering breaks meld as diff viewer
 # Add the next line to your git-cola.local if you don't use meld.

--- a/etc/profile-a-l/gmpc.profile
+++ b/etc/profile-a-l/gmpc.profile
@@ -24,6 +24,8 @@ include whitelist-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+writable-run-user
+
 apparmor
 caps.drop all
 ipc-namespace
@@ -45,7 +47,6 @@ disable-mnt
 private-cache
 private-etc
 private-tmp
-writable-run-user
 
 dbus-user filter
 dbus-user.talk org.mpris.MediaPlayer2.mpd

--- a/etc/profile-a-l/gnome-schedule.profile
+++ b/etc/profile-a-l/gnome-schedule.profile
@@ -42,6 +42,8 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+writable-var
+
 apparmor
 caps.keep chown,dac_override,setgid,setuid
 ipc-namespace
@@ -60,4 +62,3 @@ tracelog
 disable-mnt
 private-cache
 private-dev
-writable-var

--- a/etc/profile-a-l/kmail.profile
+++ b/etc/profile-a-l/kmail.profile
@@ -41,6 +41,9 @@ include disable-programs.inc
 include whitelist-run-common.inc
 include whitelist-var-common.inc
 
+# writable-run-user is needed for signing and encrypting emails
+writable-run-user
+
 #apparmor
 caps.drop all
 netfilter
@@ -59,8 +62,6 @@ seccomp !chroot,!io_getevents,!io_setup,!io_submit,!ioprio_set
 
 private-dev
 #private-tmp # interrupts connection to akonadi, breaks opening of email attachments
-# writable-run-user is needed for signing and encrypting emails
-writable-run-user
 
 # To harden kmail.profile, add the following lines to kmail.local:
 #dbus-user filter

--- a/etc/profile-a-l/kopete.profile
+++ b/etc/profile-a-l/kopete.profile
@@ -21,6 +21,8 @@ include disable-programs.inc
 whitelist /var/lib/winpopup
 include whitelist-var-common.inc
 
+writable-var
+
 caps.drop all
 netfilter
 nodvd
@@ -35,6 +37,5 @@ seccomp
 
 private-dev
 private-tmp
-writable-var
 
 restrict-namespaces

--- a/etc/profile-a-l/kube.profile
+++ b/etc/profile-a-l/kube.profile
@@ -51,6 +51,8 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+writable-run-user
+
 apparmor
 caps.drop all
 netfilter
@@ -75,7 +77,6 @@ private-cache
 private-dev
 private-etc @tls-ca,@x11
 private-tmp
-writable-run-user
 
 dbus-user filter
 dbus-user.talk ca.desrt.dconf

--- a/etc/profile-a-l/lbreakouthd.profile
+++ b/etc/profile-a-l/lbreakouthd.profile
@@ -28,6 +28,8 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+writable-var # game scores are stored under /var/games
+
 apparmor
 caps.drop all
 ipc-namespace
@@ -49,7 +51,6 @@ private-bin lbreakouthd
 private-dev
 private-etc @games,@sound,@x11
 private-tmp
-writable-var # game scores are stored under /var/games
 
 dbus-user none
 dbus-system none

--- a/etc/profile-a-l/less.profile
+++ b/etc/profile-a-l/less.profile
@@ -15,6 +15,8 @@ include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
 
+writable-var-log
+
 apparmor
 caps.drop all
 ipc-namespace
@@ -40,7 +42,6 @@ x11 none
 #private-lib
 private-cache
 private-dev
-writable-var-log
 
 dbus-user none
 dbus-system none

--- a/etc/profile-a-l/lutris.profile
+++ b/etc/profile-a-l/lutris.profile
@@ -63,6 +63,8 @@ include whitelist-runuser-common.inc
 include whitelist-var-common.inc
 
 #allow-debuggers
+keep-dev-ntsync
+
 #apparmor
 caps.drop all
 ipc-namespace
@@ -79,7 +81,6 @@ protocol unix,inet,inet6,netlink
 seccomp !clone3,!modify_ldt,!process_vm_readv,!ptrace
 seccomp.32 !modify_ldt
 
-keep-dev-ntsync
 # Add the next line to your lutris.local if you do not need controller support.
 #private-dev
 private-tmp

--- a/etc/profile-m-z/mutt.profile
+++ b/etc/profile-m-z/mutt.profile
@@ -104,6 +104,9 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+writable-run-user
+writable-var
+
 apparmor
 caps.drop all
 ipc-namespace
@@ -129,8 +132,6 @@ private-cache
 private-dev
 private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gai.conf,gnupg,hosts.conf,mail,mailname,msmtprc,nntpserver,terminfo
 private-tmp
-writable-run-user
-writable-var
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/nano.profile
+++ b/etc/profile-m-z/nano.profile
@@ -21,6 +21,12 @@ include disable-programs.inc
 whitelist /usr/share/nano
 include whitelist-usr-share-common.inc
 
+# Add the next lines to your nano.local if you want to edit files in /etc directly.
+#ignore private-etc
+#writable-etc
+# Add the next line to your nano.local if you want to edit files in /var directly.
+#writable-var
+
 apparmor
 caps.drop all
 ipc-namespace
@@ -45,12 +51,7 @@ x11 none
 private-bin nano,rnano
 private-cache
 private-dev
-# Add the next lines to your nano.local if you want to edit files in /etc directly.
-#ignore private-etc
-#writable-etc
 private-etc nanorc
-# Add the next line to your nano.local if you want to edit files in /var directly.
-#writable-var
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/ncmpcpp.profile
+++ b/etc/profile-m-z/ncmpcpp.profile
@@ -39,6 +39,8 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+writable-var
+
 apparmor
 caps.drop all
 ipc-namespace
@@ -66,7 +68,6 @@ private-cache
 private-dev
 private-etc terminfo
 private-tmp
-writable-var
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/neomutt.profile
+++ b/etc/profile-m-z/neomutt.profile
@@ -96,6 +96,9 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+writable-run-user
+writable-var
+
 apparmor
 caps.drop all
 ipc-namespace
@@ -121,8 +124,6 @@ private-cache
 private-dev
 private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gnupg,hosts.conf,mail,mailname,msmtprc,neomuttrc,neomuttrc.d,nntpserver
 private-tmp
-writable-run-user
-writable-var
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/nethack-vultures.profile
+++ b/etc/profile-m-z/nethack-vultures.profile
@@ -20,6 +20,8 @@ whitelist /var/log/vultures
 include whitelist-common.inc
 include whitelist-var-common.inc
 
+writable-var
+
 caps.drop all
 ipc-namespace
 net none
@@ -38,7 +40,6 @@ disable-mnt
 private-cache
 private-dev
 private-tmp
-writable-var
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/nethack.profile
+++ b/etc/profile-m-z/nethack.profile
@@ -18,6 +18,8 @@ whitelist /var/games/nethack
 include whitelist-common.inc
 include whitelist-var-common.inc
 
+writable-var
+
 caps.drop all
 ipc-namespace
 net none
@@ -38,7 +40,6 @@ disable-mnt
 private-cache
 private-dev
 private-tmp
-writable-var
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/pkglog.profile
+++ b/etc/profile-m-z/pkglog.profile
@@ -23,6 +23,8 @@ whitelist /var/log/apt/history.log
 whitelist /var/log/dnf.rpm.log
 whitelist /var/log/pacman.log
 
+writable-var-log
+
 apparmor
 caps.drop all
 ipc-namespace
@@ -50,7 +52,6 @@ private-dev
 private-etc
 private-opt none
 private-tmp
-writable-var-log
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/plv.profile
+++ b/etc/profile-m-z/plv.profile
@@ -23,6 +23,8 @@ include whitelist-usr-share-common.inc
 include whitelist-runuser-common.inc
 include whitelist-var-common.inc
 
+writable-var-log
+
 apparmor
 caps.drop all
 ipc-namespace
@@ -48,7 +50,6 @@ private-dev
 private-etc
 private-opt none
 private-tmp
-writable-var-log
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/pyradio.profile
+++ b/etc/profile-m-z/pyradio.profile
@@ -69,6 +69,8 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+writable-run-user
+
 apparmor
 caps.drop all
 ipc-namespace
@@ -93,7 +95,6 @@ private-dev
 # python-exec is required by any python executable on Gentoo Linux
 private-etc @sound,@tls-ca,mplayer,mpv,python-exec,terminfo
 private-tmp
-writable-run-user
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/seahorse.profile
+++ b/etc/profile-m-z/seahorse.profile
@@ -36,6 +36,8 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+writable-run-user
+
 apparmor
 caps.drop all
 machine-id
@@ -59,7 +61,6 @@ private-cache
 private-dev
 private-etc @tls-ca,@x11,gconf,host.conf,pkcs11,rpc,services,ssh
 private-tmp
-writable-run-user
 
 dbus-user filter
 dbus-user.own org.gnome.seahorse

--- a/etc/profile-m-z/seamonkey.profile
+++ b/etc/profile-m-z/seamonkey.profile
@@ -44,6 +44,8 @@ whitelist ${HOME}/.zotero
 whitelist ${HOME}/dwhelper
 include whitelist-common.inc
 
+writable-run-user
+
 caps.drop all
 netfilter
 nodvd
@@ -56,6 +58,5 @@ tracelog
 
 disable-mnt
 #private-etc adobe,alternatives,asound.conf,ca-certificates,crypto-policies,firefox,fonts,group,gtk-2.0,hostname,hosts,iceweasel,localtime,machine-id,mailcap,mime.types,nsswitch.conf,pango,passwd,pki,pulse,resolv.conf,ssl
-writable-run-user
 
 restrict-namespaces

--- a/etc/profile-m-z/server.profile
+++ b/etc/profile-m-z/server.profile
@@ -51,6 +51,10 @@ include disable-xdg.inc
 #include whitelist-usr-share-common.inc
 #include whitelist-var-common.inc
 
+#writable-run-user
+#writable-var
+#writable-var-log
+
 # people use to install servers all over the place!
 # apparmor runs executable only from default system locations
 #apparmor
@@ -82,9 +86,6 @@ private-dev
 #private-lib
 #private-opt none
 private-tmp
-#writable-run-user
-#writable-var
-#writable-var-log
 
 dbus-user none
 #dbus-system none

--- a/etc/profile-m-z/slashem.profile
+++ b/etc/profile-m-z/slashem.profile
@@ -18,6 +18,8 @@ whitelist /var/games/slashem
 include whitelist-common.inc
 include whitelist-var-common.inc
 
+writable-var
+
 caps.drop all
 ipc-namespace
 net none
@@ -38,7 +40,6 @@ disable-mnt
 private-cache
 private-dev
 private-tmp
-writable-var
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/spectre-meltdown-checker.profile
+++ b/etc/profile-m-z/spectre-meltdown-checker.profile
@@ -26,6 +26,7 @@ include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
 allow-debuggers
+
 caps.keep sys_rawio
 ipc-namespace
 net none

--- a/etc/profile-m-z/ssh-agent.profile
+++ b/etc/profile-m-z/ssh-agent.profile
@@ -17,6 +17,8 @@ include disable-x11.inc
 
 include whitelist-usr-share-common.inc
 
+writable-run-user
+
 caps.drop all
 netfilter
 no3d
@@ -28,8 +30,6 @@ novideo
 protocol unix,inet,inet6
 seccomp
 tracelog
-
-writable-run-user
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/ssh.profile
+++ b/etc/profile-m-z/ssh.profile
@@ -26,6 +26,8 @@ whitelist ${RUNUSER}/keyring/ssh
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 
+writable-run-user
+
 apparmor
 caps.drop all
 ipc-namespace
@@ -47,7 +49,6 @@ tracelog
 private-cache
 private-dev
 #private-tmp # Breaks when exiting
-writable-run-user
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -153,6 +153,8 @@ include whitelist-var-common.inc
 #mkdir ${HOME}/.config/RogueLegacyStorageContainer
 #mkdir ${HOME}/.local/share/RogueLegacyStorageContainer
 
+keep-dev-ntsync
+
 caps.drop all
 #ipc-namespace
 netfilter
@@ -185,7 +187,6 @@ seccomp.32 !process_vm_readv
 # To view screenshots add the next line to your steam.local.
 #private-bin eog,eom,gthumb,pix,viewnior,xviewer
 
-keep-dev-ntsync
 private-dev
 # private-etc breaks a small selection of games on some systems. Add 'ignore private-etc'
 # to your steam.local to support those.

--- a/etc/profile-m-z/system-log-common.profile
+++ b/etc/profile-m-z/system-log-common.profile
@@ -24,6 +24,8 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+writable-var-log
+
 apparmor
 caps.drop all
 ipc-namespace
@@ -57,4 +59,3 @@ restrict-namespaces
 # Add 'ignore read-only ${HOME}' to your system-log-common.local
 # if you export logs to a file under your ${HOME}.
 read-only ${HOME}
-writable-var-log

--- a/etc/profile-m-z/tor.profile
+++ b/etc/profile-m-z/tor.profile
@@ -24,6 +24,8 @@ include disable-interpreters.inc
 include disable-programs.inc
 include disable-xdg.inc
 
+writable-var
+
 caps.keep dac_read_search,net_bind_service,setgid,setuid
 ipc-namespace
 machine-id
@@ -47,7 +49,6 @@ private-cache
 private-dev
 private-etc @tls-ca,tor
 private-tmp
-writable-var
 
 memory-deny-write-execute
 restrict-namespaces

--- a/etc/profile-m-z/transmission-daemon.profile
+++ b/etc/profile-m-z/transmission-daemon.profile
@@ -13,6 +13,9 @@ mkdir ${HOME}/.config/transmission-daemon
 whitelist ${HOME}/.config/transmission-daemon
 whitelist /var/lib/transmission
 
+writable-var-log
+writable-run-user
+
 caps.keep ipc_lock,net_bind_service,setgid,setuid,sys_chroot
 protocol packet
 
@@ -20,8 +23,6 @@ private-bin transmission-daemon
 private-etc @tls-ca
 
 read-write /var/lib/transmission
-writable-var-log
-writable-run-user
 
 # Redirect
 include transmission-common.profile

--- a/etc/profile-m-z/tuxtype.profile
+++ b/etc/profile-m-z/tuxtype.profile
@@ -24,6 +24,8 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+writable-var # game scores are stored under /var/games
+
 apparmor
 caps.drop all
 ipc-namespace
@@ -45,7 +47,6 @@ private-bin tuxtype
 private-dev
 private-etc @games,@sound,@x11,tuxtype
 private-tmp
-writable-var # game scores are stored under /var/games
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/typespeed.profile
+++ b/etc/profile-m-z/typespeed.profile
@@ -20,6 +20,8 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+writable-var # game scores are stored under /var/games
+
 apparmor
 caps.drop all
 ipc-namespace
@@ -40,7 +42,6 @@ private
 private-dev
 private-etc @games,@sound,@x11
 private-tmp
-writable-var # game scores are stored under /var/games
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/unbound.profile
+++ b/etc/profile-m-z/unbound.profile
@@ -27,6 +27,8 @@ read-only /var/lib/ca-certificates
 whitelist /var/lib/unbound
 whitelist /var/run
 
+writable-var
+
 caps.keep net_admin,net_bind_service,setgid,setuid,sys_chroot,sys_resource
 ipc-namespace
 machine-id
@@ -46,7 +48,6 @@ disable-mnt
 private
 private-dev
 private-tmp
-writable-var
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/virt-manager.profile
+++ b/etc/profile-m-z/virt-manager.profile
@@ -45,6 +45,8 @@ include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
 
+writable-var
+
 # breaks app
 #apparmor
 # For host-only network sys_admin is needed.
@@ -59,7 +61,6 @@ tracelog
 private-cache
 private-etc @network,@sound,@tls-ca,@x11
 private-tmp
-writable-var
 
 dbus-user filter
 dbus-user.own org.virt-manager.virt-manager

--- a/etc/profile-m-z/vmware.profile
+++ b/etc/profile-m-z/vmware.profile
@@ -17,13 +17,14 @@ include disable-interpreters.inc
 include disable-programs.inc
 include disable-xdg.inc
 
+# Add the next lines to your vmware.local if you need to use "shared VM".
+#whitelist /var/lib/vmware
+#writable-var
+
 mkdir ${HOME}/.cache/vmware
 mkdir ${HOME}/.vmware
 whitelist ${HOME}/.cache/vmware
 whitelist ${HOME}/.vmware
-# Add the next lines to your vmware.local if you need to use "shared VM".
-#whitelist /var/lib/vmware
-#writable-var
 include whitelist-common.inc
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc

--- a/etc/profile-m-z/wine.profile
+++ b/etc/profile-m-z/wine.profile
@@ -26,6 +26,8 @@ include whitelist-var-common.inc
 
 # Some applications don't need allow-debuggers. Add 'ignore allow-debuggers' to your wine.local if you want to override this.
 allow-debuggers
+keep-dev-ntsync
+
 caps.drop all
 #net none
 netfilter
@@ -39,7 +41,6 @@ notv
 #novideo
 seccomp
 
-keep-dev-ntsync
 private-dev
 
 restrict-namespaces

--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -155,8 +155,16 @@ include globals.local
 #include landlock-common.inc
 
 # Commands that increase access to resources.
+#
+# Note: Keep this in sync with ../../etc/profile-m-z/noprofile.profile.
+##allow-debuggers
 ##allusers
+##keep-config-pulse
 ##keep-dev-ntsync
+##keep-dev-shm
+##keep-fd all
+##keep-shell-rc
+##keep-var-tmp
 ##writable-etc
 ##writable-run-user
 ##writable-var

--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -154,7 +154,15 @@ include globals.local
 ##landlock.fs.execute PATH
 #include landlock-common.inc
 
+# Commands that increase access to resources.
 ##allusers
+##keep-dev-ntsync
+##writable-etc
+##writable-run-user
+##writable-var
+##writable-var-log
+
+# Commands that reduce access to resources.
 #apparmor
 #caps.drop all
 ##caps.keep CAPS
@@ -195,7 +203,6 @@ include globals.local
 ##x11 none
 
 #disable-mnt
-##keep-dev-ntsync
 ##private
 # It's common practice to refer to the python executable(s) in private-bin with `python*`, which covers both v2 and v3
 #private-bin PROGRAMS
@@ -224,10 +231,6 @@ include globals.local
 ##  - use 'private-opt NAME'
 ##private-opt NAME
 #private-tmp
-##writable-etc
-##writable-run-user
-##writable-var
-##writable-var-log
 
 # Since 0.9.63 also a more granular control of dbus is supported.
 # To get the dbus-addresses an application needs access to you can


### PR DESCRIPTION
This should clarify which commands do what (increase/reduce access) and
also make etc/templates/profile.template more consistent with
etc/profile-m-z/noprofile.profile.

Command used to search for the relevant profiles:

    git grep -El 'allow-debuggers|allusers|keep-|writable-' -- etc

This is a follow-up to #6660.

See also the discussion at [1].

[1] https://github.com/netblue30/firejail/pull/6660#discussion_r1975233984
