### PR TITLE
tests: man: fix timeout error

### DIFF
--- a/test/sysutils/man.exp
+++ b/test/sysutils/man.exp
@@ -10,7 +10,7 @@ match_max 100000
 send -- "rm -f /tmp/t\r"
 after 500
 
-send -- "firejail man firejail > /tmp/t\r"
+send -- "firejail /usr/bin/man firecfg > /tmp/t\r"
 sleep 1
 
 send -- "cat /tmp/t\r"


### PR DESCRIPTION
For a long time there have been intermittent failures in CI when trying
to open the firejail man page with `man`[1]:

    2025-08-05T14:15:03.2742048Z runner@pkrvm76nib4usnx:~/work/firejail/firejail/test/sysutils$ rm -f /tmp/t
    2025-08-05T14:15:03.2742725Z runner@pkrvm76nib4usnx:~/work/firejail/firejail/test/sysutils$
    2025-08-05T14:15:03.2743522Z <ejail/test/sysutils$ firejail man firejail > /tmp/t
    2025-08-05T14:15:03.2743913Z cat /tmp/t
    2025-08-05T14:15:03.5645359Z troff: <standard input>:89: warning [p 2, 2.3i]: cannot adjust line
    2025-08-05T14:15:03.5862718Z troff: <standard input>:3738: warning [p 40, 11.8i]: cannot adjust line
    2025-08-05T14:15:13.5920525Z runner@pkrvm76nib4usnx:~/work/firejail/firejail/test/sysutils$ TESTING ERROR 0

It seems to happen due to a timeout, so use the firecfg man page
instead, as that results in over 10 times less lines in the output and
thus should be less likely to cause issues:

    $ man src/man/firejail.1.in | wc -l
    3057
    $ man src/man/firecfg.1.in | wc -l
    184

Also, use the full path to `man` just in case.

[1] https://github.com/netblue30/firejail/actions/runs/16752574198/job/47426439265