### PR TITLE
New profile: elixir

### DIFF
--- a/etc/profile-a-l/elixir-common.inc
+++ b/etc/profile-a-l/elixir-common.inc
@@ -1,0 +1,52 @@
+
+blacklist ${RUNUSER}
+
+ignore read-only ${HOME}/.mix
+
+noblacklist ${HOME}/.mix
+mkdir ${HOME}/.mix
+#whitelist ${HOME}/.mix
+
+include allow-bin-sh.inc
+
+include disable-common.inc
+include disable-exec.inc
+include disable-programs.inc
+include disable-shell.inc
+include disable-x11.inc
+include disable-xdg.inc
+
+include whitelist-runuser-common.inc
+include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
+
+caps.drop all
+ipc-namespace
+machine-id
+netfilter
+no3d
+nodvd
+nogroups
+noinput
+nonewprivs
+noprinters
+noroot
+nosound
+notv
+nou2f
+novideo
+protocol unix,inet,inet6,netlink
+seccomp
+seccomp.block-secondary
+
+disable-mnt
+private-dev
+private-etc @tls-ca,@x11,host.conf,mime.types,rpc,services
+private-tmp
+
+dbus-user none
+dbus-system none
+
+restrict-namespaces
+
+#memory-deny-write-execute # breaks JIT

--- a/etc/profile-a-l/elixir.profile
+++ b/etc/profile-a-l/elixir.profile
@@ -9,60 +9,12 @@ include globals.local
 
 # Note: mix and most other tools are shell scripts
 # using the `#!/usr/bin/env elixir` shebang.
+# yet, mix will download some binaries even if they are available,
+# unless you opt out via the env vars bellow.
 # NOTE: EXCEPT `iex` is also a shell script but it will
 #       invoke elixir from deep paths, so it IS NOT covered!!!
 
-blacklist ${RUNUSER}
+# opt-out of downloading binaries, if your dist provides them
+#env MIX_REBAR3=/usr/bin/rebar3
 
-ignore read-only ${HOME}/.mix
-
-noblacklist ${HOME}/.mix
-mkdir ${HOME}/.mix
-#whitelist ${HOME}/.mix
-
-include allow-bin-sh.inc
-
-include disable-common.inc
-include disable-exec.inc
-include disable-programs.inc
-include disable-shell.inc
-include disable-x11.inc
-include disable-xdg.inc
-
-#whitelist /usr/share/doc/node
-#whitelist /usr/share/nvm
-#whitelist /usr/share/systemtap/tapset/node.stp
-include whitelist-runuser-common.inc
-include whitelist-usr-share-common.inc
-include whitelist-var-common.inc
-
-caps.drop all
-ipc-namespace
-machine-id
-netfilter
-no3d
-nodvd
-nogroups
-noinput
-nonewprivs
-noprinters
-noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix,inet,inet6,netlink
-seccomp
-seccomp.block-secondary
-
-disable-mnt
-private-dev
-private-etc @tls-ca,@x11,host.conf,mime.types,rpc,services
-private-tmp
-
-dbus-user none
-dbus-system none
-
-restrict-namespaces
-
-#memory-deny-write-execute # breaks JIT
+include elixir-common.inc

--- a/etc/profile-a-l/elixir.profile
+++ b/etc/profile-a-l/elixir.profile
@@ -1,0 +1,68 @@
+# Firejail profile for elixir
+# Description: Elixir-lang
+quiet
+# This file is overwritten after every install/update
+# Persistent local customizations
+include elixir.local
+# Persistent global definitions
+include globals.local
+
+# Note: mix and most other tools are shell scripts
+# using the `#!/usr/bin/env elixir` shebang.
+# NOTE: EXCEPT `iex` is also a shell script but it will
+#       invoke elixir from deep paths, so it IS NOT covered!!!
+
+blacklist ${RUNUSER}
+
+ignore read-only ${HOME}/.mix
+
+noblacklist ${HOME}/.mix
+mkdir ${HOME}/.mix
+#whitelist ${HOME}/.mix
+
+include allow-bin-sh.inc
+
+include disable-common.inc
+include disable-exec.inc
+include disable-programs.inc
+include disable-shell.inc
+include disable-x11.inc
+include disable-xdg.inc
+
+#whitelist /usr/share/doc/node
+#whitelist /usr/share/nvm
+#whitelist /usr/share/systemtap/tapset/node.stp
+include whitelist-runuser-common.inc
+include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
+
+caps.drop all
+ipc-namespace
+machine-id
+netfilter
+no3d
+nodvd
+nogroups
+noinput
+nonewprivs
+noprinters
+noroot
+nosound
+notv
+nou2f
+novideo
+protocol unix,inet,inet6,netlink
+seccomp
+seccomp.block-secondary
+
+disable-mnt
+private-dev
+private-etc @tls-ca,@x11,host.conf,mime.types,rpc,services
+private-tmp
+
+dbus-user none
+dbus-system none
+
+restrict-namespaces
+
+#memory-deny-write-execute # breaks JIT

--- a/etc/profile-a-l/iex.profile
+++ b/etc/profile-a-l/iex.profile
@@ -1,0 +1,14 @@
+# Firejail profile for iex
+# Description: Elixir-lang interactive repl
+quiet
+# This file is overwritten after every install/update
+# Persistent local customizations
+include iex.local
+# Persistent global definitions
+include globals.local
+
+# iex is just a shell script that fork into elixir, but it will
+# always use full path, bypassing firejail unless itself
+# is already jailed.
+
+include elixir-common.inc

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -443,6 +443,7 @@ iceweasel
 idea
 idea.sh
 ideaIC
+iex
 imagej
 img2txt
 impressive

--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -244,6 +244,7 @@ electron-mail
 electrum
 element-desktop
 elinks
+elixir
 empathy
 enchant
 enchant-2


### PR DESCRIPTION
`elixir`/`mix` profile.

`iex` escapes it, should annoy upstream to use paths correctly i guess.

Relates to:

* #6726