### PR TITLE
qutebrowser: whitelist /usr/share/pdf.js

### DIFF
--- a/etc/profile-m-z/qutebrowser.profile
+++ b/etc/profile-m-z/qutebrowser.profile
@@ -36,6 +36,7 @@ whitelist ${HOME}/.cache/qutebrowser
 whitelist ${HOME}/.config/qutebrowser
 whitelist ${HOME}/.local/share/qutebrowser
 whitelist ${RUNUSER}/qutebrowser
+whitelist /usr/share/pdf.js
 whitelist /usr/share/qutebrowser
 include whitelist-common.inc
 include whitelist-run-common.inc


### PR DESCRIPTION
/usr/share/pdf.js is necessary for pdf preview in qutebrowser.
