### PR TITLE
profiles: freetube: allow mpv integration

### DIFF
--- a/etc/profile-a-l/freetube.profile
+++ b/etc/profile-a-l/freetube.profile
@@ -6,7 +6,18 @@ include freetube.local
 # Persistent global definitions
 include globals.local
 
+# mpv integration
+ignore include disable-programs.inc
+ignore include disable-shell.inc
+
+private-etc mpv
+
 ignore dbus-user none
+ignore dbus-system none
+
+ignore restrict-namespaces
+
+include mpv.profile
 
 noblacklist ${HOME}/.config/FreeTube
 


### PR DESCRIPTION
Clicking the launch in mpv button in freetube results in an EACESS
error. Include mpv.profile with some ignore fixes to allow freetube
profile to launch mpv profile

I ran sort.py but didnt see any reasonable auto arranges, so I rearranged the profile to how it made sense to me.
