### PR TITLE
build: cppcheck: use --check-level=exhaustive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,7 +377,7 @@ extras: all
 .PHONY: cppcheck
 cppcheck:
 	$(CPPCHECK) --force --error-exitcode=1 --enable=warning,performance \
-	  --max-ctu-depth=40 \
+	  --check-level=exhaustive \
 	  -i src/firejail/checkcfg.c \
 	  -i src/firejail/main.c \
 	  -i src/lib/syscall.c \


### PR DESCRIPTION

The `--check-level=exhaustive` option was briefly added, then changed to
`--max-ctu-depth=40`, presumably because the version being used in CI
(cppcheck 2.7 on ubuntu-22.04) did not support the former.

The current version in CI (cppcheck 2.13 on ubuntu-24.04) supports that
option, so restore it.

This fixes a flood of `information:` messages (which appear even with
`-q`) in the latest version of cppcheck:

    $ cppcheck --version
    Cppcheck 2.18.0
    $ make cppcheck
    cppcheck -q -j 4 --force --error-exitcode=1 --enable=warning,performance \
      --max-ctu-depth=40 \
      -i src/firejail/checkcfg.c \
      -i src/firejail/main.c \
      -i src/lib/syscall.c \
      .
    cppcheck: --max-ctu-depth is being capped at 10. This limitation will be removed in a future Cppcheck version.
    src/etc-cleanup/main.c:0:0: information: Limiting analysis of branches. Use --check-level=exhaustive to analyze all branches. [normalCheckLevelMaxBranches]

    ^
    src/fbuilder/build_bin.c:0:0: information: Limiting analysis of branches. Use --check-level=exhaustive to analyze all branches. [normalCheckLevelMaxBranches]

    ^
    src/fbuilder/build_fs.c:0:0: information: Limiting analysis of branches. Use --check-level=exhaustive to analyze all branches. [normalCheckLevelMaxBranches]

    ^
    [...]

This is a follow-up to #6874.

Related commits:

* be3c2a071 ("some problems reported by ccpcheck", 2025-08-17)
* d4881b6bc ("cppcheck cleanup", 2025-08-17)
* ebb368780 ("ci: cppcheck: upgrade ubuntu-22.04 to ubuntu-24.04",
  2025-08-20) / PR #6874
