### PR TITLE
bugfix: error on invalid syscall name in seccomp

### DIFF
--- a/src/lib/syscall.c
+++ b/src/lib/syscall.c
@@ -2567,6 +2567,10 @@ static void syscall_process_name(const char *name, int *syscall_nr, int *error_n
 				*syscall_nr = SYSCALL_ERROR;
 		}
 	}
+	if (*syscall_nr == SYSCALL_ERROR) {
+		free(str);
+		goto error;
+	}
 
 	free(str);
 	return;


### PR DESCRIPTION
Currently, an error is produced when an invalid syscall group is used:

    $ firejail --quiet --seccomp.drop=@clock /bin/true
    $ firejail --quiet --seccomp.drop=@foo /bin/true
    Error fseccomp: unknown syscall group @foo

But not when an invalid syscall name is used (resulting in it being
silently ignored by firejail).

Make sure to also fail when that happens.

Before:

    $ firejail --quiet --seccomp.drop=uname /bin/true
    $ firejail --quiet --seccomp.drop=foo /bin/true

After:

    $ firejail --quiet --seccomp.drop=uname /bin/true
    $ firejail --quiet --seccomp.drop=foo /bin/true
    Error fseccomp: invalid syscall list entry foo

Misc: From a cursory glance, this appears to have been an issue since
the `syscall_process_name()` function was introduced on commit 322ce2cdc
("seccomp rework", 2016-11-06).

Fixes #2931.

Reported-by: @aoand
Reported-by: @cobratbq