### PR TITLE
profiles: finish converting private-opt to whitelist

### DIFF
--- a/etc/profile-a-l/basilisk.profile
+++ b/etc/profile-a-l/basilisk.profile
@@ -12,6 +12,7 @@ mkdir ${HOME}/.cache/moonchild productions/basilisk
 mkdir ${HOME}/.moonchild productions
 whitelist ${HOME}/.cache/moonchild productions/basilisk
 whitelist ${HOME}/.moonchild productions
+whitelist /opt/basilisk
 whitelist /usr/share/basilisk
 
 # Basilisk can use the full firejail seccomp filter (unlike firefox >= 60)
@@ -20,7 +21,6 @@ ignore seccomp
 
 #private-bin basilisk
 private-etc basilisk
-#private-opt basilisk
 
 restrict-namespaces
 ignore restrict-namespaces

--- a/etc/profile-a-l/enpass.profile
+++ b/etc/profile-a-l/enpass.profile
@@ -28,6 +28,7 @@ whitelist ${HOME}/.config/sinew.in
 whitelist ${HOME}/.config/Sinew Software Systems
 whitelist ${HOME}/.local/share/Enpass
 whitelist ${DOCUMENTS}
+whitelist /opt/Enpass
 include whitelist-common.inc
 include whitelist-var-common.inc
 
@@ -55,7 +56,6 @@ tracelog
 private-bin Enpass,dirname,importer_enpass,readlink,sh
 ?HAS_APPIMAGE: ignore private-dev
 private-dev
-private-opt Enpass
 private-tmp
 
 #memory-deny-write-execute # breaks on Arch (see issue #1803)

--- a/etc/profile-m-z/mate-dictionary.profile
+++ b/etc/profile-m-z/mate-dictionary.profile
@@ -16,6 +16,7 @@ include disable-shell.inc
 
 mkdir ${HOME}/.config/mate/mate-dictionary
 whitelist ${HOME}/.config/mate/mate-dictionary
+whitelist /opt/mate-dictionary
 include whitelist-common.inc
 
 apparmor
@@ -37,7 +38,6 @@ seccomp
 disable-mnt
 private-bin mate-dictionary
 private-etc @tls-ca
-private-opt mate-dictionary
 private-dev
 private-tmp
 

--- a/etc/profile-m-z/microsoft-edge-dev.profile
+++ b/etc/profile-m-z/microsoft-edge-dev.profile
@@ -14,10 +14,7 @@ mkdir ${HOME}/.cache/microsoft-edge-dev
 mkdir ${HOME}/.config/microsoft-edge-dev
 whitelist ${HOME}/.cache/microsoft-edge-dev
 whitelist ${HOME}/.config/microsoft-edge-dev
-
 whitelist /opt/microsoft/msedge-dev
-# private-opt might break file-copy-limit, see #5307
-#private-opt microsoft
 
 # Redirect
 include chromium-common.profile

--- a/etc/profile-m-z/microsoft-edge.profile
+++ b/etc/profile-m-z/microsoft-edge.profile
@@ -14,10 +14,7 @@ mkdir ${HOME}/.cache/microsoft-edge
 mkdir ${HOME}/.config/microsoft-edge
 whitelist ${HOME}/.cache/microsoft-edge
 whitelist ${HOME}/.config/microsoft-edge
-
 whitelist /opt/microsoft/msedge
-# private-opt might break default file-copy-limit, see #5307
-#private-opt microsoft
 
 # Redirect
 include chromium-common.profile

--- a/etc/profile-m-z/minecraft-launcher.profile
+++ b/etc/profile-m-z/minecraft-launcher.profile
@@ -27,6 +27,7 @@ mkdir ${HOME}/.minecraft
 whitelist ${HOME}/.minecraft
 # Needs keyring access in order to save logins
 whitelist ${RUNUSER}/keyring
+whitelist /opt/minecraft-launcher
 include whitelist-common.inc
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
@@ -53,7 +54,6 @@ private-dev
 # If multiplayer or realms break, add 'private-etc <your-own-java-folder-from-/etc>'
 # or 'ignore private-etc' to your minecraft-launcher.local.
 private-etc @tls-ca,@x11,host.conf,java*,mime.types,services,timezone
-private-opt minecraft-launcher
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/postman.profile
+++ b/etc/profile-m-z/postman.profile
@@ -13,16 +13,13 @@ mkdir ${HOME}/.config/Postman
 mkdir ${HOME}/Postman
 whitelist ${HOME}/.config/Postman
 whitelist ${HOME}/Postman
