### PR TITLE
modif: rlimit: allow uppercase suffixes

### DIFF
--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -51,6 +51,7 @@ long long unsigned parse_arg_size(char *str) {
 	sscanf(str, "%llu", &result);
 
 	char suffix = *(str + len - 1);
+	suffix = tolower((unsigned char)suffix);
 	if (!isdigit(suffix) && (suffix == 'k' || suffix == 'm' || suffix == 'g')) {
 		len -= 1;
 	}


### PR DESCRIPTION
For better usability and because the proper suffixes (KiB, MiB and GiB)
are uppercase.

Affected commands:

* `rlimit-as`
* `rlimit-fsize`

Before:

    $ firejail --quiet --noprofile --rlimit-as=100m /bin/true
    $ firejail --quiet --noprofile --rlimit-as=100M /bin/true
    Error: invalid rlimit-as. Only use positive numbers and k, m or g suffix.: No such file or directory

After:

    $ firejail --quiet --noprofile --rlimit-as=100m /bin/true
    $ firejail --quiet --noprofile --rlimit-as=100M /bin/true

Relates to #4315.
