### PR TITLE
profiles: chafa: quiet output

### DIFF
--- a/etc/profile-a-l/chafa.profile
+++ b/etc/profile-a-l/chafa.profile
@@ -1,6 +1,7 @@
 # Firejail profile for chafa
 # Description: A terminal-based image viewer and image-to-text converter.
 # This file is overwritten after every install/update
+quiet
 # Persistent local customizations
 include chafa.local
 # Persistent global definitions


### PR DESCRIPTION
When using chafa as an image viewer for other apps, it litters the
output with firejail (debug/output) messages.

Use `quiet` so that the image is displayed cleanly.
