### PR TITLE
build: fix discarded const qualifier compiler warnings

### DIFF
--- a/src/fcopy/main.c
+++ b/src/fcopy/main.c
@@ -430,7 +430,7 @@ static void duplicate_file(const char *src, const char *dest, struct stat *s) {
 
 	// build destination file name
 	char *name;
-	char *ptr = (arg_follow_link)? strrchr(src, '/'): strrchr(rsrc, '/');
+	const char *ptr = (arg_follow_link)? strrchr(src, '/'): strrchr(rsrc, '/');
 	ptr++;
 	if (asprintf(&name, "%s/%s", rdest, ptr) == -1)
 		errExit("asprintf");
@@ -454,7 +454,7 @@ static void duplicate_link(const char *src, const char *dest, struct stat *s) {
 	// build destination file name
 	char *name;
 	//     char *ptr = strrchr(rsrc, '/');
-	char *ptr = strrchr(src, '/');
+	const char *ptr = strrchr(src, '/');
 	ptr++;
 	if (asprintf(&name, "%s/%s", rdest, ptr) == -1)
 		errExit("asprintf");

--- a/src/firejail/dbus.c
+++ b/src/firejail/dbus.c
@@ -120,7 +120,7 @@ int dbus_check_name(const char *name) {
 
 int dbus_check_call_rule(const char *rule) {
 	char buf[DBUS_MAX_NAME_LENGTH + 1];
-	char *name_end = strchr(rule, '=');
+	const char *name_end = strchr(rule, '=');
 	if (name_end == NULL)
 		return 0;
 	size_t name_length = (size_t) (name_end - rule);
@@ -131,7 +131,7 @@ int dbus_check_call_rule(const char *rule) {
 	if (!dbus_check_name(buf))
 		return 0;
 	++name_end;
-	char *interface_end = strchr(name_end, '@');
+	const char *interface_end = strchr(name_end, '@');
 	if (interface_end == NULL)
 		return check_bus_or_interface_name(name_end, 0);
 	size_t interface_length = (size_t) (interface_end - name_end);

--- a/src/firejail/env.c
+++ b/src/firejail/env.c
@@ -158,7 +158,7 @@ void env_store(const char *str, ENV_OP op) {
 	// some basic checking
 	if (*str == '\0')
 		goto errexit;
-	char *ptr = strchr(str, '=');
+	const char *ptr = strchr(str, '=');
 	if (op == SETENV) {
 		if (!ptr)
 			goto errexit;
@@ -175,7 +175,7 @@ void env_store(const char *str, ENV_OP op) {
 	if (env->name == NULL)
 		errExit("strdup");
 	if (op == SETENV) {
-		char *ptr2 = strchr(env->name, '=');
+		char *ptr2 = (char *) strchr(env->name, '=');
 		assert(ptr2);
 		*ptr2 = '\0';
 		env->value = ptr2 + 1;

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -1750,7 +1750,7 @@ void profile_read(const char *fname) {
 		int errsv = errno;
 		// if the file ends in ".local", do not exit
 		const char *base = gnu_basename(fname);
-		char *ptr = strstr(base, ".local");
+		const char *ptr = strstr(base, ".local");
 		if (ptr && strlen(ptr) == 6 && errsv != EACCES) {
 			if (arg_debug) {
 				printf("Cannot access .local file %s: %s, skipping...\n",
@@ -1766,7 +1766,7 @@ void profile_read(const char *fname) {
 
 	// --allow-debuggers - skip disable-devel.inc file
 	if (arg_allow_debuggers) {
-		char *tmp = strrchr(fname, '/');
+		const char *tmp = strrchr(fname, '/');
 		if (tmp && *(tmp + 1) != '\0') {
 			tmp++;
 			if (strcmp(tmp, "disable-devel.inc") == 0)
@@ -1775,7 +1775,7 @@ void profile_read(const char *fname) {
 	}
 	// --appimage - skip disable-shell.inc file
 	if (arg_appimage) {
-		char *tmp = strrchr(fname, '/');
+		const char *tmp = strrchr(fname, '/');
 		if (tmp && *(tmp + 1) != '\0') {
 			tmp++;
 			if (strcmp(tmp, "disable-shell.inc") == 0)

--- a/src/fnet/interface.c
+++ b/src/fnet/interface.c
@@ -337,8 +337,8 @@ void net_if_ip6(const char *ifname, const char *addr6) {
 
 	// extract prefix
 	unsigned long prefix;
-	char *ptr;
-	if ((ptr = strchr(addr6, '/'))) {
+	char *ptr = (char *) strchr(addr6, '/');
+	if (ptr) {
 		prefix = atol(ptr + 1);
 		if (prefix > 128) {
 			fprintf(stderr, "Error fnet: invalid prefix for IPv6 address %s\n", addr6);


### PR DESCRIPTION
Fix the following `-Wdiscarded-qualifiers` warnings:

    $ pacman -Q gcc glibc
    gcc 15.2.1+r604+g0b99615a8aef-1
    glibc 2.43+r5+g856c426a7534-1
    $ ./configure >/dev/null && make clean >/dev/null && make >/dev/null
    ../../src/firejail/dbus.c: In function ‘dbus_check_call_rule’:
    ../../src/firejail/dbus.c:123:26: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
      123 |         char *name_end = strchr(rule, '=');
          |                          ^~~~~~
    ../../src/firejail/env.c: In function ‘env_store’:
    ../../src/firejail/env.c:161:21: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
      161 |         char *ptr = strchr(str, '=');
          |                     ^~~~~~
    ../../src/firejail/env.c:178:30: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
      178 |                 char *ptr2 = strchr(env->name, '=');
          |                              ^~~~~~
    ../../src/firejail/profile.c: In function ‘profile_read’:
    ../../src/firejail/profile.c:1753:29: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
     1753 |                 char *ptr = strstr(base, ".local");
          |                             ^~~~~~
    ../../src/firejail/profile.c:1769:29: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
     1769 |                 char *tmp = strrchr(fname, '/');
          |                             ^~~~~~~
    ../../src/firejail/profile.c:1778:29: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
     1778 |                 char *tmp = strrchr(fname, '/');
          |                             ^~~~~~~
    ../../src/fcopy/main.c: In function ‘duplicate_file’:
    ../../src/fcopy/main.c:433:21: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
      433 |         char *ptr = (arg_follow_link)? strrchr(src, '/'): strrchr(rsrc, '/');
          |                     ^
    ../../src/fcopy/main.c: In function ‘duplicate_link’:
    ../../src/fcopy/main.c:457:21: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
      457 |         char *ptr = strrchr(src, '/');
          |                     ^~~~~~~
    ../../src/fnet/interface.c: In function ‘net_if_ip6’:
    ../../src/fnet/interface.c:341:18: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
      341 |         if ((ptr = strchr(addr6, '/'))) {
          |                  ^

Note: Only the following instances actually modify the pointed-to value:

* src/firejail/env.c:178
* src/fnet/interface.c:341