### PR TITLE
profiles: ssh: add `${RUNUSER}/openssh_agent` socket path

### DIFF
--- a/etc/inc/allow-ssh.inc
+++ b/etc/inc/allow-ssh.inc
@@ -8,6 +8,7 @@ noblacklist /etc/ssh/ssh_config
 noblacklist /etc/ssh/ssh_config.d
 noblacklist /etc/ssh/ssh_revoked_hosts # RevokedHostKeys on Gentoo
 noblacklist ${PATH}/ssh*
+noblacklist ${RUNUSER}/openssh_agent
 noblacklist /tmp/ssh-*
 # Arch Linux and derivatives
 noblacklist /usr/lib/ssh

--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -433,6 +433,7 @@ read-only ${HOME}/.config/MangoHud
 read-only ${HOME}/.local/share/thumbnailers
 
 # prevent access to ssh-agent
+blacklist ${RUNUSER}/openssh_agent
 blacklist /tmp/ssh-*
 
 # top secret

--- a/etc/profile-a-l/keepassxc.profile
+++ b/etc/profile-a-l/keepassxc.profile
@@ -14,6 +14,7 @@ noblacklist ${HOME}/.config/KeePassXCrc
 noblacklist ${HOME}/.keepassxc
 noblacklist ${DOCUMENTS}
 noblacklist ${RUNUSER}/app
+noblacklist ${RUNUSER}/openssh_agent
 noblacklist /tmp/ssh-*
 
 # Allow browser profiles, required for browser integration.
@@ -66,6 +67,7 @@ include disable-xdg.inc
 
 mkdir ${RUNUSER}/app/org.keepassxc.KeePassXC
 whitelist ${RUNUSER}/app/org.keepassxc.KeePassXC
+whitelist ${RUNUSER}/openssh_agent
 whitelist /tmp/ssh-*
 whitelist /usr/share/keepassxc
 include whitelist-run-common.inc

--- a/etc/profile-m-z/seahorse.profile
+++ b/etc/profile-m-z/seahorse.profile
@@ -24,6 +24,7 @@ include disable-xdg.inc
 #mkdir ${HOME}/.ssh
 #whitelist ${HOME}/.gnupg
 #whitelist ${HOME}/.ssh
+whitelist ${RUNUSER}/openssh_agent
 whitelist /tmp/ssh-*
 whitelist /usr/share/gnupg
 whitelist /usr/share/gnupg2


### PR DESCRIPTION
Added another default socket path, that is used in Debian for [socket-activated ssh-agent](https://salsa.debian.org/ssh-team/openssh/-/commit/e17cd096bf231d3bb2e1d73e2b59b6e4fa5a03a8#6f53c63e7838092b9c769752e298ee74da6f326f_0_8) to disable-common.inc.


