### PR TITLE
docs: man: clarify what ipc-namespace affects

### DIFF
--- a/src/man/firejail-profile.5.in
+++ b/src/man/firejail-profile.5.in
@@ -838,6 +838,13 @@ env CFLAGS="-W -Wall -Werror"
 \fBipc-namespace
 Enable a new IPC namespace if the sandbox was started as a regular user.
 IPC namespace is enabled by default for sandboxes started as root.
+.br
+
+.br
+Note: This only affects the IPC resources that are mentioned in
+\fBipc_namespaces\fR(7).
+It does not affect other IPC resources, such as Unix sockets (see
+\fBunix\fR(7)).
 
 .TP
 \fBkeep-fd

--- a/src/man/firejail.1.in
+++ b/src/man/firejail.1.in
@@ -1122,6 +1122,13 @@ IPC namespace is enabled by default for sandboxes started as root.
 .br
 
 .br
+Note: This only affects the IPC resources that are mentioned in
+\fBipc_namespaces\fR(7).
+It does not affect other IPC resources, such as Unix sockets (see
+\fBunix\fR(7)).
+.br
+
+.br
 Example:
 .br
 $ firejail \-\-ipc-namespace firefox


### PR DESCRIPTION
Clarify that even though Unix sockets are an IPC mechanism, IPC
namespaces do not affect them (see ipc_namespaces(7)).

Relates to #6928.

Reported-by: @tupo2