### PR TITLE
profiles: mpv: add private-etc

### DIFF
--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -91,7 +91,7 @@ private-bin env,mpv,python*,waf,youtube-dl,yt-dlp
 # private-cache causes slow OSD, see #2838
 #private-cache
 private-dev
-private-etc @sound,ca-certificates,drirc,gnutls,igfx_user_feature.txt,igfx_user_feature_next.txt,libva.conf,mpv,pkcs11,ssl,vdpau_wrapper.cfg,vulkan,xdg,xkb,yt-dlp,yt-dlp-plugins,yt-dlp.conf
+private-etc @sound,@tls_ca,@x11,igfx_user_feature.txt,igfx_user_feature_next.txt,libva.conf,mpv,pkcs11,vdpau_wrapper.cfg,xkb,yt-dlp,yt-dlp-plugins,yt-dlp.conf
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -91,6 +91,7 @@ private-bin env,mpv,python*,waf,youtube-dl,yt-dlp
 # private-cache causes slow OSD, see #2838
 #private-cache
 private-dev
+private-etc alsa,asound.conf,ca-certificates,drirc,fonts,gnutls,igfx_user_feature.txt,igfx_user_feature_next.txt,libva.conf,login.defs,machine-id,mpv,pipewire,pkcs11,pulse,ssl,vdpau_wrapper.cfg,vulkan,xdg,xkb,yt-dlp,yt-dlp-plugins,yt-dlp.conf
 
 dbus-user none
 dbus-system none

--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -91,7 +91,7 @@ private-bin env,mpv,python*,waf,youtube-dl,yt-dlp
 # private-cache causes slow OSD, see #2838
 #private-cache
 private-dev
-private-etc alsa,asound.conf,ca-certificates,drirc,fonts,gnutls,igfx_user_feature.txt,igfx_user_feature_next.txt,libva.conf,login.defs,machine-id,mpv,pipewire,pkcs11,pulse,ssl,vdpau_wrapper.cfg,vulkan,xdg,xkb,yt-dlp,yt-dlp-plugins,yt-dlp.conf
+private-etc @sound,ca-certificates,drirc,gnutls,igfx_user_feature.txt,igfx_user_feature_next.txt,libva.conf,mpv,pkcs11,ssl,vdpau_wrapper.cfg,vulkan,xdg,xkb,yt-dlp,yt-dlp-plugins,yt-dlp.conf
 
 dbus-user none
 dbus-system none


### PR DESCRIPTION
add private-etc for mpv

Please verify is all functions are working and none are broken.

Also test hardware acceleration for various GPUs.

Let me know if i need to trim private-etc for other profiles which `include mpv.profile` such that they do not overlap.

Related: #6779
