### PR TITLE
whitelist: allow placing an overlay into the sandbox

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -146,6 +146,7 @@ typedef struct profile_entry_t {
 		char *file;		// resolved file path
 		char *link;		// link path
 		TopDir *top;	// top level directory
+		int overlay_fd; // fd of the overlay (-1 if not overlaying)
 	} *wparam;
 
 } ProfileEntry;


### PR DESCRIPTION
The use case for this option might not be that common, but I though of sharing it anyway. If you think that this feature is not of general use, feel free to just close this.

This is similar to what a few comments requested in https://github.com/netblue30/firejail/issues/1743 and can be though of a generalisation of the `--hosts-file=<file>` option. Our use case is that we unpack the application in a special directory, and then when launching it we map some files and directories from the application package into the sandbox. For example:

     whitelist /usr/share/application-data=/path/to/application/data

This operation might deserve its own command name, but since its functionality is 95% the same as the one of the "whitelist" command, I implemented it by just expanding the syntax:

    whitelist <path>[=<overlay>]

Maybe `overlay`, `map` or `replace` would be better names for this.

Note: if "`<path>`" does not exist, it will be created as a new file or directory (depending on whether "`<overlay>`" is a file or a directory).

