### PR TITLE
modif: rlimit: use uppercase suffixes in the code/docs

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1629,7 +1629,7 @@ int main(int argc, char **argv, char **envp) {
 		else if (strncmp(argv[i], "--rlimit-fsize=", 15) == 0) {
 			cfg.rlimit_fsize = parse_arg_size(argv[i] + 15);
 			if (cfg.rlimit_fsize == 0) {
-				perror("Error: invalid rlimit-fsize. Only use positive numbers and k, m or g suffix.");
+				perror("Error: invalid rlimit-fsize. Only use positive numbers and K, M or G suffix.");
 				exit(1);
 			}
 			arg_rlimit_fsize = 1;
@@ -1642,7 +1642,7 @@ int main(int argc, char **argv, char **envp) {
 		else if (strncmp(argv[i], "--rlimit-as=", 12) == 0) {
 			cfg.rlimit_as = parse_arg_size(argv[i] + 12);
 			if (cfg.rlimit_as == 0) {
-				perror("Error: invalid rlimit-as. Only use positive numbers and k, m or g suffix.");
+				perror("Error: invalid rlimit-as. Only use positive numbers and K, M or G suffix.");
 				exit(1);
 			}
 			arg_rlimit_as = 1;

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -1643,7 +1643,7 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		else if (strncmp(ptr, "rlimit-fsize ", 13) == 0) {
 			cfg.rlimit_fsize = parse_arg_size(ptr + 13);
 			if (cfg.rlimit_fsize == 0) {
-				perror("Error: invalid rlimit-fsize in profile file. Only use positive numbers and k, m or g suffix.");
+				perror("Error: invalid rlimit-fsize in profile file. Only use positive numbers and K, M or G suffix.");
 				exit(1);
 			}
 			arg_rlimit_fsize = 1;
@@ -1656,7 +1656,7 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		else if (strncmp(ptr, "rlimit-as ", 10) == 0) {
 			cfg.rlimit_as = parse_arg_size(ptr + 10);
 			if (cfg.rlimit_as == 0) {
-				perror("Error: invalid rlimit-as in profile file. Only use positive numbers and k, m or g suffix.");
+				perror("Error: invalid rlimit-as in profile file. Only use positive numbers and K, M or G suffix.");
 				exit(1);
 			}
 			arg_rlimit_as = 1;

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -52,7 +52,7 @@ long long unsigned parse_arg_size(char *str) {
 
 	char suffix = *(str + len - 1);
 	suffix = tolower((unsigned char)suffix);
-	if (!isdigit(suffix) && (suffix == 'k' || suffix == 'm' || suffix == 'g')) {
+	if (!isdigit(suffix) && (suffix == 'K' || suffix == 'M' || suffix == 'G')) {
 		len -= 1;
 	}
 
@@ -68,13 +68,13 @@ long long unsigned parse_arg_size(char *str) {
 		return result;
 
 	switch (suffix) {
-	case 'k':
+	case 'K':
 		result *= 1024;
 		break;
-	case 'm':
+	case 'M':
 		result *= 1024 * 1024;
 		break;
-	case 'g':
+	case 'G':
 		result *= 1024 * 1024 * 1024;
 		break;
 	default:

--- a/src/man/firejail.1.in
+++ b/src/man/firejail.1.in
@@ -2577,7 +2577,7 @@ $ firejail \-\-restrict-namespaces=user,net
 .TP
 \fB\-\-rlimit-as=number
 Set the maximum size of the process's virtual memory (address space) in bytes.
-Use k(ilobyte), m(egabyte) or g(igabyte) for size suffix (base 1024).
+Use K(ilobyte), M(egabyte) or G(igabyte) for size suffix (base 1024).
 
 .TP
 \fB\-\-rlimit-cpu=number
@@ -2591,7 +2591,7 @@ track of CPU seconds for each process independently.
 .TP
 \fB\-\-rlimit-fsize=number
 Set the maximum file size that can be created by a process.
-Use k(ilobyte), m(egabyte) or g(igabyte) for size suffix (base 1024).
+Use K(ilobyte), M(egabyte) or G(igabyte) for size suffix (base 1024).
 .TP
 \fB\-\-rlimit-nofile=number
 Set the maximum number of files that can be opened by a process.

--- a/test/environment/rlimit-bad-profile.exp
+++ b/test/environment/rlimit-bad-profile.exp
@@ -11,7 +11,7 @@ match_max 100000
 send -- "firejail --profile=rlimit-bad1.profile\r"
 expect {
 	timeout {puts "TESTING ERROR 4\n";exit}
-	"invalid rlimit-fsize in profile file. Only use positive numbers and k, m or g suffix."
+	"invalid rlimit-fsize in profile file. Only use positive numbers and K, M or G suffix."
 }
 after 100
 

--- a/test/environment/rlimit-bad.exp
+++ b/test/environment/rlimit-bad.exp
@@ -10,7 +10,7 @@ match_max 100000
 send -- "firejail --rlimit-fsize=-1024\r"
 expect {
 	timeout {puts "TESTING ERROR 0\n";exit}
-	"invalid rlimit-fsize. Only use positive numbers and k, m or g suffix."
+	"invalid rlimit-fsize. Only use positive numbers and K, M or G suffix."
 }
 after 100
 


### PR DESCRIPTION
The proper suffixes (KiB, MiB and GiB) are uppercase.

This is a follow-up to #6890.

Relates to #4315.
