### PR TITLE
bugfix: fix "Not enforcing Landlock" message always being printed

### DIFF
--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -520,14 +520,15 @@ void start_application(int no_sandbox, int fd, char *set_sandbox_status) {
 	//****************************
 	// Configure Landlock
 	//****************************
-	if (arg_landlock_enforce && ll_restrict(0)) {
+	if (!arg_landlock_enforce) {
+		if (arg_debug)
+			fprintf(stderr, "Not enforcing Landlock (see landlock.enforce)\n");
+	}
+	else if (ll_restrict(0)) {
 		// It isn't safe to continue if Landlock self-restriction was
 		// enabled and the "landlock_restrict_self" syscall has failed.
 		fprintf(stderr, "Error: ll_restrict() failed, exiting...\n");
 		exit(1);
-	} else {
-		if (arg_debug)
-			fprintf(stderr, "Not enforcing Landlock\n");
 	}
 #endif
 


### PR DESCRIPTION
Even when Landlock is in fact being enforced.

Also, mention the `landlock.enforce` command in the message.

This amends commit 760f50f78 ("landlock: move commands into profile and
add landlock.enforce", 2023-11-17) / PR #6125.

Relates to #6078 #6796.

Reported-by: @osevan