### PR TITLE
bugfix: firemon: fix inconsistent debug message format

### DIFF
--- a/src/firemon/procevent.c
+++ b/src/firemon/procevent.c
@@ -153,7 +153,7 @@ doexit:
 	fclose(fp);
 	free(file);
 #ifdef DEBUG_PRCTL
-	printf("%s: %d: return %d\n", __FUNCTION__, __LINE__, rv);
+	printf("%s: %d, return %d\n", __FUNCTION__, __LINE__, rv);
 #endif
 	return rv;
 }


### PR DESCRIPTION
All other debug messages in procevent.c use the `%s: %d, ` format.

Note that by default this line is not actually compiled (unless
`DEBUG_PRCTL` is defined).

Added on commit d72a43af0 ("firemon fixes", 2016-02-29).

Kind of relates to #6792.