### PR TITLE
bugfix: make checkcfg init/cfg vars global

### DIFF
--- a/src/firejail/checkcfg.c
+++ b/src/firejail/checkcfg.c
@@ -26,8 +26,8 @@
 
 #define MAX_READ 8192				  // line buffer for profile files
 
-static int firejail_config_init = 0;
-static int cfg_val[CFG_MAX];
+int firejail_config_init = 0;
+int cfg_val[CFG_MAX];
 char *xephyr_screen = "800x600";
 char *xephyr_extra_params = "";
 char *xpra_extra_params = "";

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -869,6 +869,8 @@ enum {
 	CFG_TRACELOG,
 	CFG_MAX // this should always be the last entry
 };
+extern int firejail_config_init;
+extern int cfg_val[CFG_MAX];
 extern char *xephyr_screen;
 extern char *xephyr_extra_params;
 extern char *xpra_extra_params;


### PR DESCRIPTION
Instead of them being local to the translation unit.

This should ensure that firejail.config is not read more than once (as
is intended by the code), especially after options like `private-etc`
are applied (which could render the file inaccessible when calling
`checkcfg()`).

Related commits:

* 8bff773d6 ("add symlink resolution for home directories", 2019-07-09)
  / issue #2877
* d32509945 ("rewrite/partial revert of
  8bff773d6a7bf70c97b3d5b751df9ec0dd6c8b5d", 2019-08-09)
  / issue #2877
* d1aeeb4fa ("feature: add arg-max-count and arg-max-len options to
  firejail.config (#6878)", 2025-10-30)

Relates to #2877 #6966.