### PR TITLE
update system call groups

### DIFF
--- a/contrib/syntax/lists/syscall_groups.list
+++ b/contrib/syntax/lists/syscall_groups.list
@@ -11,6 +11,7 @@ file-system
 io-event
 ipc
 keyring
+memfd
 memlock
 module
 mount
@@ -21,6 +22,7 @@ process
 raw-io
 reboot
 resources
+sandbox
 setuid
 signal
 swap

--- a/etc/templates/syscalls.txt
+++ b/etc/templates/syscalls.txt
@@ -1,7 +1,6 @@
 Hints to write own seccomp filters
 ==================================
 
-
 The different seccomp commands
 ------------------------------
 
@@ -27,64 +26,66 @@ Always have a look at 'man 1 firejail'.
 Definition of groups
 --------------------
 
-@aio=io_cancel,io_destroy,io_getevents,io_pgetevents,io_setup,io_submit,io_uring_enter,io_uring_register,io_uring_setup
+@aio=io_cancel,io_destroy,io_getevents,io_pgetevents,io_pgetevents_time64,io_setup,io_submit,io_uring_enter,io_uring_register,io_uring_setup
 @basic-io=_llseek,close,close_range,dup,dup2,dup3,lseek,pread64,preadv,preadv2,pwrite64,pwritev,pwritev2,read,readv,write,writev
 @chown=chown,chown32,fchown,fchown32,fchownat,lchown,lchown32
-@clock=adjtimex,clock_adjtime,clock_settime,settimeofday,stime
+@clock=adjtimex,clock_adjtime,clock_adjtime64,clock_gettime,clock_gettime,clock_gettime64,clock_getres_time64,clock_nanosleep,clock_nanosleep_time64,clock_settime,clock_settime64,gettimeofday,old_adjtimex,osf_gettimeofday,osf_settimeofday,settimeofday,stime,time
 @cpu-emulation=modify_ldt,subpage_prot,switch_endian,vm86,vm86old
-@debug=lookup_dcookie,perf_event_open,pidfd_getfd,process_vm_writev,rtas,s390_runtime_instr,sys_debug_setcontext
-@default=@clock,@cpu-emulation,@debug,@module,@mount,@obsolete,@raw-io,@reboot,@swap,open_by_handle_at,name_to_handle_at,ioprio_set,ni_syscall,syslog,fanotify_init,add_key,request_key,mbind,migrate_pages,move_pages,keyctl,io_setup,io_destroy,io_getevents,io_submit,io_cancel,remap_file_pages,set_mempolicyvmsplice,userfaultfd,acct,bpf,nfsservctl,setdomainname,sethostname,vhangup
+@debug=lookup_dcookie,perf_event_open,pidfd_getfd,process_vm_writev,rtas,s390_runtime_instr,sys_debug_setcontext,uprobe,uretprobe
+@default=@clock,@cpu-emulation,@debug,@module,@mount,@obsolete,@raw-io,@reboot,@swap,open_by_handle_at,name_to_handle_at,ioprio_set,syslog,fanotify_init,add_key,request_key,mbind,migrate_pages,move_pages,keyctl,io_setup,io_destroy,io_getevents,io_submit,io_cancel,remap_file_pages,set_mempolicy,vmsplice,userfaultfd,acct,bpf,nfsservctl,setdomainname,sethostname,vhangup,mincore
+@default-keep=arch_prctl,execv,execveat,execve,futex,mmap,mmap2,mprotect,prctl
 @default-nodebuggers=@default,ptrace,personality,process_vm_readv
-@default-keep=execveat,execve,prctl
-@file-system=access,chdir,chmod,close,close_range,creat,faccessat,faccessat2,fallocate,fchdir,fchmod,fchmodat,fcntl,fcntl64,fgetxattr,flistxattr,fremovexattr,fsetxattr,fstat,fstat64,fstatat64,fstatfs,fstatfs64,ftruncate,ftruncate64,futimesat,getcwd,getdents,getdents64,getxattr,inotify_add_watch,inotify_init,inotify_init1,inotify_rm_watch,lgetxattr,link,linkat,listxattr,llistxattr,lremovexattr,lsetxattr,lstat,lstat64,mkdir,mkdirat,mknod,mknodat,mmap,mmap2,munmap,newfstatat,oldfstat,oldlstat,oldstat,open,openat,openat2,readlink,readlinkat,removexattr,rename,renameat,renameat2,rmdir,setxattr,stat,stat64,statfs,statfs64,statx,symlink,symlinkat,truncate,truncate64,unlink,unlinkat,utime,utimensat,utimes
-@io-event=_newselect,epoll_create,epoll_create1,epoll_ctl,epoll_ctl_old,epoll_pwait,epoll_wait,epoll_wait_old,eventfd,eventfd2,poll,ppoll,pselect6,select
-@ipc=ipc,memfd_create,mq_getsetattr,mq_notify,mq_open,mq_timedreceive,mq_timedsend,mq_unlink,msgctl,msgget,msgrcv,msgsnd,pipe,pipe2,process_madvise,process_vm_readv,process_vm_writev,semctl,semget,semop,semtimedop,shmat,shmctl,shmdt,shmget
+@file-system=access,cachestat,chdir,chmod,close,close_range,creat,faccessat,faccessat2,fallocate,fanotify_mark,fchdir,fchmod,fchmodat,fchmodat2,fcntl,fcntl64,fgetxattr,file_getattr,file_setattr,flistxattr,fremovexattr,fsetxattr,fstat,fstat64,fstatat64,fstatfs,fstatfs64,ftruncate,ftruncate64,futimesat,getcwd,getdents,getdents64,getxattr,getxattrat,inotify_add_watch,inotify_init,inotify_init1,inotify_rm_watch,lgetxattr,link,linkat,listxattr,listxattrat,llistxattr,lremovexattr,lsetxattr,lstat,lstat64,mkdir,mkdirat,mknod,mknodat,munmap,newfstatat,oldfstat,oldlstat,oldstat,open,openat,openat2,osf_fstat,osf_fstatfs,osf_fstatfs64,osf_getdirentries,osf_lstat,osf_proplist_syscall,osf_utimes,quotactl_fd,readlink,readlinkat,removexattr,removexattrat,rename,renameat,renameat2,rmdir,setxattr,setxattrat,stat,stat64,statfs,statfs64,statx,symlink,symlinkat,truncate,truncate64,unlink,unlinkat,utime,utimensat,utimes
+@io-event=_newselect,epoll_create,epoll_create1,epoll_ctl,epoll_pwait,epoll_pwait2,epoll_wait,eventfd,eventfd2,osf_select,poll,ppoll,ppoll_time64,pselect6_time64,pselect6,select
+@ipc=ipc,mq_getsetattr,mq_notify,mq_open,mq_timedreceive,mq_timedreceive_time64,mq_timedsend,mq_timedsend_time64,mq_unlink,msgctl,msgget,msgrcv,msgsnd,pipe,pipe2,process_madvise,process_mrelease,process_vm_readv,process_vm_writev,semctl,semget,semop,semtimedop,semtimedop_time64,shmat,shmctl,shmdt,shmget
 @keyring=add_key,keyctl,request_key
+@memfd=memfd_create,memfd_secret
 @memlock=mlock,mlock2,mlockall,munlock,munlockall
 @module=delete_module,finit_module,init_module
-@mount=chroot,fsconfig,fsmount,fsopen,fspick,mount,move_mount,open_tree,pivot_root,umount,umount2
-@network-io=accept,accept4,bind,connect,getpeername,getsockname,getsockopt,listen,recv,recvfrom,recvmmsg,recvmsg,send,sendmmsg,sendmsg,sendto,setsockopt,shutdown,socket,socketcall,socketpair
-@obsolete=_sysctl,afs_syscall,bdflush,break,create_module,ftime,get_kernel_syms,getpmsg,gtty,idle,lock,mpx,prof,profil,putpmsg,query_module,security,sgetmask,ssetmask,stty,sysfs,tuxcall,ulimit,uselib,ustat,vserver
+@mount=chroot,fsconfig,fsmount,fsopen,fspick,listmount,mount,mount_setattr,move_mount,open_oldumount,open_tree,open_tree_attr,osf_mount,pivot_root,statmount,umount,umount2
+@network-io=accept,accept4,bind,connect,getpeername,getsockname,getsockopt,listen,recv,recvfrom,recvmmsg,recvmmsg_time64,recvmsg,send,sendmmsg,sendmsg,sendto,setsockopt,shutdown,socket,socketcall,socketpair
+@obsolete=_sysctl,afs_syscall,bdflush,break,create_module,dipc,epoll_ctl_old,epoll_wait_old,exec_with_loader,ftime,get_kernel_syms,getpmsg,gtty,idle,llseek,lock,mpx,multiplexer,osf_adjtime,osf_afs_syscall,osf_alt_plock,osf_alt_setsid,osf_alt_sigpending,osf_asynch_daemon,osf_audcntl,osf_audgen,osf_chflags,osf_execve,osf_exportfs,osf_fchflags,osf_fdatasync,osf_fpathconf,osf_fuser,osf_getaddressconf,osf_getfh,osf_getfsstat,osf_gethostid,osf_getlogin,osf_getmnt,osf_kloadcall,osf_kmodcall,osf_memcntl,osf_mincore,osf_mremap,osf_msfs_syscall,osf_msleep,osf_mvalid,osf_mwakeup,osf_naccept,osf_nfssvc,osf_ngetpeername,osf_ngetsockname,osf_nrecvfrom,osf_nrecvmsg,osf_nsendmsg,osf_ntp_adjtime,osf_ntp_gettime,osf_old_creat,osf_old_fstat,osf_old_getpgrp,osf_old_killpg,osf_old_lstat,osf_old_open,osf_old_sigaction,osf_old_sigblock,osf_old_sigreturn,osf_old_sigsetmask,osf_old_sigvec,osf_old_stat,osf_old_vadvise,osf_old_vtrace,osf_old_wait,osf_oldquota,osf_pathconf,osf_pid_block,osf_pid_unblock,osf_plock,osf_priocntlset,osf_profil,osf_reboot,osf_revoke,osf_sbrk,osf_security,osf_set_speculative,osf_sethostid,osf_setlogin,osf_signal,osf_sigsendset,osf_sigwaitprim,osf_sstk,osf_stat,osf_statfs,osf_statfs64,osf_subsys_info,osf_swapctl,osf_table,osf_uadmin,osf_uswitch,osf_utc_adjtime,osf_utc_gettime,osf_waitid,perfctr,prof,profil,putpmsg,query_module,security,sgetmask,spill,ssetmask,stty,sysfs,timerfd,tuxcall,ulimit,uselib,ustat,vserver,xtensa
 @privileged=@chown,@clock,@module,@raw-io,@reboot,@swap,_sysctl,acct,bpf,capset,chroot,fanotify_init,mount,nfsservctl,open_by_handle_at,pivot_root,quotactl,setdomainname,setfsuid,setfsuid32,setgroups,setgroups32,sethostname,setresuid,setresuid32,setreuid,setreuid32,setuid,setuid32,umount2,vhangup
-@process=arch_prctl,capget,clone,clone3,execveat,fork,getrusage,kill,pidfd_open,pidfd_send_signal,prctl,rt_sigqueueinfo,rt_tgsigqueueinfo,setns,swapcontext,tgkill,times,tkill,unshare,vfork,wait4,waitid,waitpid
+@process=arc_gettls,arc_settls,arc_usr_cmpxchg,atomic_barrier,atomic_cmpxchg_32,cachectl,cacheflush,capget,clone,clone3,exit,exit_group,fork,futex_requeue,futex_time64,futex_wait,futex_waitv,futex_wake,get_robust_list,get_thread_area,getegid,geteuid,geteuid32,getgid,getegid32,getgroups,getgroups32,getpgid,getpgrp,getpid,getppid,getresgid,getresgid32,getresuid,getresuid32,getsid,gettid,getuid,getuid32,getxgid,getxpid,getxuid,kill,membarrier,or1k_atomic,osf_set_program_attributes,osf_wait4,pidfd_open,pidfd_send_signal,riscv_flush_icache,rseq,rt_sigqueueinfo,rt_tgsigqueueinfo,s390_guarded_storage,sched_get_affinity,setns,set_robust_list,set_thread_area,set_tid_address,sethae,setpgrp,setpriority,spu_create,spu_run,swapcontext,tgkill,times,tkill,unshare,utimensat_time64,vfork,wait4,waitid,waitpid
 @raw-io=ioperm,iopl,pciconfig_iobase,pciconfig_read,pciconfig_write,s390_pci_mmio_read,s390_pci_mmio_write
 @reboot=kexec_load,kexec_file_load,reboot
-@resources=ioprio_set,mbind,migrate_pages,move_pages,nice,sched_setaffinity,sched_setattr,sched_setparam,sched_setscheduler,set_mempolicy
+@resources=getdtablesize,getrlimit,getrusage,ioprio_set,mbind,migrate_pages,move_pages,nice,osf_getrusage,prlimit64,sched_set_affinity,set_mempolicy_home_node,sched_setaffinity,sched_setattr,sched_setparam,sched_setrlimit,sched_setscheduler,set_mempolicy,ugetrlimit
+@sandbox=landlock_add_rule,landlock_create_ruleset,landlock_restrict_self,seccomp
 @setuid=setgid,setgid32,setgroups,setgroups32,setregid,setregid32,setresgid,setresgid32,setresuid,setresuid32,setreuid,setreuid32,setuid,setuid32
