### PR TITLE
feature: add warn command

### DIFF
--- a/contrib/syntax/lists/profile_commands_arg1.list
+++ b/contrib/syntax/lists/profile_commands_arg1.list
@@ -79,6 +79,7 @@ shell
 timeout
 tmpfs
 veth-name
+warn
 whitelist
 whitelist-ro
 x11

--- a/etc/inc/disable-X11.inc
+++ b/etc/inc/disable-X11.inc
@@ -2,7 +2,7 @@
 # Persistent customizations should go in a .local file.
 include disable-X11.local
 
-# Warning: This file is deprecated; use disable-x11.inc (lowercase) instead.
+warn This file is deprecated; use disable-x11.inc (lowercase) instead.
 
 # Redirect
 include disable-x11.inc

--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -59,6 +59,8 @@ include globals.local
 ##ignore noexec ${HOME}
 ##ignore noexec /tmp
 
+##warn foo
+
 # It is common practice to add files/dirs containing program-specific configuration
 # (often ${HOME}/PROGRAMNAME or ${HOME}/.config/PROGRAMNAME) into disable-programs.inc
 # (keep list sorted) and then disable blacklisting below.

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -295,6 +295,11 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		return 0;
 	}
 
+	if (strncmp(ptr, "warn ", 5) == 0) {
+		fwarning("%s:%d: %s\n", fname, lineno, ptr + 5);
+		return 0;
+	}
+
 	if (strncmp(ptr, "keep-fd ", 8) == 0) {
 		if (strcmp(ptr + 8, "all") == 0)
 			arg_keep_fd_all = 1;

--- a/src/man/firejail-profile.5.in
+++ b/src/man/firejail-profile.5.in
@@ -235,6 +235,13 @@ Example: "ignore net eth0"
 Disable Firejail's output. This should be the first uncommented command in the profile file.
 
 Example: "quiet"
+.TP
+\fBwarn message
+Print a warning message to stderr.
+Everything after the command is printed as is (that is, without macro
+expansion).
+
+Example: "warn This file is deprecated; use foo instead."
 
 .SH Filesystem
 These profile entries define a chroot filesystem built on top of the existing


### PR DESCRIPTION
And use it in etc/inc/disable-X11.inc.

This allows printing a warning message from inside a profile.

Everything after the command is printed as is to stderr.

Relates to #6294.

This is a follow-up to #6709.