### PR TITLE
bugfix: fcopy: add /usr/share + "runner:root" exception to fix CI

### DIFF
--- a/src/fcopy/main.c
+++ b/src/fcopy/main.c
@@ -374,6 +374,16 @@ static char *check(const char *src) {
 		if (s.st_uid != user && s.st_uid != p->pw_uid)
 			goto errexit;
 	}
+	// Some system paths may be owned by "runner:root" on GitHub Actions
+	// runner images (see #6797), such as the following pointed-to path:
+	//
+	//     /etc/localtime -> /usr/share/zoneinfo/Etc/UTC
+	else if (user == 0 &&
+			(strncmp(rsrc, "/usr/share/", 11) == 0) &&
+			(strncmp(src_username, "runner", 6) == 0)) {
+		fprintf(stderr, "Warning fcopy: ignoring path for CI: %s -> %s (type=%c uid=%lu, name=%s)\n",
+		        src, rsrc, ftype, (unsigned long)src_uid, src_username);
+	}
 	else {
 		if (s.st_uid != user)
 			goto errexit;


### PR DESCRIPTION
The following CI jobs started failing since the GitHub Actions runner
image for ubuntu-22.04 was (automatically) upgraded from version
20250615.1.0[1] to 20250622.1.0[2]:

* test-fs
* test-environment
* test-network

Most/all fail with the same fcopy error message for the same path,
presumably due to using `private-etc`, as `localtime` is in the default
private-etc group (see the full log below):

    Error fcopy: invalid ownership for /etc/localtime -> /usr/share/zoneinfo/Etc/UTC (type=- uid=1001 name=runner)
    Error: failed to run /run/firejail/lib/fcopy, exiting...

In at least the newer runner image, `/usr/share/zoneinfo/Etc/UTC` is
owned by `runner:root` instead of the usual `root:root`, so add an
exception in fcopy to allow it.

From a run of the `test-fs` job for commit 1f92779d2 ("modif: improve
fcopy error messages in check() (#6801)", 2025-07-07) [3]:

    make -C test private-etc
    make[1]: Entering directory '/home/runner/work/firejail/firejail/test'
    cd private-etc && ./private-etc.sh 2>&1 | tee private-etc.log
    TESTING: private-etc (test/private-etc/private-etc.exp)
    spawn /bin/bash
    firejail --private-etc=passwd,group,resolv.conf,X11
    runner@pkrvmdyo8zrnvmk:~/work/firejail/firejail/test/private-etc$
    <firejail --private-etc=passwd,group,resolv.conf,X11
    Reading profile /etc/firejail/default.profile
    Reading profile /etc/firejail/disable-common.inc
    Reading profile /etc/firejail/disable-programs.inc
    Reading profile /etc/firejail/landlock-common.inc

    ** Note: you can use --noprofile to disable default.profile **

    firejail version 0.9.75

    Parent pid 4511, child pid 4512
    Error fcopy: invalid ownership for /etc/localtime -> /usr/share/zoneinfo/Etc/UTC (type=- uid=1001 name=runner)
    Error: failed to run /run/firejail/lib/fcopy, exiting...
    Error: proc 4511 cannot sync with peer: unexpected EOF
    Peer 4512 unexpectedly exited with status 1
    runner@pkrvmdyo8zrnvmk:~/work/firejail/firejail/test/private-etc$ TESTING ERROR 1

Fixes #6797.

Relates to #1531 #6801.

[1] https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20250615.1
[2] https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20250622.1
[3] https://github.com/netblue30/firejail/actions/runs/16122142799/job/45490345354