### PR TITLE
ci: allow new github domain for codeql download

### DIFF
--- a/.github/workflows/check-c.yml
+++ b/.github/workflows/check-c.yml
@@ -120,6 +120,7 @@ jobs:
           api.github.com:443
           github.com:443
           objects.githubusercontent.com:443
+          release-assets.githubusercontent.com:443
           uploads.github.com:443
 
     - name: Checkout repository

--- a/.github/workflows/check-python.yml
+++ b/.github/workflows/check-python.yml
@@ -41,6 +41,7 @@ jobs:
           github.com:443
           objects.githubusercontent.com:443
           pypi.org:443
+          release-assets.githubusercontent.com:443
           uploads.github.com:443
 
     - name: Checkout repository


### PR DESCRIPTION
The `codeql-cpp` CI job for #6844 is failing[1]:

    ##[group]Setup CodeQL tools
    [...]
    Did not find CodeQL tools version 2.22.2 in the toolcache.
    Using CodeQL CLI version 2.22.2 sourced from https://github.com/github/codeql-action/releases/download/codeql-bundle-v2.22.2/codeql-bundle-linux64.tar.zst .
    Downloading CodeQL tools from https://github.com/github/codeql-action/releases/download/codeql-bundle-v2.22.2/codeql-bundle-linux64.tar.zst . This may take a while.
    Streaming the extraction of the CodeQL bundle.
    node:events:502
          throw er; // Unhandled 'error' event
          ^

    Error: connect ECONNREFUSED 54.185.253.63:443
        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1611:16)
    [...]
      errno: -111,
      code: 'ECONNREFUSED',
      syscall: 'connect',
      address: '54.185.253.63',
      port: 443
    }

    Node.js v20.19.3
    Post job cleanup.
    [...]

Allow `release-assets.githubusercontent.com:443`, which is what the
download link above resolves to.

[1] https://github.com/netblue30/firejail/actions/runs/16638865345/job/47085091964