### PR TITLE
build: cppcheck: ignore src/lib/syscalls.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -380,6 +380,7 @@ cppcheck:
 	  --max-ctu-depth=40 \
 	  -i src/firejail/checkcfg.c \
 	  -i src/firejail/main.c \
+	  -i src/lib/syscall.c \
 	  .
 
 .PHONY: scan-build


### PR DESCRIPTION
cppcheck 2.18.0 fails to parse this file:

    $ cppcheck --version
    Cppcheck 2.18.0
    $ cppcheck -q --force --error-exitcode=1 \
      --enable=warning,performance --max-ctu-depth=40 \
      src/lib/syscall.c
    cppcheck: --max-ctu-depth is being capped at 10. This limitation will be removed in a future Cppcheck version.
    src/lib/syscall.c:80:26: error: syntax error [syntaxError]
     { .name = "@aio", .list =
                             ^
    src/lib/syscall.c:109:31: error: syntax error [syntaxError]
     { .name = "@basic-io", .list =
                                  ^