### PR TITLE
feature: add --xephyr-extra-params= command

### DIFF
--- a/contrib/syntax/lists/profile_commands_arg1.list
+++ b/contrib/syntax/lists/profile_commands_arg1.list
@@ -84,3 +84,4 @@ whitelist
 whitelist-ro
 x11
 xephyr-screen
+xephyr-extra-params

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -1409,6 +1409,12 @@ int main(int argc, char **argv, char **envp) {
 			else
 				exit_err_feature("x11");
 		}
+		else if (strncmp(argv[i], "--xephyr-extra-params=", 16) == 0) {
+			if (checkcfg(CFG_X11))
+				; // the processing is done directly in x11.c
+			else
+				exit_err_feature("x11");
+		}
 #endif
 		//*************************************
 		// filtering

--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -302,6 +302,7 @@ static const char *const usage_str =
 	"    --x11=xpra - enable Xpra X11 server.\n"
 	"    --x11=xvfb - enable Xvfb X11 server.\n"
 	"    --xephyr-screen=WIDTHxHEIGHT - set screen size for --x11=xephyr.\n"
+	"    --xephyr-extra-params=OPTIONS - set Xephyr server command extra parameters for --x11=xephyr.\n"
 #endif
 	"\n"
 	"Examples:\n"

--- a/src/firejail/x11.c
+++ b/src/firejail/x11.c
@@ -434,6 +434,11 @@ void x11_start_xephyr(int argc, char **argv) {
 	if (newscreen)
 		xephyr_screen = newscreen;
 
+	// default xephyr options can be overwritten by a --xephyr-extra-params= command line option
+	char *new_xephyr_extra_params = extract_setting(argc, argv, "--xephyr-extra-params=");
+	if (new_xephyr_extra_params)
+		xephyr_extra_params = new_xephyr_extra_params;
+
 	env_store_name_val("FIREJAIL_X11", "yes", SETENV);
 
 	// unfortunately, xephyr does a number of weird things when started by root user!!!
@@ -711,7 +716,7 @@ static void __attribute__((noreturn)) x11_start_xpra_old(int argc, char **argv, 
 
 	assert(xpra_extra_params);		  // should be "" if empty
 
-	// parse xephyr_extra_params
+	// parse xpra_extra_params
 	// very basic quoting support
 	char *temp = strdup(xpra_extra_params);
 	if (*xpra_extra_params != '\0') {

--- a/src/man/firejail-profile.5.in
+++ b/src/man/firejail-profile.5.in
@@ -687,6 +687,20 @@ Example:
 xephyr-screen 640x480
 .br
 x11 xephyr
+
+.TP
+\fBxephyr-extra-params OPTIONS
+Set Xephyr server command extra parameters for x11 xephyr. This command should be included in the profile file before x11 xephyr command.
+.br
+
+.br
+Example:
+.br
+
+.br
+xephyr-extra-params -grayscale
+.br
+x11 xephyr
 #endif
 #ifdef HAVE_DBUSPROXY
 .SH DBus filtering

--- a/src/man/firejail.1.in
+++ b/src/man/firejail.1.in
@@ -3467,6 +3467,18 @@ Example:
 .br
 $ firejail --net=eth0 --x11=xephyr --xephyr-screen=640x480 firefox
 .br
+
+.TP
+\fB\-\-xephyr-extra-params=OPTIONS
+Set Xephyr server command extra parameters for x11 --x11=xephyr. The setting will overwrite the default set in /etc/firejail/firejail.config
+for the current sandbox. Run Xephyr -help to get a list of available options.
+.br
+
+.br
+Example:
+.br
+$ firejail --net=eth0 --x11=xephyr --xephyr-extra-params="-title firefox" firefox
+.br
 #endif
 .\" Note: Keep this in sync with invalid_name() in src/firejail/util.c.
 #ifdef HAVE_APPARMOR

--- a/src/zsh_completion/_firejail.in
+++ b/src/zsh_completion/_firejail.in
@@ -271,6 +271,7 @@ _firejail_args=(
     '--x11[enable X11 sandboxing. The software checks first if Xpra is installed, then it checks if Xephyr is installed. If all fails, it will attempt to use X11 security extension]'
     '--x11=-[disable or enable specific X11 server]: :(none xephyr xorg xpra xvfb)'
     '--xephyr-screen=-[set screen size for --x11=xephyr]: :(WIDTHxHEIGHT)'
+    '--xephyr-extra-params=-[set Xephyr command server extra parameters for --x11=xephyr]: :(OPTIONS)'
 #endif
 )
 


### PR DESCRIPTION
This lets user specify Xephyr options for each sandbox without modifying the `firejai.config` file. 

It can also provide visual indication for sandboxed programs — for example, setting `-name` changes the window's `WM_CLASS` property, which window managers and desktop environments can use in rules to alter its appearance.

Related issues:
- https://github.com/netblue30/firejail/issues/3843
- https://github.com/netblue30/firejail/issues/1983