### PR TITLE
bugfix: fnettrace-icmp: fix uninitialized vars (cppcheck)

### DIFF
--- a/src/fnettrace-icmp/main.c
+++ b/src/fnettrace-icmp/main.c
@@ -86,14 +86,14 @@ char *code_bad_ip_header[3] = {
 };
 
 static void print_icmp(uint32_t ip_dest, uint32_t ip_src, uint8_t type, uint8_t code, unsigned icmp_bytes) {
-	char type_number[10];
+	char type_number[10] = {0};
 	char *type_ptr = type_number;
 	if (type < 19)
 		type_ptr = type_description[type];
 	else
 		sprintf(type_number, "%u", type);
 
-	char code_number[10];
+	char code_number[10] = {0};
 	char *code_ptr = code_number;
 	if (type ==3 && code < 16)
 		code_ptr = code_dest_unreachable[code];


### PR DESCRIPTION
These warnings break CI when using `ubuntu-24.04`:

    $ cppcheck --version
    Cppcheck 2.13.0
    $ make cppcheck
    cppcheck -q -j '4' --force --error-exitcode=1 --enable=warning,performance --max-ctu-depth=40 \
      -i src/firejail/checkcfg.c -i src/firejail/main.c .
    src/fnettrace-icmp/main.c:116:3: warning: Uninitialized variable: type_ptr [uninitvar]
      type_ptr,
      ^
    src/fnettrace-icmp/main.c:90:19: note: Assignment 'type_ptr=type_number', assigned value is <Uninit>
     char *type_ptr = type_number;
                      ^
    src/fnettrace-icmp/main.c:91:11: note: Assuming condition is true
     if (type < 19)
              ^
    src/fnettrace-icmp/main.c:116:3: note: Uninitialized variable: type_ptr
      type_ptr,
      ^
    src/fnettrace-icmp/main.c:117:3: warning: Uninitialized variable: code_ptr [uninitvar]
      code_ptr);
      ^
    src/fnettrace-icmp/main.c:97:19: note: Assignment 'code_ptr=code_number', assigned value is <Uninit>
     char *code_ptr = code_number;
                      ^
    src/fnettrace-icmp/main.c:98:15: note: Assuming condition is true
     if (type ==3 && code < 16)
                  ^
    src/fnettrace-icmp/main.c:117:3: note: Uninitialized variable: code_ptr
      code_ptr);
      ^
    make: *** [Makefile:379: cppcheck] Error 1

Kind of relates to #6868.
