### PR TITLE
build: add localstatedir and use in VARDIR

### DIFF
--- a/config.mk.in
+++ b/config.mk.in
@@ -20,6 +20,7 @@ libdir=@libdir@
 datarootdir=@datarootdir@
 docdir=@docdir@
 mandir=@mandir@
+localstatedir=@localstatedir@
 sysconfdir=@sysconfdir@
 
 # Misc flags
@@ -99,7 +100,7 @@ COMMON_CFLAGS = \
 	-fstack-protector-all \
 	-DPREFIX='"$(prefix)"' -DSYSCONFDIR='"$(sysconfdir)/$(TARNAME)"' \
 	-DLIBDIR='"$(libdir)"' -DBINDIR='"$(bindir)"' \
-	-DVARDIR='"/var/lib/$(TARNAME)"'
+	-DVARDIR='"$(localstatedir)/lib/$(TARNAME)"'
 
 PROG_CFLAGS = \
 	$(COMMON_CFLAGS) \


### PR DESCRIPTION
By default autoconf expands `@localstatedir@` to `/var`.

`VARDIR` was first added on commit a627071b3 ("intrusion detection
system", 2021-07-28) and is only used in src/firejail/ids.c.

This is a follow-up to commit 5b4524a74 ("build: use TARNAME in
SYSCONFDIR/VARDIR (#6713)", 2025-04-19).