-@signal=rt_sigaction,rt_sigpending,rt_sigprocmask,rt_sigsuspend,rt_sigtimedwait,sigaction,sigaltstack,signal,signalfd,signalfd4,sigpending,sigprocmask,sigsuspend
-@swap=swapon,swapoff
-@sync=fdatasync,fsync,msync,sync,sync_file_range,sync_file_range2,syncfs
-@system-service=@aio,@basic-io,@chown,@default,@file-system,@io-event,@ipc,@keyring,@memlock,@network-io,@process,@resources,@setuid,@signal,@sync,@timer,brk,capget,capset,copy_file_range,fadvise64,fadvise64_64,flock,get_mempolicy,getcpu,getpriority,getrandom,ioctl,ioprio_get,kcmp,madvise,mprotect,mremap,name_to_handle_at,oldolduname,olduname,personality,readahead,readdir,remap_file_pages,sched_get_priority_max,sched_get_priority_min,sched_getaffinity,sched_getattr,sched_getparam,sched_getscheduler,sched_rr_get_interval,sched_yield,sendfile,sendfile64,setfsgid,setfsgid32,setfsuid,setfsuid32,setpgid,setsid,splice,sysinfo,tee,umask,uname,userfaultfd,vmsplice
-@timer=alarm,getitimer,setitimer,timer_create,timer_delete,timer_getoverrun,timer_gettime,timer_settime,timerfd_create,timerfd_gettime,timerfd_settime,times
+@signal=osf_sigprocmask,osf_sigstack,pause,restart_syscall,rt_sigaction,rt_sigpending,rt_sigprocmask,rt_sigreturn,rt_sigtimedwait_time64,rt_sigsuspend,rt_sigtimedwait,sigaction,sigaltstack,signal,signalfd,signalfd4,sigpending,sigprocmask,sigreturn,sigsuspend,utrap_install
+@swap=osf_swapon,swapon,swapoff
+@sync=arm_sync_file_range,fdatasync,fsync,msync,sync,sync_file_range,sync_file_range2,syncfs
+@system-service=@aio,@basic-io,@chown,@default,@file-system,@io-event,@ipc,@keyring,@memlock,@network-io,@process,@resources,@setuid,@signal,@sync,@timer,arm_fadvise64_64,brk,capget,capset,copy_file_range,fadvise64,fadvise64_64,flock,get_mempolicy,getcpu,getdomainname,gethostname,getpagesize,getpriority,getrandom,ioctl,ioprio_get,kcmp,kern_features,listns,lsm_get_self_attr,lsm_list_modules,lsm_set_self_attr,map_shadow_stack,madvise,memory_ordering,mremap,mseal,name_to_handle_at,oldolduname,olduname,osf_getdomainname,osf_getsysinfo,osf_setsysinfo,osf_syscall,osf_sysinfo,osf_utsname,personality,pkey_alloc,pkey_free,pkey_mprotect,readahead,readdir,remap_file_pages,riscv_hwprobe,s390_sthyi,sched_get_priority_max,sched_get_priority_min,sched_getaffinity,sched_getattr,sched_getparam,sched_getscheduler,sched_rr_get_interval,sched_rr_get_interval_time64,sched_yield,sendfile,sendfile64,setfsgid,setfsgid32,setfsuid,setfsuid32,setpgid,setsid,splice,syscall,sysinfo,sysmips,tee,umask,uname,userfaultfd,vmsplice
+@timer=alarm,getitimer,nanosleep,osf_getitimer,osf_setitimer,osf_usleep_thread,setitimer,timer_create,timer_delete,timer_getoverrun,timer_gettime,timer_gettime64,timer_settime,timer_settime64,timerfd_create,timerfd_gettime,timerfd_gettime64,timerfd_settime,timerfd_settime64,times
 
 Inheritance of groups
 ---------------------
 
-+---------------+
-| @default-keep |
-+---------------+
+                               +---------------+
+                               | @default-keep |
+                               +---------------+
 
-+----------------+  +---------+  +--------+  +--------------+
-| @cpu-emulation |  | @clock  |  | @chown |  | @aio         |
-| @debug         |  | @module |  +--------+  | @basic-io    |
-| @obsolete      |  | @raw-io |     :  :     | @file-system |
-| @mount         |  | @reboot |     :  :     | @io-event    |
-+----------------+  | @swap   |     :  :     | @ipc         |
-   :                +---------+     :  :     | @keyring     |
-   :                  :  :          :  :     | @memlock     |
-   :    ..............:  :          :  :     | @network-io  |
-   :    :                :  ........:  :     | @process     |
-   :    :                :  :          :     | @resources   |
-+----------+    +-------------+        :     | @setuid      |
-| @default |    | @privileged |        :     | @signal      |
-+----------+    +-------------+        :     | @sync        |
-   :    :                              :     | @timer       |
-   :    :...........................   :     +--------------+
-   :                               :   :        :
-+----------------------+        +-----------------+
-| @default-nodebuggers |        | @system-service |
-+----------------------+        +-----------------+
 
+   +----------------------+                    +-----------------+
+   | @default-nodebuggers |                    | @system-service |
+   +----------------------+                    +-----------------+
+           :      ...............................:     :       :
+           :      :                                    :       :
+         +----------+  +-------------+  ...............:       :..
+         | @default |  | @privileged |  :              :         :
+         +----------+  +-------------+  :              :         :
+           :      :....     :      :    :              :         :
+           :          :     :      :    :              :         :
++----------------+  +---------+  +--------+  +--------------+  +--------------+
+| @cpu-emulation |  | @clock  |  | @chown |  | @aio         |  | @network-io  |
+| @debug         |  | @module |  +--------+  | @basic-io    |  | @process     |
+| @mount         |  | @raw-io |              | @file-system |  | @resources   |
+| @obsolete      |  | @reboot |              | @io-event    |  | @sandbox     |
++----------------+  | @swap   |              | @ipc         |  | @setuid      |
+                    +---------+              | @keyring     |  | @signal      |
+                                             | @memfd       |  | @sync        |
+                                             | @memlock     |  | @timer       |
+                                             +--------------+  +--------------+
 
 What to do if seccomp breaks a program
 --------------------------------------

--- a/src/lib/syscall.c
+++ b/src/lib/syscall.c
@@ -48,1428 +48,2238 @@ typedef struct {
 	int syscall;
 } SyscallCheckList;
 
-// Native syscalls (64 bit versions for 64 bit arch etc)
+// Native syscalls (64-bit versions for 64-bit archs, etc)
 static const SyscallEntry syslist[] = {
-#if defined(__x86_64__)
-// code generated using
-// awk '/__NR_/ { print "{ \"" gensub("__NR_", "", "g", $2) "\", " $3 " },"; }' < /usr/include/x86_64-linux-gnu/asm/unistd_64.h
-#include "../include/syscall_x86_64.h"
+#if defined(__aarch64__)
+	#include "../include/syscall_aarch64.h"
+#elif defined(__alpha__)
+	#include "../include/syscall_alpha.h"
+#elif defined(__arc__)
+	#include "../include/syscall_arc_32.h"
+#elif defined(__arm__) && defined(__ARM_EABI__)
+	#include "../include/syscall_armeabi.h" // Identical to syscall_aarch32.h
+#elif defined(__arm__) && !defined(__ARM_EABI__)
+	#include "../include/syscall_armoabi.h"
+#elif defined(__csky__) || defined(__CSKY__)
+	#include "../include/syscall_csky.h"
+#elif defined(__hexagon__)
+	#include "../include/syscall_hexagon_32.h"
 #elif defined(__i386__)
-// awk '/__NR_/ { print "{ \"" gensub("__NR_", "", "g", $2) "\", " $3 " },"; }' < /usr/include/x86_64-linux-gnu/asm/unistd_32.h
-#include "../include/syscall_i386.h"
-#elif defined(__arm__)
-#include "../include/syscall_armeabi.h"
-#elif defined(__aarch64__)
-#include "../include/syscall_aarch64.h"
+	#include "../include/syscall_i386.h"
+#elif defined(__loongarch64) || __loongarch_grlen == 64
+	#include "../include/syscall_loongarch_64.h"
+#elif defined(__m68k__)
+	#include "../include/syscall_m68k.h"
+#elif defined(__microblaze__) || defined(__MICROBLAZE__)
+	#include "../include/syscall_microblaze.h"
+#elif defined(__mips__) && _MIPS_SIM == _ABIN32
+	#include "../include/syscall_mips_n32.h"
+#elif defined(__mips__) && _MIPS_SIM == _ABI64
+	#include "../include/syscall_mips_n64.h"
+#elif defined(__mips__) && _MIPS_SIM == _ABIO32
+	#include "../include/syscall_mips_o32.h"
+#elif defined(__nios2__) // Support for Nios II is removed in GCC 15
+	#include "../include/syscall_nios2.h"
+#elif defined(__or1k__) || defined(__OR1K__)
+	#include "../include/syscall_openrisc_32.h"
+#elif (defined(__hppa__) || defined(__hppa)) && !defined(__LP64__)
+	#include "../include/syscall_parisc_32.h"
+#elif (defined(__hppa__) || defined(__hppa)) && defined(__LP64__)
+	#include "../include/syscall_parisc_64.h"
+#elif (defined(__powerpc__) || defined(__PPC__)) && (!defined(__powerpc64__) && !defined(__PPC64__))
+	#include "../include/syscall_powerpc_32_nospu.h"
+#elif defined(__powerpc64__) || defined(__PPC64__)
+	#include "../include/syscall_powerpc_64_nospu.h"
+#elif defined(__riscv) && __riscv_xlen == 32
+	#include "../include/syscall_riscv_32.h"
+#elif defined(__riscv) && __riscv_xlen == 64
+	#include "../include/syscall_riscv_64.h"
+#elif defined(__s390__) && !defined(__s390x__)
+	#include "../include/syscall_s390_32.h"
+#elif defined(__s390x__)
+	#include "../include/syscall_s390_64.h"
+#elif defined(__sparc__) && !defined(__arch64__)
+	#include "../include/syscall_sparc_32.h"
+#elif defined(__sparc__) && defined(__arch64__)
+	#include "../include/syscall_sparc_64.h"
+#elif defined(__sh__)
+	#include "../include/syscall_superh.h"
+#elif defined(__x86_64__)
+	#include "../include/syscall_x86_64.h"
+#elif defined(__xtensa__) || defined(__XTENSA__)
+	#include "../include/syscall_xtensa.h"
 #else
-#warning "Please submit a syscall table for your architecture"
+	#warning "Please submit a syscall table for your architecture"
 #endif
 };
 
