### PR TITLE
profiles: remove mkdir ~/.pki

### DIFF
--- a/etc/profile-a-l/chromium-common.profile
+++ b/etc/profile-a-l/chromium-common.profile
@@ -32,7 +32,6 @@ blacklist ${PATH}/wget
 blacklist ${PATH}/wget2
 
 mkdir ${HOME}/.local/share/pki
-mkdir ${HOME}/.pki
 whitelist ${HOME}/.local/share/pki
 whitelist ${HOME}/.pki
 whitelist /usr/share/mozilla/extensions

--- a/etc/profile-a-l/ephemeral.profile
+++ b/etc/profile-a-l/ephemeral.profile
@@ -24,7 +24,6 @@ include disable-programs.inc
 # enforce private-cache
 #mkdir ${HOME}/.cache/ephemeral
 mkdir ${HOME}/.local/share/pki
-mkdir ${HOME}/.pki
 # enforce private-cache
 #whitelist ${HOME}/.cache/ephemeral
 whitelist ${HOME}/.local/share/pki

--- a/etc/profile-a-l/ferdi.profile
+++ b/etc/profile-a-l/ferdi.profile
@@ -21,7 +21,6 @@ include disable-programs.inc
 mkdir ${HOME}/.cache/Ferdi
 mkdir ${HOME}/.config/Ferdi
 mkdir ${HOME}/.local/share/pki
-mkdir ${HOME}/.pki
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.cache/Ferdi
 whitelist ${HOME}/.config/Ferdi

--- a/etc/profile-a-l/firefox-common.profile
+++ b/etc/profile-a-l/firefox-common.profile
@@ -44,7 +44,6 @@ include disable-proc.inc
 include disable-programs.inc
 
 mkdir ${HOME}/.local/share/pki
-mkdir ${HOME}/.pki
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.local/share/pki
 whitelist ${HOME}/.pki

--- a/etc/profile-a-l/franz.profile
+++ b/etc/profile-a-l/franz.profile
@@ -21,7 +21,6 @@ include disable-programs.inc
 mkdir ${HOME}/.cache/Franz
 mkdir ${HOME}/.config/Franz
 mkdir ${HOME}/.local/share/pki
-mkdir ${HOME}/.pki
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.cache/Franz
 whitelist ${HOME}/.config/Franz

--- a/etc/profile-m-z/midori.profile
+++ b/etc/profile-m-z/midori.profile
@@ -34,7 +34,6 @@ mkdir ${HOME}/.local/share/midori
 mkdir ${HOME}/.local/share/pki
 mkdir ${HOME}/.local/share/webkit
 mkdir ${HOME}/.local/share/webkitgtk
-mkdir ${HOME}/.pki
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.cache/gnome-mplayer/plugin
 whitelist ${HOME}/.cache/midori

--- a/etc/profile-m-z/otter-browser.profile
+++ b/etc/profile-m-z/otter-browser.profile
@@ -23,7 +23,6 @@ include disable-xdg.inc
 mkdir ${HOME}/.cache/Otter
 mkdir ${HOME}/.config/otter
 mkdir ${HOME}/.local/share/pki
-mkdir ${HOME}/.pki
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.cache/Otter
 whitelist ${HOME}/.config/otter

--- a/etc/profile-m-z/rambox.profile
+++ b/etc/profile-m-z/rambox.profile
@@ -17,7 +17,6 @@ include disable-programs.inc
 
 mkdir ${HOME}/.config/Rambox
 mkdir ${HOME}/.local/share/pki
-mkdir ${HOME}/.pki
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.config/Rambox
 whitelist ${HOME}/.local/share/pki

--- a/etc/profile-m-z/seamonkey.profile
+++ b/etc/profile-m-z/seamonkey.profile
@@ -21,7 +21,6 @@ mkdir ${HOME}/.cache/mozilla
 mkdir ${HOME}/.gnupg
 mkdir ${HOME}/.mozilla
 mkdir ${HOME}/.local/share/pki
-mkdir ${HOME}/.pki
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.cache/gnome-mplayer/plugin
 whitelist ${HOME}/.cache/mozilla


### PR DESCRIPTION
To reduce clutter in the user home.

This appears to be a legacy path and the relevant profiles already
create an XDG path as well:

    mkdir ${HOME}/.local/share/pki

From nss 3.111[1]:

    /**
     * Return the path to user's NSS database.
     * We search in the following dirs in order:
     * (1) $HOME/.pki/nssdb;
     * (2) $XDG_DATA_HOME/pki/nssdb if XDG_DATA_HOME is set;
     * (3) $HOME/.local/share/pki/nssdb (default XDG_DATA_HOME value).
     * If (1) does not exist, then the returned dir will be set to either
     * (2) or (3), depending if XDG_DATA_HOME is set.
     */

The XDG path has apparently been supported since nss 3.42, which was
released on 2019-01-25[2] [3] [4].

Misc: The original path was first added on commit 3a71eb2af ("added
mkdir in all whitelisted profiles", 2016-02-18) and the XDG path was
first added on commit 63c35052b ("Add '$HOME/.local/share/pki' to
blacklist", 2019-02-03).

Relates to #4262.

[1] https://github.com/nss-dev/nss/blob/NSS_3_111_RTM/lib/sysinit/nsssysinit.c#L64-L72
[2] https://github.com/nss-dev/nss/blob/NSS_3_42_RTM/lib/sysinit/nsssysinit.c#L65-L73
[3] https://github.com/nss-dev/nss/commit/7f21d4f49716d9f0c18123ca8c1330671e67ec7c
[4] https://github.com/nss-dev/nss/releases/tag/NSS_3_42_RTM