### PR TITLE
profiles: ripperx/sound-juicer: fix profile name typos

### DIFF
--- a/etc/profile-m-z/ripperx.profile
+++ b/etc/profile-m-z/ripperx.profile
@@ -1,4 +1,4 @@
-# Firejail profile for mpv
+# Firejail profile for ripperx
 # Description: Graphical audio CD ripper and encoder
 # This file is overwritten after every install/update
 # Persistent local customizations

--- a/etc/profile-m-z/sound-juicer.profile
+++ b/etc/profile-m-z/sound-juicer.profile
@@ -1,4 +1,4 @@
-# Firejail profile for mpv
+# Firejail profile for sound-juicer
 # Description: Graphical audio CD ripper and encoder
 # This file is overwritten after every install/update
 # Persistent local customizations


### PR DESCRIPTION
They are currently named as "mpv".

This amends commit 5dbdf657b ("new profiles: ripperx, sound-juicer",
2020-03-19).

Misc: This was noticed on #6779.