### PR TITLE
modif: keep tcm/tcmrm devices if keep-dev-tpm is used

### DIFF
--- a/src/firejail/fs_dev.c
+++ b/src/firejail/fs_dev.c
@@ -84,6 +84,8 @@ static DevEntry dev[] = {
 	{"/dev/video[0-9]*", RUN_DEV_DIR "/video[0-9]*", DEV_VIDEO}, // video camera devices
 	{"/dev/dvb", RUN_DEV_DIR "/dvb", DEV_TV}, // DVB (Digital Video Broadcasting) - TV device
 	{"/dev/sr[0-9]*", RUN_DEV_DIR "/sr[0-9]*", DEV_DVD}, // for DVD and audio CD players
+	{"/dev/tcm[0-9]*", RUN_DEV_DIR "/tcm[0-9]*", DEV_TPM}, // TCM (Trusted Cryptography Module) devices
+	{"/dev/tcmrm[0-9]*", RUN_DEV_DIR "/tcmrm[0-9]*", DEV_TPM},
 	{"/dev/tpm[0-9]*", RUN_DEV_DIR "/tpm[0-9]*", DEV_TPM}, // TPM (Trusted Platform Module) devices
 	{"/dev/tpmrm[0-9]*", RUN_DEV_DIR "/tpmrm[0-9]*", DEV_TPM},
 	{"/dev/hidraw[0-9]*", RUN_DEV_DIR "/hidraw[0-9]*", DEV_U2F},

--- a/src/man/firejail-profile.5.in
+++ b/src/man/firejail-profile.5.in
@@ -316,7 +316,7 @@ running certain programs through Wine.
 /dev/shm directory is untouched (even with private-dev).
 .TP
 \fBkeep-dev-tpm
-Allow access to the /dev/tpm[0-9]* and /dev/tpmrm[0-9]* Trusted Platform Module
+Allow access to Trusted Cryptography Module (TCM) and Trusted Platform Module
 (TPM) devices (even with \fBprivate-dev\fR), which are blocked by default.
 .TP
 \fBkeep-shell-rc

--- a/src/man/firejail.1.in
+++ b/src/man/firejail.1.in
@@ -1255,8 +1255,20 @@ $ firejail --keep-dev-shm --private-dev
 
 .TP
 \fB\-\-keep-dev-tpm
-Allow access to the /dev/tpm[0-9]* and /dev/tpmrm[0-9]* Trusted Platform Module
+Allow access to Trusted Cryptography Module (TCM) and Trusted Platform Module
 (TPM) devices (even with \fB\-\-private-dev\fR), which are blocked by default.
+.br
+
+.br
+Paths:
+.br
+/dev/tcm[0-9]*
+.br
+/dev/tcmrm[0-9]*
+.br
+/dev/tpm[0-9]*
+.br
+/dev/tpmrm[0-9]*
 .br
 
 .br


### PR DESCRIPTION
Paths:

* `/dev/tcm[0-9]*`
* `/dev/tcmrm[0-9]*`

Apparently Trusted Cryptography Module (TCM) is a standard from China
that is an alternative to the TCG Trusted Compute Module (TPM)
standard[1].

udev rules from tpm2-tss master[2]:

    # tpm devices can only be accessed by the tss user but the tss
    # group members can access tpmrm devices
    KERNEL=="tpm[0-9]*", TAG+="systemd", MODE="0660", OWNER="tss"
    KERNEL=="tpmrm[0-9]*", TAG+="systemd", MODE="0660", GROUP="tss"
    KERNEL=="tcm[0-9]*", TAG+="systemd", MODE="0660", OWNER="tss"
    KERNEL=="tcmrm[0-9]*", TAG+="systemd", MODE="0660", GROUP="tss"

This is a follow-up to #6719.

Relates to #6390.

Misc: This was noticed on #6700.