### PR TITLE
docs: clarify that only latest and dev versions are supported

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -63,6 +63,7 @@ Note: Items are checked with an "x", like so:
 - [x] This is a checked item.
 -->
 
+- [ ] I am using a [supported version](https://github.com/netblue30/firejail/tree/master/SECURITY.md) of firejail
 - [ ] The issues is caused by firejail (i.e. running the program by path (e.g. `/usr/bin/vlc`) "fixes" it).
 - [ ] I can reproduce the issue without custom modifications (e.g. globals.local).
 - [ ] The program has a profile. (If not, request one in `https://github.com/netblue30/firejail/issues/1139`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,11 @@
 
 Welcome to firejail, and thank you for your interest in contributing!
 
+## Support
+
+Make sure that you are using a [supported version](SECURITY.md) of firejail
+before commenting on an issue/discussion/PR or opening a new one.
+
 ## Opening an issue
 
 We welcome issues, whether to ask a question, provide information, request a

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ See [SECURITY.md](SECURITY.md).
 
 ## Installing
 
+For the supported versions, see [SECURITY.md](SECURITY.md).
+
 ### Debian
 
 Debian stable (bullseye): We recommend to use the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,31 @@
 
 ## Supported Versions
 
+Unless explicitly stated otherwise, we only support the latest released version
+(and the current development version) of firejail, which should be the one in
+the following page:
+
+* <https://github.com/netblue30/firejail/releases/latest>
+
+Versions older than the latest usually have outdated profiles and may contain
+bugs and security vulnerabilities that were already fixed in a later version.
+
+See [Installing](README.md#installing) for distribution-specific instructions
+and recommendations.
+
+If the firejail version in your distribution is older than the latest released
+version (and at least a few days have passed since the release), please contact
+the maintainers for your distribution and request an update to the relevant
+package(s).
+
+In the meantime, you can [build and install](README.md#building) the current
+development version.
+
+See also [CONTRIBUTING.md](CONTRIBUTING.md).
+
+Released versions are listed in the table below, which is mostly intended for
+historical reference and may be outdated and/or incomplete.
+
 | Version | Supported by us    | EOL                | Supported by distribution                                                         |
 | ------- | ------------------ | ------------------ | --------------------------------------------------------------------------------- |
 | 0.9.76  | :heavy_check_mark: |                    |                                                                                   |


### PR DESCRIPTION
To avoid wasting time due to (for example):

* Bugs that were already fixed
* Old versions with different/missing verbosity in the output
* Behavior that only affects (or differs in) old versions
* Copying and pasting profile lines which contain commands that are
  unsupported in old versions (or that depend on other changes to
  profiles in the current version)

This is a follow-up to #6964.