### PR TITLE
ci: gitlab: install missing git-buildpackage dependency

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -148,7 +148,7 @@ debian_ci:
         - git commit -m 'add debian/'
         - export CI_COMMIT_SHA="$(git rev-parse HEAD)"
     script:
-        - apt-get install --no-install-recommends -qy gawk
+        - apt-get install --no-install-recommends -qy gawk git-buildpackage
         - ./ci/printenv.sh
         - gitlab-ci-git-buildpackage
         - gitlab-ci-lintian


### PR DESCRIPTION
Fixes the following error in `debian_ci`[1]:

    Running with gitlab-runner 18.7.0~pre.433.g3a5f2314 (3a5f2314)
      on green-1.saas-linux-small-amd64.runners-manager.gitlab.com/default JLgUopmMV, system ID: s_deaa2ca09de7
    Preparing the "docker+machine" executor
    Using Docker executor with image registry.salsa.debian.org/salsa-ci-team/ci-image-git-buildpackage:latest ...
    Using effective pull policy of [always] for container registry.salsa.debian.org/salsa-ci-team/ci-image-git-buildpackage:latest
    Pulling docker image registry.salsa.debian.org/salsa-ci-team/ci-image-git-buildpackage:latest ...
    Using docker image sha256:d3583847cf2ed2f794f97a09510fd08a07c483a37718e81fe01d5576d4aca1a7 for registry.salsa.debian.org/salsa-ci-team/ci-image-git-buildpackage:latest with digest registry.salsa.debian.org/salsa-ci-team/ci-image-git-buildpackage@sha256:1416995f1e5984f414b083806cc591223d176678a9252de990b38b887981efc3 ...
    [...]
    Executing "step_script" stage of the job script
    Using effective pull policy of [always] for container registry.salsa.debian.org/salsa-ci-team/ci-image-git-buildpackage:latest
    Using docker image sha256:d3583847cf2ed2f794f97a09510fd08a07c483a37718e81fe01d5576d4aca1a7 for registry.salsa.debian.org/salsa-ci-team/ci-image-git-buildpackage:latest with digest registry.salsa.debian.org/salsa-ci-team/ci-image-git-buildpackage@sha256:1416995f1e5984f414b083806cc591223d176678a9252de990b38b887981efc3 ...
    $ git checkout -B ci_build "$CI_COMMIT_SHA"
    Switched to a new branch 'ci_build'
    $ gitlab-ci-enable-sid
    $ gitlab-ci-enable-experimental
    [...]
    $ apt-get install --no-install-recommends -qy gawk
    [...]
    $ gitlab-ci-git-buildpackage
    [...]
    make master branch current for gbp
    Switched to a new branch 'master'
    + '[' -z '' ']'
    + gbp buildpackage -uc -us --git-pristine-tar --git-debian-branch=master
    /usr/bin/gitlab-ci-git-buildpackage: line 66: gbp: command not found
    Cleaning up project directory and file based variables

    ERROR: Job failed: exit code 1

[1] https://gitlab.com/Firejail/firejail_ci/-/jobs/12593768999