### PR TITLE
fix: avoid cmd double-free in procevent_monitor

### DIFF
--- a/src/firemon/procevent.c
+++ b/src/firemon/procevent.c
@@ -496,7 +496,9 @@ static void __attribute__((noreturn)) procevent_monitor(const int sock, pid_t my
 					sprintf(lineptr, "\n");
 				else {
 					sprintf(lineptr, " %s\n", cmd);
-					free(cmd);
+					if (cmd != pids[pid].option.event.cmd) {
+						free(cmd);
+					}
 				}
 				lineptr += strlen(lineptr);
 			}


### PR DESCRIPTION
There is a possible execution path in procevent_monitor function, where allocated memory for cmd may be deallocated twice:

```
char *cmd = pids[pid].option.event.cmd;
if (!cmd) {
	cmd = pid_proc_cmdline(pid);
}
if (add_new) {
    ...
}
else if (proc_ev->what == PROC_EVENT_EXIT && pids[pid].level == 1) {
    ...				
}
else {
	if (!cmd) {
		cmd = pid_proc_cmdline(pid);
	}
	if (cmd == NULL || nodisplay)
		sprintf(lineptr, "\n");
	else {
		sprintf(lineptr, " %s\n", cmd);
		free(cmd);  // <-- First deallocation
	}
	lineptr += strlen(lineptr);
}
	...
// unflag pid for exit events
if (remove_pid) {
	if (pids[pid].option.event.user)
		free(pids[pid].option.event.user);
	if (pids[pid].option.event.cmd)
		free(pids[pid].option.event.cmd);  // <-- Second deallocation
	memset(&pids[pid], 0, sizeof(Process));
}
```

The double-free could occur if:

* pids[pid].option.event.cmd != NULL (i.e., a command was previously cached);
* remove_pid != 0 (i.e., the process is exiting);
* Control flow passes through both code blocks (e.g., for a non-Firejail process exit event).


In PR we add check before deallocating memory.

Fixes: #6792 