### PR TITLE
profiles: xreader: disable no3d to fix startup

### DIFF
--- a/etc/profile-m-z/xreader.profile
+++ b/etc/profile-m-z/xreader.profile
@@ -22,7 +22,7 @@ include disable-xdg.inc
 
 #apparmor
 caps.drop all
-no3d
+#no3d # breaks program startup on Linux Mint (see #6829)
 nodvd
 nogroups
 noinput


### PR DESCRIPTION
`xreader` fails to start on my system because of `no3d`. The error is related to `/dev/dri`:

```
$ firejail --private=Documents/ xreader
Reading profile /etc/firejail/xreader.profile
...
MESA: error: Failed to query drm device.
libEGL warning: egl: failed to create dri2 screen
libEGL warning: DRI2: could not open /dev/dri/card1 (No such file or directory)
MESA: error: ZINK: failed to choose pdev
libEGL warning: egl: failed to create dri2 screen

$ xreader --version
xreader 4.2.6
```

Removing this fixes the problem.

Running on Linux Mint 22.1.