### PR TITLE
ci: standardize "apt-get install" step name

### DIFF
--- a/.github/workflows/check-c.yml
+++ b/.github/workflows/check-c.yml
@@ -59,7 +59,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - name: update package information
       run: sudo apt-get update -qy
-    - name: install clang-tools-14 and dependencies
+    - name: install dependencies
       run: >
         sudo apt-get install -qy
         clang-tools-14 libapparmor-dev libselinux1-dev
@@ -92,7 +92,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - name: update package information
       run: sudo apt-get update -qy
-    - name: install cppcheck
+    - name: install dependencies
       run: sudo apt-get install -qy cppcheck
     - name: configure
       run: >


### PR DESCRIPTION
For consistency and simplicity, name the `apt-get install` step just
"install dependencies" in all jobs.

Affected jobs:

* check-c.yml: scan-build
* check-c.yml: cppcheck

Related commits:

* 94e2ce275 ("Create build.yml (#3651)", 2020-10-01)
* 0fa11826b ("build: test build with apparmor and selinux in CI",
  2020-10-01)