### PR TITLE
profiles: mpv: remove mkfile ~/.netrc

### DIFF
--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -55,7 +55,6 @@ read-only ${DESKTOP}
 mkdir ${HOME}/.cache/mpv
 mkdir ${HOME}/.config/mpv
 mkdir ${HOME}/.local/state/mpv
-mkfile ${HOME}/.netrc
 whitelist ${HOME}/.cache/mpv
 whitelist ${HOME}/.config/mpv
 whitelist ${HOME}/.config/youtube-dl


### PR DESCRIPTION
To reduce clutter in the user home.

This file is apparently intended to specify login information for remote
systems, such as username and password for ftp/http connections
(similarly to using ~/.ssh/config for ssh connections).

From inetutils.info of GNU inetutils 2.6, which provides ftp and telnet
binaries (among others):

> 11.7 The ‘.netrc’ file

> The ‘.netrc’ file contains login and initialization information used
> by the auto-login process.  It generally resides in the user's home
> directory, but a location outside of the home directory can be set
> using the environment variable ‘NETRC’.  Both locations are overridden
> by the command line option ‘-N’.  The selected file must be a regular
> file, or access will be denied.

It seems that the file is intended to be created manually (just like
~/.ssh/config), as it is not mentioned in mpv(1).  mpv supports using
yt-dlp and ~/.netrc is mentined in yt-dlp(1), though it does not look
like it would create the file either.

Note also that this entry is not present in any other profile (including
the ones that allow ~/.netrc).

Related commits:

* 5d741795c ("Use whitelisting for video players (#3472)", 2020-08-15)
* 8bf892d67 ("Fix missing mkfile in
  5d741795c3bb2060730e282a8f512b999418e098", 2020-08-16)

This is a follow-up to #6732.
