### PR TITLE
build: add sort-profiles target for sort.py

### DIFF
--- a/.github/workflows/check-profiles.yml
+++ b/.github/workflows/check-profiles.yml
@@ -43,15 +43,12 @@ jobs:
     - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
     - name: print env
       run: ./ci/printenv.sh
+    - name: configure
+      run: ./configure || (cat config.log; exit 1)
     - run: python3 --version
 
-    - name: sort.py
-      run: >
-        set +e;
-        ./ci/check/profiles/sort.py
-        etc/inc/*.inc etc/profile*/*.profile
-        echo;
-        git diff --exit-code
+    - name: sort profiles
+      run: make sort-profiles || (echo; git diff --exit-code)
 # Currently broken (see #5610)
 #   - name: private-etc-always-required.sh
 #     run: >

--- a/Makefile
+++ b/Makefile
@@ -410,6 +410,10 @@ print-env:
 installcheck: config.mk
 	command -V $(TARNAME) && $(TARNAME) --version
 
+.PHONY: sort-profiles
+sort-profiles: $(PROFILES_INC) $(PROFILES_PRO)
+	@./ci/check/profiles/sort.py $(PROFILES_INC) $(PROFILES_PRO)
+
 #
 # make test
 #


### PR DESCRIPTION
And use it in CI.

Note: The target currently always runs sort.py for all profiles.

Before:

    $ ./ci/check/profiles/sort.py etc/inc/*.inc etc/profile*/*.profile

After:

    $ make sort-profiles