### PR TITLE
Fix: [Firefox/Tridactyl] add alternative config path

### DIFF
--- a/etc/profile-a-l/firefox-common-addons.profile
+++ b/etc/profile-a-l/firefox-common-addons.profile
@@ -83,6 +83,7 @@ whitelist ${HOME}/.netrc
 whitelist ${HOME}/.pentadactyl
 whitelist ${HOME}/.pentadactylrc
 whitelist ${HOME}/.tridactylrc
+whitelist ${HOME}/.config/tridactyl/tridactylrc
 whitelist ${HOME}/.vimperator
 whitelist ${HOME}/.vimperatorrc
 whitelist ${HOME}/.wine-pipelight


### PR DESCRIPTION
### Description
Fixes #6720 

Tridactyl: the default rc path isn't only  
`~/.tridactylrc` but also `~/.config/tridactyl/tridactylrc`.

Actually, second path is more default than other paths.

Therefore, in `/etc/profile-a-l/firefox-common-addons.profile`:

```ini
# old
whitelist ${HOME}/.tridactylrc
```

must be replaced (or complemented) with:

```ini
# new
whitelist ${HOME}/.config/tridactyl/tridactylrc
whitelist ${HOME}/.tridactylrc   # optional legacy line
```

### Proposed patch

```diff
diff --git a/etc/profile-a-l/firefox-common-addons.profile b/etc/profile-a-l/firefox-common-addons.profile
--- a/etc/profile-a-l/firefox-common-addons.profile
+++ b/etc/profile-a-l/firefox-common-addons.profile
@@
- whitelist ${HOME}/.tridactylrc
+ whitelist ${HOME}/.config/tridactyl/tridactylrc
+ whitelist ${HOME}/.tridactylrc
```
