### PR TITLE
docs: clarify --private bug in man pages

### DIFF
--- a/src/man/firejail-profile.5.in
+++ b/src/man/firejail-profile.5.in
@@ -386,8 +386,9 @@ Use directory as user home.
 .br
 
 .br
-Bug: Even with this enabled, some commands (such as mkdir, mkfile and
-private-cache) will still operate on the original home directory.
+Bug: Even with this enabled, some firejail commands (such as \fBmkdir\fR,
+\fBmkfile\fR and \fBprivate-cache\fR) will still operate on the original home
+directory.
 Workaround: Disable the incompatible commands, such as by using "ignore mkdir"
 and "ignore mkfile".
 For details, see

--- a/src/man/firejail.1.in
+++ b/src/man/firejail.1.in
@@ -2166,8 +2166,9 @@ $ firejail \-\-private=/home/netblue/firefox-home firefox
 .br
 
 .br
-Bug: Even with this enabled, some commands (such as mkdir, mkfile and
-private-cache) will still operate on the original home directory.
+Bug: Even with this enabled, some firejail commands (such as \fBmkdir\fR,
+\fBmkfile\fR and \fBprivate-cache\fR) will still operate on the original home
+directory.
 Workaround: Disable the incompatible commands, such as by using "ignore mkdir"
 and "ignore mkfile".
 For details, see


### PR DESCRIPTION
Make it clearer that the bug affects firejail commands and not shell
commands like `mkdir(1p)` [1].

This amends commit 94368a343 ("docs: mention inconsistent homedir bug
involving --private=dir", 2022-03-14) / PR #5052.

Relates to #903.

[1] https://github.com/netblue30/firejail/issues/903#issuecomment-3044544685

Reported-by: @giddie