### PR TITLE
build: replace _SYSCONFDIR_ with @sysconfdir@

### DIFF
--- a/src/bash_completion/Makefile
+++ b/src/bash_completion/Makefile
@@ -10,7 +10,7 @@ all: firejail.bash_completion
 
 firejail.bash_completion: firejail.bash_completion.in $(ROOT)/config.mk
 	$(GAWK) -f ../man/preproc.awk -- $(MANFLAGS) < $< > $@.tmp
-	sed "s|_SYSCONFDIR_|$(sysconfdir)|" < $@.tmp > $@
+	sed "s|@sysconfdir@|$(sysconfdir)|" < $@.tmp > $@
 	$(RM) $@.tmp
 
 .PHONY: clean

--- a/src/bash_completion/firejail.bash_completion.in
+++ b/src/bash_completion/firejail.bash_completion.in
@@ -15,7 +15,7 @@ _profiles() {
     fi
 }
 _all_profiles() {
-    local sys_profiles=$(_profiles _SYSCONFDIR_/firejail)
+    local sys_profiles=$(_profiles @sysconfdir@/firejail)
     local user_profiles=$(_profiles $HOME/.config/firejail)
     COMPREPLY=($(compgen -W "${sys_profiles} ${user_profiles}" -- "$cur"))
 }

--- a/src/zsh_completion/Makefile
+++ b/src/zsh_completion/Makefile
@@ -10,7 +10,7 @@ all: _firejail
 
 _firejail: _firejail.in $(ROOT)/config.mk
 	$(GAWK) -f ../man/preproc.awk -- $(MANFLAGS) < $< > $@.tmp
-	sed "s|_SYSCONFDIR_|$(sysconfdir)|" < $@.tmp > $@
+	sed "s|@sysconfdir@|$(sysconfdir)|" < $@.tmp > $@
 	$(RM) $@.tmp
 
 .PHONY: clean

--- a/src/zsh_completion/_firejail.in
+++ b/src/zsh_completion/_firejail.in
@@ -26,7 +26,7 @@ _profiles_with_ext() {
 }
 
 _all_profiles() {
-    _values 'profiles' $(_profiles _SYSCONFDIR_/firejail) $(_profiles $HOME/.config/firejail) $(_profiles_with_ext .)
+    _values 'profiles' $(_profiles @sysconfdir@/firejail) $(_profiles $HOME/.config/firejail) $(_profiles_with_ext .)
 }
 
 _session_bus_names() {


### PR DESCRIPTION
For consistency, use the conventional autoconf variable name (see also
config.mk.in).

Commands used to search and replace:

    $ git grep -Ilz '_SYSCONFDIR_' | xargs -0 \
      perl -pi -e 's/_SYSCONFDIR_/\@sysconfdir\@/'

Added on commit a37ffc337 ("Add first version of zsh completion",
2021-01-02) / PR #3864.