### PR TITLE
Add comments indicating how to get qute-pass working in qutebrowser

### DIFF
--- a/etc/profile-m-z/qutebrowser.profile
+++ b/etc/profile-m-z/qutebrowser.profile
@@ -43,6 +43,14 @@ include whitelist-run-common.inc
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc
 include whitelist-var-common.inc
+# Put the following in qutebrowser.local if you want to use qute-pass
+# Note that using this will leave zombie processes in the sandbox when you
+# close qutebrowser
+# Defaults for gpg and pass respectively
+#noblacklist ${HOME}/.password-store
+#noblacklist ${HOME}/.gnupg
+#whitelist ${HOME}/.password-store
+#whitelist ${HOME}/.gnupg
 
 #apparmor # breaks userscripts under ${HOME}, see #5639
 caps.drop all

--- a/etc/profile-m-z/qutebrowser.profile
+++ b/etc/profile-m-z/qutebrowser.profile
@@ -46,7 +46,7 @@ include whitelist-var-common.inc
 # Put the following in qutebrowser.local if you want to use qute-pass
 # Note that using this will leave zombie processes in the sandbox when you
 # close qutebrowser
-# Defaults for gpg and pass respectively
+# Defaults for pass and gpg respectively
 #noblacklist ${HOME}/.password-store
 #noblacklist ${HOME}/.gnupg
 #whitelist ${HOME}/.password-store


### PR DESCRIPTION
Suffered from this shortfall over the past day, so I felt like contributing this back so no one else has to go through my pain.

Not really sure how to lay this out, both `noblacklist` and `whitelist` are required in qutebrowser.local to make this functionality work. Eliminating either causes qute-pass to error out.

Feedback welcome
