### PR TITLE
profiles: use private-etc groups in more profiles

### DIFF
--- a/etc/profile-a-l/ani-cli.profile
+++ b/etc/profile-a-l/ani-cli.profile
@@ -33,7 +33,7 @@ notv
 disable-mnt
 private-bin ani-cli,aria2c,cat,cp,curl,cut,ffmpeg,fzf,grep,head,mkdir,mktemp,mv,nl,nohup,patch,printf,rm,rofi,sed,sh,sort,tail,tput,tr,uname,wc
 #private-cache
-private-etc X11,alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,mpv,nsswitch.conf,pango,pki,protocols,pulse,resolv.conf,rpc,services,ssl,xdg
+private-etc @network,@sound,@tls-ca,@x11,host.conf,mime.types,mpv,rpc,services
 private-tmp
 
 # Redirect

--- a/etc/profile-a-l/fluffychat.profile
+++ b/etc/profile-a-l/fluffychat.profile
@@ -59,7 +59,7 @@ disable-mnt
 private-bin firefox,fluffychat,sh,which,zenity
 private-cache
 private-dev
-private-etc X11,alsa,alternatives,asound.conf,ca-certificates,crypto-policies,dconf,fonts,gconf,gtk-3.0,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,pango,pki,protocols,pulse,resolv.conf,rpc,services,ssl,xdg
+private-etc @network,@sound,@tls-ca,@x11,gconf,host.conf,mime.types,rpc,services
 private-tmp
 
 dbus-user filter

--- a/etc/profile-a-l/lobster.profile
+++ b/etc/profile-a-l/lobster.profile
@@ -44,7 +44,7 @@ notv
 disable-mnt
 private-bin base64,basename,bash,cat,curl,cut,date,dirname,echo,ffmpeg,ffprobe,find,fzf,grep,head,hxunent,ln,lobster,ls,mkdir,mkfifo,nano,nohup,openssl,patch,pgrep,ps,rm,rofi,sed,sh,sleep,socat,tail,tee,tput,tr,ueberzugpp,uname,uuidgen,vim,wc
 #private-cache
-private-etc X11,alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,mime.types,nsswitch.conf,pango,pki,protocols,pulse,resolv.conf,rpc,services,ssl,xdg
+private-etc @network,@sound,@tls-ca,@x11,host.conf,mime.types,rpc,services
 private-tmp
 
 # Redirect

--- a/etc/profile-m-z/mov-cli.profile
+++ b/etc/profile-m-z/mov-cli.profile
@@ -31,7 +31,7 @@ notv
 disable-mnt
 private-bin fzf,mov-cli,nano,sh,uname
 #private-cache
-private-etc X11,alsa,alternatives,asound.conf,ca-certificates,crypto-policies,fonts,group,host.conf,hostname,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,machine-id,magic,magic.mgc,mime.types,nanorc,nsswitch.conf,pango,passwd,pki,protocols,pulse,resolv.conf,rpc,services,ssl,xdg
+private-etc @network,@sound,@tls-ca,@x11,host.conf,magic,magic.mgc,mime.types,nanorc,rpc,services
 private-tmp
 
 # Redirect

--- a/etc/profile-m-z/postman.profile
+++ b/etc/profile-m-z/postman.profile
@@ -18,7 +18,7 @@ include whitelist-run-common.inc
 protocol unix,inet,inet6,netlink
 
 private-bin Postman,electron,electron[0-9],electron[0-9][0-9],locale,node,postman,sh
-private-etc alternatives,ca-certificates,crypto-policies,fonts,hosts,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,localtime,nsswitch.conf,pki,resolv.conf,ssl
+private-etc @network,@tls-ca
 # private-opt breaks file-copy-limit, use a whitelist instead of draining RAM
 # https://github.com/netblue30/firejail/discussions/5307
 #private-opt postman


### PR DESCRIPTION
For simplicity and to make diffs more readable.

Use them in the remaining profiles that have `private-etc` enabled but
are not currently using private-etc groups.

Note: All of the profiles in question were created between 0.9.72 and
0.9.74 (which is when private-etc groups were introduced).

Command used to search for relevant profiles:

    $ git grep '^private-etc .*alternatives' -- etc

Misc: The changes were made somewhat manually.

This is a follow-up to #6779.

Relates to #5691 #5706 #5707 #5710 #6007 #6400.