### PR TITLE
profiles: godot: allow ~/.local/share/Trash

### DIFF
--- a/etc/profile-a-l/godot.profile
+++ b/etc/profile-a-l/godot.profile
@@ -11,8 +11,8 @@ ignore noexec ${HOME}
 
 noblacklist ${HOME}/.cache/godot
 noblacklist ${HOME}/.config/godot
-noblacklist ${HOME}/.local/share/godot
 noblacklist ${HOME}/.local/share/Trash
+noblacklist ${HOME}/.local/share/godot
 
 include disable-common.inc
 include disable-devel.inc


### PR DESCRIPTION
Fixes an error in Godot 4.5 where files can't be deleted from within the Editor.