### PR TITLE
profiles: wine: allow python to fix Epic Games Launcher

### DIFF
--- a/etc/profile-m-z/wine.profile
+++ b/etc/profile-m-z/wine.profile
@@ -15,6 +15,10 @@ noblacklist ${HOME}/.steam
 noblacklist ${HOME}/.wine
 noblacklist /tmp/.wine-*
 
+# Allow python (blacklisted by disable-interpreters.inc)
+include allow-python2.inc
+include allow-python3.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-interpreters.inc


### PR DESCRIPTION

As reported by @kolAflash[1]:

> ### Description
>
> If `~/.cache/gstreamer-1.0/` is empty, `/usr/lib/python3*` is needed
> to initialize it.
>
> Wine needs gstreamer for example in the case of
> EpicGamesLauncherInstaller.msi[2] (2025-05-29).
>
> ### Steps to Reproduce
>
> 1. Copy `EpicInstaller-18.5.0.msi` to `~/.wine/drive_c/`.
> 2. Run:
>
>     firejail --profile=wine --whitelist="${HOME}"/.wine \
>       wine msiexec /i 'C:\\EpicInstaller-18.5.0.msi' /q
>
>     firejail --profile=wine --whitelist="${HOME}"/.wine \
>       wine 'C:\\Program Files (x86)\\Epic Games\\Launcher\\Portal\\Binaries\\Win32\\EpicGamesLauncher.exe'
>
> ### Expected behavior
>
> Epic Games Launcher login screen should show up.
>
> ### Actual behavior
>
> Epic Games Launcher is stuck loading the login screen.
>
> ### Additional context
>
> Workaround: Add `--noblacklist=/usr/lib/python3*`.

> - Name/version of the relevant program(s)/package(s):
> `gstreamer-1.26.1` by Debian-13, Wine-Devel-10.8 from
> https://gitlab.winehq.org/wine/wine/-/wikis/Debian-Ubuntu

Note: Python is already allowed on lutris.profile and steam.profile.

Fixes #6762.

[1] https://github.com/netblue30/firejail/issues/6762#issue-3101581116
[2] https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/installer/download/EpicGamesLauncherInstaller.msi

Reported-by: @kolAflash
Suggested-by: @kolAflash