+whitelist /opt/postman
 include whitelist-run-common.inc
 
 protocol unix,inet,inet6,netlink
 
 private-bin Postman,electron,electron[0-9],electron[0-9][0-9],locale,node,postman,sh
 private-etc @network,@tls-ca
-# private-opt breaks file-copy-limit, use a whitelist instead of draining RAM
-# https://github.com/netblue30/firejail/discussions/5307
-#private-opt postman
-whitelist /opt/postman
 
 # Redirect
 include electron-common.profile

--- a/etc/profile-m-z/ppsspp.profile
+++ b/etc/profile-m-z/ppsspp.profile
@@ -20,6 +20,7 @@ include disable-xdg.inc
 
 mkdir ${HOME}/.config/ppsspp
 whitelist ${HOME}/.config/ppsspp
+whitelist /opt/ppsspp
 whitelist /usr/share/ppsspp
 include whitelist-common.inc
 include whitelist-runuser-common.inc
@@ -43,7 +44,6 @@ private-bin PPSSPP,PPSSPPQt,PPSSPPSDL,ppsspp
 # Add the next line to your ppsspp.local if you do not need controller support.
 #private-dev
 private-etc @tls-ca,@x11,host.conf
-private-opt ppsspp
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/tidal-hifi.profile
+++ b/etc/profile-m-z/tidal-hifi.profile
@@ -14,6 +14,7 @@ include disable-proc.inc
 include disable-shell.inc
 
 whitelist ${HOME}/.config/tidal-hifi
+whitelist /opt/tidal-hifi
 
 caps.drop all
 no3d
@@ -27,7 +28,6 @@ tracelog
 
 private-bin chrome-sandbox,tidal-hifi
 private-etc @network,@sound,@tls-ca,@xdg
-private-opt tidal-hifi
 
 ignore dbus-user none
 dbus-user filter

--- a/etc/templates/profile.template
+++ b/etc/templates/profile.template
@@ -233,12 +233,8 @@ include globals.local
 #  Qt: Trolltech.conf
 ##private-lib LIBS
 ## Note: private-opt copies the entire path(s) to RAM, which may break
-## file-copy-limit in firejail.config (see firejail(1)).
-## For sizeable apps (if in doubt, do this):
-##  - never use 'private-opt NAME'
-##  - place 'whitelist /opt/NAME' in the whitelist section above
-## For acceptable apps:
-##  - use 'private-opt NAME'
+## file-copy-limit in firejail.config (see firejail(1)), so for new profiles
+## use 'whitelist /opt/NAME' instead 'private-opt NAME'.
 ##private-opt NAME
 #private-tmp
 


### PR DESCRIPTION
Changes:

* Convert all private-opt entries (other than `private-opt none`) to
  whitelist entries
* Remove remaining commented private-opt entries and related comments
  (for profiles that also have a corresponding whitelist entry)
* Enable `whitelist /opt/basilisk` in basilisk.profile (similarly to
  mullvad-browser.profile and palemoon.profile)
* Update private-opt comment in etc/templates/profile.template

Most private-opt entries were converted into whitelist entries on commit
175905530 ("profiles: exchange private-opt with a whitelist (#6021)",
2023-10-18), while some of them were left alone due to the program size
being deemed small enough as not to break file-copy-limit in
firejail.config.

For the sake of simplicity and clarity (and to avoid potential issues
with program install sizes increasing over time), convert those
private-opt entries into whitelist entries as well (note that users can
still enable private-opt in the corresponding .local profile).

Also, some commented private-opt entries remain (with a note about
potential issues with private-opt).

Since commit 175905530 also documented the drawbacks of private-opt in
firejail.1, it should be fine to remove the commented entries and
related comments (note that in all of the profiles containing such
comments, there is already an equivalent whitelist entry).

Related commits:

* f3f739c5d ("microsoft-edge.profile: rewrite profile for stable
  channel", 2022-08-11) /
  PR #5709
* 121e043df ("microsoft-edge-{dev,beta}: replaced private-opt by
  whitelist #5307", 2022-08-11) /
  PR #5709
* 2cb40fbec ("microsoft-edge fixes (#5697)", 2023-03-14)
* 58732a654 ("Add profiles for jami and postman (#5691)", 2023-03-15)
* 175905530 ("profiles: exchange private-opt with a whitelist (#6021)",
  2023-10-18)