### PR TITLE
modif: rlimit: improve error messages

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1614,36 +1614,38 @@ int main(int argc, char **argv, char **envp) {
 		else if (strncmp(argv[i], "--rlimit-as=", 12) == 0) {
 			cfg.rlimit_as = parse_arg_size(argv[i] + 12);
 			if (cfg.rlimit_as == 0) {
-				perror("Error: invalid rlimit-as. Only use positive numbers and K, M or G suffix.");
+				fprintf(stderr, "Error: invalid rlimit-as: %s; use only positive numbers and K, M or G suffix\n",
+				        argv[i] + 12);
 				exit(1);
 			}
 			arg_rlimit_as = 1;
 		}
 		else if (strncmp(argv[i], "--rlimit-cpu=", 13) == 0) {
-			check_unsigned(argv[i] + 13, "Error: invalid rlimit");
+			check_unsigned(argv[i] + 13, "Error: invalid rlimit-cpu");
 			sscanf(argv[i] + 13, "%llu", &cfg.rlimit_cpu);
 			arg_rlimit_cpu = 1;
 		}
 		else if (strncmp(argv[i], "--rlimit-fsize=", 15) == 0) {
 			cfg.rlimit_fsize = parse_arg_size(argv[i] + 15);
 			if (cfg.rlimit_fsize == 0) {
-				perror("Error: invalid rlimit-fsize. Only use positive numbers and K, M or G suffix.");
+				fprintf(stderr, "Error: invalid rlimit-fsize: %s; use only positive numbers and K, M or G suffix\n",
+				        argv[i] + 15);
 				exit(1);
 			}
 			arg_rlimit_fsize = 1;
 		}
 		else if (strncmp(argv[i], "--rlimit-nofile=", 16) == 0) {
-			check_unsigned(argv[i] + 16, "Error: invalid rlimit");
+			check_unsigned(argv[i] + 16, "Error: invalid rlimit-nofile");
 			sscanf(argv[i] + 16, "%llu", &cfg.rlimit_nofile);
 			arg_rlimit_nofile = 1;
 		}
 		else if (strncmp(argv[i], "--rlimit-nproc=", 15) == 0) {
-			check_unsigned(argv[i] + 15, "Error: invalid rlimit");
+			check_unsigned(argv[i] + 15, "Error: invalid rlimit-nproc");
 			sscanf(argv[i] + 15, "%llu", &cfg.rlimit_nproc);
 			arg_rlimit_nproc = 1;
 		}
 		else if (strncmp(argv[i], "--rlimit-sigpending=", 20) == 0) {
-			check_unsigned(argv[i] + 20, "Error: invalid rlimit");
+			check_unsigned(argv[i] + 20, "Error: invalid rlimit-sigpending");
 			sscanf(argv[i] + 20, "%llu", &cfg.rlimit_sigpending);
 			arg_rlimit_sigpending = 1;
 		}

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -1628,36 +1628,38 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		if (strncmp(ptr, "rlimit-as ", 10) == 0) {
 			cfg.rlimit_as = parse_arg_size(ptr + 10);
 			if (cfg.rlimit_as == 0) {
-				perror("Error: invalid rlimit-as in profile file. Only use positive numbers and K, M or G suffix.");
+				fprintf(stderr, "Error: invalid rlimit-as: %s; use only positive numbers and K, M or G suffix\n",
+				        ptr + 10);
 				exit(1);
 			}
 			arg_rlimit_as = 1;
 		}
 		else if (strncmp(ptr, "rlimit-cpu ", 11) == 0) {
-			check_unsigned(ptr + 11, "Error: invalid rlimit-cpu in profile file: ");
+			check_unsigned(ptr + 11, "Error: invalid rlimit-cpu");
 			sscanf(ptr + 11, "%llu", &cfg.rlimit_cpu);
 			arg_rlimit_cpu = 1;
 		}
 		else if (strncmp(ptr, "rlimit-fsize ", 13) == 0) {
 			cfg.rlimit_fsize = parse_arg_size(ptr + 13);
 			if (cfg.rlimit_fsize == 0) {
-				perror("Error: invalid rlimit-fsize in profile file. Only use positive numbers and K, M or G suffix.");
+				fprintf(stderr, "Error: invalid rlimit-fsize: %s; use only positive numbers and K, M or G suffix\n",
+				        ptr + 13);
 				exit(1);
 			}
 			arg_rlimit_fsize = 1;
 		}
 		else if (strncmp(ptr, "rlimit-nofile ", 14) == 0) {
-			check_unsigned(ptr + 14, "Error: invalid rlimit in profile file: ");
+			check_unsigned(ptr + 14, "Error: invalid rlimit-nofile");
 			sscanf(ptr + 14, "%llu", &cfg.rlimit_nofile);
 			arg_rlimit_nofile = 1;
 		}
 		else if (strncmp(ptr, "rlimit-nproc ", 13) == 0) {
-			check_unsigned(ptr + 13, "Error: invalid rlimit-nproc in profile file: ");
+			check_unsigned(ptr + 13, "Error: invalid rlimit-nproc");
 			sscanf(ptr + 13, "%llu", &cfg.rlimit_nproc);
 			arg_rlimit_nproc = 1;
 		}
 		else if (strncmp(ptr, "rlimit-sigpending ", 18) == 0) {
-			check_unsigned(ptr + 18, "Error: invalid rlimit-sigpending in profile file: ");
+			check_unsigned(ptr + 18, "Error: invalid rlimit-sigpending");
 			sscanf(ptr + 18, "%llu", &cfg.rlimit_sigpending);
 			arg_rlimit_sigpending = 1;
 		}

--- a/src/firejail/util.c
+++ b/src/firejail/util.c
@@ -805,7 +805,7 @@ void check_unsigned(const char *str, const char *msg) {
 	const char *ptr = str;
 	while (*ptr != ' ' && *ptr != '\t' && *ptr != '\0') {
 		if (!isdigit(*ptr)) {
-			fprintf(stderr, "%s %s\n", msg, str);
+			fprintf(stderr, "%s: %s\n", msg, str);
 			exit(1);
 		}
 		ptr++;

--- a/test/environment/rlimit-bad-profile.exp
+++ b/test/environment/rlimit-bad-profile.exp
@@ -10,27 +10,27 @@ match_max 100000
 send -- "firejail --profile=rlimit-bad-fsize.profile\r"
 expect {
 	timeout {puts "TESTING ERROR 4\n";exit}
-	"invalid rlimit-fsize in profile file. Only use positive numbers and K, M or G suffix."
+	"invalid rlimit-fsize:"
 }
 after 100
 
 send -- "firejail --profile=rlimit-bad-nofile.profile\r"
 expect {
 	timeout {puts "TESTING ERROR 5\n";exit}
-	"invalid rlimit"
+	"invalid rlimit-nofile:"
 }
 after 100
 
 send -- "firejail --profile=rlimit-bad-nproc.profile\r"
 expect {
 	timeout {puts "TESTING ERROR 6\n";exit}
-	"invalid rlimit"
+	"invalid rlimit-nproc:"
 }
 after 100
 send -- "firejail --profile=rlimit-bad-sigpending.profile\r"
 expect {
 	timeout {puts "TESTING ERROR 7\n";exit}
-	"invalid rlimit"
+	"invalid rlimit-sigpending:"
 }
 after 100
 

--- a/test/environment/rlimit-bad.exp
+++ b/test/environment/rlimit-bad.exp
@@ -10,27 +10,27 @@ match_max 100000
 send -- "firejail --rlimit-fsize=-1024\r"
 expect {
 	timeout {puts "TESTING ERROR 0\n";exit}
-	"invalid rlimit-fsize. Only use positive numbers and K, M or G suffix."
+	"invalid rlimit-fsize: -1024"
 }
 after 100
 
 send -- "firejail --rlimit-nofile=asdf\r"
 expect {
 	timeout {puts "TESTING ERROR 1\n";exit}
-	"invalid rlimit"
+	"invalid rlimit-nofile: asdf"
 }
 after 100
 
 send -- "firejail --rlimit-nproc=100.23\r"
 expect {
 	timeout {puts "TESTING ERROR 2\n";exit}
-	"invalid rlimit"
+	"invalid rlimit-nproc: 100.23"
 }
 after 100
 send -- "firejail --rlimit-sigpending=2345-78\r"
 expect {
 	timeout {puts "TESTING ERROR 3\n";exit}
-	"invalid rlimit"
+	"invalid rlimit-sigpending: 2345-78"
 }
 after 100
 


### PR DESCRIPTION
Changes:

* Remove unrelated `strerror` output from some error messages
* Remove periods from some error messages
* Ensure that the invalid value is in the error message
* Ensure that the full command name is in the error message (instead of
  just `rlimit` in some cases)
* Standardize output
* tests: Expect the full command name (and argument in some cases)

Examples:

Before:

    $ firejail --quiet --noprofile --rlimit-cpu=-1 /bin/true
    Error: invalid rlimit -1
    $ firejail --quiet --noprofile --rlimit-nproc=-1 /bin/true
    Error: invalid rlimit -1
    $ firejail --quiet --noprofile --rlimit-as=-1 /bin/true
    Error: invalid rlimit-as. Only use positive numbers and K, M or G suffix.: No such file or directory

After:

    $ firejail --quiet --noprofile --rlimit-cpu=-1 /bin/true
    Error: invalid rlimit-cpu: -1
    $ firejail --quiet --noprofile --rlimit-nproc=-1 /bin/true
    Error: invalid rlimit-nproc: -1
    $ firejail --quiet --noprofile --rlimit-as=-1 /bin/true
    Error: invalid rlimit-as: -1; use only positive numbers and K, M or G suffix

This is a follow-up to #6891.

Relates to #4315.