### PR TITLE
profiles: discord-common: add env to private-bin

### DIFF
--- a/etc/profile-a-l/discord-common.profile
+++ b/etc/profile-a-l/discord-common.profile
@@ -15,7 +15,7 @@ ignore novideo
 whitelist ${HOME}/.config/BetterDiscord
 whitelist ${HOME}/.local/share/betterdiscordctl
 
-private-bin awk,bash,cut,echo,egrep,electron,electron[0-9],electron[0-9][0-9],fish,grep,head,sed,sh,tclsh,tr,which,xdg-mime,xdg-open,zsh
+private-bin awk,bash,cut,echo,egrep,electron,electron[0-9],electron[0-9][0-9],env,fish,grep,head,sed,sh,tclsh,tr,which,xdg-mime,xdg-open,zsh
 private-etc @tls-ca
 
 # allow D-Bus notifications


### PR DESCRIPTION
The discord wrapper script in gentoo runs `#!/usr/bin/env bash`.

See https://github.com/gentoo/gentoo/blob/master/net-im/discord/files/launcher.sh