### PR TITLE
modif: improve new network namespace error message

### DIFF
--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -1430,7 +1430,7 @@ void enter_network_namespace(pid_t pid) {
 		errExit("asprintf");
 	struct stat s;
 	if (stat(name, &s) == -1) {
-		fprintf(stderr, "Error: the sandbox doesn't use a new network namespace\n");
+		fprintf(stderr, "Error: the sandbox doesn't use a new network namespace (see --net)\n");
 		exit(1);
 	}
 	free(name);


### PR DESCRIPTION
Clarify that `--net` should be used to create a new network namespace
before using a firejail command that needs to be executed inside a
(firejail) network namespace.

Example:

    $ firejail --netfilter.print=10000
    Switching to pid 10001, the first child process inside the sandbox
    Error: the sandbox doesn't use a new network namespace (see --net)

Reported-by: @osevan

Relates to #6820.