### PR TITLE
bugfix: fix add NULL check for cmdline in find_child()

### DIFF
--- a/src/jailcheck/utils.c
+++ b/src/jailcheck/utils.c
@@ -79,6 +79,8 @@ int find_child(int id) {
 		if (pids[i].level == 2 && pids[i].parent == id) {
 			// skip /usr/bin/xdg-dbus-proxy (started by firejail for dbus filtering)
 			char *cmdline = pid_proc_cmdline(i);
+			if (cmdline == NULL)
+				continue;
 			if (strncmp(cmdline, XDG_DBUS_PROXY_PATH, strlen(XDG_DBUS_PROXY_PATH)) == 0) {
 				free(cmdline);
 				continue;


### PR DESCRIPTION
### Describe

Add a NULL check for `cmdline` returned by `pid_proc_cmdline()` in the `find_child()` function.

This prevents a possible NULL pointer dereference when accessing `strncmp(cmdline, ...)`.

### Version

- **Firejail version**: 0.9.66
- **Distribution**: Ubuntu 24.04.2 LTS

### Expected Behavior

When a process has `level == 2` and is a child of the given `id`,

Firejail should safely check the command line and continue without crashing,

even if `pid_proc_cmdline()` fails and returns NULL.

### Actual Behavior

If `pid_proc_cmdline()` returns NULL (e.g. due to missing `/proc/[pid]/cmdline`),

`strncmp(cmdline, ...)` dereferences a NULL pointer, which may lead to a crash.

This is a small bugfix patch to improve robustness.

Not a security vulnerability, but aligns with NULL Pointer Dereference.

Thanks for reviewing.