### PR TITLE
profiles: centralize nvm allow line (archivers/hashers)

### DIFF
--- a/etc/profile-a-l/archiver-common.profile
+++ b/etc/profile-a-l/archiver-common.profile
@@ -4,6 +4,9 @@ include archiver-common.local
 
 # common profile for archiver/compression tools
 
+# If you use nvm, add the following to archiver-common.local:
+#noblacklist ${HOME}/.nvm
+
 blacklist ${RUNUSER}
 
 # Comment/uncomment the relevant include file(s) in your archiver-common.local

--- a/etc/profile-a-l/hasher-common.profile
+++ b/etc/profile-a-l/hasher-common.profile
@@ -4,6 +4,9 @@ include hasher-common.local
 
 # common profile for hasher/checksum tools
 
+# If you use nvm, add the following to hasher-common.local:
+#noblacklist ${HOME}/.nvm
+
 blacklist ${RUNUSER}
 
 # Comment/uncomment the relevant include file(s) in your hasher-common.local

--- a/etc/profile-m-z/sha256sum.profile
+++ b/etc/profile-m-z/sha256sum.profile
@@ -7,9 +7,6 @@ include sha256sum.local
 # Persistent global definitions
 include globals.local
 
-# If you use nvm, add the below lines to your sha256sum.local
-#noblacklist ${HOME}/.nvm
-
 private-bin sha256sum
 
 # Redirect

--- a/etc/profile-m-z/tar.profile
+++ b/etc/profile-m-z/tar.profile
@@ -7,9 +7,6 @@ include tar.local
 # Persistent global definitions
 include globals.local
 
-# If you use nvm, add the below lines to your tar.local
-#noblacklist ${HOME}/.nvm
-
 # Included in archiver-common.profile
 ignore include disable-shell.inc
 


### PR DESCRIPTION
For simplicity and to avoid having to update the profiles if nvm changes
which archiver/hasher it uses, move the entry from a specific
archiver/hasher into archiver-common and hasher-common.

Related commits:

* 713249c98 ("sha256sum: add nvm support comment", 2022-03-20) /
  PR #5058
* d96cf4c8c ("tar: add nvm support comment", 2022-03-20) /
  PR #5058