### PR TITLE
profiles: firecfg: disable checksum programs

### DIFF
--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -88,8 +88,8 @@ avidemux3_jobs_qt5
 avidemux3_qt5
 aweather
 axel
-b2sum
-b3sum
+#b2sum # breaks with too many arguments (see #4633)
+#b3sum # breaks with too many arguments (see #4633)
 ballbuster
 baloo_file
 baloo_filemetadata_temp_extractor
@@ -156,7 +156,7 @@ chromium-freeworld
 cin
 cinelerra
 cinelerra-gg
-cksum
+#cksum # breaks with too many arguments (see #4633)
 clac
 clamdscan
 clamdtop
@@ -571,7 +571,7 @@ matrix-mirage
 mattermost-desktop
 mcabber
 mcomix
-md5sum
+#md5sum # breaks with too many arguments (see #4633)
 mediainfo
 mediathekview
 megaglest
@@ -809,11 +809,11 @@ secret-tool
 session-desktop
 session-messenger
 session-messenger-desktop
-sha1sum
-sha224sum
-sha256sum
-sha384sum
-sha512sum
+#sha1sum # breaks with too many arguments (see #4633)
+#sha224sum # breaks with too many arguments (see #4633)
+#sha256sum # breaks with too many arguments (see #4633)
+#sha384sum # breaks with too many arguments (see #4633)
+#sha512sum # breaks with too many arguments (see #4633)
 shellcheck
 shortwave
 shotcut


### PR DESCRIPTION
As reported by @hlein[1]:

> A number of packages can't compile on Gentoo when various `*sum` tools
> are firejailed; they'll die like:
>
>     ...
>     -- Installing: /var/tmp/portage/dev-libs/protobuf-30.2/image/usr/lib64/cmake/protobuf/protobuf-options.cmake
>     Error: too many arguments: argc (166) >= MAX_ARGS (128)
>      * ERROR: dev-libs/protobuf-30.2::gentoo failed (install phase):
>     ...
>      * The specific snippet of code:
>      *       cksum=$(_multilib_header_cksum) || die;
>
> Same for various others.
>
> `_multilib_header_cksum` is defined in `eclass/multilib-build.eclass`
> and it does a `find ... -exec chksum {} +` - behaves similar to `xargs`.
> `chksum` is wrapped by `firecfg` by default.
>
> So this points out anything that uses `find ... -exec ... {} +` or
> `xargs` and runs a firejail'ed process is prone to failure. When bulding
> a couple hundred packages, these all failed this way:
>
>     # find /var/tmp/portage/ -name build.log | xargs egrep -l MAX_ARGS |
>       cut -d/ -f5,6 | uniq
>     dev-libs/icu-77.1
>     dev-libs/boost-1.88.0-r1
>     dev-libs/protobuf-30.2
>     media-video/ffmpeg-7.1.1-r1
>     app-crypt/rpm-sequoia-1.8.0
>     media-libs/opencv-4.11.0
>     app-misc/binwalk-3.1.0-r1
>     llvm-core/clang-19.1.7
>     llvm-core/llvm-20.1.5
>     x11-libs/wxGTK-3.2.8
>
> The largest of which being:
>
>     # find /var/tmp/portage/ -name build.log | xargs egrep MAX_ARGS |
>       cut -d\( -f2 | cut -d\) -f1 | sort -rn | head -n1
>     1438

Command used to search and replace:

    $ perl -pi -e 's/^[^#]+sum/#$& # breaks with too many arguments (see #4633)/' \
      src/firecfg/firecfg.config

Related commits:

* f7e232c1b ("Add profile for checksum tools", 2021-03-08) /
  PR #4069
* 713249c98 ("sha256sum: add nvm support comment", 2022-03-20) /
  PR #5058
* 7176e6324 ("private-etc: libreoffice, audacity, forzen-bubble,
  transmission, md5sum/sha512sum, more sysutils testing, fix
  electron-hardened.inc.profile", 2023-02-08)
* 028d236b8 ("profiles: firecfg: fix sha384sum & add b2sum/cksum
  (#6578)", 2024-12-26)
* afce4679b ("New profile: b3sum (blake3) (#6577)", 2024-12-26)

Relates to #4633.

[1] https://github.com/netblue30/firejail/issues/4633#issuecomment-2889232775

Reported-by: @hlein