### PR TITLE
bugfix: fix French translation for ${PICTURES} macro

### DIFF
--- a/src/firejail/macros.c
+++ b/src/firejail/macros.c
@@ -52,7 +52,7 @@ Macro macro[] = {
 	{
 		"${PICTURES}",
 		"XDG_PICTURES_DIR=\"$HOME/",
-		{"Pictures", "Изображения", "Photos", "Immagini", "Imágenes", "Imagens", "Bilder"}
+		{"Pictures", "Изображения", "Images", "Immagini", "Imágenes", "Imagens", "Bilder"}
 	},
 
 	{


### PR DESCRIPTION
From /usr/share/locale/fr/LC_MESSAGES/xdg-user-dirs.mo:

    msgid "Pictures"
    msgstr "Images"
