### PR TITLE
profiles: fix allowing netcat

### DIFF
--- a/etc/profile-m-z/playonlinux.profile
+++ b/etc/profile-m-z/playonlinux.profile
@@ -11,6 +11,9 @@ noblacklist ${HOME}/.PlayOnLinux
 
 # nc is needed to run playonlinux
 noblacklist ${PATH}/nc
+noblacklist ${PATH}/nc.openbsd
+noblacklist ${PATH}/nc.traditional
+noblacklist ${PATH}/ncat
 
 # Allow perl (blacklisted by disable-interpreters.inc)
 include allow-perl.inc

--- a/etc/profile-m-z/ssh.profile
+++ b/etc/profile-m-z/ssh.profile
@@ -9,6 +9,8 @@ include globals.local
 
 # nc can be used as ProxyCommand, e.g. when using tor
 noblacklist ${PATH}/nc
+noblacklist ${PATH}/nc.openbsd
+noblacklist ${PATH}/nc.traditional
 noblacklist ${PATH}/ncat
 
 # Allow ssh (blacklisted by disable-common.inc)


### PR DESCRIPTION
disable-common.inc has these lines:

    blacklist ${PATH}/nc
    blacklist ${PATH}/nc.openbsd
    blacklist ${PATH}/nc.traditional
    blacklist ${PATH}/ncat

With openbsd-netcat on Artix, `/usr/bin/nc.openbsd` is symlinked to
`/usr/bin/nc`:

    $ pacman -Fl gnu-netcat openbsd-netcat | grep bin/nc
    gnu-netcat usr/bin/nc
    openbsd-netcat usr/bin/nc
    openbsd-netcat usr/bin/nc.openbsd
    $ realpath /usr/bin/nc.openbsd
    /usr/bin/nc

So `noblacklist ${PATH}/nc` is not enough, as
`blacklist ${PATH}/nc.openbsd` will follow the symlink to `/usr/bin/nc`
and still blacklist it.

To prevent `/usr/bin/nc` from being blacklisted,
`noblacklist ${PATH}/nc.openbsd` is also needed in this case.

To ensure that netcat is allowed, always `noblacklist` all netcat paths.

Fixes #6911.