### PR TITLE
profiles: mullvad-browser: allow readlink and realpath

### DIFF
--- a/etc/profile-m-z/mullvad-browser.profile
+++ b/etc/profile-m-z/mullvad-browser.profile
@@ -76,7 +76,7 @@ seccomp.block-secondary
 #tracelog # may cause issues, see #1930
 
 disable-mnt
-private-bin bash,cat,cp,cut,dirname,env,expr,file,gpg,grep,gxmessage,id,kdialog,ln,mkdir,mullvad-browser,mv,python*,rm,sed,sh,tail,tar,tclsh,test,update-desktop-database,xmessage,xz,zenity
+private-bin bash,cat,cp,cut,dirname,env,expr,file,gpg,grep,gxmessage,id,kdialog,ln,mkdir,mullvad-browser,mv,python*,readlink,realpath,rm,sed,sh,tail,tar,tclsh,test,update-desktop-database,xmessage,xz,zenity
 private-dev
 private-etc @tls-ca
 private-tmp


### PR DESCRIPTION
The start-mullvad-browser script uses readlink and realpath when it is a symlink, so these need to be included as part of private-bin, or the following error dialog appears, and the browser fails to start:

<img width="382" height="259" alt="image" src="https://github.com/user-attachments/assets/c11f406d-1644-47d6-997e-207667a6ff01" alt="start-mullvad-browser cannot be run using a symlink on this operating system" />

This problem is observed using Mullvad Browser 14.5.7 as packaged for Fedora 42.

Repo: https://repository.mullvad.net/rpm/stable/mullvad.repo
Fedora script path: /usr/lib/mullvad-browser/start-mullvad-browser
Upstream: https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/blob/2f802636b89d7d51326296abd5d7c34e8ec6a738/projects/browser/RelativeLink/start-browser#L202-207