### PR TITLE
ci: cppcheck: upgrade ubuntu-22.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/check-c.yml
+++ b/.github/workflows/check-c.yml
@@ -75,7 +75,7 @@ jobs:
       run: make -j "$(nproc)" scan-build
 
   cppcheck:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
     - name: Harden Runner


### PR DESCRIPTION
Relevant software changes:

* cppcheck 2.7 -> 2.13

This is a follow-up to #6873.

See also [1] and [2].

Fixes CI breakage in #6856[3]:

    $ cppcheck --version
    Cppcheck 2.7
    $ make cppcheck
    cppcheck -q -j '4' --force --error-exitcode=1 --enable=warning,performance \
      --max-ctu-depth=40 \
      -i src/firejail/checkcfg.c \
      -i src/firejail/main.c \
      -i src/lib/syscall.c \
      .
    src/firemon/procevent.c:306:6: error: syntax error [syntaxError]
         debug_prctl("event fork\n");
         ^
    make: *** [Makefile:379: cppcheck] Error 1

[1] https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
[2] https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
[3] https://github.com/netblue30/firejail/actions/runs/17047583642/job/48327251189
