### PR TITLE
modif: keep /dev/tpmrm devices if keep-dev-tpm is used

### DIFF
--- a/src/firejail/fs_dev.c
+++ b/src/firejail/fs_dev.c
@@ -85,6 +85,7 @@ static DevEntry dev[] = {
 	{"/dev/dvb", RUN_DEV_DIR "/dvb", DEV_TV}, // DVB (Digital Video Broadcasting) - TV device
 	{"/dev/sr[0-9]*", RUN_DEV_DIR "/sr[0-9]*", DEV_DVD}, // for DVD and audio CD players
 	{"/dev/tpm[0-9]*", RUN_DEV_DIR "/tpm[0-9]*", DEV_TPM}, // TPM (Trusted Platform Module) devices
+	{"/dev/tpmrm[0-9]*", RUN_DEV_DIR "/tpmrm[0-9]*", DEV_TPM},
 	{"/dev/hidraw[0-9]*", RUN_DEV_DIR "/hidraw[0-9]*", DEV_U2F},
 	{"/dev/usb", RUN_DEV_DIR "/usb", DEV_U2F}, // USB devices such as Yubikey, U2F
 	{"/dev/input", RUN_DEV_DIR "/input", DEV_INPUT},

--- a/src/man/firejail-profile.5.in
+++ b/src/man/firejail-profile.5.in
@@ -316,8 +316,8 @@ running certain programs through Wine.
 /dev/shm directory is untouched (even with private-dev).
 .TP
 \fBkeep-dev-tpm
-Allow access to the /dev/tpm* Trusted Platform Module (TPM) devices (even with
-\fBprivate-dev\fR), which are blocked by default.
+Allow access to the /dev/tpm[0-9]* and /dev/tpmrm[0-9]* Trusted Platform Module
+(TPM) devices (even with \fBprivate-dev\fR), which are blocked by default.
 .TP
 \fBkeep-shell-rc
 Do not copy shell rc files (such as ~/.bashrc and ~/.zshrc) from /etc/skel.

--- a/src/man/firejail.1.in
+++ b/src/man/firejail.1.in
@@ -1255,8 +1255,8 @@ $ firejail --keep-dev-shm --private-dev
 
 .TP
 \fB\-\-keep-dev-tpm
-Allow access to the /dev/tpm* Trusted Platform Module (TPM) devices (even with
-\fBprivate-dev\fR), which are blocked by default.
+Allow access to the /dev/tpm[0-9]* and /dev/tpmrm[0-9]* Trusted Platform Module
+(TPM) devices (even with \fB\-\-private-dev\fR), which are blocked by default.
 .br
 
 .br


### PR DESCRIPTION
Treat them like `/dev/tpm[0-9]*` devices.

It seems that `/dev/tpm[0-9]*` allows direct access to the TPM device
while `/dev/tpmrm[0-9]*` mediates access through a "resource manager"
inside of the kernel (for example, to facilitate concurrent access).
Alternatively, it looks like the resource management can be done in
userspace through tpm2-abrmd, the "TPM2 Access Broker & Resource
Management Daemon", which also supports older kernels (Linux 3.x vs
4.12) [1] [2] [3].

udev rules from tpm2-tss 4.1.3[4]:

    # tpm devices can only be accessed by the tss user but the tss
    # group members can access tpmrm devices
    KERNEL=="tpm[0-9]*", TAG+="systemd", MODE="0660", OWNER="tss"
    KERNEL=="tpmrm[0-9]*", TAG+="systemd", MODE="0660", GROUP="tss"

This is a follow-up to #6718.

Misc: This was noticed on #6700.

Relates to #6390.

[1] https://github.com/tpm2-software/tpm2-abrmd
[2] https://github.com/tpm2-software/tpm2-abrmd/issues/830
[3] https://github.com/tpm2-software/tpm2-tss-engine/issues/149
[4] https://github.com/tpm2-software/tpm2-tss/blob/4.1.3/dist/tpm-udev.rules