### PR TITLE
bugfix: firemon: fix potential memory leak in procevent_monitor

### DIFF
--- a/src/firemon/procevent.c
+++ b/src/firemon/procevent.c
@@ -471,8 +471,10 @@ static void __attribute__((noreturn)) procevent_monitor(const int sock, pid_t my
 
 
 			int sandbox_closed = 0; // exit sandbox flag
+			int cmd_dup = 0;
 			char *cmd = pids[pid].option.event.cmd;
 			if (!cmd) {
+				cmd_dup = 1;
 				cmd = pid_proc_cmdline(pid);
 			}
 			if (add_new) {
@@ -490,19 +492,21 @@ static void __attribute__((noreturn)) procevent_monitor(const int sock, pid_t my
 			}
 			else {
 				if (!cmd) {
+					cmd_dup = 1;
 					cmd = pid_proc_cmdline(pid);
 				}
-				if (cmd == NULL || nodisplay)
+				if (!cmd || nodisplay)
 					sprintf(lineptr, "\n");
-				else {
+				else
 					sprintf(lineptr, " %s\n", cmd);
-					if (cmd != pids[pid].option.event.cmd) {
-						free(cmd);
-					}
-				}
 				lineptr += strlen(lineptr);
 			}
 			(void) lineptr;
+
+			if (cmd && cmd_dup) {
+				free(cmd);
+				cmd = NULL;
+			}
 
 			// print the event
 			printf("%s", line);


### PR DESCRIPTION
Simplify the deallocation of `cmd` to make it easier to understand,
which looks like it would fix a potential memory leak of `cmd`:

    if (!cmd) {
        cmd = pid_proc_cmdline(pid); // alloc
    }
    if (add_new) {
        // ...                       // no dealloc
    }
    else if (proc_ev->what == PROC_EVENT_EXIT && pids[pid].level == 1) {
        // ...                       // no dealloc
    }
    else {
        // ...
        else {
            sprintf(lineptr, " %s\n", cmd);
            if (cmd != pids[pid].option.event.cmd) {
                free(cmd);           // dealloc
            }
        }
        // ...
    }

This is a follow-up to commit 5ec00f70c ("fix: avoid cmd double-free in
procevent_monitor", 2025-07-31) / PR #6846.

Relates to #6792.