### PR TITLE
profiles: curl: allow ~/.netrc

### DIFF
--- a/etc/profile-a-l/curl.profile
+++ b/etc/profile-a-l/curl.profile
@@ -15,6 +15,7 @@ noblacklist ${HOME}/.config/curlrc # since curl 7.73.0
 # and 'noblacklist /path/to/curl/hsts/file' to curl.local to keep the sandbox logic intact.
 noblacklist ${HOME}/.curl-hsts
 noblacklist ${HOME}/.curlrc
+noblacklist ${HOME}/.netrc
 
 blacklist ${RUNUSER}
 


### PR DESCRIPTION
From curl(1):

> -n, --netrc
>        Make curl scan the .netrc file in the user's home directory for
>        login name and password. This is typically used for FTP on
>        Unix.  If used with HTTP, curl enables user authentication. See
>        netrc(5) and ftp(1) for details on the file format. curl does
>        not complain if that file does not have the right permissions
>        (it should be neither world- nor group-readable). The
>        environment variable "HOME" is used to find the home directory.

Environment: curl 8.13.0-2 on Artix Linux.

This is a follow-up to #6735.