### PR TITLE
build: use TARNAME in SYSCONFDIR/VARDIR

### DIFF
--- a/config.mk.in
+++ b/config.mk.in
@@ -97,9 +97,9 @@ COMMON_CFLAGS = \
 	-Wall -Wextra $(HAVE_FATAL_WARNINGS) \
 	-Wformat -Wformat-security \
 	-fstack-protector-all \
-	-DPREFIX='"$(prefix)"' -DSYSCONFDIR='"$(sysconfdir)/firejail"' \
+	-DPREFIX='"$(prefix)"' -DSYSCONFDIR='"$(sysconfdir)/$(TARNAME)"' \
 	-DLIBDIR='"$(libdir)"' -DBINDIR='"$(bindir)"' \
-	-DVARDIR='"/var/lib/firejail"'
+	-DVARDIR='"/var/lib/$(TARNAME)"'
 
 PROG_CFLAGS = \
 	$(COMMON_CFLAGS) \


### PR DESCRIPTION
To reduce hardcoding.
