### PR TITLE
profiles: wine: disable noinput so gamepads work

### DIFF
--- a/etc/profile-m-z/wine.profile
+++ b/etc/profile-m-z/wine.profile
@@ -37,7 +37,7 @@ caps.drop all
 netfilter
 nodvd
 nogroups
-noinput
+#noinput # breaks gamepads (see #6707)
 nonewprivs
 noroot
 #nosound


### PR DESCRIPTION
From @kolAflash[1]:

> The `noinput` setting for Wine prevents Joysticks from being used in
> Wine.

> Use the Wine "control" center for testing: `wine control`.
>
> There you find a `Gamecontroller` program for testing.

Fixes #6866.

Relates to #6707.

[1] https://github.com/netblue30/firejail/issues/6866#issue-3328634575

Suggested-by: @kolAflash