### PR TITLE
docs: add debian ci/ubuntu ppa links to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ alt="Tor Browser Security" width="240" height="142" border="10" />
 * Wiki: <https://github.com/netblue30/firejail/wiki>
 * GitHub Actions: <https://github.com/netblue30/firejail/actions>
 * GitLab CI: <https://gitlab.com/Firejail/firejail_ci/pipelines>
+* Debian CI: <https://salsa.debian.org/reiner/firejail>
+* Ubuntu PPA: <https://launchpad.net/~deki/+archive/ubuntu/firejail>
 * Video Channel: <https://odysee.com/@netblue30:9?order=new>
 * Backup Video Channel: <https://www.bitchute.com/profile/JSBsA1aoQVfW/>
 


### PR DESCRIPTION
The Debian CI site is apparently where the official Debian packages are
built.

Relates to #6702 #6842.