### PR TITLE
profiles: firecfg: disable foliate

### DIFF
--- a/src/firecfg/firecfg.config
+++ b/src/firecfg/firecfg.config
@@ -181,7 +181,7 @@ cola
 colorful
 com.github.bleakgrey.tootle
 com.github.dahenson.agenda
-com.github.johnfactotum.Foliate
+#com.github.johnfactotum.Foliate # webkit2gtk-4.x requires bwrap (see #3647)
 com.github.phase1geo.minder
 com.github.tchx84.Flatseal
 com.gitlab.newsflash
@@ -293,7 +293,7 @@ flashpeak-slimjet
 floorp
 flowblade
 fluffychat
-foliate
+#foliate # webkit2gtk-4.x requires bwrap (see #3647)
 font-manager
 fontforge
 fossamail


### PR DESCRIPTION
It seems unable to open ebooks on Arch (even with `--noprofile` and
`--profile=noprofile`), likely due due to webkitgtk / bwrap.

Error log[1]:

    $ firejail --profile=noprofile /usr/bin/foliate
    Reading profile /etc/firejail/noprofile.profile
    firejail version 0.9.74

    Parent pid 16189, child pid 16190
    Warning: cannot open source file /usr/lib/firejail/seccomp.debug32, file not copied
    Base filesystem installed in 0.01 ms
    Child process initialized in 12.32 ms
    MESA-INTEL: warning: ../mesa-25.1.3/src/intel/vulkan_hasvk/anv_formats.c:759: FINISHME: support YUV colorspace with DRM format modifiers
    MESA-INTEL: warning: ../mesa-25.1.3/src/intel/vulkan_hasvk/anv_formats.c:790: FINISHME: support more multi-planar formats with DRM modifiers
    bwrap: Can't mount proc on /newroot/proc: Operation not permitted

    ** (com.github.johnfactotum.Foliate:3): ERROR **: 23:16:32.030: Failed to fully launch dbus-proxy: Child process exited with code 1

Relates to #3647 #6782.

[1] https://github.com/netblue30/firejail/issues/6782#issuecomment-2982568811

Reported-by: @rsramkis