### PR TITLE
profiles: firefox: add new ~/.config/mozilla dir

### DIFF
--- a/etc/inc/disable-common.inc
+++ b/etc/inc/disable-common.inc
@@ -359,6 +359,7 @@ blacklist /etc/hosts.equiv
 read-only ${HOME}/.cache/deno
 read-only ${HOME}/.caffrc
 read-only ${HOME}/.cargo/env
+read-only ${HOME}/.config/mozilla/firefox/profiles.ini
 read-only ${HOME}/.config/mpv
 read-only ${HOME}/.config/msmtp
 read-only ${HOME}/.config/nano

--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -583,6 +583,7 @@ blacklist ${HOME}/.config/mirage
 blacklist ${HOME}/.config/monero-project
 blacklist ${HOME}/.config/mono
 blacklist ${HOME}/.config/mov-cli
+blacklist ${HOME}/.config/mozilla
 blacklist ${HOME}/.config/mpDris2
 blacklist ${HOME}/.config/mpd
 blacklist ${HOME}/.config/mps-youtube

--- a/etc/profile-a-l/abrowser.profile
+++ b/etc/profile-a-l/abrowser.profile
@@ -6,11 +6,14 @@ include abrowser.local
 include globals.local
 
 noblacklist ${HOME}/.cache/mozilla
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.mozilla
 
 mkdir ${HOME}/.cache/mozilla/abrowser
+mkdir ${HOME}/.config/mozilla
 mkdir ${HOME}/.mozilla
 whitelist ${HOME}/.cache/mozilla/abrowser
+whitelist ${HOME}/.config/mozilla
 whitelist ${HOME}/.mozilla
 whitelist /usr/share/abrowser
 

--- a/etc/profile-a-l/armcord.profile
+++ b/etc/profile-a-l/armcord.profile
@@ -15,7 +15,9 @@ include globals.local
 # The lines below are needed to find the default Firefox profile name, to allow
 # opening links in an existing instance of Firefox (note that it still fails if
 # there isn't a Firefox instance running with the default profile; see #5352)
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.mozilla
+whitelist ${HOME}/.config/mozilla/firefox/profiles.ini
 whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 noblacklist ${HOME}/.config/ArmCord

--- a/etc/profile-a-l/electron-mail.profile
+++ b/etc/profile-a-l/electron-mail.profile
@@ -23,7 +23,9 @@ whitelist /opt/ElectronMail
 # The lines below are needed to find the default Firefox profile name, to allow
 # opening links in an existing instance of Firefox (note that it still fails if
 # there isn't a Firefox instance running with the default profile; see #5352)
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.mozilla
+whitelist ${HOME}/.config/mozilla/firefox/profiles.ini
 whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 machine-id

--- a/etc/profile-a-l/email-common.profile
+++ b/etc/profile-a-l/email-common.profile
@@ -34,7 +34,9 @@ include disable-xdg.inc
 # The lines below are needed to find the default Firefox profile name, to allow
 # opening links in an existing instance of Firefox (note that it still fails if
 # there isn't a Firefox instance running with the default profile; see #5352)
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.mozilla
+whitelist ${HOME}/.config/mozilla/firefox/profiles.ini
 whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 mkdir ${HOME}/.gnupg

--- a/etc/profile-a-l/firedragon.profile
+++ b/etc/profile-a-l/firedragon.profile
@@ -16,7 +16,9 @@ whitelist ${HOME}/.firedragon
 whitelist /usr/share/firedragon
 
 # Add the next lines to your firedragon.local if you want to use the migration wizard.
+#noblacklist ${HOME}/.config/mozilla
 #noblacklist ${HOME}/.mozilla
+#whitelist ${HOME}/.config/mozilla
 #whitelist ${HOME}/.mozilla
 
 # FireDragon requires a shell to launch on Arch. We can possibly remove sh though.

--- a/etc/profile-a-l/firefox-common.profile
+++ b/etc/profile-a-l/firefox-common.profile
@@ -13,7 +13,9 @@ include firefox-common.local
 
 # Add the next lines to firefox-common.local if you want to use the migration
 # wizard.
