### PR TITLE
profiles: add more xorg paths

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -35,6 +35,7 @@ blacklist-nolog /tmp/clipmenu*
 # X11 session autostart
 # this will kill --x11=xpra cmdline option for all programs
 #blacklist ${HOME}/.xpra
+blacklist ${HOME}/.Xresources
 blacklist ${HOME}/.Xsession
 blacklist ${HOME}/.blackbox
 blacklist ${HOME}/.config/autostart
@@ -62,14 +63,20 @@ blacklist ${HOME}/.kde4/shutdown
 blacklist ${HOME}/.kde4/share/config/startupconfig
 blacklist ${HOME}/.kde4/share/config/startupconfigkeys
 blacklist ${HOME}/.local/share/autostart
+blacklist ${HOME}/.local/share/xorg
 blacklist ${HOME}/.xinitrc
 blacklist ${HOME}/.xprofile
 blacklist ${HOME}/.xserverrc
 blacklist ${HOME}/.xsession
 blacklist ${HOME}/.xsessionrc
 blacklist /etc/X11/Xsession.d
+blacklist /etc/X11/xinit
+blacklist /etc/X11/xorg.conf.d
 blacklist /etc/xdg/autostart
+blacklist /var/log/Xorg.*
 read-only ${HOME}/.Xauthority
+read-only ${HOME}/.Xdefaults
+read-only ${HOME}/.Xdefaults-*
 read-only ${HOME}/.config/awesome/autorun.sh
 read-only ${HOME}/.config/openbox/autostart
 read-only ${HOME}/.config/openbox/environment

--- a/etc/inc/disable-x11.inc
+++ b/etc/inc/disable-x11.inc
@@ -4,6 +4,8 @@ include disable-x11.local
 
 blacklist /tmp/.X11-unix
 blacklist ${HOME}/.Xauthority
+blacklist ${HOME}/.Xdefaults
+blacklist ${HOME}/.Xdefaults-*
 blacklist ${RUNUSER}/gdm/Xauthority
 blacklist ${RUNUSER}/.mutter-Xwaylandauth*
 blacklist ${RUNUSER}/xauth_*

--- a/etc/inc/whitelist-common.inc
+++ b/etc/inc/whitelist-common.inc
@@ -5,6 +5,8 @@ include whitelist-common.local
 # common whitelist for all profiles
 
 whitelist ${HOME}/.XCompose
+whitelist ${HOME}/.Xdefaults
+whitelist ${HOME}/.Xdefaults-*
 whitelist ${HOME}/.alsaequal.bin
 whitelist ${HOME}/.asoundrc
 whitelist ${HOME}/.config/ibus


### PR DESCRIPTION
Add the following files, which may be used to configure X clients:

* `~/.Xdefaults`
* `~/.Xdefaults-*` (`~/.Xdefaults-$(hostname)`)
* `~/.Xresources`

And block the following paths, which are intended for the X server:

* `~/.local/share/xorg` (rootless Xorg log directory)
* `/etc/X11/xinit`
* `/etc/X11/xorg.conf.d`
* `/var/log/Xorg.*` (default Xorg log path)

Note: ~/.Xdefaults is read directly by each application when it starts,
while ~/.Xresources is loaded once into the X root window with xrdb(1)
when starting the session, such as by a DE or directly in ~/.xinitrc.
Both use the same format and it appears that users are encouraged to use
~/.Xresources instead of ~/.Xdefaults but applications still try to read
~/.Xdefaults if it exists.

From xrdb(1):

> FILES
>        Xrdb does not load any files on its own, but many desktop
>        environments use xrdb to load ~/.Xresources files on session
>        startup to initialize the resource database, as a generalized
>        replacement for ~/.Xdefaults files.

See X(1), Xorg(1), xinit(1) and xrdb(1).