### PR TITLE
tests: man: disable test due to timeout

### DIFF
--- a/test/sysutils/sysutils.sh
+++ b/test/sysutils/sysutils.sh
@@ -113,8 +113,8 @@ fi
 
 if command -v man
 then
-	echo "TESTING: man"
-	./man.exp
+	echo "TESTING: FIXME: man"
+	#./man.exp # FIXME: Broken in CI (see #6949)
 else
 	echo "TESTING SKIP: man not found"
 fi


### PR DESCRIPTION
It still timeouts randomly, even with the changes from commit b613c3062
("tests: man: fix timeout error (#6949)", 2025-10-29).

When the test passes, the relevant commands appear to execute in less
than a second.

Log from a successful run of test-network on commit f5d82cc58 ("feature:
add env-max-count / env-max-len to firejail.config (#6951)",
2025-11-01)[1]:

    2025-11-01T13:57:55.6533345Z /usr/bin/man
    2025-11-01T13:57:55.6533649Z TESTING: man
    2025-11-01T13:57:55.6564238Z spawn /bin/bash
    2025-11-01T13:57:57.1602002Z rm -f /tmp/t
    2025-11-01T13:57:57.1612808Z runner@runnervmxu1zt:~/work/firejail/firejail/test/sysutils$ rm -f /tmp/t
    2025-11-01T13:57:57.1613686Z runner@runnervmxu1zt:~/work/firejail/firejail/test/sysutils$
    2025-11-01T13:57:57.1614509Z <st/sysutils$ firejail /usr/bin/man firecfg > /tmp/t
    2025-11-01T13:57:57.1615014Z runner@runnervmxu1zt:~/work/firejail/firejail/test/sysutils$ cat /tmp/t
    2025-11-01T13:57:57.1615466Z FIRECFG(1)                     firecfg man page                     FIRECFG(1)
    2025-11-01T13:57:57.1615727Z
    2025-11-01T13:57:57.1615799Z NAME
    2025-11-01T13:57:57.1616119Z        Firecfg - Desktop integration utility for Firejail software.
    [...]
    2025-11-01T13:57:57.1627646Z OPTIONS
    2025-11-01T13:57:57.1627819Z        --add-users user [user]
    2025-11-01T13:57:57.7620833Z
    2025-11-01T13:57:57.7621314Z all done
    2025-11-01T13:57:57.7621564Z
    2025-11-01T13:57:57.7634133Z /usr/bin/wget
    2025-11-01T13:57:57.7634892Z TESTING: FIXME: wget

Misc: It seems that the last commit to disable a test in this manner was
commit 7e91a0414 ("tests: disable broken wget tests in utils/sysutils",
2023-08-28).

[1] https://github.com/netblue30/firejail/actions/runs/18997725218/job/54259933026