### PR TITLE
modif: keep tss group if keep-dev-tpm is used

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -3243,6 +3243,15 @@ int main(int argc, char **argv, char **envp) {
 				}
 			}
 
+			// add tss group
+			if (arg_keep_dev_tpm) {
+				g = get_group_id("tss");
+				if (g) {
+					sprintf(ptr, "%d %d 1\n", g, g);
+					ptr += strlen(ptr);
+				}
+			}
+
 			// add plugdev group
 			if (!arg_nou2f) {
 				g = get_group_id("plugdev");

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -240,6 +240,11 @@ static void clean_supplementary_groups(gid_t gid) {
 		                  new_groups, &new_ngroups, MAX_GROUPS);
 	}
 
+	if (arg_keep_dev_tpm) {
+		copy_group_ifcont("tss", groups, ngroups,
+				  new_groups, &new_ngroups, MAX_GROUPS);
+	}
+
 	if (!arg_nou2f) {
 		copy_group_ifcont("plugdev", groups, ngroups,
 				  new_groups, &new_ngroups, MAX_GROUPS);


### PR DESCRIPTION
This group is apparently used by tpm2-tss for accessing TPM devices.

udev rules from tpm2-tss 4.1.3[1]:

    # tpm devices can only be accessed by the tss user but the tss
    # group members can access tpmrm devices
    KERNEL=="tpm[0-9]*", TAG+="systemd", MODE="0660", OWNER="tss"
    KERNEL=="tpmrm[0-9]*", TAG+="systemd", MODE="0660", GROUP="tss"

Misc: This was noticed on #6700.

Relates to #6390.

[1] https://github.com/tpm2-software/tpm2-tss/blob/4.1.3/dist/tpm-udev.rules