### PR TITLE
feature: add a new option `--debug-syscall-groups` - part 2

### DIFF
--- a/src/firejail/usage.c
+++ b/src/firejail/usage.c
@@ -86,6 +86,8 @@ static const char *const usage_str =
 	"    --debug-private-lib - debug for --private-lib option.\n"
 #endif
 	"    --debug-protocols - print all recognized protocols.\n"
+	"    --debug-syscall-groups - print all system call groups and descriptions.\n"
+	"    --debug-syscall-groups=@group1,@group2,@all,... - print all recognized system calls in specified groups.\n"
 	"    --debug-syscalls - print all recognized system calls.\n"
 	"    --debug-syscalls32 - print all recognized 32 bit system calls.\n"
 	"    --debug-whitelists - debug whitelisting.\n"

--- a/src/lib/syscall.c
+++ b/src/lib/syscall.c
@@ -2458,8 +2458,8 @@ void is_syscall_groups_exist(const char *groups_list)
 	}
 
 	if (new_str[0] != '\0') {
-		fprintf(stderr, "Unrecognized group(s): %s\n", new_str);
-		fprintf(stderr, "See --debug-syscall-groups for valid groups\n");
+		fprintf(stderr, "Unrecognized syscall group(s): %s\n", new_str);
+		fprintf(stderr, "See --debug-syscall-groups for valid seccomp groups\n");
 		free(copy);
 		free(new_str);
 		exit(1);

--- a/src/man/firejail.1.in
+++ b/src/man/firejail.1.in
@@ -766,6 +766,23 @@ Example:
 .br
 $ firejail \-\-debug\-protocols
 .TP
+\fB\-\-debug-syscall-groups[=@group1,@group2,@all,...]
+Print all system call groups and descriptions then exit.
+.br
+
+.br
+Specify seccomp groups separated by a comma to print their system calls in the current Firejail software build and exit. The special group @all can be used to print all seccomp groups and related syscalls.
+.br
+
+.br
+Example:
+.br
+$ firejail \-\-debug-syscall-groups
+.br
+$ firejail \-\-debug-syscall-groups=@chown,@mount,@swap
+.br
+$ firejail \-\-debug-syscall-groups=@all
+.TP
 \fB\-\-debug-syscalls
 Print all recognized system calls in the current Firejail software build and exit.
 .br
@@ -2633,10 +2650,10 @@ then it is @default.
 To help creating useful seccomp filters more easily, the following
 system call groups are defined: @aio, @basic-io, @chown, @clock,
 @cpu-emulation, @debug, @default, @default-nodebuggers, @default-keep,
-@file-system, @io-event, @ipc, @keyring, @memlock, @module, @mount,
+@file-system, @io-event, @ipc, @keyring, @memfd, @memlock, @module, @mount,
 @network-io, @obsolete, @privileged, @process, @raw-io, @reboot,
-@resources, @setuid, @swap, @sync, @system-service and @timer.
-More information about groups can be found in /usr/share/doc/firejail/syscalls.txt
+@resources, @sandbox, @setuid, @swap, @sync, @system-service and @timer.
+More information about groups can be found in /usr/share/doc/firejail/syscalls.txt and see also \-\-debug-syscall-groups.
 .br
 
 .br

--- a/src/zsh_completion/_firejail.in
+++ b/src/zsh_completion/_firejail.in
@@ -68,6 +68,8 @@ _firejail_args=(
     '--debug-errnos[print all recognized error numbers]'
     '--debug-private-lib[debug for --private-lib option]'
     '--debug-protocols[print all recognized protocols]'
+    '--debug-syscall-groups[print all system call groups and descriptions]'
+    '--debug-syscall-groups=-[print all recognized system calls in specified groups: @group1,@group2,@all,...]: :'
     '--debug-syscalls[print all recognized system calls]'
     '--debug-syscalls32[print all recognized 32 bit system calls]'
     '--debug-whitelists[debug whitelisting]'


### PR DESCRIPTION
- src/firejail/usage.c
- src/zsh_completion/_firejail.in
  - Add entries for `--debug-syscall-groups`
- src/lib/syscall.c
  - Complete string literals
- src/man/firejail.1.in
  - Add an entry for `--debug-syscall-groups`
  - Add `@memfd` and `@sandbox` syscall groups for the `--seccomp` option

This is the last part.