### PR TITLE
bugfix: fix potential infinite loop in checkcfg (-fanalyzer)

### DIFF
--- a/src/firejail/checkcfg.c
+++ b/src/firejail/checkcfg.c
@@ -135,7 +135,7 @@ int checkcfg(int val) {
 			else if (strncmp(ptr, "netfilter-default ", 18) == 0) {
 				char *fname = ptr + 18;
 				while (*fname == ' ' || *fname == '\t')
-					ptr++;
+					fname++;
 				char *end = strchr(fname, ' ');
 				if (end)
 					*end = '\0';


### PR DESCRIPTION
It looks like it could happen if a line in /etc/firejail/firejail.config
starts with `netfilter-default ` and there is a space or tab right after
that.

    $ pacman -Q gcc14 glibc
    gcc14 14.3.1+r25+g42e99e057bd7-1
    glibc 2.42+r3+gbc13db739377-1
    $ ./configure --enable-analyzer CC=gcc-14 >/dev/null &&
      make clean >/dev/null && make >/dev/null
    [...]
    ../../src/firejail/checkcfg.c: In function ‘checkcfg’:
    ../../src/firejail/checkcfg.c:137:40: warning: infinite loop [CWE-835] [-Wanalyzer-infinite-loop]
      137 |                                 while (*fname == ' ' || *fname == '\t')
          |                                        ^~~~~~
      ‘checkcfg’: events 1-5
        |
        |  137 |                                 while (*fname == ' ' || *fname == '\t')
        |      |                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        |      |                                        |             |
        |      |                                        |             (2) if it ever follows ‘true’ branch, it will always do so...
        |      |                                        (1) infinite loop here
        |      |                                        (5) ...to here
        |  138 |                                         ptr++;
        |      |                                         ~~~~~
        |      |                                            |
        |      |                                            (3) ...to here
        |      |                                            (4) looping back...
        |
    [...]

Added on commit 340a6b2ee ("added netfilter-default config option in
/etc/firejail/firejail.config", 2016-07-28).