### PR TITLE
profiles: replace hosts.conf with host.conf in private-etc

### DIFF
--- a/etc/profile-a-l/email-common.profile
+++ b/etc/profile-a-l/email-common.profile
@@ -87,7 +87,7 @@ tracelog
 #disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca,@x11,bogofilter,bogofilter.cf,clamav,gnupg,hosts.conf,mailname,timezone
+private-etc @tls-ca,@x11,bogofilter,bogofilter.cf,clamav,gnupg,host.conf,mailname,timezone
 private-tmp
 
 dbus-user filter

--- a/etc/profile-m-z/mutt.profile
+++ b/etc/profile-m-z/mutt.profile
@@ -130,7 +130,7 @@ tracelog
 #disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gai.conf,gnupg,hosts.conf,mail,mailname,msmtprc,nntpserver,terminfo
+private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gai.conf,gnupg,host.conf,mail,mailname,msmtprc,nntpserver,terminfo
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/neomutt.profile
+++ b/etc/profile-m-z/neomutt.profile
@@ -122,7 +122,7 @@ tracelog
 #disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gnupg,hosts.conf,mail,mailname,msmtprc,neomuttrc,neomuttrc.d,nntpserver
+private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gnupg,host.conf,mail,mailname,msmtprc,neomuttrc,neomuttrc.d,nntpserver
 private-tmp
 
 dbus-user none


### PR DESCRIPTION

`hosts.conf` was added in #3849 and is only used in 3 profiles, while
all other profiles use `host.conf` (which is documented in
`host.conf(5)`):

    $ git grep -E 'private-etc .*,host\.conf(,|$| +#)' -- etc | wc -l
    64
    $ git grep -E 'private-etc .*,hosts\.conf(,|$| +#)' -- etc | wc -l
    3

Considering that and as discussed with @bbhtt (the author of #3849),
`hosts.conf` is likely a typo of `host.conf`[1].

Commands used to search and replace:

    $ git grep -IElz 'private-etc .*,hosts\.conf(,|$| +#)' -- etc |
      xargs -0 \
      perl -pi -e 's/(private-etc .*,)hosts\.conf(,|$| +#)/$1host.conf$2/'

Related commits:

* a8a8e33bc ("Add whitelisting to mutt; improve geary, new profile for
  neomutt", 2020-12-28) /
  PR #3849
* 144aee26f ("Improve whitelisting and dbus of Sylpheed and Claws-mail",
  2020-12-31) /
  PR #3849

Kind of relates to #6400.

[1] https://github.com/netblue30/firejail/pull/3849#issuecomment-3001532350