### PR TITLE
ci: codespell: upgrade ubuntu-22.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -20,7 +20,7 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 
 jobs:
   codespell:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
     - name: Harden Runner


### PR DESCRIPTION
Relevant software changes:

* codespell 2.1.0 -> 2.2.6

See also [1] and [2].

[1] https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
[2] https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
