### PR TITLE
profiles: allow org.kde.kwalletd6 for Plasma 6 systems

### DIFF
--- a/etc/profile-a-l/gajim.profile
+++ b/etc/profile-a-l/gajim.profile
@@ -71,6 +71,7 @@ dbus-user.talk ca.desrt.dconf
 dbus-user.talk org.freedesktop.Notifications
 dbus-user.talk org.freedesktop.secrets
 dbus-user.talk org.kde.kwalletd5
+dbus-user.talk org.kde.kwalletd6
 dbus-user.talk org.mpris.MediaPlayer2.*
 dbus-system filter
 dbus-system.talk org.freedesktop.login1

--- a/etc/profile-m-z/neochat.profile
+++ b/etc/profile-m-z/neochat.profile
@@ -61,6 +61,7 @@ dbus-user.own org.kde.neochat
 dbus-user.talk org.freedesktop.Notifications
 ?ALLOW_TRAY: dbus-user.talk org.kde.StatusNotifierWatcher
 dbus-user.talk org.kde.kwalletd5
+dbus-user.talk org.kde.kwalletd6
 dbus-system none
 
 restrict-namespaces


### PR DESCRIPTION
This is needed for the login credentials to be saved on systems using KDE Plasma 6.
