### PR TITLE
bugfix: correct directory traversal checking logic

### DIFF
--- a/src/firecfg/main.c
+++ b/src/firecfg/main.c
@@ -224,7 +224,7 @@ static void parse_config_file(const char *cfgfile, int do_symlink) {
 			continue;
 
 		// do not accept .. and/or / in file name
-		if (strstr(buf, "..") || strchr(buf, '/')) {
+		if (contains_directory_traversal(buf) || strchr(buf, '/')) {
 			fprintf(stderr, "Error: invalid line %d in %s\n", lineno, cfgfile);
 			exit(1);
 		}

--- a/src/firejail/fs_bin.c
+++ b/src/firejail/fs_bin.c
@@ -86,7 +86,7 @@ static int valid_full_path_file(const char *name) {
 
 	if (*name != '/')
 		return 0;
-	if (strstr(name, ".."))
+	if (contains_directory_traversal(name))
 		return 0;
 
 	// do we have a file?
@@ -136,7 +136,7 @@ static void duplicate(char *fname) {
 	EUID_ASSERT();
 	assert(fname);
 
-	if (*fname == '~' || strstr(fname, "..")) {
+	if (*fname == '~' || contains_directory_traversal(fname)) {
 		fprintf(stderr, "Error: \"%s\" is an invalid filename\n", fname);
 		exit(1);
 	}

--- a/src/firejail/fs_etc.c
+++ b/src/firejail/fs_etc.c
@@ -301,7 +301,7 @@ static void duplicate(const char *fname, const char *private_dir, const char *pr
 static void duplicate_globbing(const char *fname, const char *private_dir, const char *private_run_dir) {
 	assert(fname);
 
-	if (*fname == '~' || *fname == '/' || strstr(fname, "..")) {
+	if (*fname == '~' || *fname == '/' || contains_directory_traversal(fname)) {
 		fprintf(stderr, "Error: \"%s\" is an invalid filename\n", fname);
 		exit(1);
 	}

--- a/src/firejail/fs_home.c
+++ b/src/firejail/fs_home.c
@@ -474,7 +474,7 @@ void fs_check_private_cwd(const char *dir) {
 	cfg.cwd = expand_macros(dir);
 
 	// realpath/is_dir not used because path may not exist outside of jail
-	if (strstr(cfg.cwd, "..") || *cfg.cwd != '/')
+	if (contains_directory_traversal(cfg.cwd) || *cfg.cwd != '/')
 		goto errout;
 
 	return;

--- a/src/firejail/fs_lib.c
+++ b/src/firejail/fs_lib.c
@@ -103,7 +103,7 @@ static const char *masked_lib_dirs[] = {
 
 // return 1 if the file is in masked_lib_dirs[]
 static int valid_full_path(const char *full_path) {
-	if (strstr(full_path, ".."))
+	if (contains_directory_traversal(full_path))
 		return 0;
 
 	int i = 0;
@@ -279,7 +279,7 @@ static void install_list_entry(const char *lib) {
 	// filename check
 	reject_meta_chars(lib, 1);
 
-	if (strstr(lib, "..")) {
+	if (contains_directory_traversal(lib)) {
 		fprintf(stderr, "Error: \"%s\" is an invalid library\n", lib);
 		exit(1);
 	}

--- a/src/firejail/fs_whitelist.c
+++ b/src/firejail/fs_whitelist.c
@@ -619,7 +619,7 @@ void fs_whitelist(void) {
 		if (arg_debug || arg_debug_whitelists)
 			printf("Debug %d: new_name: %s\n", __LINE__, new_name);
 
-		if (strstr(new_name, ".."))
+		if (contains_directory_traversal(new_name))
 			whitelist_error(new_name);
 
 		TopDir *current_top = NULL;

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -778,7 +778,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 			}
 			char *path = argv[i + 1];
 			invalid_filename(path, 0); // no globbing
-			if (strstr(path, "..")) {
+			if (contains_directory_traversal(path)) {
 				fprintf(stderr, "Error: invalid file name %s\n", path);
 				exit(1);
 			}
@@ -806,13 +806,13 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 			}
 			char *path1 = argv[i + 1];
 			invalid_filename(path1, 0); // no globbing
-			if (strstr(path1, "..")) {
+			if (contains_directory_traversal(path1)) {
 				fprintf(stderr, "Error: invalid file name %s\n", path1);
 				exit(1);
 			}
 			char *path2 = argv[i + 2];
 			invalid_filename(path2, 0); // no globbing
-			if (strstr(path2, "..")) {
+			if (contains_directory_traversal(path2)) {
 				fprintf(stderr, "Error: invalid file name %s\n", path2);
 				exit(1);
 			}
@@ -840,7 +840,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 			}
 			char *path = argv[i + 1];
 			invalid_filename(path, 0); // no globbing
-			if (strstr(path, "..")) {
+			if (contains_directory_traversal(path)) {
 				fprintf(stderr, "Error: invalid file name %s\n", path);
 				exit(1);
 			}
@@ -869,7 +869,7 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 			}
 			char *path = argv[i + 1];
 			invalid_filename(path, 0); // no globbing
-			if (strstr(path, "..")) {
+			if (contains_directory_traversal(path)) {
 				fprintf(stderr, "Error: invalid file name %s\n", path);
 				exit(1);
 			}
@@ -1624,7 +1624,7 @@ int main(int argc, char **argv, char **envp) {
 				exit(1);
 			}
 			invalid_filename(arg_tracefile, 0); // no globbing
-			if (strstr(arg_tracefile, "..") || has_cntrl_chars(arg_tracefile)) {
+			if (contains_directory_traversal(arg_tracefile) || has_cntrl_chars(arg_tracefile)) {
 				fprintf(stderr, "Error: invalid file name %s\n", arg_tracefile);
 				exit(1);
 			}
@@ -1836,7 +1836,7 @@ int main(int argc, char **argv, char **envp) {
 
 				// check name
 				invalid_filename(subdirname, 0); // no globbing
-				if (strstr(subdirname, "..") || strstr(subdirname, "/")) {
+				if (contains_directory_traversal(subdirname) || strstr(subdirname, "/")) {
 					fprintf(stderr, "Error: invalid overlay name\n");
 					exit(1);
 				}

--- a/src/firejail/netfilter.c
+++ b/src/firejail/netfilter.c
@@ -124,7 +124,7 @@ void check_netfilter_file(const char *fname) {
 
 	invalid_filename(tmp, 0); // no globbing
 
-	if (is_dir(tmp) || is_link(tmp) || strstr(tmp, "..") || access(tmp, R_OK )) {
+	if (is_dir(tmp) || is_link(tmp) || contains_directory_traversal(tmp) || access(tmp, R_OK )) {
 		fprintf(stderr, "Error: invalid network filter file %s\n", tmp);
 		exit(1);
 	}

--- a/src/firejail/netns.c
+++ b/src/firejail/netns.c
@@ -45,7 +45,7 @@ static char *netns_etc_dir(const char *nsname) {
 }
 
 void check_netns(const char *nsname) {
-	if (strchr(nsname, '/') || strstr(nsname, "..")) {
+	if (strchr(nsname, '/') || contains_directory_traversal(nsname)) {
 		fprintf(stderr, "Error: invalid netns name %s\n", nsname);
 		exit(1);
 	}

--- a/src/firejail/output.c
+++ b/src/firejail/output.c
@@ -66,7 +66,7 @@ void check_output(int argc, char **argv) {
 	}
 
 	// do not accept directories, links, and files with ".."
-	if (strstr(outfile, "..") || is_link(outfile) || is_dir(outfile) || has_cntrl_chars(outfile)) {
+	if (contains_directory_traversal(outfile) || is_link(outfile) || is_dir(outfile) || has_cntrl_chars(outfile)) {
 		fprintf(stderr, "Error: invalid output file. Links, directories, files with \"..\" and control characters in filenames are not allowed.\n");
 		exit(1);
 	}

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -20,6 +20,7 @@
 #include "firejail.h"
 #include "../include/gcov_wrapper.h"
 #include "../include/seccomp.h"
+#include "../include/common.h"
 #include "../include/syscall.h"
 #include <dirent.h>
 #include <sys/stat.h>
@@ -1534,7 +1535,7 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 
 			// check name
 			invalid_filename(subdirname, 0); // no globbing
-			if (strstr(subdirname, "..") || strstr(subdirname, "/")) {
+			if (contains_directory_traversal(subdirname) || strstr(subdirname, "/")) {
 				fprintf(stderr, "Error: invalid overlay name\n");
 				exit(1);
 			}
@@ -1605,7 +1606,7 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 			// check directories
 			invalid_filename(dname1, 0); // no globbing
 			invalid_filename(dname2, 0); // no globbing
-			if (strstr(dname1, "..") || strstr(dname2, "..")) {
+			if (contains_directory_traversal(dname1) || contains_directory_traversal(dname2)) {
 				fprintf(stderr, "Error: invalid file name.\n");
 				exit(1);
 			}
@@ -1763,7 +1764,7 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 
 	// some characters just don't belong in filenames
 	invalid_filename(ptr, 1); // globbing
-	if (strstr(ptr, "..")) {
+	if (contains_directory_traversal(ptr)) {
 		if (lineno == 0)
 			fprintf(stderr, "Error: \"%s\" is an invalid filename\n", ptr);
 		else if (fname != NULL)

--- a/src/ftee/Makefile
+++ b/src/ftee/Makefile
@@ -7,4 +7,7 @@ MOD_DIR = $(ROOT)/src/$(MOD)
 PROG = $(MOD_DIR)/$(MOD)
 TARGET = $(PROG)
 
+EXTRA_OBJS = \
+../lib/common.o
+
 include $(ROOT)/src/prog.mk

--- a/src/ftee/main.c
+++ b/src/ftee/main.c
@@ -199,7 +199,7 @@ int main(int argc, char **argv) {
 
 
 	// do not accept directories, links, and files with ".."
-	if (strstr(fname, "..") || is_link(fname) || is_dir(fname))
+	if (contains_directory_traversal(fname) || is_link(fname) || is_dir(fname))
 		goto errexit;
 
 	struct stat s;

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -156,6 +156,7 @@ char *do_replace_cntrl_chars(char *str, char c);
 char *replace_cntrl_chars(const char *str, char c);
 char *escape_cntrl_chars(const char *str);
 int has_cntrl_chars(const char *str);
+int contains_directory_traversal(const char *fname);
 void reject_cntrl_chars(const char *fname);
 void reject_meta_chars(const char *fname, int globbing);
 void warn_dumpable(void);

--- a/src/lib/common.c
+++ b/src/lib/common.c
@@ -473,6 +473,25 @@ int has_cntrl_chars(const char *str) {
 	return 0;
 }
 
+int str_ends_with(const char *str, const char *postfix) {
+	int str_length = strlen(str);
+	int postfix_length = strlen(postfix);
+
+	if (str_length < postfix_length)
+		return false;
+
+	const char *str_tail = str + str_length - postfix_length;
+
+	return !strcmp(str_tail, postfix);
+}
+
+int contains_directory_traversal(const char *fname) {
+	return    !strcmp(fname, "..")
+		|| strstr(fname, "../")
+		|| str_ends_with(fname, "/..");
+}
+
+
 void reject_cntrl_chars(const char *fname) {
 	assert(fname);
 

--- a/src/libtracelog/libtracelog.c
+++ b/src/libtracelog/libtracelog.c
@@ -33,6 +33,7 @@
 #include <dirent.h>
 #include <limits.h>
 #include "../include/rundefs.h"
+#include "../include/common.h"
 
 //#define DEBUG
 
@@ -110,7 +111,7 @@ static char *storage_find(const char *str) {
 	const char *tofind = str;
 	int allocated = 0;
 
-	if (strstr(str, "..") || strstr(str, "/./") || strstr(str, "//") || str[0] != '/') {
+	if (contains_directory_traversal(str) || strstr(str, "/./") || strstr(str, "//") || str[0] != '/') {
 		if (cwd != NULL && str[0] != '/') {
 			char *fullpath=malloc(PATH_MAX);
 			if (!fullpath) {


### PR DESCRIPTION
Fixes #6915

The logic checking for the presence of directory traversal 'tokens' yields false positives.
It is perhaps rare though entirely valid for a filename to contain a double dot.
The linked issue is how it manifested in my usage of Firejail.

I aim to fix this by checking any of the following instead:
1. the string is a full match of ".."
2. the string contains "../"
3. the string ends with "/.."

if I am missing any scenarios in which a '..' would ordinarily be valid, please let me know.
PS: should I add `str_ends_with` to the common.h header? I figure it couldn't hurt, no? Let me know.