### PR TITLE
modif: update syscall groups (syscall.c) - part 3

### DIFF
--- a/src/lib/syscall.c
+++ b/src/lib/syscall.c
@@ -447,9 +447,7 @@ static const SyscallGroupList sysgroups[] = {
 #endif
 	  "execve,"
 	  "execveat," // commonly used by fexecve
-#ifdef SYS_exit
 	  "exit," // breaks most Qt applications
-#endif
 	  "futex," // frequently used and causes breakages
 #ifdef SYS_mmap
 	  "mmap," // cannot load shared libraries


### PR DESCRIPTION
  - Add new syscalls
  - Add `execv`, `exit` and `futex` in `@default-keep`
  - Add two new groups: `@memfd` and `@sandbox`
  - Add `@memfd` and `@sandbox` in the `@system-service` group
  - Move `memfd_create` from `@ipc` to `@memfd`

Thanks to @rusty-snake for information and suggestions.

Relates to:

* #7027