### PR TITLE
profiles: godot: remove noinput so gamepads work

### DIFF
--- a/etc/profile-a-l/godot.profile
+++ b/etc/profile-a-l/godot.profile
@@ -26,7 +26,7 @@ caps.drop all
 netfilter
 nodvd
 nogroups
-noinput
+#noinput # may break gamepads (see #6707)
 nonewprivs
 noroot
 notv

--- a/etc/profile-a-l/godot.profile
+++ b/etc/profile-a-l/godot.profile
@@ -26,7 +26,7 @@ caps.drop all
 netfilter
 nodvd
 nogroups
-#noinput # may break gamepads (see #6707)
+#noinput # breaks gamepads (see #6707)
 nonewprivs
 noroot
 notv


### PR DESCRIPTION
As you might know, Godot is a game engine. For this reason, they support the very commonly used gamepads and other potentially exotic input devices. `noinput` is incompatible with that and interferes with normal operation.