### PR TITLE
profiles: w3m: add xdg folders and allow x11

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -356,6 +356,7 @@ read-only ${HOME}/.config/ncmpcpp/config
 read-only ${HOME}/.config/nsxiv/exec
 read-only ${HOME}/.config/nvim
 read-only ${HOME}/.config/pkcs11
+read-only ${HOME}/.config/w3m
 read-only ${HOME}/.dotfiles
 read-only ${HOME}/.elinks
 read-only ${HOME}/.emacs
@@ -368,6 +369,7 @@ read-only ${HOME}/.iscreenrc
 read-only ${HOME}/.local/lib
 read-only ${HOME}/.local/share/cool-retro-term
 read-only ${HOME}/.local/share/nvim
+read-only ${HOME}/.local/share/w3m
 read-only ${HOME}/.local/state/nvim
 read-only ${HOME}/.mailcap
 read-only ${HOME}/.mozilla/firefox/profiles.ini

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -242,6 +242,7 @@ blacklist ${HOME}/.cache/vivaldi
 blacklist ${HOME}/.cache/vivaldi-snapshot
 blacklist ${HOME}/.cache/vlc
 blacklist ${HOME}/.cache/vmware
+blacklist ${HOME}/.cache/w3m
 blacklist ${HOME}/.cache/warsow-2.1
 blacklist ${HOME}/.cache/waterfox
 blacklist ${HOME}/.cache/wesnoth
@@ -697,6 +698,7 @@ blacklist ${HOME}/.config/viewnior
 blacklist ${HOME}/.config/vivaldi
 blacklist ${HOME}/.config/vivaldi-snapshot
 blacklist ${HOME}/.config/vlc
+blacklist ${HOME}/.config/w3m
 blacklist ${HOME}/.config/wesnoth
 blacklist ${HOME}/.config/wget
 blacklist ${HOME}/.config/wireshark
@@ -1096,6 +1098,7 @@ blacklist ${HOME}/.local/share/uzbl
 blacklist ${HOME}/.local/share/vlc
 blacklist ${HOME}/.local/share/vpltd
 blacklist ${HOME}/.local/share/vulkan
+blacklist ${HOME}/.local/share/w3m
 blacklist ${HOME}/.local/share/warsow-2.1
 blacklist ${HOME}/.local/share/warzone2100
 blacklist ${HOME}/.local/share/warzone2100-3.*

--- a/etc/profile-m-z/w3m.profile
+++ b/etc/profile-m-z/w3m.profile
@@ -12,9 +12,12 @@ include globals.local
 #ignore private-dev
 #ignore private-etc
 
+noblacklist ${HOME}/.cache/w3m
+noblacklist ${HOME}/.config/w3m
+noblacklist ${HOME}/.local/share/w3m
 noblacklist ${HOME}/.w3m
 
-blacklist ${RUNUSER}/wayland-*
+#blacklist ${RUNUSER}/wayland-*
 
 # Allow /bin/sh (blacklisted by disable-shell.inc)
 include allow-bin-sh.inc
@@ -28,12 +31,15 @@ include disable-exec.inc
 include disable-interpreters.inc
 include disable-programs.inc
 include disable-shell.inc
-include disable-x11.inc
+#include disable-x11.inc
 include disable-xdg.inc
 
 mkdir ${HOME}/.w3m
 whitelist /usr/share/w3m
 whitelist ${DOWNLOADS}
+whitelist ${HOME}/.cache/w3m
+whitelist ${HOME}/.config/w3m
+whitelist ${HOME}/.local/share/w3m
 whitelist ${HOME}/.w3m
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
@@ -68,5 +74,7 @@ dbus-user none
 dbus-system none
 
 memory-deny-write-execute
+read-write ${HOME}/.config/w3m
+read-write ${HOME}/.local/share/w3m
 read-write ${HOME}/.w3m
 restrict-namespaces


### PR DESCRIPTION
w3m has an environment variable to move the config folder and a config option to move the cache.

I'm adding, the xdg folders, because this is where typically people will move them.

EDIT: include disable-x11.inc blocks images on X