### PR TITLE
profiles: add missing mailcap entries

### DIFF
--- a/etc/profile-a-l/ephemeral.profile
+++ b/etc/profile-a-l/ephemeral.profile
@@ -10,6 +10,7 @@ include globals.local
 #noblacklist ${HOME}/.cache/ephemeral
 
 noblacklist ${HOME}/.local/share/pki
+noblacklist ${HOME}/.mailcap
 noblacklist ${HOME}/.pki
 
 # noexec ${HOME} breaks DRM binaries.
@@ -27,6 +28,7 @@ mkdir ${HOME}/.local/share/pki
 # enforce private-cache
 #whitelist ${HOME}/.cache/ephemeral
 whitelist ${HOME}/.local/share/pki
+whitelist ${HOME}/.mailcap
 whitelist ${HOME}/.pki
 whitelist ${DOWNLOADS}
 include whitelist-common.inc

--- a/etc/profile-a-l/falkon.profile
+++ b/etc/profile-a-l/falkon.profile
@@ -8,6 +8,7 @@ include globals.local
 
 noblacklist ${HOME}/.cache/falkon
 noblacklist ${HOME}/.config/falkon
+noblacklist ${HOME}/.mailcap
 
 include disable-common.inc
 include disable-devel.inc
@@ -21,6 +22,7 @@ mkdir ${HOME}/.config/falkon
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.cache/falkon
 whitelist ${HOME}/.config/falkon
+whitelist ${HOME}/.mailcap
 whitelist /usr/share/falkon
 include whitelist-common.inc
 include whitelist-run-common.inc

--- a/etc/profile-a-l/firefox-common.profile
+++ b/etc/profile-a-l/firefox-common.profile
@@ -30,6 +30,7 @@ include firefox-common.local
 #include firefox-common-addons.profile
 
 noblacklist ${HOME}/.local/share/pki
+noblacklist ${HOME}/.mailcap
 noblacklist ${HOME}/.pki
 
 blacklist ${PATH}/curl
@@ -46,6 +47,7 @@ include disable-programs.inc
 mkdir ${HOME}/.local/share/pki
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.local/share/pki
+whitelist ${HOME}/.mailcap
 whitelist ${HOME}/.pki
 whitelist /usr/share/doc
 whitelist /usr/share/gtk-doc/html

--- a/etc/profile-a-l/geary.profile
+++ b/etc/profile-a-l/geary.profile
@@ -14,6 +14,7 @@ noblacklist ${HOME}/.config/geary
 noblacklist ${HOME}/.local/share/evolution
 noblacklist ${HOME}/.local/share/geary
 noblacklist ${HOME}/.local/share/pki
+noblacklist ${HOME}/.mailcap
 noblacklist ${HOME}/.pki
 
 # sh is needed to allow Firefox to open links
@@ -49,6 +50,7 @@ whitelist ${HOME}/.config/geary
 whitelist ${HOME}/.local/share/evolution
 whitelist ${HOME}/.local/share/geary
 whitelist ${HOME}/.local/share/pki
+whitelist ${HOME}/.mailcap
 whitelist ${HOME}/.pki
 whitelist /usr/share/geary
 include whitelist-common.inc

--- a/etc/profile-m-z/Viber.profile
+++ b/etc/profile-m-z/Viber.profile
@@ -6,6 +6,7 @@ include Viber.local
 include globals.local
 
 noblacklist ${HOME}/.ViberPC
+noblacklist ${HOME}/.mailcap
 noblacklist ${PATH}/dig
 
 include disable-common.inc
@@ -17,6 +18,7 @@ include disable-programs.inc
 mkdir ${HOME}/.ViberPC
 whitelist ${DOWNLOADS}
 whitelist ${HOME}/.ViberPC
+whitelist ${HOME}/.mailcap
 include whitelist-common.inc
 
 caps.drop all

--- a/etc/profile-m-z/mutt.profile
+++ b/etc/profile-m-z/mutt.profile
@@ -130,7 +130,7 @@ tracelog
 #disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gai.conf,gnupg,host.conf,mail,mailname,msmtprc,nntpserver,terminfo
+private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gai.conf,gnupg,host.conf,mail,mailcap,mailname,msmtprc,nntpserver,terminfo
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/neomutt.profile
+++ b/etc/profile-m-z/neomutt.profile
@@ -122,7 +122,7 @@ tracelog
 #disable-mnt
 private-cache
 private-dev
-private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gnupg,host.conf,mail,mailname,msmtprc,neomuttrc,neomuttrc.d,nntpserver
+private-etc @tls-ca,@x11,Mutt,Muttrc,Muttrc.d,gnupg,host.conf,mail,mailcap,mailname,msmtprc,neomuttrc,neomuttrc.d,nntpserver
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/otter-browser.profile
+++ b/etc/profile-m-z/otter-browser.profile
@@ -11,6 +11,7 @@ include globals.local
 noblacklist ${HOME}/.cache/Otter
 noblacklist ${HOME}/.config/otter
 noblacklist ${HOME}/.local/share/pki
+noblacklist ${HOME}/.mailcap
 noblacklist ${HOME}/.pki
 
 include disable-common.inc
@@ -27,6 +28,7 @@ whitelist ${DOWNLOADS}
 whitelist ${HOME}/.cache/Otter
 whitelist ${HOME}/.config/otter
 whitelist ${HOME}/.local/share/pki
+whitelist ${HOME}/.mailcap
 whitelist ${HOME}/.pki
 whitelist /usr/share/otter-browser
 include whitelist-common.inc

--- a/etc/profile-m-z/seamonkey.profile
+++ b/etc/profile-m-z/seamonkey.profile
@@ -9,6 +9,7 @@ include globals.local
 noblacklist ${HOME}/.cache/mozilla
 noblacklist ${HOME}/.gnupg
 noblacklist ${HOME}/.local/share/pki
+noblacklist ${HOME}/.mailcap
 noblacklist ${HOME}/.mozilla
 noblacklist ${HOME}/.pki
 
@@ -31,6 +32,7 @@ whitelist ${HOME}/.gnupg
 whitelist ${HOME}/.keysnail.js
 whitelist ${HOME}/.lastpass
 whitelist ${HOME}/.local/share/pki
+whitelist ${HOME}/.mailcap
 whitelist ${HOME}/.mozilla
 whitelist ${HOME}/.pentadactyl
 whitelist ${HOME}/.pentadactylrc

--- a/etc/profile-m-z/w3m.profile
+++ b/etc/profile-m-z/w3m.profile
@@ -12,6 +12,7 @@ include globals.local
 #ignore private-dev
 #ignore private-etc
 
+noblacklist ${HOME}/.mailcap
 noblacklist ${HOME}/.w3m
 
 blacklist ${RUNUSER}/wayland-*
@@ -33,6 +34,7 @@ include disable-xdg.inc
 
 mkdir ${HOME}/.w3m
 whitelist ${DOWNLOADS}
+whitelist ${HOME}/.mailcap
 whitelist ${HOME}/.w3m
 whitelist /usr/share/w3m
 include whitelist-runuser-common.inc


### PR DESCRIPTION
Allow `~/.mailcap` for the profiles that have `mailcap` in `private-etc`
and vice-versa.

Fixes #6883.

Reported-by: @vinc17fr
Suggested-by: @vinc17fr