### PR TITLE
profiles: wusc: add /usr/share/gtk-4.0

### DIFF
--- a/etc/inc/whitelist-usr-share-common.inc
+++ b/etc/inc/whitelist-usr-share-common.inc
@@ -25,6 +25,7 @@ whitelist /usr/share/glib-2.0
 whitelist /usr/share/glvnd
 whitelist /usr/share/gtk-2.0
 whitelist /usr/share/gtk-3.0
+whitelist /usr/share/gtk-4.0
 whitelist /usr/share/gtk-engines
 whitelist /usr/share/gtksourceview-3.0
 whitelist /usr/share/gtksourceview-4


### PR DESCRIPTION
This directory is part of the gtk4 package (version 1:4.20.1-1) on Artix
Linux.

Add it just in case, as wusc already contains the same analogous paths
for gtk2 and gtk3.

This is a follow-up to #6907.