### PR TITLE
profiles: fix include of deprecated disable-X11.inc (uppercase)

### DIFF
--- a/etc/profile-a-l/aria2p.profile
+++ b/etc/profile-a-l/aria2p.profile
@@ -20,7 +20,7 @@ include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
 #include disable-write-mnt.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 include whitelist-common.inc

--- a/etc/profile-a-l/aria2rpc.profile
+++ b/etc/profile-a-l/aria2rpc.profile
@@ -21,7 +21,7 @@ include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
 #include disable-write-mnt.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 include whitelist-common.inc

--- a/etc/profile-a-l/buku.profile
+++ b/etc/profile-a-l/buku.profile
@@ -26,7 +26,7 @@ include disable-programs.inc
 include disable-shell.inc
 # Superseded by disable-mnt
 #include disable-write-mnt.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.local/share/buku

--- a/etc/profile-a-l/hledger.profile
+++ b/etc/profile-a-l/hledger.profile
@@ -25,7 +25,7 @@ include disable-shell.inc
 # Superseded by disable-mnt
 #include disable-write-mnt.inc
 # Superseded by x11 none
-#include disable-X11.inc
+#include disable-x11.inc
 include disable-xdg.inc
 
 whitelist ${HOME}/.hledger.journal

--- a/etc/profile-a-l/irssi.profile
+++ b/etc/profile-a-l/irssi.profile
@@ -20,7 +20,7 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.irssi

--- a/etc/profile-m-z/monero-wallet-cli.profile
+++ b/etc/profile-m-z/monero-wallet-cli.profile
@@ -19,7 +19,7 @@ include disable-programs.inc
 include disable-shell.inc
 # Superseded by disable-mnt
 #include disable-write-mnt.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.shared-ringdb

--- a/etc/profile-m-z/ncmpcpp.profile
+++ b/etc/profile-m-z/ncmpcpp.profile
@@ -25,7 +25,7 @@ include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
 #include disable-write-mnt.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.config/ncmpcpp

--- a/etc/profile-m-z/pyradio.profile
+++ b/etc/profile-m-z/pyradio.profile
@@ -38,7 +38,7 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 whitelist ${HOME}/.cache/mpv

--- a/etc/profile-m-z/tremc.profile
+++ b/etc/profile-m-z/tremc.profile
@@ -22,7 +22,7 @@ include disable-proc.inc
 include disable-programs.inc
 include disable-shell.inc
 #include disable-write-mnt.inc
-include disable-X11.inc
+include disable-x11.inc
 include disable-xdg.inc
 
 # I want to add torrent files from various places in ${HOME}


### PR DESCRIPTION
Replace it with the current disable-x11.inc (lowercase) include.

See commit 0060b5105 ("profiles: rename disable-X11.inc to
disable-x11.inc (#6294)", 2024-03-27).

Commands used to search and replace:

    $ git grep -Ilz 'disable-X11' -- etc/profile* | xargs -0 \
      perl -pi -e 's/disable-X11/disable-x11/'

Relates to #6549 #6583 #6584 #6585 #6586 #6587 #6589 #6590.