### PR TITLE
ci: upgrade debian:buster to debian:bullseye

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ build_ubuntu_package:
         - make installcheck
 
 build_debian_package:
-    image: debian:buster
+    image: debian:bullseye
     timeout: 10 minutes
     variables:
         DEBIAN_FRONTEND: noninteractive


### PR DESCRIPTION
Instead of Debian 10, use Debian 11 in `build_debian_package`.

It currently fails to update the package index[1]:

    Executing "step_script" stage of the job script 00:01
    Using effective pull policy of [always] for container debian:buster
    Using docker image sha256:69530eaa9e7e18d0aad40c38b75a22b40c6ebdc374c059bd5f2eb07042caa50a for debian:buster with digest debian@sha256:58ce6f1271ae1c8a2006ff7d3e54e9874d839f573d8009c20154ad0f2fb0a225 ...
    $ apt-get update -qy
    Ign:1 http://deb.debian.org/debian buster InRelease
    Ign:2 http://deb.debian.org/debian-security buster/updates InRelease
    Ign:3 http://deb.debian.org/debian buster-updates InRelease
    Err:4 http://deb.debian.org/debian buster Release
      404  Not Found [IP: 151.101.2.132 80]
    Err:5 http://deb.debian.org/debian-security buster/updates Release
      404  Not Found [IP: 151.101.2.132 80]
    Err:6 http://deb.debian.org/debian buster-updates Release
      404  Not Found [IP: 151.101.2.132 80]
    Reading package lists...
    E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
    E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
    E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
    Cleaning up project directory and file based variables 00:00
    ERROR: Job failed: exit code 1

Also, note that LTS support for Debian 10 ended on 2024-06-30, while
Debian 11 has LTS support until 2026-08-31[2].

See also commit 7b8ce3acf ("ci: upgrade debian:stretch to
debian:buster", 2023-04-25) / issue #5818.

[1] https://gitlab.com/Firejail/firejail_ci/-/jobs/10737624219
[2] https://wiki.debian.org/LTS