### PR TITLE
profiles: steam: allow ~/.local/share/doublefine

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -965,6 +965,7 @@ blacklist ${HOME}/.local/share/dev.nhex
 blacklist ${HOME}/.local/share/dino
 blacklist ${HOME}/.local/share/dolphin
 blacklist ${HOME}/.local/share/dolphin-emu
+blacklist ${HOME}/.local/share/doublefine
 blacklist ${HOME}/.local/share/emailidentities
 blacklist ${HOME}/.local/share/epiphany
 blacklist ${HOME}/.local/share/evolution

--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -22,6 +22,7 @@ noblacklist ${HOME}/.local/share/Baba_Is_You
 noblacklist ${HOME}/.local/share/bohemiainteractive
 noblacklist ${HOME}/.local/share/cdprojektred
 noblacklist ${HOME}/.local/share/Colossal Order
+noblacklist ${HOME}/.local/share/doublefine
 noblacklist ${HOME}/.local/share/Dredmor
 noblacklist ${HOME}/.local/share/FasterThanLight
 noblacklist ${HOME}/.local/share/feral-interactive
@@ -78,6 +79,7 @@ mkdir ${HOME}/.local/share/Baba_Is_You
 mkdir ${HOME}/.local/share/bohemiainteractive
 mkdir ${HOME}/.local/share/cdprojektred
 mkdir ${HOME}/.local/share/Colossal Order
+mkdir ${HOME}/.local/share/doublefine
 mkdir ${HOME}/.local/share/Dredmor
 mkdir ${HOME}/.local/share/FasterThanLight
 mkdir ${HOME}/.local/share/feral-interactive
@@ -118,6 +120,7 @@ whitelist ${HOME}/.local/share/Baba_Is_You
 whitelist ${HOME}/.local/share/bohemiainteractive
 whitelist ${HOME}/.local/share/cdprojektred
 whitelist ${HOME}/.local/share/Colossal Order
+whitelist ${HOME}/.local/share/doublefine
 whitelist ${HOME}/.local/share/Dredmor
 whitelist ${HOME}/.local/share/FasterThanLight
 whitelist ${HOME}/.local/share/feral-interactive


### PR DESCRIPTION
Allow the folder that Day of the Tentacle Remastered uses to store save
files. Without adding them in the steam profile, save states don't work
in the game (or it didn't even start, don't remember exactly).

See https://www.pcgamingwiki.com/wiki/Day_of_the_Tentacle_Remastered

Probably it would also allow save games for other games done by
doublefine (https://store.steampowered.com/developer/doublefine), but I
have no other game from them and I have not checked it.