### PR TITLE
profiles: add deno paths

### DIFF
--- a/etc/inc/allow-common-devel.inc
+++ b/etc/inc/allow-common-devel.inc
@@ -6,6 +6,10 @@ include allow-common-devel.local
 noblacklist ${HOME}/.arduino15
 noblacklist ${HOME}/Arduino
 
+# Deno
+noblacklist ${HOME}/.cache/deno
+noblacklist ${HOME}/.deno
+
 # Git
 noblacklist ${HOME}/.config/git
 noblacklist ${HOME}/.gitconfig

--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -348,6 +348,7 @@ blacklist ${HOME}/.ssh/rc
 blacklist /etc/hosts.equiv
 
 # Initialization files that allow arbitrary command execution
+read-only ${HOME}/.cache/deno
 read-only ${HOME}/.caffrc
 read-only ${HOME}/.cargo/env
 read-only ${HOME}/.config/mpv
@@ -357,6 +358,7 @@ read-only ${HOME}/.config/ncmpcpp/config
 read-only ${HOME}/.config/nsxiv/exec
 read-only ${HOME}/.config/nvim
 read-only ${HOME}/.config/pkcs11
+read-only ${HOME}/.deno
 read-only ${HOME}/.dotfiles
 read-only ${HOME}/.elinks
 read-only ${HOME}/.emacs

--- a/etc/inc/disable-interpreters.inc
+++ b/etc/inc/disable-interpreters.inc
@@ -2,6 +2,9 @@
 # Persistent customizations should go in a .local file.
 include disable-interpreters.local
 
+# Deno
+blacklist ${PATH}/deno
+
 # gjs
 blacklist ${PATH}/gjs
 blacklist ${PATH}/gjs-console

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -106,6 +106,7 @@ blacklist ${HOME}/.cache/cliqz
 blacklist ${HOME}/.cache/com.github.johnfactotum.Foliate
 blacklist ${HOME}/.cache/darktable
 blacklist ${HOME}/.cache/deja-dup
+blacklist ${HOME}/.cache/deno
 blacklist ${HOME}/.cache/discover
 blacklist ${HOME}/.cache/dnox
 blacklist ${HOME}/.cache/dolphin
@@ -742,6 +743,7 @@ blacklist ${HOME}/.cups
 blacklist ${HOME}/.curl-hsts
 blacklist ${HOME}/.curlrc
 blacklist ${HOME}/.dashcore
+blacklist ${HOME}/.deno
 blacklist ${HOME}/.devilspie
 blacklist ${HOME}/.dia
 blacklist ${HOME}/.digrc

--- a/etc/profile-m-z/nodejs-common.profile
+++ b/etc/profile-m-z/nodejs-common.profile
@@ -15,11 +15,15 @@ include nodejs-common.local
 # used by nvm: curl, sha256sum, tar and wget. We have comments in these
 # profiles on how to enable nvm support via local overrides.
 
+ignore read-only ${HOME}/.cache/deno
+ignore read-only ${HOME}/.deno
 ignore read-only ${HOME}/.npm-packages
 ignore read-only ${HOME}/.npmrc
 ignore read-only ${HOME}/.nvm
 ignore read-only ${HOME}/.yarnrc
 
+noblacklist ${HOME}/.cache/deno
+noblacklist ${HOME}/.deno
 noblacklist ${HOME}/.local/share/pnpm
 noblacklist ${HOME}/.node-gyp
 noblacklist ${HOME}/.npm

--- a/etc/profile-m-z/yt-dlp.profile
+++ b/etc/profile-m-z/yt-dlp.profile
@@ -21,6 +21,8 @@ include globals.local
 # (yt-dlp needs the browser cookie):
 #noblacklist ${HOME}/.mozilla
 
+noblacklist ${PATH}/deno
+
 noblacklist ${HOME}/.cache/yt-dlp
 noblacklist ${HOME}/.config/yt-dlp
 noblacklist ${HOME}/.config/yt-dlp.conf


### PR DESCRIPTION
Add paths in the same places as nodejs/npm paths.

Deno is a javascript runtime and development tool similar to nodejs.

The following paths seem to be intended for downloading and caching
dependencies (and apparently also artifacts from .ts to .js compilation)
globally during development (as can be done with ~/.npm):

* ~/.cache/deno
* ~/.deno

Note that this commit makes these paths read-only (as npm dependencies
are usually executable code), which may potentially affect users of the
runtime (like yt-dlp).

Related commits:

* f2de86464 ("tentative fix for yt-dlp/javaScript deno profile (#6999)",
  2026-01-13)