-// 32 bit syscalls for 64 bit arch
+// 32-bit syscalls for 64-bit archs
 static const SyscallEntry syslist32[] = {
-#if defined(__x86_64__)
-#include "../include/syscall_i386.h"
-// TODO for other 64 bit archs
-#elif defined(__i386__) || defined(__arm__) || defined(__powerpc__)
-// no secondary arch for 32 bit archs
+#if defined(__aarch64__)
+	#include "../include/syscall_armeabi.h"
+#elif defined(__mips__) && _MIPS_SIM == _ABI64
+	#include "../include/syscall_mips_o32.h"
+#elif defined(__riscv) && __riscv_xlen == 64
+	#include "../include/syscall_riscv_32.h"
+#elif defined(__s390x__)
+	#include "../include/syscall_s390_32.h"
+#elif defined(__sparc__) && defined(__arch64__)
+	#include "../include/syscall_sparc_32.h"
+#elif defined(__x86_64__)
+	#include "../include/syscall_i386.h"
+/*
+#elif defined(__i386__) || defined(__arm__) || defined(__m68k__) || ...
+	no secondary arch for 32-bit archs
+*/
 #endif
 };
 
 static const SyscallGroupList sysgroups[] = {
 	{ .name = "@aio", .list =
-#ifdef SYS_io_cancel
-	  "io_cancel,"
+#ifdef __NR_io_cancel
+	"io_cancel,"
 #endif
-#ifdef SYS_io_destroy
-	  "io_destroy,"
+#ifdef __NR_io_destroy
+	"io_destroy,"
 #endif
-#ifdef SYS_io_getevents
-	  "io_getevents,"
+#ifdef __NR_io_getevents
+	"io_getevents,"
 #endif
-#ifdef SYS_io_pgetevents
-	  "io_pgetevents,"
+#ifdef __NR_io_pgetevents
+	"io_pgetevents,"
 #endif
-#ifdef SYS_io_setup
-	  "io_setup,"
+#ifdef __NR_io_pgetevents_time64
+	"io_pgetevents_time64,"
 #endif
-#ifdef SYS_io_submit
-	  "io_submit,"
+#ifdef __NR_io_setup
+	"io_setup,"
 #endif
-#ifdef SYS_io_uring_enter
-	  "io_uring_enter,"
+#ifdef __NR_io_submit
+	"io_submit,"
 #endif
-#ifdef SYS_io_uring_register
-	  "io_uring_register,"
+#ifdef __NR_io_uring_enter
+	"io_uring_enter,"
 #endif
-#ifdef SYS_io_uring_setup
-	  "io_uring_setup"
+#ifdef __NR_io_uring_register
+	"io_uring_register,"
+#endif
+#ifdef __NR_io_uring_setup
+	"io_uring_setup"
 #endif
 	},
 	{ .name = "@basic-io", .list =
-#ifdef SYS__llseek
-	  "_llseek,"
+#ifdef __NR__llseek
+	"_llseek,"
 #endif
-#ifdef SYS_close
-	  "close,"
+#ifdef __NR_close
+	"close,"
 #endif
-#ifdef SYS_close_range
-	  "close_range,"
+#ifdef __NR_close_range
+	"close_range,"
 #endif
-#ifdef SYS_dup
-	  "dup,"
+#ifdef __NR_dup
+	"dup,"
 #endif
-#ifdef SYS_dup2
-	  "dup2,"
+#ifdef __NR_dup2
+	"dup2,"
 #endif
-#ifdef SYS_dup3
-	  "dup3,"
+#ifdef __NR_dup3
+	"dup3,"
 #endif
-#ifdef SYS_lseek
-	  "lseek,"
+#ifdef __NR_lseek
+	"lseek,"
 #endif
-#ifdef SYS_pread64
-	  "pread64,"
+#ifdef __NR_pread64
+	"pread64,"
 #endif
-#ifdef SYS_preadv
-	  "preadv,"
+#ifdef __NR_preadv
+	"preadv,"
 #endif
-#ifdef SYS_preadv2
-	  "preadv2,"
+#ifdef __NR_preadv2
+	"preadv2,"
 #endif
-#ifdef SYS_pwrite64
-	  "pwrite64,"
+#ifdef __NR_pwrite64
+	"pwrite64,"
 #endif
-#ifdef SYS_pwritev
-	  "pwritev,"
+#ifdef __NR_pwritev
+	"pwritev,"
 #endif
-#ifdef SYS_pwritev2
-	  "pwritev2,"
+#ifdef __NR_pwritev2
+	"pwritev2,"
 #endif
-#ifdef SYS_read
-	  "read,"
+#ifdef __NR_read
+	"read,"
 #endif
-#ifdef SYS_readv
-	  "readv,"
+#ifdef __NR_readv
+	"readv,"
 #endif
-#ifdef SYS_write
-	  "write,"
+#ifdef __NR_write
+	"write,"
 #endif
-#ifdef SYS_writev
-	  "writev"
+#ifdef __NR_writev
+	"writev"
 #endif
 	},
 	{ .name = "@chown", .list =
-#ifdef SYS_chown
-	  "chown,"
+#ifdef __NR_chown
+	"chown,"
 #endif
-#ifdef SYS_chown32
-	  "chown32,"
+#ifdef __NR_chown32
+	"chown32,"
 #endif
-#ifdef SYS_fchown
-	  "fchown,"
+#ifdef __NR_fchown
+	"fchown,"
 #endif
-#ifdef SYS_fchown32
-	  "fchown32,"
+#ifdef __NR_fchown32
+	"fchown32,"
 #endif
-#ifdef SYS_fchownat
-	  "fchownat,"
+#ifdef __NR_fchownat
+	"fchownat,"
 #endif
-#ifdef SYS_lchown
-	  "lchown,"
+#ifdef __NR_lchown
+	"lchown,"
 #endif
-#ifdef SYS_lchown32
-	  "lchown32"
+#ifdef __NR_lchown32
+	"lchown32"
 #endif
 	},
 	{ .name = "@clock", .list =
-#ifdef SYS_adjtimex
-	  "adjtimex,"
+#ifdef __NR_adjtimex
+	"adjtimex,"
 #endif
-#ifdef SYS_clock_adjtime
-	  "clock_adjtime,"
+#ifdef __NR_clock_adjtime
+	"clock_adjtime,"
 #endif
-#ifdef SYS_clock_settime
-	  "clock_settime,"
+#ifdef __NR_clock_adjtime64
+	"clock_adjtime64,"
 #endif
-#ifdef SYS_settimeofday
-	  "settimeofday,"
+#ifdef __NR_clock_gettime
+	"clock_gettime,"
 #endif
-#ifdef SYS_stime
-	  "stime"
+#ifdef __NR_clock_gettime
+	"clock_gettime,"
+#endif
+#ifdef __NR_clock_gettime64
+	"clock_gettime64,"
+#endif
+#ifdef __NR_clock_getres_time64
+	"clock_getres_time64,"
+#endif
+#ifdef __NR_clock_nanosleep
+	"clock_nanosleep,"
+#endif
+#ifdef __NR_clock_nanosleep_time64
+	"clock_nanosleep_time64,"
+#endif
+#ifdef __NR_clock_settime
+	"clock_settime,"
+#endif
+#ifdef __NR_clock_settime64
+	"clock_settime64,"
+#endif
+#ifdef __NR_gettimeofday
+	"gettimeofday,"
+#endif
+#ifdef __NR_old_adjtimex
+	"old_adjtimex,"
+#endif
+#ifdef __NR_osf_gettimeofday
+	"osf_gettimeofday,"
+#endif
+#ifdef __NR_osf_settimeofday
+	"osf_settimeofday,"
+#endif
+#ifdef __NR_settimeofday
+	"settimeofday,"
+#endif
+#ifdef __NR_stime
+	"stime,"
+#endif
+#ifdef __NR_time
+	"time"
 #endif
 	},
 	{ .name = "@cpu-emulation", .list =
-#ifdef SYS_modify_ldt
-	  "modify_ldt,"
+#ifdef __NR_modify_ldt
+	"modify_ldt,"
 #endif
-#ifdef SYS_subpage_prot
-	  "subpage_prot,"
+#ifdef __NR_subpage_prot
+	"subpage_prot,"
 #endif
-#ifdef SYS_switch_endian
-	  "switch_endian,"
+#ifdef __NR_switch_endian
+	"switch_endian,"
 #endif
-#ifdef SYS_vm86
-	  "vm86,"
+#ifdef __NR_vm86
+	"vm86,"
 #endif
-#ifdef SYS_vm86old
-	  "vm86old"
+#ifdef __NR_vm86old
+	"vm86old"
 #endif
-#if !defined(SYS_modify_ldt) && !defined(SYS_subpage_prot) && !defined(SYS_switch_endian) && !defined(SYS_vm86) && !defined(SYS_vm86old)
-	  "__dummy_syscall__" // workaround for arm64, s390x and sparc64 which don't have any of above defined and empty syscall lists are not allowed
+#if !defined(__NR_modify_ldt) && !defined(__NR_subpage_prot) && !defined(__NR_switch_endian) && !defined(__NR_vm86) && !defined(__NR_vm86old)
+	"__dummy_syscall__" // workaround for the following architectures which don't have any of above defined and empty syscall lists are not allowed:
+						// arm64, alpha, arc32, armeabi, armoabi, csky, hexagon32, loongarch64, m68k, mips_n32, mips_n64, nios2, openrisc32, parisc32, parisc64, riscv32, riscv64, s390_32, s390_64, sparc32, sparc64, superh and xtensa
 #endif
 	},
 	{ .name = "@debug", .list =
-#ifdef SYS_lookup_dcookie
-	  "lookup_dcookie,"
+#ifdef __NR_lookup_dcookie
+	"lookup_dcookie,"
 #endif
-#ifdef SYS_perf_event_open
-	  "perf_event_open,"
+#ifdef __NR_perf_event_open
+	"perf_event_open,"
 #endif
-#ifdef SYS_pidfd_getfd
-	  "pidfd_getfd,"
+#ifdef __NR_pidfd_getfd
+	"pidfd_getfd,"
 #endif
-#ifdef SYS_process_vm_writev
-	  "process_vm_writev,"
+#ifdef __NR_process_vm_writev
+	"process_vm_writev,"
 #endif
-#ifdef SYS_rtas
-	  "rtas,"
+#ifdef __NR_rtas
+	"rtas,"
 #endif
-#ifdef SYS_s390_runtime_instr
-	  "s390_runtime_instr,"
+#ifdef __NR_s390_runtime_instr
+	"s390_runtime_instr,"
 #endif
-#ifdef SYS_sys_debug_setcontext
-	  "sys_debug_setcontext,"
+#ifdef __NR_sys_debug_setcontext
+	"sys_debug_setcontext,"
+#endif
+#ifdef __NR_uprobe
+	"uprobe,"
+#endif
+#ifdef __NR_uretprobe
+	"uretprobe" // occasional breakages with seccomp reported, see https://lwn.net/Articles/1005662
 #endif
 	},
 	{ .name = "@default", .list =
-	  "@clock,"
-	  "@cpu-emulation,"
-	  "@debug,"
-	  "@module,"
-	  "@mount,"
-	  "@obsolete,"
-	  "@raw-io,"
-	  "@reboot,"
-	  "@swap,"
-#ifdef SYS_open_by_handle_at
-	  "open_by_handle_at,"
+	"@clock,"
+	"@cpu-emulation,"
+	"@debug,"
+	"@module,"
+	"@mount,"
+	"@obsolete,"
+	"@raw-io,"
+	"@reboot,"
+	"@swap,"
+#ifdef __NR_open_by_handle_at
+	"open_by_handle_at,"
 #endif
-#ifdef SYS_name_to_handle_at
-	  "name_to_handle_at,"
+#ifdef __NR_name_to_handle_at
+	"name_to_handle_at,"
 #endif
-#ifdef SYS_ioprio_set
-	  "ioprio_set,"
+#ifdef __NR_ioprio_set
+	"ioprio_set,"
 #endif
-#ifdef SYS_ni_syscall
-	  "ni_syscall,"
+#ifdef __NR_syslog
+	"syslog,"
 #endif
-#ifdef SYS_syslog
-	  "syslog,"
+#ifdef __NR_fanotify_init
+	"fanotify_init,"
 #endif
-#ifdef SYS_fanotify_init
-	  "fanotify_init,"
+#ifdef __NR_add_key
+	"add_key,"
 #endif
-#ifdef SYS_add_key
-	  "add_key,"
+#ifdef __NR_request_key
+	"request_key,"
 #endif
-#ifdef SYS_request_key
-	  "request_key,"
+#ifdef __NR_mbind
+	"mbind,"
 #endif
-#ifdef SYS_mbind
-	  "mbind,"
+#ifdef __NR_migrate_pages
+	"migrate_pages,"
 #endif
-#ifdef SYS_migrate_pages
-	  "migrate_pages,"
+#ifdef __NR_move_pages
+	"move_pages,"
 #endif
-#ifdef SYS_move_pages
-	  "move_pages,"
+#ifdef __NR_keyctl
+	"keyctl,"
 #endif
-#ifdef SYS_keyctl
-	  "keyctl,"
+#ifdef __NR_io_setup
+	"io_setup,"
 #endif
-#ifdef SYS_io_setup
-	  "io_setup,"
+#ifdef __NR_io_destroy
+	"io_destroy,"
 #endif
-#ifdef SYS_io_destroy
-	  "io_destroy,"
+#ifdef __NR_io_getevents
+	"io_getevents,"
 #endif
-#ifdef SYS_io_getevents
-	  "io_getevents,"
+#ifdef __NR_io_submit
+	"io_submit,"
 #endif
-#ifdef SYS_io_submit
-	  "io_submit,"
+#ifdef __NR_io_cancel
+	"io_cancel,"
 #endif
-#ifdef SYS_io_cancel
-	  "io_cancel,"
+#ifdef __NR_remap_file_pages
+	"remap_file_pages,"
 #endif
-#ifdef SYS_remap_file_pages
-	  "remap_file_pages,"
+#ifdef __NR_set_mempolicy
+	"set_mempolicy,"
 #endif
-#ifdef SYS_set_mempolicy
-	  "set_mempolicy,"
+#ifdef __NR_vmsplice
+	"vmsplice,"
 #endif
-#ifdef SYS_vmsplice
-	  "vmsplice,"
+#ifdef __NR_userfaultfd
+	"userfaultfd,"
 #endif
-#ifdef SYS_userfaultfd
-	  "userfaultfd,"
+#ifdef __NR_acct
+	"acct,"
 #endif
-#ifdef SYS_acct
-	  "acct,"
+#ifdef __NR_bpf
+	"bpf,"
 #endif
-#ifdef SYS_bpf
-	  "bpf,"
+#ifdef __NR_nfsservctl
+	"nfsservctl,"
 #endif
-#ifdef SYS_nfsservctl
-	  "nfsservctl,"
+#ifdef __NR_setdomainname
+	"setdomainname,"
 #endif
-#ifdef SYS_setdomainname
-	  "setdomainname,"
+#ifdef __NR_sethostname
+	"sethostname,"
 #endif
-#ifdef SYS_sethostname
-	  "sethostname,"
-#endif
-#ifdef SYS_vhangup
-	  "vhangup"
-#endif
-//#ifdef SYS_mincore	// 0.9.57 - problem fixed in Linux kernel 5.0; on 4.x it will break kodi, mpv, totem
-//	  "mincore"
-//#endif
-	},
-	{ .name = "@default-nodebuggers", .list =
-	  "@default,"
-#ifdef SYS_ptrace
-	  "ptrace,"
-#endif
-#ifdef SYS_personality
-	  "personality,"
-#endif
-#ifdef SYS_process_vm_readv
-	  "process_vm_readv"
+#ifdef __NR_vhangup
+	"vhangup"
 #endif
 	},
 	{ .name = "@default-keep", .list =
-	  "execveat," // commonly used by fexecve
-	  "execve,"
-	  "prctl"
+#ifdef __NR_arch_prctl
+	"arch_prctl," // breaks glibc, i386 and x86_64 only
+#endif
+#ifdef __NR_execv
+	"execv," // sparc only
+#endif
+	"execveat," // commonly used by fexecve
+	"execve,"
+	"futex,"
+#ifdef __NR_mmap
+	"mmap," // cannot load shared libraries
+#endif
+#ifdef __NR_mmap2
+	"mmap2,"
+#endif
+	"mprotect," // cannot load shared libraries
+	"prctl"
+	},
+	{ .name = "@default-nodebuggers", .list =
+	"@default,"
+#ifdef __NR_ptrace
+	"ptrace,"
+#endif
+#ifdef __NR_personality
+	"personality,"
+#endif
+#ifdef __NR_process_vm_readv
+	"process_vm_readv"
+#endif
 	},
 	{ .name = "@file-system", .list =
-#ifdef SYS_access
-	  "access,"
+#ifdef __NR_access
+	"access,"
 #endif
-#ifdef SYS_chdir
-	  "chdir,"
+#ifdef __NR_cachestat
+	"cachestat,"
 #endif
-#ifdef SYS_chmod
-	  "chmod,"
+#ifdef __NR_chdir
+	"chdir,"
 #endif
-#ifdef SYS_close
-	  "close,"
+#ifdef __NR_chmod
+	"chmod,"
 #endif
-#ifdef SYS_close_range
-	  "close_range,"
+#ifdef __NR_close
+	"close,"
 #endif
-#ifdef SYS_creat
-	  "creat,"
+#ifdef __NR_close_range
+	"close_range,"
 #endif
-#ifdef SYS_faccessat
-	  "faccessat,"
+#ifdef __NR_creat
+	"creat,"
 #endif
-#ifdef SYS_faccessat2
-	  "faccessat2,"
+#ifdef __NR_faccessat
+	"faccessat,"
 #endif
-#ifdef SYS_fallocate
-	  "fallocate,"
+#ifdef __NR_faccessat2
+	"faccessat2,"
 #endif
-#ifdef SYS_fchdir
-	  "fchdir,"
+#ifdef __NR_fallocate
+	"fallocate,"
 #endif
-#ifdef SYS_fchmod
-	  "fchmod,"
+#ifdef __NR_fanotify_mark
+	"fanotify_mark,"
 #endif
-#ifdef SYS_fchmodat
-	  "fchmodat,"
+#ifdef __NR_fchdir
+	"fchdir,"
 #endif
-#ifdef SYS_fcntl
-	  "fcntl,"
+#ifdef __NR_fchmod
+	"fchmod,"
 #endif
-#ifdef SYS_fcntl64
-	  "fcntl64,"
+#ifdef __NR_fchmodat
+	"fchmodat,"
 #endif
-#ifdef SYS_fgetxattr
-	  "fgetxattr,"
+#ifdef __NR_fchmodat2
+	"fchmodat2,"
 #endif
-#ifdef SYS_flistxattr
-	  "flistxattr,"
+#ifdef __NR_fcntl
+	"fcntl,"
 #endif
-#ifdef SYS_fremovexattr
-	  "fremovexattr,"
+#ifdef __NR_fcntl64
+	"fcntl64,"
 #endif
-#ifdef SYS_fsetxattr
-	  "fsetxattr,"
+#ifdef __NR_fgetxattr
+	"fgetxattr,"
 #endif
-#ifdef SYS_fstat
-	  "fstat,"
+#ifdef __NR_file_getattr
+	"file_getattr,"
 #endif
-#ifdef SYS_fstat64
-	  "fstat64,"
+#ifdef __NR_file_setattr
+	"file_setattr,"
 #endif
-#ifdef SYS_fstatat64
-	  "fstatat64,"
+#ifdef __NR_flistxattr
+	"flistxattr,"
 #endif
-#ifdef SYS_fstatfs
-	  "fstatfs,"
+#ifdef __NR_fremovexattr
+	"fremovexattr,"
 #endif
-#ifdef SYS_fstatfs64
-	  "fstatfs64,"
+#ifdef __NR_fsetxattr
+	"fsetxattr,"
 #endif
-#ifdef SYS_ftruncate
-	  "ftruncate,"
+#ifdef __NR_fstat
+	"fstat,"
 #endif
-#ifdef SYS_ftruncate64
-	  "ftruncate64,"
+#ifdef __NR_fstat64
+	"fstat64,"
 #endif
-#ifdef SYS_futimesat
-	  "futimesat,"
+#ifdef __NR_fstatat64
+	"fstatat64,"
 #endif
-#ifdef SYS_getcwd
-	  "getcwd,"
+#ifdef __NR_fstatfs
+	"fstatfs,"
 #endif
-#ifdef SYS_getdents
-	  "getdents,"
+#ifdef __NR_fstatfs64
+	"fstatfs64,"
 #endif
-#ifdef SYS_getdents64
-	  "getdents64,"
+#ifdef __NR_ftruncate
+	"ftruncate,"
 #endif
-#ifdef SYS_getxattr
-	  "getxattr,"
+#ifdef __NR_ftruncate64
+	"ftruncate64,"
 #endif
-#ifdef SYS_inotify_add_watch
-	  "inotify_add_watch,"
+#ifdef __NR_futimesat
+	"futimesat,"
 #endif
-#ifdef SYS_inotify_init
-	  "inotify_init,"
+#ifdef __NR_getcwd
+	"getcwd,"
 #endif
-#ifdef SYS_inotify_init1
-	  "inotify_init1,"
+#ifdef __NR_getdents
+	"getdents,"
 #endif
-#ifdef SYS_inotify_rm_watch
-	  "inotify_rm_watch,"
+#ifdef __NR_getdents64
+	"getdents64,"
 #endif
-#ifdef SYS_lgetxattr
-	  "lgetxattr,"
+#ifdef __NR_getxattr
+	"getxattr,"
 #endif
-#ifdef SYS_link
-	  "link,"
+#ifdef __NR_getxattrat
+	"getxattrat,"
 #endif
-#ifdef SYS_linkat
-	  "linkat,"
+#ifdef __NR_inotify_add_watch
+	"inotify_add_watch,"
 #endif
-#ifdef SYS_listxattr
-	  "listxattr,"
+#ifdef __NR_inotify_init
+	"inotify_init,"
 #endif
-#ifdef SYS_llistxattr
-	  "llistxattr,"
+#ifdef __NR_inotify_init1
+	"inotify_init1,"
 #endif
-#ifdef SYS_lremovexattr
-	  "lremovexattr,"
+#ifdef __NR_inotify_rm_watch
+	"inotify_rm_watch,"
 #endif
-#ifdef SYS_lsetxattr
-	  "lsetxattr,"
+#ifdef __NR_lgetxattr
+	"lgetxattr,"
 #endif
-#ifdef SYS_lstat
-	  "lstat,"
+#ifdef __NR_link
+	"link,"
 #endif
-#ifdef SYS_lstat64
-	  "lstat64,"
+#ifdef __NR_linkat
+	"linkat,"
 #endif
-#ifdef SYS_mkdir
-	  "mkdir,"
+#ifdef __NR_listxattr
+	"listxattr,"
 #endif
-#ifdef SYS_mkdirat
-	  "mkdirat,"
+#ifdef __NR_listxattrat
+	"listxattrat,"
 #endif
-#ifdef SYS_mknod
-	  "mknod,"
+#ifdef __NR_llistxattr
+	"llistxattr,"
 #endif
-#ifdef SYS_mknodat
-	  "mknodat,"
+#ifdef __NR_lremovexattr
+	"lremovexattr,"
 #endif
-#ifdef SYS_mmap
-	  "mmap,"
+#ifdef __NR_lsetxattr
+	"lsetxattr,"
 #endif
-#ifdef SYS_mmap2
-	  "mmap2,"
+#ifdef __NR_lstat
+	"lstat,"
 #endif
-#ifdef SYS_munmap
-	  "munmap,"
+#ifdef __NR_lstat64
+	"lstat64,"
 #endif
-#ifdef SYS_newfstatat
-	  "newfstatat,"
+#ifdef __NR_mkdir
+	"mkdir,"
 #endif
-#ifdef SYS_oldfstat
-	  "oldfstat,"
+#ifdef __NR_mkdirat
+	"mkdirat,"
 #endif
-#ifdef SYS_oldlstat
-	  "oldlstat,"
+#ifdef __NR_mknod
+	"mknod,"
 #endif
-#ifdef SYS_oldstat
-	  "oldstat,"
+#ifdef __NR_mknodat
+	"mknodat,"
 #endif
-#ifdef SYS_open
-	  "open,"
+#ifdef __NR_munmap
+	"munmap,"
 #endif
-#ifdef SYS_openat
-	  "openat,"
+#ifdef __NR_newfstatat
+	"newfstatat,"
 #endif
-#ifdef SYS_openat2
-	  "openat2,"
+#ifdef __NR_oldfstat
+	"oldfstat,"
 #endif
-#ifdef SYS_readlink
-	  "readlink,"
+#ifdef __NR_oldlstat
+	"oldlstat,"
 #endif
-#ifdef SYS_readlinkat
-	  "readlinkat,"
+#ifdef __NR_oldstat
+	"oldstat,"
 #endif
-#ifdef SYS_removexattr
-	  "removexattr,"
+#ifdef __NR_open
+	"open,"
 #endif
-#ifdef SYS_rename
-	  "rename,"
+#ifdef __NR_openat
+	"openat,"
 #endif
-#ifdef SYS_renameat
-	  "renameat,"
+#ifdef __NR_openat2
+	"openat2,"
 #endif
-#ifdef SYS_renameat2
-	  "renameat2,"
+#ifdef __NR_osf_fstat
+	"osf_fstat,"
 #endif
-#ifdef SYS_rmdir
-	  "rmdir,"
+#ifdef __NR_osf_fstatfs
+	"osf_fstatfs,"
 #endif
-#ifdef SYS_setxattr
-	  "setxattr,"
+#ifdef __NR_osf_fstatfs64
+	"osf_fstatfs64,"
 #endif
-#ifdef SYS_stat
-	  "stat,"
+#ifdef __NR_osf_getdirentries
+	"osf_getdirentries,"
 #endif
-#ifdef SYS_stat64
-	  "stat64,"
+#ifdef __NR_osf_lstat
+	"osf_lstat,"
 #endif
-#ifdef SYS_statfs
-	  "statfs,"
+#ifdef __NR_osf_proplist_syscall
+	"osf_proplist_syscall,"
 #endif
-#ifdef SYS_statfs64
-	  "statfs64,"
+#ifdef __NR_osf_utimes
+	"osf_utimes,"
 #endif
-#ifdef SYS_statx
-	  "statx,"
+#ifdef __NR_quotactl_fd
+	"quotactl_fd,"
 #endif
-#ifdef SYS_symlink
-	  "symlink,"
+#ifdef __NR_readlink
+	"readlink,"
 #endif
-#ifdef SYS_symlinkat
-	  "symlinkat,"
+#ifdef __NR_readlinkat
+	"readlinkat,"
 #endif
-#ifdef SYS_truncate
-	  "truncate,"
+#ifdef __NR_removexattr
+	"removexattr,"
 #endif
-#ifdef SYS_truncate64
-	  "truncate64,"
+#ifdef __NR_removexattrat
+	"removexattrat,"
 #endif
-#ifdef SYS_unlink
-	  "unlink,"
+#ifdef __NR_rename
+	"rename,"
 #endif
-#ifdef SYS_unlinkat
-	  "unlinkat,"
+#ifdef __NR_renameat
+	"renameat,"
 #endif
-#ifdef SYS_utime
-	  "utime,"
+#ifdef __NR_renameat2
+	"renameat2,"
 #endif
-#ifdef SYS_utimensat
-	  "utimensat,"
+#ifdef __NR_rmdir
+	"rmdir,"
 #endif
-#ifdef SYS_utimes
-	  "utimes"
+#ifdef __NR_setxattr
+	"setxattr,"
+#endif
+#ifdef __NR_setxattrat
+	"setxattrat,"
+#endif
+#ifdef __NR_stat
+	"stat,"
+#endif
+#ifdef __NR_stat64
+	"stat64,"
+#endif
+#ifdef __NR_statfs
+	"statfs,"
+#endif
+#ifdef __NR_statfs64
+	"statfs64,"
+#endif
+#ifdef __NR_statx
+	"statx,"
+#endif
+#ifdef __NR_symlink
+	"symlink,"
+#endif
+#ifdef __NR_symlinkat
+	"symlinkat,"
+#endif
+#ifdef __NR_truncate
+	"truncate,"
+#endif
+#ifdef __NR_truncate64
+	"truncate64,"
+#endif
+#ifdef __NR_unlink
+	"unlink,"
+#endif
+#ifdef __NR_unlinkat
+	"unlinkat,"
+#endif
+#ifdef __NR_utime
+	"utime,"
+#endif
+#ifdef __NR_utimensat
+	"utimensat,"
+#endif
+#ifdef __NR_utimes
+	"utimes"
 #endif
 	},
 	{ .name = "@io-event", .list =
-#ifdef SYS__newselect
-	  "_newselect,"
+#ifdef __NR__newselect
+	"_newselect,"
 #endif
-#ifdef SYS_epoll_create
-	  "epoll_create,"
+#ifdef __NR_epoll_create
+	"epoll_create,"
 #endif
-#ifdef SYS_epoll_create1
-	  "epoll_create1,"
+#ifdef __NR_epoll_create1
+	"epoll_create1,"
 #endif
-#ifdef SYS_epoll_ctl
-	  "epoll_ctl,"
+#ifdef __NR_epoll_ctl
+	"epoll_ctl,"
 #endif
-#ifdef SYS_epoll_ctl_old
-	  "epoll_ctl_old,"
+#ifdef __NR_epoll_pwait
+	"epoll_pwait,"
 #endif
-#ifdef SYS_epoll_pwait
-	  "epoll_pwait,"
+#ifdef __NR_epoll_pwait2
+	"epoll_pwait2,"
 #endif
-#ifdef SYS_epoll_wait
-	  "epoll_wait,"
+#ifdef __NR_epoll_wait
+	"epoll_wait,"
 #endif
-#ifdef SYS_epoll_wait_old
-	  "epoll_wait_old,"
+#ifdef __NR_eventfd
+	"eventfd,"
 #endif
-#ifdef SYS_eventfd
-	  "eventfd,"
+#ifdef __NR_eventfd2
+	"eventfd2,"
 #endif
-#ifdef SYS_eventfd2
-	  "eventfd2,"
+#ifdef __NR_osf_select
+	"osf_select,"
 #endif
-#ifdef SYS_poll
-	  "poll,"
+#ifdef __NR_poll
+	"poll,"
 #endif
-#ifdef SYS_ppoll
-	  "ppoll,"
+#ifdef __NR_ppoll
+	"ppoll,"
 #endif
-#ifdef SYS_pselect6
-	  "pselect6,"
+#ifdef __NR_ppoll_time64
+	"ppoll_time64,"
 #endif
-#ifdef SYS_select
-	  "select"
+#ifdef __NR_pselect6_time64
+	"pselect6_time64,"
+#endif
+#ifdef __NR_pselect6
+	"pselect6,"
+#endif
+#ifdef __NR_select
+	"select"
 #endif
 	},
 	{ .name = "@ipc", .list =
-#ifdef SYS_ipc
-	  "ipc,"
+#ifdef __NR_ipc
+	"ipc,"
 #endif
-#ifdef SYS_memfd_create
-	  "memfd_create,"
+#ifdef __NR_mq_getsetattr
+	"mq_getsetattr,"
 #endif
-#ifdef SYS_mq_getsetattr
-	  "mq_getsetattr,"
+#ifdef __NR_mq_notify
+	"mq_notify,"
 #endif
-#ifdef SYS_mq_notify
-	  "mq_notify,"
+#ifdef __NR_mq_open
+	"mq_open,"
 #endif
-#ifdef SYS_mq_open
-	  "mq_open,"
+#ifdef __NR_mq_timedreceive
+	"mq_timedreceive,"
 #endif
-#ifdef SYS_mq_timedreceive
-	  "mq_timedreceive,"
+#ifdef __NR_mq_timedreceive_time64
+	"mq_timedreceive_time64,"
 #endif
-#ifdef SYS_mq_timedsend
-	  "mq_timedsend,"
+#ifdef __NR_mq_timedsend
+	"mq_timedsend,"
 #endif
-#ifdef SYS_mq_unlink
-	  "mq_unlink,"
+#ifdef __NR_mq_timedsend_time64
+	"mq_timedsend_time64,"
 #endif
-#ifdef SYS_msgctl
-	  "msgctl,"
+#ifdef __NR_mq_unlink
+	"mq_unlink,"
 #endif
-#ifdef SYS_msgget
-	  "msgget,"
+#ifdef __NR_msgctl
+	"msgctl,"
 #endif
-#ifdef SYS_msgrcv
-	  "msgrcv,"
+#ifdef __NR_msgget
+	"msgget,"
 #endif
-#ifdef SYS_msgsnd
-	  "msgsnd,"
+#ifdef __NR_msgrcv
+	"msgrcv,"
 #endif
-#ifdef SYS_pipe
-	  "pipe,"
+#ifdef __NR_msgsnd
+	"msgsnd,"
 #endif
-#ifdef SYS_pipe2
-	  "pipe2,"
+#ifdef __NR_pipe
+	"pipe,"
 #endif
-#ifdef SYS_process_madvise
-	  "process_madvise,"
+#ifdef __NR_pipe2
+	"pipe2,"
 #endif
-#ifdef SYS_process_vm_readv
-	  "process_vm_readv,"
+#ifdef __NR_process_madvise
+	"process_madvise,"
 #endif
-#ifdef SYS_process_vm_writev
-	  "process_vm_writev,"
+#ifdef __NR_process_mrelease
+	"process_mrelease,"
 #endif
-#ifdef SYS_semctl
-	  "semctl,"
+#ifdef __NR_process_vm_readv
+	"process_vm_readv,"
 #endif
-#ifdef SYS_semget
-	  "semget,"
+#ifdef __NR_process_vm_writev
+	"process_vm_writev,"
 #endif
-#ifdef SYS_semop
-	  "semop,"
+#ifdef __NR_semctl
+	"semctl,"
 #endif
-#ifdef SYS_semtimedop
-	  "semtimedop,"
+#ifdef __NR_semget
+	"semget,"
 #endif
-#ifdef SYS_shmat
-	  "shmat,"
+#ifdef __NR_semop
+	"semop,"
 #endif
-#ifdef SYS_shmctl
-	  "shmctl,"
+#ifdef __NR_semtimedop
+	"semtimedop,"
 #endif
-#ifdef SYS_shmdt
-	  "shmdt,"
+#ifdef __NR_semtimedop_time64
+	"semtimedop_time64,"
 #endif
-#ifdef SYS_shmget
-	  "shmget"
+#ifdef __NR_shmat
+	"shmat,"
+#endif
+#ifdef __NR_shmctl
+	"shmctl,"
+#endif
+#ifdef __NR_shmdt
+	"shmdt,"
+#endif
+#ifdef __NR_shmget
+	"shmget"
 #endif
 	},
 	{ .name = "@keyring", .list =
-#ifdef SYS_add_key
-	  "add_key,"
+#ifdef __NR_add_key
+	"add_key,"
 #endif
-#ifdef SYS_keyctl
-	  "keyctl,"
+#ifdef __NR_keyctl
+	"keyctl,"
 #endif
-#ifdef SYS_request_key
-	  "request_key"
+#ifdef __NR_request_key
+	"request_key"
+#endif
+	},
+	{ .name = "@memfd", .list =
+#ifdef __NR_memfd_create
+	"memfd_create,"
+#endif
+#ifdef __NR_memfd_secret
+	"memfd_secret"
 #endif
 	},
 	{ .name = "@memlock", .list =
-#ifdef SYS_mlock
-	  "mlock,"
+#ifdef __NR_mlock
+	"mlock,"
 #endif
-#ifdef SYS_mlock2
-	  "mlock2,"
+#ifdef __NR_mlock2
+	"mlock2,"
 #endif
-#ifdef SYS_mlockall
-	  "mlockall,"
+#ifdef __NR_mlockall
+	"mlockall,"
 #endif
-#ifdef SYS_munlock
-	  "munlock,"
+#ifdef __NR_munlock
+	"munlock,"
 #endif
-#ifdef SYS_munlockall
-	  "munlockall"
+#ifdef __NR_munlockall
+	"munlockall"
 #endif
 	},
 	{ .name = "@module", .list =
-#ifdef SYS_delete_module
-	  "delete_module,"
+#ifdef __NR_delete_module
+	"delete_module,"
 #endif
-#ifdef SYS_finit_module
-	  "finit_module,"
+#ifdef __NR_finit_module
+	"finit_module,"
 #endif
-#ifdef SYS_init_module
-	  "init_module"
+#ifdef __NR_init_module
+	"init_module"
 #endif
 	},
 	{ .name = "@mount", .list =
-#ifdef SYS_chroot
-	  "chroot,"
+#ifdef __NR_chroot
+	"chroot,"
 #endif
-#ifdef SYS_fsconfig
-	  "fsconfig,"
+#ifdef __NR_fsconfig
+	"fsconfig,"
 #endif
-#ifdef SYS_fsmount
-	  "fsmount,"
+#ifdef __NR_fsmount
+	"fsmount,"
 #endif
-#ifdef SYS_fsopen
-	  "fsopen,"
+#ifdef __NR_fsopen
+	"fsopen,"
 #endif
-#ifdef SYS_fspick
-	  "fspick,"
+#ifdef __NR_fspick
+	"fspick,"
 #endif
-#ifdef SYS_mount
-	  "mount,"
+#ifdef __NR_listmount
+	"listmount,"
 #endif
-#ifdef SYS_move_mount
-	  "move_mount,"
+#ifdef __NR_mount
+	"mount,"
 #endif
-#ifdef SYS_open_tree
-	  "open_tree,"
+#ifdef __NR_mount_setattr
+	"mount_setattr,"
 #endif
-#ifdef SYS_pivot_root
-	  "pivot_root,"
+#ifdef __NR_move_mount
+	"move_mount,"
 #endif
-#ifdef SYS_umount
-	  "umount,"
+#ifdef __NR_oldumount
+	"open_oldumount,"
 #endif
-#ifdef SYS_umount2
-	  "umount2"
+#ifdef __NR_open_tree
+	"open_tree,"
+#endif
+#ifdef __NR_open_tree_attr
+	"open_tree_attr,"
+#endif
+#ifdef __NR_osf_mount
+	"osf_mount,"
+#endif
+#ifdef __NR_pivot_root
+	"pivot_root,"
+#endif
+#ifdef __NR_statmount
+	"statmount,"
+#endif
+#ifdef __NR_umount
+	"umount,"
+#endif
+#ifdef __NR_umount2
+	"umount2"
 #endif
 	},
 	{ .name = "@network-io", .list =
-#ifdef SYS_accept
-	  "accept,"
+#ifdef __NR_accept
+	"accept,"
 #endif
-#ifdef SYS_accept4
-	  "accept4,"
+#ifdef __NR_accept4
+	"accept4,"
 #endif
-#ifdef SYS_bind
-	  "bind,"
+#ifdef __NR_bind
+	"bind,"
 #endif
-#ifdef SYS_connect
-	  "connect,"
+#ifdef __NR_connect
+	"connect,"
 #endif
-#ifdef SYS_getpeername
-	  "getpeername,"
+#ifdef __NR_getpeername
+	"getpeername,"
 #endif
-#ifdef SYS_getsockname
-	  "getsockname,"
+#ifdef __NR_getsockname
+	"getsockname,"
 #endif
-#ifdef SYS_getsockopt
-	  "getsockopt,"
+#ifdef __NR_getsockopt
+	"getsockopt,"
 #endif
-#ifdef SYS_listen
-	  "listen,"
+#ifdef __NR_listen
+	"listen,"
 #endif
-#ifdef SYS_recv
-	  "recv,"
+#ifdef __NR_recv
+	"recv,"
 #endif
-#ifdef SYS_recvfrom
-	  "recvfrom,"
+#ifdef __NR_recvfrom
+	"recvfrom,"
 #endif
-#ifdef SYS_recvmmsg
-	  "recvmmsg,"
+#ifdef __NR_recvmmsg
+	"recvmmsg,"
 #endif
-#ifdef SYS_recvmsg
-	  "recvmsg,"
+#ifdef __NR_recvmmsg_time64
+	"recvmmsg_time64,"
 #endif
-#ifdef SYS_send
-	  "send,"
+#ifdef __NR_recvmsg
+	"recvmsg,"
 #endif
-#ifdef SYS_sendmmsg
-	  "sendmmsg,"
+#ifdef __NR_send
+	"send,"
 #endif
-#ifdef SYS_sendmsg
-	  "sendmsg,"
+#ifdef __NR_sendmmsg
+	"sendmmsg,"
 #endif
-#ifdef SYS_sendto
-	  "sendto,"
+#ifdef __NR_sendmsg
+	"sendmsg,"
 #endif
-#ifdef SYS_setsockopt
-	  "setsockopt,"
+#ifdef __NR_sendto
+	"sendto,"
 #endif
-#ifdef SYS_shutdown
-	  "shutdown,"
+#ifdef __NR_setsockopt
+	"setsockopt,"
 #endif
-#ifdef SYS_socket
-	  "socket,"
+#ifdef __NR_shutdown
+	"shutdown,"
 #endif
-#ifdef SYS_socketcall
-	  "socketcall,"
+#ifdef __NR_socket
+	"socket,"
 #endif
-#ifdef SYS_socketpair
-	  "socketpair"
+#ifdef __NR_socketcall
+	"socketcall,"
+#endif
+#ifdef __NR_socketpair
+	"socketpair"
 #endif
 	},
 	{ .name = "@obsolete", .list =
-#ifdef SYS__sysctl
-	  "_sysctl,"
+#ifdef __NR__sysctl
+	"_sysctl,"
 #endif
-#ifdef SYS_afs_syscall
-	  "afs_syscall,"
+#ifdef __NR_afs_syscall
+	"afs_syscall,"
 #endif
-#ifdef SYS_bdflush
-	  "bdflush,"
+#ifdef __NR_bdflush
+	"bdflush,"
 #endif
-#ifdef SYS_break
-	  "break,"
+#ifdef __NR_break
+	"break,"
 #endif
-#ifdef SYS_create_module
-	  "create_module,"
+#ifdef __NR_create_module
+	"create_module,"
 #endif
-#ifdef SYS_ftime
-	  "ftime,"
+#ifdef __NR_dipc
+	"dipc,"
 #endif
-#ifdef SYS_get_kernel_syms
-	  "get_kernel_syms,"
+#ifdef __NR_epoll_ctl_old
+	"epoll_ctl_old,"
 #endif
-#ifdef SYS_getpmsg
-	  "getpmsg,"
+#ifdef __NR_epoll_wait_old
+	"epoll_wait_old,"
 #endif
-#ifdef SYS_gtty
-	  "gtty,"
+#ifdef __NR_exec_with_loader
+	"exec_with_loader,"
 #endif
-#ifdef SYS_idle
-	  "idle,"
+#ifdef __NR_ftime
+	"ftime,"
 #endif
-#ifdef SYS_lock
-	  "lock,"
+#ifdef __NR_get_kernel_syms
+	"get_kernel_syms,"
 #endif
-#ifdef SYS_mpx
-	  "mpx,"
+#ifdef __NR_getpmsg
+	"getpmsg,"
 #endif
-#ifdef SYS_prof
-	  "prof,"
+#ifdef __NR_gtty
+	"gtty,"
 #endif
-#ifdef SYS_profil
-	  "profil,"
+#ifdef __NR_idle
+	"idle,"
 #endif
-#ifdef SYS_putpmsg
-	  "putpmsg,"
+#ifdef __NR_llseek
+	"llseek,"
 #endif
-#ifdef SYS_query_module
-	  "query_module,"
+#ifdef __NR_lock
+	"lock,"
 #endif
-#ifdef SYS_security
-	  "security,"
+#ifdef __NR_mpx
+	"mpx,"
 #endif
-#ifdef SYS_sgetmask
-	  "sgetmask,"
+#ifdef __NR_multiplexer
+	"multiplexer,"
 #endif
-#ifdef SYS_ssetmask
-	  "ssetmask,"
+#ifdef __NR_osf_adjtime
+	"osf_adjtime,"
 #endif
-#ifdef SYS_stty
-	  "stty,"
+#ifdef __NR_osf_afs_syscall
+	"osf_afs_syscall,"
 #endif
-#ifdef SYS_sysfs
-	  "sysfs,"
+#ifdef __NR_osf_alt_plock
+	"osf_alt_plock,"
 #endif
-#ifdef SYS_tuxcall
-	  "tuxcall,"
+#ifdef __NR_osf_alt_setsid
+	"osf_alt_setsid,"
 #endif
-#ifdef SYS_ulimit
-	  "ulimit,"
+#ifdef __NR_osf_alt_sigpending
+	"osf_alt_sigpending,"
 #endif
-#ifdef SYS_uselib
-	  "uselib,"
+#ifdef __NR_osf_asynch_daemon
+	"osf_asynch_daemon,"
 #endif
-#ifdef SYS_ustat
-	  "ustat,"
+#ifdef __NR_osf_audcntl
+	"osf_audcntl,"
 #endif
-#ifdef SYS_vserver
-	  "vserver"
+#ifdef __NR_osf_audgen
+	"osf_audgen,"
 #endif
-#if !defined(SYS__sysctl) && !defined(SYS_afs_syscall) && !defined(SYS_bdflush) && !defined(SYS_break) && !defined(SYS_create_module) && !defined(SYS_ftime) && !defined(SYS_get_kernel_syms) && !defined(SYS_getpmsg) && !defined(SYS_gtty) && !defined(SYS_lock) && !defined(SYS_mpx) && !defined(SYS_prof) && !defined(SYS_profil) && !defined(SYS_putpmsg) && !defined(SYS_query_module) && !defined(SYS_security) && !defined(SYS_sgetmask) && !defined(SYS_ssetmask) && !defined(SYS_stty) && !defined(SYS_sysfs) && !defined(SYS_tuxcall) && !defined(SYS_ulimit) && !defined(SYS_uselib) && !defined(SYS_ustat) && !defined(SYS_vserver)
-	  "__dummy_syscall__" // workaround for arm64 which doesn't have any of above defined and empty syscall lists are not allowed
+#ifdef __NR_osf_chflags
+	"osf_chflags,"
+#endif
+#ifdef __NR_osf_execve
+	"osf_execve,"
+#endif
+#ifdef __NR_osf_exportfs
+	"osf_exportfs,"
+#endif
+#ifdef __NR_osf_fchflags
+	"osf_fchflags,"
+#endif
+#ifdef __NR_osf_fdatasync
+	"osf_fdatasync,"
+#endif
+#ifdef __NR_osf_fpathconf
+	"osf_fpathconf,"
+#endif
+#ifdef __NR_osf_fuser
+	"osf_fuser,"
+#endif
+#ifdef __NR_osf_getaddressconf
+	"osf_getaddressconf,"
+#endif
+#ifdef __NR_osf_getfh
+	"osf_getfh,"
+#endif
+#ifdef __NR_osf_getfsstat
+	"osf_getfsstat,"
+#endif
+#ifdef __NR_osf_gethostid
+	"osf_gethostid,"
+#endif
+#ifdef __NR_osf_getlogin
+	"osf_getlogin,"
+#endif
+#ifdef __NR_osf_getmnt
+	"osf_getmnt,"
+#endif
+#ifdef __NR_osf_kloadcall
+	"osf_kloadcall,"
+#endif
+#ifdef __NR_osf_kmodcall
+	"osf_kmodcall,"
+#endif
+#ifdef __NR_osf_memcntl
+	"osf_memcntl,"
+#endif
+#ifdef __NR_osf_mincore
+	"osf_mincore,"
+#endif
+#ifdef __NR_osf_mremap
+	"osf_mremap,"
+#endif
+#ifdef __NR_osf_msfs_syscall
+	"osf_msfs_syscall,"
+#endif
+#ifdef __NR_osf_msleep
+	"osf_msleep,"
+#endif
+#ifdef __NR_osf_mvalid
+	"osf_mvalid,"
+#endif
+#ifdef __NR_osf_mwakeup
+	"osf_mwakeup,"
+#endif
+#ifdef __NR_osf_naccept
+	"osf_naccept,"
+#endif
+#ifdef __NR_osf_nfssvc
+	"osf_nfssvc,"
+#endif
+#ifdef __NR_osf_ngetpeername
+	"osf_ngetpeername,"
+#endif
+#ifdef __NR_osf_ngetsockname
+	"osf_ngetsockname,"
+#endif
+#ifdef __NR_osf_nrecvfrom
+	"osf_nrecvfrom,"
+#endif
+#ifdef __NR_osf_nrecvmsg
+	"osf_nrecvmsg,"
+#endif
+#ifdef __NR_osf_nsendmsg
+	"osf_nsendmsg,"
+#endif
+#ifdef __NR_osf_ntp_adjtime
+	"osf_ntp_adjtime,"
+#endif
+#ifdef __NR_osf_ntp_gettime
+	"osf_ntp_gettime,"
+#endif
+#ifdef __NR_osf_old_creat
+	"osf_old_creat,"
+#endif
+#ifdef __NR_osf_old_fstat
+	"osf_old_fstat,"
+#endif
+#ifdef __NR_osf_old_getpgrp
+	"osf_old_getpgrp,"
+#endif
+#ifdef __NR_osf_old_killpg
+	"osf_old_killpg,"
+#endif
+#ifdef __NR_osf_old_lstat
+	"osf_old_lstat,"
+#endif
+#ifdef __NR_osf_old_open
+	"osf_old_open,"
+#endif
+#ifdef __NR_osf_old_sigaction
+	"osf_old_sigaction,"
+#endif
+#ifdef __NR_osf_old_sigblock
+	"osf_old_sigblock,"
+#endif
+#ifdef __NR_osf_old_sigreturn
+	"osf_old_sigreturn,"
+#endif
+#ifdef __NR_osf_old_sigsetmask
+	"osf_old_sigsetmask,"
+#endif
+#ifdef __NR_osf_old_sigvec
+	"osf_old_sigvec,"
+#endif
+#ifdef __NR_osf_old_stat
+	"osf_old_stat,"
+#endif
+#ifdef __NR_osf_old_vadvise
+	"osf_old_vadvise,"
+#endif
+#ifdef __NR_osf_old_vtrace
+	"osf_old_vtrace,"
+#endif
+#ifdef __NR_osf_old_wait
+	"osf_old_wait,"
+#endif
+#ifdef __NR_osf_oldquota
+	"osf_oldquota,"
+#endif
+#ifdef __NR_osf_pathconf
+	"osf_pathconf,"
+#endif
+#ifdef __NR_osf_pid_block
+	"osf_pid_block,"
+#endif
+#ifdef __NR_osf_pid_unblock
+	"osf_pid_unblock,"
+#endif
+#ifdef __NR_osf_plock
+	"osf_plock,"
+#endif
+#ifdef __NR_osf_priocntlset
+	"osf_priocntlset,"
+#endif
+#ifdef __NR_osf_profil
+	"osf_profil,"
+#endif
+#ifdef __NR_osf_reboot
+	"osf_reboot,"
+#endif
+#ifdef __NR_osf_revoke
+	"osf_revoke,"
+#endif
+#ifdef __NR_osf_sbrk
+	"osf_sbrk,"
+#endif
+#ifdef __NR_osf_security
+	"osf_security,"
+#endif
+#ifdef __NR_osf_set_speculative
+	"osf_set_speculative,"
+#endif
+#ifdef __NR_osf_sethostid
+	"osf_sethostid,"
+#endif
+#ifdef __NR_osf_setlogin
+	"osf_setlogin,"
+#endif
+#ifdef __NR_osf_signal
+	"osf_signal,"
+#endif
+#ifdef __NR_osf_sigsendset
+	"osf_sigsendset,"
+#endif
+#ifdef __NR_osf_sigwaitprim
+	"osf_sigwaitprim,"
+#endif
+#ifdef __NR_osf_sstk
+	"osf_sstk,"
+#endif
+#ifdef __NR_osf_stat
+	"osf_stat,"
+#endif
+#ifdef __NR_osf_statfs
+	"osf_statfs,"
+#endif
+#ifdef __NR_osf_statfs64
+	"osf_statfs64,"
+#endif
+#ifdef __NR_osf_subsys_info
+	"osf_subsys_info,"
+#endif
+#ifdef __NR_osf_swapctl
+	"osf_swapctl,"
+#endif
+#ifdef __NR_osf_table
+	"osf_table,"
+#endif
+#ifdef __NR_osf_uadmin
+	"osf_uadmin,"
+#endif
+#ifdef __NR_osf_uswitch
+	"osf_uswitch,"
+#endif
+#ifdef __NR_osf_utc_adjtime
+	"osf_utc_adjtime,"
+#endif
+#ifdef __NR_osf_utc_gettime
+	"osf_utc_gettime,"
+#endif
+#ifdef __NR_osf_waitid
+	"osf_waitid,"
+#endif
+#ifdef __NR_perfctr
+	"perfctr,"
+#endif
+#ifdef __NR_prof
+	"prof,"
+#endif
+#ifdef __NR_profil
+	"profil,"
+#endif
+#ifdef __NR_putpmsg
+	"putpmsg,"
+#endif
+#ifdef __NR_query_module
+	"query_module,"
+#endif
+#ifdef __NR_security
+	"security,"
+#endif
+#ifdef __NR_sgetmask
+	"sgetmask,"
+#endif
+#ifdef __NR_spill
+	"spill,"
+#endif
+#ifdef __NR_ssetmask
+	"ssetmask,"
+#endif
+#ifdef __NR_stty
+	"stty,"
+#endif
+#ifdef __NR_sysfs
+	"sysfs,"
+#endif
+#ifdef __NR_timerfd
+	"timerfd,"
+#endif
+#ifdef __NR_tuxcall
+	"tuxcall,"
+#endif
+#ifdef __NR_ulimit
+	"ulimit,"
+#endif
+#ifdef __NR_uselib
+	"uselib,"
+#endif
+#ifdef __NR_ustat
+	"ustat,"
+#endif
+#ifdef __NR_vserver
+	"vserver,"
+#endif
+#ifdef __NR_xtensa
+	"xtensa"
+#endif
+#if defined(__aarch64__) || defined(__loongarch64) || __loongarch_grlen == 64 || (defined(__riscv) && __riscv_xlen == 64)
+	"__dummy_syscall__" // workaround for arm64, loongarch64 and riscv64 which doesn't have any of above defined and empty syscall lists are not allowed
 #endif
 	},
 	{ .name = "@privileged", .list =
-	  "@chown,"
-	  "@clock,"
-	  "@module,"
-	  "@raw-io,"
-	  "@reboot,"
-	  "@swap,"
-#ifdef SYS__sysctl
-	  "_sysctl,"
+	"@chown,"
+	"@clock,"
+	"@module,"
+	"@raw-io,"
+	"@reboot,"
+	"@swap,"
+#ifdef __NR__sysctl
+	"_sysctl,"
 #endif
-#ifdef SYS_acct
-	  "acct,"
+#ifdef __NR_acct
+	"acct,"
 #endif
-#ifdef SYS_bpf
-	  "bpf,"
+#ifdef __NR_bpf
+	"bpf,"
 #endif
-#ifdef SYS_capset
-	  "capset,"
+#ifdef __NR_capset
+	"capset,"
 #endif
-#ifdef SYS_chroot
-	  "chroot,"
+#ifdef __NR_chroot
+	"chroot,"
 #endif
-#ifdef SYS_fanotify_init
-	  "fanotify_init,"
+#ifdef __NR_fanotify_init
+	"fanotify_init,"
 #endif
-#ifdef SYS_mount
-	  "mount,"
+#ifdef __NR_mount
+	"mount,"
 #endif
-#ifdef SYS_nfsservctl
-	  "nfsservctl,"
+#ifdef __NR_nfsservctl
+	"nfsservctl,"
 #endif
-#ifdef SYS_open_by_handle_at
-	  "open_by_handle_at,"
+#ifdef __NR_open_by_handle_at
+	"open_by_handle_at,"
 #endif
-#ifdef SYS_pivot_root
-	  "pivot_root,"
+#ifdef __NR_pivot_root
+	"pivot_root,"
 #endif
-#ifdef SYS_quotactl
-	  "quotactl,"
+#ifdef __NR_quotactl
+	"quotactl,"
 #endif
-#ifdef SYS_setdomainname
-	  "setdomainname,"
+#ifdef __NR_setdomainname
+	"setdomainname,"
 #endif
-#ifdef SYS_setfsuid
-	  "setfsuid,"
+#ifdef __NR_setfsuid
+	"setfsuid,"
 #endif
-#ifdef SYS_setfsuid32
-	  "setfsuid32,"
+#ifdef __NR_setfsuid32
+	"setfsuid32,"
 #endif
-#ifdef SYS_setgroups
-	  "setgroups,"
+#ifdef __NR_setgroups
+	"setgroups,"
 #endif
-#ifdef SYS_setgroups32
-	  "setgroups32,"
+#ifdef __NR_setgroups32
+	"setgroups32,"
 #endif
-#ifdef SYS_sethostname
-	  "sethostname,"
+#ifdef __NR_sethostname
+	"sethostname,"
 #endif
-#ifdef SYS_setresuid
-	  "setresuid,"
+#ifdef __NR_setresuid
+	"setresuid,"
 #endif
-#ifdef SYS_setresuid32
-	  "setresuid32,"
+#ifdef __NR_setresuid32
+	"setresuid32,"
 #endif
-#ifdef SYS_setreuid
-	  "setreuid,"
+#ifdef __NR_setreuid
+	"setreuid,"
 #endif
-#ifdef SYS_setreuid32
-	  "setreuid32,"
+#ifdef __NR_setreuid32
+	"setreuid32,"
 #endif
-#ifdef SYS_setuid
-	  "setuid,"
+#ifdef __NR_setuid
+	"setuid,"
 #endif
-#ifdef SYS_setuid32
-	  "setuid32,"
+#ifdef __NR_setuid32
+	"setuid32,"
 #endif
-#ifdef SYS_umount2
-	  "umount2,"
+#ifdef __NR_umount2
+	"umount2,"
 #endif
-#ifdef SYS_vhangup
-	  "vhangup"
+#ifdef __NR_vhangup
+	"vhangup"
 #endif
 	},
 	{ .name = "@process", .list =
-#ifdef SYS_arch_prctl
-	  "arch_prctl,"
+#ifdef __NR_arc_gettls
+	"arc_gettls,"
 #endif
-#ifdef SYS_capget
-	  "capget,"
+#ifdef __NR_arc_settls
+	"arc_settls,"
 #endif
-#ifdef SYS_clone
-	  "clone,"
+#ifdef __NR_arc_usr_cmpxchg
+	"arc_usr_cmpxchg,"
 #endif
-#ifdef SYS_clone3
-	  "clone3,"
+#ifdef __NR_atomic_barrier
+	"atomic_barrier,"
 #endif
-#ifdef SYS_execveat
-	  "execveat,"
+#ifdef __NR_atomic_cmpxchg_32
+	"atomic_cmpxchg_32,"
 #endif
-#ifdef SYS_fork
-	  "fork,"
+#ifdef __NR_cachectl
+	"cachectl,"
 #endif
-#ifdef SYS_getrusage
-	  "getrusage,"
+#ifdef __NR_cacheflush
+	"cacheflush,"
 #endif
-#ifdef SYS_kill
-	  "kill,"
+#ifdef __NR_capget
+	"capget,"
 #endif
-#ifdef SYS_pidfd_open
-	  "pidfd_open,"
+#ifdef __NR_clone
+	"clone,"
 #endif
-#ifdef SYS_pidfd_send_signal
-	  "pidfd_send_signal,"
+#ifdef __NR_clone3
+	"clone3,"
 #endif
-#ifdef SYS_prctl
-	  "prctl,"
+#ifdef __NR_exit
+	"exit,"
 #endif
-#ifdef SYS_rt_sigqueueinfo
-	  "rt_sigqueueinfo,"
+#ifdef __NR_exit_group
+	"exit_group,"
 #endif
-#ifdef SYS_rt_tgsigqueueinfo
-	  "rt_tgsigqueueinfo,"
+#ifdef __NR_fork
+	"fork,"
 #endif
-#ifdef SYS_setns
-	  "setns,"
+#ifdef __NR_futex_requeue
+	"futex_requeue,"
 #endif
-#ifdef SYS_swapcontext
-	  "swapcontext,"
+#ifdef __NR_futex_time64
+	"futex_time64,"
 #endif
-#ifdef SYS_tgkill
-	  "tgkill,"
+#ifdef __NR_futex_wait
+	"futex_wait,"
 #endif
-#ifdef SYS_times
-	  "times,"
+#ifdef __NR_futex_waitv
+	"futex_waitv,"
 #endif
-#ifdef SYS_tkill
-	  "tkill,"
+#ifdef __NR_futex_wake
+	"futex_wake,"
 #endif
-#ifdef SYS_unshare
-	  "unshare,"
+#ifdef __NR_get_robust_list
+	"get_robust_list,"
 #endif
-#ifdef SYS_vfork
-	  "vfork,"
+#ifdef __NR_get_thread_area
+	"get_thread_area,"
 #endif
-#ifdef SYS_wait4
-	  "wait4,"
+#ifdef __NR_getegid
+	"getegid,"
 #endif
-#ifdef SYS_waitid
-	  "waitid,"
+#ifdef __NR_geteuid
+	"geteuid,"
 #endif
-#ifdef SYS_waitpid
-	  "waitpid"
+#ifdef __NR_geteuid32
+	"geteuid32,"
+#endif
+#ifdef __NR_getgid
+	"getgid,"
+#endif
+#ifdef __NR_getegid32
+	"getegid32,"
+#endif
+#ifdef __NR_getgroups
+	"getgroups,"
+#endif
+#ifdef __NR_getgroups32
+	"getgroups32,"
+#endif
+#ifdef __NR_getpgid
+	"getpgid,"
+#endif
+#ifdef __NR_getpgrp
+	"getpgrp,"
+#endif
+#ifdef __NR_getpid
+	"getpid,"
+#endif
+#ifdef __NR_getppid
+	"getppid,"
+#endif
+#ifdef __NR_getresgid
+	"getresgid,"
+#endif
+#ifdef __NR_getresgid32
+	"getresgid32,"
+#endif
+#ifdef __NR_getresuid
+	"getresuid,"
+#endif
+#ifdef __NR_getresuid32
+	"getresuid32,"
+#endif
+#ifdef __NR_getsid
+	"getsid,"
+#endif
+#ifdef __NR_gettid
+	"gettid,"
+#endif
+#ifdef __NR_getuid
+	"getuid,"
+#endif
+#ifdef __NR_getuid32
+	"getuid32,"
+#endif
+#ifdef __NR_getxgid
+	"getxgid,"
+#endif
+#ifdef __NR_getxpid
+	"getxpid,"
+#endif
+#ifdef __NR_getxuid
+	"getxuid,"
+#endif
+#ifdef __NR_kill
+	"kill,"
+#endif
+#ifdef __NR_membarrier
+	"membarrier,"
+#endif
+#ifdef __or1k_atomic
+	"or1k_atomic,"
+#endif
+#ifdef __NR_osf_set_program_attributes
+	"osf_set_program_attributes,"
+#endif
+#ifdef __NR_osf_wait4
+	"osf_wait4,"
+#endif
+#ifdef __NR_pidfd_open
+	"pidfd_open,"
+#endif
+#ifdef __NR_pidfd_send_signal
+	"pidfd_send_signal,"
+#endif
+#ifdef __NR_riscv_flush_icache
+	"riscv_flush_icache,"
+#endif
+#ifdef __NR_rseq
+	"rseq,"
+#endif
+#ifdef __NR_rt_sigqueueinfo
+	"rt_sigqueueinfo,"
+#endif
+#ifdef __NR_rt_tgsigqueueinfo
+	"rt_tgsigqueueinfo,"
+#endif
+#ifdef __NR_s390_guarded_storage
+	"s390_guarded_storage,"
+#endif
+#ifdef __NR_sched_get_affinity
+	"sched_get_affinity,"
+#endif
+#ifdef __NR_setns
+	"setns,"
+#endif
+#ifdef __NR_set_robust_list
+	"set_robust_list,"
+#endif
+#ifdef __NR_set_thread_area
+	"set_thread_area,"
+#endif
+#ifdef __NR_set_tid_address
+	"set_tid_address,"
+#endif
+#ifdef __NR_sethae
+	"sethae,"
+#endif
+#ifdef __NR_setpgrp
+	"setpgrp,"
+#endif
+#ifdef __NR_setpriority
+	"setpriority,"
+#endif
+#ifdef __NR_spu_create
+	"spu_create,"
+#endif
+#ifdef __NR_spu_run
+	"spu_run,"
+#endif
+#ifdef __NR_swapcontext
+	"swapcontext,"
+#endif
+#ifdef __NR_tgkill
+	"tgkill,"
+#endif
+#ifdef __NR_times
+	"times,"
+#endif
+#ifdef __NR_tkill
+	"tkill,"
+#endif
+#ifdef __NR_unshare
+	"unshare,"
+#endif
+#ifdef __NR_utimensat_time64
+	"utimensat_time64,"
+#endif
+#ifdef __NR_vfork
+	"vfork,"
+#endif
+#ifdef __NR_wait4
+	"wait4,"
+#endif
+#ifdef __NR_waitid
+	"waitid,"
+#endif
+#ifdef __NR_waitpid
+	"waitpid"
 #endif
 	},
 	{ .name = "@raw-io", .list =
-#ifdef SYS_ioperm
-	  "ioperm,"
+#ifdef __NR_ioperm
+	"ioperm,"
 #endif
-#ifdef SYS_iopl
-	  "iopl,"
+#ifdef __NR_iopl
+	"iopl,"
 #endif
-#ifdef SYS_pciconfig_iobase
-	  "pciconfig_iobase,"
+#ifdef __NR_pciconfig_iobase
+	"pciconfig_iobase,"
 #endif
-#ifdef SYS_pciconfig_read
-	  "pciconfig_read,"
+#ifdef __NR_pciconfig_read
+	"pciconfig_read,"
 #endif
-#ifdef SYS_pciconfig_write
-	  "pciconfig_write,"
+#ifdef __NR_pciconfig_write
+	"pciconfig_write,"
 #endif
-#ifdef SYS_s390_pci_mmio_read
-	  "s390_pci_mmio_read,"
+#ifdef __NR_s390_pci_mmio_read
+	"s390_pci_mmio_read,"
 #endif
-#ifdef SYS_s390_pci_mmio_write
-	  "s390_pci_mmio_write"
+#ifdef __NR_s390_pci_mmio_write
+	"s390_pci_mmio_write"
 #endif
-#if !defined(SYS_ioperm) && !defined(SYS_iopl) && !defined(SYS_pciconfig_iobase) && !defined(SYS_pciconfig_read) && !defined(SYS_pciconfig_write) && !defined(SYS_s390_pci_mmio_read) && !defined(SYS_s390_pci_mmio_write)
-	  "__dummy_syscall__" // workaround for s390x which doesn't have any of above defined and empty syscall lists are not allowed
+#if !defined(__NR_ioperm) && !defined(__NR_iopl) && !defined(__NR_pciconfig_iobase) && !defined(__NR_pciconfig_read) && !defined(__NR_pciconfig_write) && !defined(__NR_s390_pci_mmio_read) && !defined(__NR_s390_pci_mmio_write)
+	"__dummy_syscall__" // workaround for the following architectures which doesn't have any of above defined and empty syscall lists are not allowed:
+						// arm64, arc32, hexagon32, loongarch64, m68k, mips_n32, mips_n64, nios2, openrisc32, parisc32, parisc64, riscv32, riscv64, superh and xtensa
 #endif
 	},
 	{ .name = "@reboot", .list =
-#ifdef SYS_kexec_load
-	  "kexec_load,"
+#ifdef __NR_kexec_load
+	"kexec_load,"
 #endif
-#ifdef SYS_kexec_file_load
-	  "kexec_file_load,"
+#ifdef __NR_kexec_file_load
+	"kexec_file_load,"
 #endif
-#ifdef SYS_reboot
-	  "reboot,"
+#ifdef __NR_reboot
+	"reboot"
 #endif
 	},
 	{ .name = "@resources", .list =
-#ifdef SYS_ioprio_set
-	  "ioprio_set,"
+#ifdef __NR_getdtablesize
+	"getdtablesize,"
 #endif
-#ifdef SYS_mbind
-	  "mbind,"
+#ifdef __NR_getrlimit
+	"getrlimit,"
 #endif
-#ifdef SYS_migrate_pages
-	  "migrate_pages,"
+#ifdef __NR_getrusage
+	"getrusage,"
 #endif
-#ifdef SYS_move_pages
-	  "move_pages,"
+#ifdef __NR_ioprio_set
+	"ioprio_set,"
 #endif
-#ifdef SYS_nice
-	  "nice,"
+#ifdef __NR_mbind
+	"mbind,"
 #endif
-#ifdef SYS_sched_setaffinity
-	  "sched_setaffinity,"
+#ifdef __NR_migrate_pages
+	"migrate_pages,"
 #endif
-#ifdef SYS_sched_setattr
-	  "sched_setattr,"
+#ifdef __NR_mincore
+	"mincore,"
 #endif
-#ifdef SYS_sched_setparam
-	  "sched_setparam,"
+#ifdef __NR_move_pages
+	"move_pages,"
 #endif
-#ifdef SYS_sched_setscheduler
-	  "sched_setscheduler,"
+#ifdef __NR_nice
+	"nice,"
 #endif
-#ifdef SYS_set_mempolicy
-	  "set_mempolicy"
+#ifdef __NR_osf_getrusage
+	"osf_getrusage,"
+#endif
+#ifdef __NR_prlimit64
+	"prlimit64,"
+#endif
+#ifdef __NR_sched_set_affinity
+	"sched_set_affinity,"
+#endif
+#ifdef __NR_sched_set_mempolicy_home_node
+	"set_mempolicy_home_node,"
+#endif
+#ifdef __NR_sched_setaffinity
+	"sched_setaffinity,"
+#endif
+#ifdef __NR_sched_setattr
+	"sched_setattr,"
+#endif
+#ifdef __NR_sched_setparam
+	"sched_setparam,"
+#endif
+#ifdef __NR_setrlimit
+	"sched_setrlimit,"
+#endif
+#ifdef __NR_sched_setscheduler
+	"sched_setscheduler,"
+#endif
+#ifdef __NR_set_mempolicy
+	"set_mempolicy,"
+#endif
+#ifdef __NR_set_mempolicy
+	"ugetrlimit"
+#endif
+	},
+	{ .name = "@sandbox", .list =
+#ifdef __NR_landlock_add_rule
+	"landlock_add_rule,"
+#endif
+#ifdef __NR_landlock_create_ruleset
+	"landlock_create_ruleset,"
+#endif
+#ifdef __NR_landlock_restrict_self
+	"landlock_restrict_self,"
+#endif
+#ifdef __NR_seccomp
+	"seccomp"
 #endif
 	},
 	{ .name = "@setuid", .list =
-#ifdef SYS_setgid
-	  "setgid,"
+#ifdef __NR_setgid
+	"setgid,"
 #endif
-#ifdef SYS_setgid32
-	  "setgid32,"
+#ifdef __NR_setgid32
+	"setgid32,"
 #endif
-#ifdef SYS_setgroups
-	  "setgroups,"
+#ifdef __NR_setgroups
+	"setgroups,"
 #endif
-#ifdef SYS_setgroups32
-	  "setgroups32,"
+#ifdef __NR_setgroups32
+	"setgroups32,"
 #endif
-#ifdef SYS_setregid
-	  "setregid,"
+#ifdef __NR_setregid
+	"setregid,"
 #endif
-#ifdef SYS_setregid32
-	  "setregid32,"
+#ifdef __NR_setregid32
+	"setregid32,"
 #endif
-#ifdef SYS_setresgid
-	  "setresgid,"
+#ifdef __NR_setresgid
+	"setresgid,"
 #endif
-#ifdef SYS_setresgid32
-	  "setresgid32,"
+#ifdef __NR_setresgid32
+	"setresgid32,"
 #endif
-#ifdef SYS_setresuid
-	  "setresuid,"
+#ifdef __NR_setresuid
+	"setresuid,"
 #endif
-#ifdef SYS_setresuid32
-	  "setresuid32,"
+#ifdef __NR_setresuid32
+	"setresuid32,"
 #endif
-#ifdef SYS_setreuid
-	  "setreuid,"
+#ifdef __NR_setreuid
+	"setreuid,"
 #endif
-#ifdef SYS_setreuid32
-	  "setreuid32,"
+#ifdef __NR_setreuid32
+	"setreuid32,"
 #endif
-#ifdef SYS_setuid
-	  "setuid,"
+#ifdef __NR_setuid
+	"setuid,"
 #endif
-#ifdef SYS_setuid32
-	  "setuid32"
+#ifdef __NR_setuid32
+	"setuid32"
 #endif
 	},
 	{ .name = "@signal", .list =
-#ifdef SYS_rt_sigaction
-	  "rt_sigaction,"
+#ifdef __NR_osf_sigprocmask
+	"osf_sigprocmask,"
 #endif
-#ifdef SYS_rt_sigpending
-	  "rt_sigpending,"
+#ifdef __NR_osf_sigstack
+	"osf_sigstack,"
 #endif
-#ifdef SYS_rt_sigprocmask
-	  "rt_sigprocmask,"
+#ifdef __NR_pause
+	"pause,"
 #endif
-#ifdef SYS_rt_sigsuspend
-	  "rt_sigsuspend,"
+#ifdef __NR_restart_syscall
+	"restart_syscall,"
 #endif
-#ifdef SYS_rt_sigtimedwait
-	  "rt_sigtimedwait,"
+#ifdef __NR_rt_sigaction
+	"rt_sigaction,"
 #endif
-#ifdef SYS_sigaction
-	  "sigaction,"
+#ifdef __NR_rt_sigpending
+	"rt_sigpending,"
 #endif
-#ifdef SYS_sigaltstack
-	  "sigaltstack,"
+#ifdef __NR_rt_sigprocmask
+	"rt_sigprocmask,"
 #endif
-#ifdef SYS_signal
-	  "signal,"
+#ifdef __NR_rt_sigreturn
+	"rt_sigreturn,"
 #endif
-#ifdef SYS_signalfd
-	  "signalfd,"
+#ifdef __NR_rt_sigtimedwait_time64
+	"rt_sigtimedwait_time64,"
 #endif
-#ifdef SYS_signalfd4
-	  "signalfd4,"
+#ifdef __NR_rt_sigsuspend
+	"rt_sigsuspend,"
 #endif
-#ifdef SYS_sigpending
-	  "sigpending,"
+#ifdef __NR_rt_sigtimedwait
+	"rt_sigtimedwait,"
 #endif
-#ifdef SYS_sigprocmask
-	  "sigprocmask,"
+#ifdef __NR_sigaction
+	"sigaction,"
 #endif
-#ifdef SYS_sigsuspend
-	  "sigsuspend"
+#ifdef __NR_sigaltstack
+	"sigaltstack,"
+#endif
+#ifdef __NR_signal
+	"signal,"
+#endif
+#ifdef __NR_signalfd
+	"signalfd,"
+#endif
+#ifdef __NR_signalfd4
+	"signalfd4,"
+#endif
+#ifdef __NR_sigpending
+	"sigpending,"
+#endif
+#ifdef __NR_sigprocmask
+	"sigprocmask,"
+#endif
+#ifdef __NR_sigreturn
+	"sigreturn,"
+#endif
+#ifdef __NR_sigsuspend
+	"sigsuspend,"
+#endif
+#ifdef __NR_utrap_install
+	"utrap_install"
 #endif
 	},
 	{ .name = "@swap", .list =
-#ifdef SYS_swapon
-	  "swapon,"
+#ifdef __NR_osf_swapon
+	"osf_swapon,"
 #endif
-#ifdef SYS_swapoff
-	  "swapoff"
+#ifdef __NR_swapon
+	"swapon,"
+#endif
+#ifdef __NR_swapoff
+	"swapoff"
 #endif
 	},
 	{ .name = "@sync", .list =
-#ifdef SYS_fdatasync
-	  "fdatasync,"
+#ifdef __NR_arm_sync_file_range
+	"arm_sync_file_range,"
 #endif
-#ifdef SYS_fsync
-	  "fsync,"
+#ifdef __NR_fdatasync
+	"fdatasync,"
 #endif
-#ifdef SYS_msync
-	  "msync,"
+#ifdef __NR_fsync
+	"fsync,"
 #endif
-#ifdef SYS_sync
-	  "sync,"
+#ifdef __NR_msync
+	"msync,"
 #endif
-#ifdef SYS_sync_file_range
-	  "sync_file_range,"
+#ifdef __NR_sync
+	"sync,"
 #endif
-#ifdef SYS_sync_file_range2
-	  "sync_file_range2,"
+#ifdef __NR_sync_file_range
+	"sync_file_range,"
 #endif
-#ifdef SYS_syncfs
-	  "syncfs"
+#ifdef __NR_sync_file_range2
+	"sync_file_range2,"
+#endif
+#ifdef __NR_syncfs
+	"syncfs"
 #endif
 	},
 	{ .name = "@system-service", .list =
-	  "@aio,"
-	  "@basic-io,"
-	  "@chown,"
-	  "@default,"
-	  "@file-system,"
-	  "@io-event,"
-	  "@ipc,"
-	  "@keyring,"
-	  "@memlock,"
-	  "@network-io,"
-	  "@process,"
-	  "@resources,"
-	  "@setuid,"
-	  "@signal,"
-	  "@sync,"
-	  "@timer,"
-#ifdef SYS_brk
-	  "brk,"
+	"@aio,"
+	"@basic-io,"
+	"@chown,"
+	"@default,"
+	"@file-system,"
+	"@io-event,"
+	"@ipc,"
+	"@keyring,"
+	"@memlock,"
+	"@network-io,"
+	"@process,"
+	"@resources,"
+	"@setuid,"
+	"@signal,"
+	"@sync,"
+	"@timer,"
+#ifdef __NR_arm_fadvise64_64
+	"arm_fadvise64_64,"
 #endif
-#ifdef SYS_capget
-	  "capget,"
+#ifdef __NR_brk
+	"brk,"
 #endif
-#ifdef SYS_capset
-	  "capset,"
+#ifdef __NR_capget
+	"capget,"
 #endif
-#ifdef SYS_copy_file_range
-	  "copy_file_range,"
+#ifdef __NR_capset
+	"capset,"
 #endif
-#ifdef SYS_fadvise64
-	  "fadvise64,"
+#ifdef __NR_copy_file_range
+	"copy_file_range,"
 #endif
-#ifdef SYS_fadvise64_64
-	  "fadvise64_64,"
+#ifdef __NR_fadvise64
+	"fadvise64,"
 #endif
-#ifdef SYS_flock
-	  "flock,"
+#ifdef __NR_fadvise64_64
+	"fadvise64_64,"
 #endif
-#ifdef SYS_get_mempolicy
-	  "get_mempolicy,"
+#ifdef __NR_flock
+	"flock,"
 #endif
-#ifdef SYS_getcpu
-	  "getcpu,"
+#ifdef __NR_get_mempolicy
+	"get_mempolicy,"
 #endif
-#ifdef SYS_getpriority
-	  "getpriority,"
+#ifdef __NR_getcpu
+	"getcpu,"
 #endif
-#ifdef SYS_getrandom
-	  "getrandom,"
+#ifdef __NR_getdomainname
+	"getdomainname,"
 #endif
-#ifdef SYS_ioctl
-	  "ioctl,"
+#ifdef __NR_gethostname
+	"gethostname,"
 #endif
-#ifdef SYS_ioprio_get
-	  "ioprio_get,"
+#ifdef __NR_getpagesize
+	"getpagesize,"
 #endif
-#ifdef SYS_kcmp
-	  "kcmp,"
+#ifdef __NR_getpriority
+	"getpriority,"
 #endif
-#ifdef SYS_madvise
-	  "madvise,"
+#ifdef __NR_getrandom
+	"getrandom,"
 #endif
-#ifdef SYS_mprotect
-	  "mprotect,"
+#ifdef __NR_ioctl
+	"ioctl,"
 #endif
-#ifdef SYS_mremap
-	  "mremap,"
+#ifdef __NR_ioprio_get
+	"ioprio_get,"
 #endif
-#ifdef SYS_name_to_handle_at
-	  "name_to_handle_at,"
+#ifdef __NR_kcmp
+	"kcmp,"
 #endif
-#ifdef SYS_oldolduname
-	  "oldolduname,"
+#ifdef __NR_kern_features
+	"kern_features,"
 #endif
-#ifdef SYS_olduname
-	  "olduname,"
+#ifdef __NR_listns
+	"listns,"
 #endif
-#ifdef SYS_personality
-	  "personality,"
+#ifdef __NR_lsm_get_self_attr
+	"lsm_get_self_attr,"
 #endif
-#ifdef SYS_readahead
-	  "readahead,"
+#ifdef __NR_lsm_list_modules
+	"lsm_list_modules,"
 #endif
-#ifdef SYS_readdir
-	  "readdir,"
+#ifdef __NR_lsm_set_self_attr
+	"lsm_set_self_attr,"
 #endif
-#ifdef SYS_remap_file_pages
-	  "remap_file_pages,"
+#ifdef __NR_map_shadow_stack
+	"map_shadow_stack,"
 #endif
-#ifdef SYS_sched_get_priority_max
-	  "sched_get_priority_max,"
+#ifdef __NR_madvise
+	"madvise,"
 #endif
-#ifdef SYS_sched_get_priority_min
-	  "sched_get_priority_min,"
+#ifdef __NR_memory_ordering
+	"memory_ordering,"
 #endif
-#ifdef SYS_sched_getaffinity
-	  "sched_getaffinity,"
+#ifdef __NR_mremap
+	"mremap,"
 #endif
-#ifdef SYS_sched_getattr
-	  "sched_getattr,"
+#ifdef __NR_mseal
+	"mseal,"
 #endif
-#ifdef SYS_sched_getparam
-	  "sched_getparam,"
+#ifdef __NR_name_to_handle_at
+	"name_to_handle_at,"
 #endif
-#ifdef SYS_sched_getscheduler
-	  "sched_getscheduler,"
+#ifdef __NR_oldolduname
+	"oldolduname,"
 #endif
-#ifdef SYS_sched_rr_get_interval
-	  "sched_rr_get_interval,"
+#ifdef __NR_olduname
+	"olduname,"
 #endif
-#ifdef SYS_sched_yield
-	  "sched_yield,"
+#ifdef __NR_osf_getdomainname
+	"osf_getdomainname,"
 #endif
-#ifdef SYS_sendfile
-	  "sendfile,"
+#ifdef __NR_osf_getsysinfo
+	"osf_getsysinfo,"
 #endif
-#ifdef SYS_sendfile64
-	  "sendfile64,"
+#ifdef __NR_osf_setsysinfo
+	"osf_setsysinfo,"
 #endif
-#ifdef SYS_setfsgid
-	  "setfsgid,"
+#ifdef __NR_osf_syscall
+	"osf_syscall,"
 #endif
-#ifdef SYS_setfsgid32
-	  "setfsgid32,"
+#ifdef __NR_osf_sysinfo
+	"osf_sysinfo,"
 #endif
-#ifdef SYS_setfsuid
-	  "setfsuid,"
+#ifdef __NR_osf_utsname
+	"osf_utsname,"
 #endif
-#ifdef SYS_setfsuid32
-	  "setfsuid32,"
+#ifdef __NR_personality
+	"personality,"
 #endif
-#ifdef SYS_setpgid
-	  "setpgid,"
+#ifdef __NR_pkey_alloc
+	"pkey_alloc,"
 #endif
-#ifdef SYS_setsid
-	  "setsid,"
+#ifdef __NR_pkey_free
+	"pkey_free,"
 #endif
-#ifdef SYS_splice
-	  "splice,"
+#ifdef __NR_pkey_mprotect
+	"pkey_mprotect,"
 #endif
-#ifdef SYS_sysinfo
-	  "sysinfo,"
+#ifdef __NR_readahead
+	"readahead,"
 #endif
-#ifdef SYS_tee
-	  "tee,"
+#ifdef __NR_readdir
+	"readdir,"
 #endif
-#ifdef SYS_umask
-	  "umask,"
+#ifdef __NR_remap_file_pages
+	"remap_file_pages,"
 #endif
-#ifdef SYS_uname
-	  "uname,"
+#ifdef __NR_riscv_hwprobe
+	"riscv_hwprobe,"
 #endif
-#ifdef SYS_userfaultfd
-	  "userfaultfd,"
+#ifdef __NR_s390_sthyi
+	"s390_sthyi,"
 #endif
-#ifdef SYS_vmsplice
-	  "vmsplice"
+#ifdef __NR_sched_get_priority_max
+	"sched_get_priority_max,"
+#endif
+#ifdef __NR_sched_get_priority_min
+	"sched_get_priority_min,"
+#endif
+#ifdef __NR_sched_getaffinity
+	"sched_getaffinity,"
+#endif
+#ifdef __NR_sched_getattr
+	"sched_getattr,"
+#endif
+#ifdef __NR_sched_getparam
+	"sched_getparam,"
+#endif
+#ifdef __NR_sched_getscheduler
+	"sched_getscheduler,"
+#endif
+#ifdef __NR_sched_rr_get_interval
+	"sched_rr_get_interval,"
+#endif
+#ifdef __NR_sched_rr_get_interval_time64
+	"sched_rr_get_interval_time64,"
+#endif
+#ifdef __NR_sched_yield
+	"sched_yield,"
+#endif
+#ifdef __NR_sendfile
+	"sendfile,"
+#endif
+#ifdef __NR_sendfile64
+	"sendfile64,"
+#endif
+#ifdef __NR_setfsgid
+	"setfsgid,"
+#endif
+#ifdef __NR_setfsgid32
+	"setfsgid32,"
+#endif
+#ifdef __NR_setfsuid
+	"setfsuid,"
+#endif
+#ifdef __NR_setfsuid32
+	"setfsuid32,"
+#endif
+#ifdef __NR_setpgid
+	"setpgid,"
+#endif
+#ifdef __NR_setsid
+	"setsid,"
+#endif
+#ifdef __NR_splice
+	"splice,"
+#endif
+#ifdef __NR_syscall
+	"syscall,"
+#endif
+#ifdef __NR_sysinfo
+	"sysinfo,"
+#endif
+#ifdef __NR_sysmips
+	"sysmips,"
+#endif
+#ifdef __NR_tee
+	"tee,"
+#endif
+#ifdef __NR_umask
+	"umask,"
+#endif
+#ifdef __NR_uname
+	"uname,"
+#endif
+#ifdef __NR_userfaultfd
+	"userfaultfd,"
+#endif
+#ifdef __NR_vmsplice
+	"vmsplice"
 #endif
 	},
 	{ .name = "@timer", .list =
-#ifdef SYS_alarm
-	  "alarm,"
+#ifdef __NR_alarm
+	"alarm,"
 #endif
-#ifdef SYS_getitimer
-	  "getitimer,"
+#ifdef __NR_getitimer
+	"getitimer,"
 #endif
-#ifdef SYS_setitimer
-	  "setitimer,"
+#ifdef __NR_nanosleep
+	"nanosleep,"
 #endif
-#ifdef SYS_timer_create
-	  "timer_create,"
+#ifdef __NR_osf_getitimer
+	"osf_getitimer,"
 #endif
-#ifdef SYS_timer_delete
-	  "timer_delete,"
+#ifdef __NR_osf_setitimer
+	"osf_setitimer,"
 #endif
-#ifdef SYS_timer_getoverrun
-	  "timer_getoverrun,"
+#ifdef __NR_osf_usleep_thread
+	"osf_usleep_thread,"
 #endif
-#ifdef SYS_timer_gettime
-	  "timer_gettime,"
+#ifdef __NR_setitimer
+	"setitimer,"
 #endif
-#ifdef SYS_timer_settime
-	  "timer_settime,"
+#ifdef __NR_timer_create
+	"timer_create,"
 #endif
-#ifdef SYS_timerfd_create
-	  "timerfd_create,"
+#ifdef __NR_timer_delete
+	"timer_delete,"
 #endif
-#ifdef SYS_timerfd_gettime
-	  "timerfd_gettime,"
+#ifdef __NR_timer_getoverrun
+	"timer_getoverrun,"
 #endif
-#ifdef SYS_timerfd_settime
-	  "timerfd_settime,"
+#ifdef __NR_timer_gettime
+	"timer_gettime,"
 #endif
-#ifdef SYS_times
-	  "times"
+#ifdef __NR_timer_gettime64
+	"timer_gettime64,"
+#endif
+#ifdef __NR_timer_settime
+	"timer_settime,"
+#endif
+#ifdef __NR_timer_settime64
+	"timer_settime64,"
+#endif
+#ifdef __NR_timerfd_create
+	"timerfd_create,"
+#endif
+#ifdef __NR_timerfd_gettime
+	"timerfd_gettime,"
+#endif
+#ifdef __NR_timerfd_gettime64
+	"timerfd_gettime64,"
+#endif
+#ifdef __NR_timerfd_settime
+	"timerfd_settime,"
+#endif
+#ifdef __NR_timerfd_settime64
+	"timerfd_settime64,"
+#endif
+#ifdef __NR_times
+	"times"
 #endif
 	}
 };


### PR DESCRIPTION
- Included new `syscall_*.h` headers
- Renamed macros `SYS_` to `__NR_`
- Moved some sycalls and added new ones
- Removed `ni_syscall` (invalid syscall)
- Allows `mincore` in `@resources`
- Added two new groups: `@memfd` and `@sandbox`

Relates to:

* #6961
* #6991
* #7000