+#noblacklist ${HOME}/.config/mozilla
 #noblacklist ${HOME}/.mozilla
+#whitelist ${HOME}/.config/mozilla
 #whitelist ${HOME}/.mozilla
 
 # To enable support for the KeePassXC extension, add the following lines to

--- a/etc/profile-a-l/firefox.profile
+++ b/etc/profile-a-l/firefox.profile
@@ -15,9 +15,11 @@ include globals.local
 # https://github.com/netblue30/firejail/issues/4206#issuecomment-824806968
 
 # (Ignore entry from disable-common.inc)
+ignore read-only ${HOME}/.config/mozilla/firefox/profiles.ini
 ignore read-only ${HOME}/.mozilla/firefox/profiles.ini
 
 noblacklist ${HOME}/.cache/mozilla
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.mozilla
 noblacklist ${RUNUSER}/*firefox*
 noblacklist ${RUNUSER}/psd/*firefox*
@@ -26,8 +28,10 @@ noblacklist ${RUNUSER}/psd/*firefox*
 #blacklist /usr/libexec
 
 mkdir ${HOME}/.cache/mozilla/firefox
+mkdir ${HOME}/.config/mozilla
 mkdir ${HOME}/.mozilla
 whitelist ${HOME}/.cache/mozilla/firefox
+whitelist ${HOME}/.config/mozilla
 whitelist ${HOME}/.mozilla
 
 whitelist /usr/share/firefox

--- a/etc/profile-a-l/fluffychat.profile
+++ b/etc/profile-a-l/fluffychat.profile
@@ -23,7 +23,9 @@ include disable-xdg.inc
 # The lines below are needed to find the default Firefox profile name, to allow
 # opening links in an existing instance of Firefox (note that it still fails if
 # there isn't a Firefox instance running with the default profile; see #5352)
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.mozilla
+whitelist ${HOME}/.config/mozilla/firefox/profiles.ini
 whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 mkdir ${HOME}/.local/share/fluffychat

--- a/etc/profile-a-l/geary.profile
+++ b/etc/profile-a-l/geary.profile
@@ -31,7 +31,9 @@ include disable-xdg.inc
 # The lines below are needed to find the default Firefox profile name, to allow
 # opening links in an existing instance of Firefox (note that it still fails if
 # there isn't a Firefox instance running with the default profile; see #5352)
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.mozilla
+whitelist ${HOME}/.config/mozilla/firefox/profiles.ini
 whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 mkdir ${HOME}/.cache/evolution

--- a/etc/profile-a-l/gtk-youtube-viewers-common.profile
+++ b/etc/profile-a-l/gtk-youtube-viewers-common.profile
@@ -12,7 +12,9 @@ ignore quiet
 # The lines below are needed to find the default Firefox profile name, to allow
 # opening links in an existing instance of Firefox (note that it still fails if
 # there isn't a Firefox instance running with the default profile; see #5352)
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.mozilla
+whitelist ${HOME}/.config/mozilla/firefox/profiles.ini
 whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 private-bin firefox,xterm

--- a/etc/profile-a-l/icecat.profile
+++ b/etc/profile-a-l/icecat.profile
@@ -6,11 +6,14 @@ include icecat.local
 include globals.local
 
 noblacklist ${HOME}/.cache/mozilla
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.mozilla
 
 mkdir ${HOME}/.cache/mozilla/icecat
+mkdir ${HOME}/.config/mozilla
 mkdir ${HOME}/.mozilla
 whitelist ${HOME}/.cache/mozilla/icecat
+whitelist ${HOME}/.config/mozilla
 whitelist ${HOME}/.mozilla
 whitelist /usr/share/icecat
 

--- a/etc/profile-a-l/keepassxc.profile
+++ b/etc/profile-a-l/keepassxc.profile
@@ -21,6 +21,7 @@ noblacklist /tmp/ssh-*
 noblacklist ${HOME}/.config/BraveSoftware
 noblacklist ${HOME}/.config/chromium
 noblacklist ${HOME}/.config/google-chrome
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.config/vivaldi
 noblacklist ${HOME}/.local/share/torbrowser
 noblacklist ${HOME}/.mozilla
@@ -55,8 +56,11 @@ include disable-xdg.inc
 #mkdir ${HOME}/.local/share/torbrowser/tbb/x86_64/tor-browser_en-US/Browser/TorBrowser/Data/Browser/.mozilla/native-messaging-hosts
 #mkfile ${HOME}/.local/share/torbrowser/tbb/x86_64/tor-browser_en-US/Browser/TorBrowser/Data/Browser/.mozilla/native-messaging-hosts/org.keepassxc.keepassxc_browser.json
 #whitelist ${HOME}/.local/share/torbrowser/tbb/x86_64/tor-browser_en-US/Browser/TorBrowser/Data/Browser/.mozilla/native-messaging-hosts/org.keepassxc.keepassxc_browser.json
+#mkdir ${HOME}/.config/mozilla/native-messaging-hosts
 #mkdir ${HOME}/.mozilla/native-messaging-hosts
+#mkfile ${HOME}/.config/mozilla/native-messaging-hosts/org.keepassxc.keepassxc_browser.json
 #mkfile ${HOME}/.mozilla/native-messaging-hosts/org.keepassxc.keepassxc_browser.json
+#whitelist ${HOME}/.config/mozilla/native-messaging-hosts/org.keepassxc.keepassxc_browser.json
 #whitelist ${HOME}/.mozilla/native-messaging-hosts/org.keepassxc.keepassxc_browser.json
 #mkdir ${HOME}/.cache/keepassxc
 #mkdir ${HOME}/.config/keepassxc

--- a/etc/profile-a-l/krunner.profile
+++ b/etc/profile-a-l/krunner.profile
@@ -14,6 +14,7 @@ include globals.local
 #noblacklist ${HOME}/.cache/krunnerbookmarkrunnerfirefoxdbfile.sqlite*
 #noblacklist ${HOME}/.config/chromium
 noblacklist ${HOME}/.config/krunnerrc
+#noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.kde/share/config/krunnerrc
 noblacklist ${HOME}/.kde4/share/config/krunnerrc
 #noblacklist ${HOME}/.local/share/baloo

--- a/etc/profile-a-l/kube.profile
+++ b/etc/profile-a-l/kube.profile
@@ -27,7 +27,9 @@ include disable-xdg.inc
 # The lines below are needed to find the default Firefox profile name, to allow
 # opening links in an existing instance of Firefox (note that it still fails if
 # there isn't a Firefox instance running with the default profile; see #5352)
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.mozilla
+whitelist ${HOME}/.config/mozilla/firefox/profiles.ini
 whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 mkdir ${HOME}/.cache/kube

--- a/etc/profile-a-l/lettura.profile
+++ b/etc/profile-a-l/lettura.profile
@@ -41,7 +41,9 @@ include whitelist-var-common.inc
 # The lines below are needed to find the default Firefox profile name, to allow
 # opening links in an existing instance of Firefox (note that it still fails if
 # there isn't a Firefox instance running with the default profile; see #5352)
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.mozilla
+whitelist ${HOME}/.config/mozilla/firefox/profiles.ini
 whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 apparmor

--- a/etc/profile-a-l/linuxqq.profile
+++ b/etc/profile-a-l/linuxqq.profile
@@ -16,7 +16,9 @@ include disable-shell.inc
 # The lines below are needed to find the default Firefox profile name, to allow
 # opening links in an existing instance of Firefox (note that it still fails if
 # there isn't a Firefox instance running with the default profile; see #5352)
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.mozilla
+whitelist ${HOME}/.config/mozilla/firefox/profiles.ini
 whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 mkdir ${HOME}/.config/QQ

--- a/etc/profile-m-z/seamonkey.profile
+++ b/etc/profile-m-z/seamonkey.profile
@@ -7,6 +7,7 @@ include seamonkey.local
 include globals.local
 
 noblacklist ${HOME}/.cache/mozilla
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.gnupg
 noblacklist ${HOME}/.local/share/pki
 noblacklist ${HOME}/.mailcap
@@ -19,6 +20,7 @@ include disable-interpreters.inc
 include disable-programs.inc
 
 mkdir ${HOME}/.cache/mozilla
+mkdir ${HOME}/.config/mozilla
 mkdir ${HOME}/.gnupg
 mkdir ${HOME}/.local/share/pki
 mkdir ${HOME}/.mozilla
@@ -26,6 +28,7 @@ whitelist ${DOWNLOADS}
 whitelist ${HOME}/.cache/gnome-mplayer/plugin
 whitelist ${HOME}/.cache/mozilla
 whitelist ${HOME}/.config/gnome-mplayer
+whitelist ${HOME}/.config/mozilla
 whitelist ${HOME}/.config/pipelight-silverlight5.1
 whitelist ${HOME}/.config/pipelight-widevine
 whitelist ${HOME}/.gnupg

--- a/etc/profile-m-z/signal-desktop.profile
+++ b/etc/profile-m-z/signal-desktop.profile
@@ -17,7 +17,9 @@ noblacklist ${HOME}/.config/Signal
 # The lines below are needed to find the default Firefox profile name, to allow
 # opening links in an existing instance of Firefox (note that it still fails if
 # there isn't a Firefox instance running with the default profile; see #5352)
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.mozilla
+whitelist ${HOME}/.config/mozilla/firefox/profiles.ini
 whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 mkdir ${HOME}/.config/Signal

--- a/etc/profile-m-z/thunderbird.profile
+++ b/etc/profile-m-z/thunderbird.profile
@@ -34,7 +34,9 @@ writable-run-user
 #writable-var
 
 # These lines are needed to allow Firefox to load your profile when clicking a link in an email
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.mozilla
+whitelist ${HOME}/.config/mozilla/firefox/profiles.ini
 whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 noblacklist ${HOME}/.cache/thunderbird

--- a/etc/profile-m-z/torbrowser.profile
+++ b/etc/profile-m-z/torbrowser.profile
@@ -10,14 +10,17 @@ include globals.local
 ignore dbus-user none
 
 noblacklist ${HOME}/.cache/mozilla
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.mozilla
 
 blacklist /sys/class/net
 blacklist /usr/libexec
 
 mkdir ${HOME}/.cache/mozilla/torbrowser
+mkdir ${HOME}/.config/mozilla
 mkdir ${HOME}/.mozilla
 whitelist ${HOME}/.cache/mozilla/torbrowser
+whitelist ${HOME}/.config/mozilla
 whitelist ${HOME}/.mozilla
 include whitelist-usr-share-common.inc
 

--- a/etc/profile-m-z/trojita.profile
+++ b/etc/profile-m-z/trojita.profile
@@ -24,7 +24,9 @@ include disable-xdg.inc
 # The lines below are needed to find the default Firefox profile name, to allow
 # opening links in an existing instance of Firefox (note that it still fails if
 # there isn't a Firefox instance running with the default profile; see #5352)
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.mozilla
+whitelist ${HOME}/.config/mozilla/firefox/profiles.ini
 whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 mkdir ${HOME}/.abook

--- a/etc/profile-m-z/tutanota-desktop.profile
+++ b/etc/profile-m-z/tutanota-desktop.profile
@@ -27,7 +27,9 @@ whitelist /opt/tutanota-desktop
 # The lines below are needed to find the default Firefox profile name, to allow
 # opening links in an existing instance of Firefox (note that it still fails if
 # there isn't a Firefox instance running with the default profile; see #5352)
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.mozilla
+whitelist ${HOME}/.config/mozilla/firefox/profiles.ini
 whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 machine-id

--- a/etc/profile-m-z/waterfox.profile
+++ b/etc/profile-m-z/waterfox.profile
@@ -15,7 +15,9 @@ whitelist ${HOME}/.waterfox
 whitelist /usr/share/waterfox
 
 # Add the next lines to your watefox.local if you want to use the migration wizard.
+#noblacklist ${HOME}/.config/mozilla
 #noblacklist ${HOME}/.mozilla
+#whitelist ${HOME}/.config/mozilla
 #whitelist ${HOME}/.mozilla
 
 # waterfox requires a shell to launch on Arch. We can possibly remove sh though.

--- a/etc/profile-m-z/yelp.profile
+++ b/etc/profile-m-z/yelp.profile
@@ -22,7 +22,9 @@ include disable-xdg.inc
 # The lines below are needed to find the default Firefox profile name, to allow
 # opening links in an existing instance of Firefox (note that it still fails if
 # there isn't a Firefox instance running with the default profile; see #5352)
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.mozilla
+whitelist ${HOME}/.config/mozilla/firefox/profiles.ini
 whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 mkdir ${HOME}/.config/yelp

--- a/etc/profile-m-z/yt-dlp.profile
+++ b/etc/profile-m-z/yt-dlp.profile
@@ -19,6 +19,7 @@ include globals.local
 
 # For age-restricted and rate-limited videos, uncomment the following line
 # (yt-dlp needs the browser cookie):
+#noblacklist ${HOME}/.config/mozilla
 #noblacklist ${HOME}/.mozilla
 
 noblacklist ${PATH}/deno

--- a/etc/profile-m-z/zeal.profile
+++ b/etc/profile-m-z/zeal.profile
@@ -25,7 +25,9 @@ include disable-xdg.inc
 # The lines below are needed to find the default Firefox profile name, to allow
 # opening links in an existing instance of Firefox (note that it still fails if
 # there isn't a Firefox instance running with the default profile; see #5352)
+noblacklist ${HOME}/.config/mozilla
 noblacklist ${HOME}/.mozilla
+whitelist ${HOME}/.config/mozilla/firefox/profiles.ini
 whitelist ${HOME}/.mozilla/firefox/profiles.ini
 
 mkdir ${HOME}/.cache/Zeal

--- a/etc/profile-m-z/zen-browser.profile
+++ b/etc/profile-m-z/zen-browser.profile
@@ -22,8 +22,11 @@ whitelist ${HOME}/.zen
 
 # Add the following lines to allow access to the .mozilla directory,
 # required by some extensions (like KeePassXC-Browser) to work properly
+#noblacklist ${HOME}/.config/mozilla
 #noblacklist ${HOME}/.mozilla
+#mkdir ${HOME}/.config/mozilla
 #mkdir ${HOME}/.mozilla
+#whitelist ${HOME}/.config/mozilla
 #whitelist ${HOME}/.mozilla
 
 # Note: Zen Browser requires a shell to launch on Arch and Fedora.


### PR DESCRIPTION
Default directories in Firefox 146 and earlier:

* ~/.cache/mozilla  # cache files
* ~/.mozilla        # config and data

In Firefox 147[1]:

* ~/.cache/mozilla  # cache files
* ~/.config/mozilla # config and data

Note that the new location apparently contains the same files as in the
former location (including settings, bookmarks, extensions, etc).
That is, even though the new directory resides in `$XDG_CONFIG_HOME` /
~/.config, it is not solely used for program configuration as described
in the XDG Base Directory specification[2] and `$XDG_DATA_HOME` /
~/.local/share/mozilla is seemingly not used at all (see also the
discussion in the bug tracker[3]).

Commands used to search and replace:

    $ perl -pi -e 's/(.* )(\${HOME}\/\.mozilla)(.*)/$1\${HOME}\/.config\/mozilla$3\n$1$2$3/' \
      -- \
      etc/inc/*.inc \
      etc/profile*/*.profile \

Note: The entries in the following profiles were sorted manually:

* etc/inc/disable-common.inc
* etc/inc/disable-programs.inc
* etc/profile-a-l/keepassxc.profile
* etc/profile-a-l/krunner.profile
* etc/profile-m-z/seamonkey.profile

Relates to #7040.

[1] https://www.firefox.com/en-US/firefox/147.0/releasenotes/
[2] https://specifications.freedesktop.org/basedir/latest/
[3] https://bugzilla.mozilla.org/show_bug.cgi?id=259356