### PR TITLE
profiles: keepassxc: add x11 group to private-etc

### DIFF
--- a/etc/profile-a-l/keepassxc.profile
+++ b/etc/profile-a-l/keepassxc.profile
@@ -95,7 +95,7 @@ private-bin keepassxc,keepassxc-cli,keepassxc-proxy
 # hardware keys) on /dev after it has already started; add "ignore private-dev"
 # to keepassxc.local if this is an issue (see #4883).
 private-dev
-private-etc
+private-etc @x11
 private-tmp
 
 dbus-user filter


### PR DESCRIPTION
It is a GUI program and without it the program does not start due to a
dbus error[1]:

    $ firejail keepassxc
    Reading profile /etc/firejail/keepassxc.profile
    [...]
    firejail version 0.9.74
    [...]
    Child process initialized in 698.63 ms
    dbus[23]: D-Bus library appears to be incorrectly set up: see the manual page for dbus-uuidgen to correct this issue. (Failed to open "/var/lib/dbus/machine-id": No such file or directory; Failed to open "/etc/machine-id": No such file or directory)
      D-Bus not built with -rdynamic so unable to print a backtrace

    Parent is shutting down, bye...

This issue is also mentioned in src/include/etc_groups.h:

    // @x11
    static char *etc_group_x11[] = {
        // [...]
        "machine-id", // QT dbus lib is crashing without it!
        // [...]
        NULL
    };

This amends commit 5d0822c52 ("private-etc: big profile changes",
2023-02-05).

Fixes #6827.

Relates to #6400.

[1] https://github.com/netblue30/firejail/issues/6827#issue-3228990975

Reported-by: @Rosika2