### PR TITLE
docs: fix man formatting of landlock.enforce

### DIFF
--- a/src/man/firejail-profile.5.in
+++ b/src/man/firejail-profile.5.in
@@ -563,7 +563,6 @@ Whitelist given Linux capabilities.
 .TP
 \fBlandlock.enforce\fR (experimental)
 Enforce the Landlock ruleset.
-.PP
 Without it, the other Landlock commands have no effect.
 .TP
 \fBlandlock.fs.read path\fR (experimental)


### PR DESCRIPTION
Remove the `.PP` macro to avoid removing the indentation from the
preceding `.TP` in firejail-profile.5.in.

This also makes it more consistent with the description of
`landlock.enforce` in firejail.1.in.

This amends commit 760f50f78 ("landlock: move commands into profile and
add landlock.enforce", 2023-11-17) / PR #6125.

Relates to #6078.
