### PR TITLE
ci: codeql-cpp: print config.log if configure fails

### DIFF
--- a/.github/workflows/check-c.yml
+++ b/.github/workflows/check-c.yml
@@ -136,7 +136,7 @@ jobs:
         languages: cpp
 
     - name: configure
-      run: ./configure
+      run: ./configure || (cat config.log; exit 1)
 
     - name: make
       run: make -j "$(nproc)"


### PR DESCRIPTION
For consistency with the other `./configure` invocations.

This amends commit 500d8f2d6 ("ci: run make in parallel where
applicable", 2023-08-14) / PR #5960.

See also commit dc826cba3 ("ci: print config.log if configure fails",
2023-05-05) / PR #5857.