### PR TITLE
profiles: rssguard: allow lua

### DIFF
--- a/etc/profile-m-z/rssguard.profile
+++ b/etc/profile-m-z/rssguard.profile
@@ -8,6 +8,9 @@ include globals.local
 
 noblacklist ${HOME}/.config/RSS Guard 4
 
+# Allow lua (blacklisted by disable-interpreters.inc)
+include allow-lua.inc
+
 # Allow nodejs (blacklisted by disable-interpreters.inc)
 include allow-nodejs.inc
 


### PR DESCRIPTION
Error log[1]:

    $ firejail rssguard
    Reading profile /etc/firejail/rssguard.profile
    [...]
    rssguard: error while loading shared libraries: libluajit-5.1.so.2: cannot open shared object file: Permission denied

Fixes #6758.

[1] https://github.com/netblue30/firejail/issues/6758#issue-3088510624

Reported-by: @1eof
