### PR TITLE
docs: github: clarify how to attach logs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -88,8 +88,14 @@ output goes here
 <summary>Output of <code>LC_ALL=C firejail --debug /path/to/program</code></summary>
 <p>
 
-<!-- If the output is too long to embed it into the comment,
-     create a secret gist at https://gist.github.com/ and link it here. -->
+<!--
+If the output is too long, save it to a file (e.g. "fjdebug.txt") and attach it
+to the comment:
+https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/attaching-files
+
+If that does not work, create a secret gist at https://gist.github.com/ and
+link it here.
+-->
 
 ```
 output goes here


### PR DESCRIPTION

Link to the GitHub docs for attaching a file[1].

This should be more straightforward in most cases and would avoid
polluting the user profile with gists unnecessarily (which might get in
the way of using/managing other gists), especially over time when
dealing with many projects/issues/comments.

Keep the gist as a fallback option just in case the file attachment
feature randomly gets broken for an extended period of time, as the
GitHub web UI overall keeps getting slower and jankier over time.

Note: It seems that in both cases (attachment/gist), the file size limit
in the web UI is 25MB[2].

Relates to #5398.

Misc: This was noticed on #5611.

[1] https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/attaching-files
[2] https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github#file-size-limits