### PR TITLE
bugfix: firecfg: fix parsing filenames with multiple ".desktop"

### DIFF
--- a/src/firecfg/desktop_files.c
+++ b/src/firecfg/desktop_files.c
@@ -186,8 +186,8 @@ void fix_desktop_files(const char *homedir) {
 		char *exec = strdup(filename);
 		if (!exec)
 			errExit("strdup");
-		char *ptr = strstr(exec, ".desktop");
-		if (ptr == NULL || *(ptr + 8) != '\0') {
+		char *ptr = strrchr(exec, '.');
+		if (ptr == NULL || strcmp(ptr, ".desktop") != 0) {
 			printf("   %s skipped (not a .desktop file)\n", exec);
 			free(exec);
 			continue;


### PR DESCRIPTION
When checking if a .desktop file is valid, firecfg currently searches
for the first occurrence of `.desktop` in the filename and checks that
it is at the end of the string.

This fails if the filename contains multiple occurrences of `.desktop`,
such as the one for Telegram Desktop, `org.telegram.desktop.desktop`:

    $ sudo firecfg
    [...]
       org.telegram.desktop.desktop skipped (not a .desktop file)

Instead, start the `.desktop` comparison from the last `.` character in
the filename.

This amends commit a9c851ee4 ("firecfg: use ignorelist also for .desktop
files", 2024-01-08) / PR #6153.

Fixes #6865.

Relates to #5245 #5876.

Reported-by: @tht2005
Reported-by: @rusty-snake
