### PR TITLE
new profile: zed-editor, zed

### DIFF
--- a/etc/profile-m-z/zed-editor.profile
+++ b/etc/profile-m-z/zed-editor.profile
@@ -15,7 +15,7 @@ include disable-exec.inc
 #include disable-interpreters.inc
 include disable-programs.inc
 include disable-xdg.inc
-# TODO: probably want to exchange this for explicits and `disable-...` entries.
+# TODO: probably want to exchange this for explicit and `disable-...` entries.
 #include default.profile
 
 novideo

--- a/etc/profile-m-z/zed-editor.profile
+++ b/etc/profile-m-z/zed-editor.profile
@@ -54,7 +54,9 @@ private-tmp
 
 # TODO: likely not complete.
 dbus-user filter
-dbus-user.talk org.freedesktop.secrets
+dbus-user.talk org.freedesktop.portal.Desktop
+# Add below line to `~/.config/firejail/zed-editor.local` to enable keyring-access.
+#dbus-user.talk org.freedesktop.secrets
 dbus-user.talk org.a11y.Bus
 dbus-system none
 

--- a/etc/profile-m-z/zed-editor.profile
+++ b/etc/profile-m-z/zed-editor.profile
@@ -1,0 +1,33 @@
+# Profile for ./libexec/zed-editor
+include zed-editor.local
+
+noexec /tmp
+noblacklist ${HOME}
+include allow-common-devel.inc
+# NOTE: add `noblacklist` entries here, such as `noblacklist ${HOME}/.cargo`, to
+# support more programming languages and development tools.
+
+# TODO: probably want to exchange this for explicits and `disable-...` entries.
+include default.profile
+
+novideo
+nosound
+nodvd
+notv
+nou2f
+
+private-dev
+private-tmp
+
+# TODO: not tested, seen working.
+dbus-user filter
+dbus-system filter
+dbus-system.talk org.freedesktop.secrets
+
+seccomp
+restrict-namespaces
+caps.drop all
+nonewprivs
+deterministic-exit-code
+deterministic-shutdown
+

--- a/etc/profile-m-z/zed-editor.profile
+++ b/etc/profile-m-z/zed-editor.profile
@@ -1,14 +1,22 @@
 # Profile for ./libexec/zed-editor
 include zed-editor.local
+# Persistent global definitions
+include globals.local
 
-noexec /tmp
 noblacklist ${HOME}
+ignore noexec ${HOME}
 include allow-common-devel.inc
-# NOTE: add `noblacklist` entries here, such as `noblacklist ${HOME}/.cargo`, to
-# support more programming languages and development tools.
+# NOTE: add `noblacklist` entries here or in `allow-common-devel.local` to allow
+# for more programming languages and tools , such as `noblacklist ${HOME}/.cargo`.
 
+include disable-common.inc
+#include disable-devel.inc
+include disable-exec.inc
+#include disable-interpreters.inc
+include disable-programs.inc
+include disable-xdg.inc
 # TODO: probably want to exchange this for explicits and `disable-...` entries.
-include default.profile
+#include default.profile
 
 novideo
 nosound
@@ -16,18 +24,23 @@ nodvd
 notv
 nou2f
 
+disable-mnt
 private-dev
 private-tmp
+noexec /tmp
 
 # TODO: not tested, seen working.
 dbus-user filter
 dbus-system filter
-dbus-system.talk org.freedesktop.secrets
+#dbus-system.talk org.freedesktop.secrets
 
+#apparmor
 seccomp
+# For hardening: `seccomp.block-secondary`
+protocol unix,inet,inet6,netlink
 restrict-namespaces
-caps.drop all
 nonewprivs
+caps.drop all
 deterministic-exit-code
 deterministic-shutdown
 

--- a/etc/profile-m-z/zed-editor.profile
+++ b/etc/profile-m-z/zed-editor.profile
@@ -55,6 +55,7 @@ private-tmp
 # TODO: likely not complete.
 dbus-user filter
 dbus-user.talk org.freedesktop.secrets
+dbus-user.talk org.a11y.Bus
 dbus-system none
 
 deterministic-exit-code

--- a/etc/profile-m-z/zed-editor.profile
+++ b/etc/profile-m-z/zed-editor.profile
@@ -1,50 +1,62 @@
-# Profile for ./libexec/zed-editor
+# Firejail profile for zed-editor
+# Description: Zed-editor
+# This file is overwritten after every install/update
 include zed-editor.local
 # Persistent global definitions
 include globals.local
 
-noblacklist ${HOME}
 ignore noexec ${HOME}
+
+noblacklist ${HOME}
+
 include allow-common-devel.inc
+
 # NOTE: add `noblacklist` entries here or in `allow-common-devel.local` to allow
 # for more programming languages and tools , such as `noblacklist ${HOME}/.cargo`.
-
 include disable-common.inc
-#include disable-devel.inc
 include disable-exec.inc
-#include disable-interpreters.inc
+include disable-proc.inc
 include disable-programs.inc
+#include disable-write-mnt.inc
 include disable-xdg.inc
-# TODO: probably want to exchange this for explicit and `disable-...` entries.
-#include default.profile
 
-novideo
-nosound
-noinput
+# TODO: consider landlock options.
+# Landlock commands
+##landlock.fs.read PATH
+##landlock.fs.write PATH
+##landlock.fs.makeipc PATH
+##landlock.fs.makedev PATH
+##landlock.fs.execute PATH
+#include landlock-common.inc
+
+# AppArmor causes issues with spawning sub-processes for language-tooling.
+# This is probably only viable when used with a specialized profile for Zed.
+#apparmor
+caps.drop all
 nodvd
+nogroups
+noinput
+nonewprivs
+noprinters
+noroot
+nosound
 notv
 nou2f
-noroot
-nogroups
+novideo
+protocol unix,inet,inet6,netlink
+seccomp
+# For hardening: `seccomp.block-secondary`
 
 disable-mnt
 private-dev
 private-tmp
-noexec /tmp
 
 # TODO: likely not complete.
 dbus-user filter
 dbus-user.talk org.freedesktop.secrets
 dbus-system none
 
-# AppArmor causes issues with spawning sub-processes for language-tooling.
-# This is probably only viable when used with a specialized profile for Zed.
-#apparmor
-seccomp
-# For hardening: `seccomp.block-secondary`
-protocol unix,inet,inet6,netlink
-restrict-namespaces
-nonewprivs
-caps.drop all
 deterministic-exit-code
 deterministic-shutdown
+noexec /tmp
+restrict-namespaces

--- a/etc/profile-m-z/zed-editor.profile
+++ b/etc/profile-m-z/zed-editor.profile
@@ -20,20 +20,24 @@ include disable-xdg.inc
 
 novideo
 nosound
+noinput
 nodvd
 notv
 nou2f
+nogroups
 
 disable-mnt
 private-dev
 private-tmp
 noexec /tmp
 
-# TODO: not tested, seen working.
+# TODO: likely not complete.
 dbus-user filter
-dbus-system filter
-#dbus-system.talk org.freedesktop.secrets
+dbus-user.talk org.freedesktop.secrets
+dbus-system none
 
+# AppArmor causes issues with spawning sub-processes for language-tooling.
+# This is probably only viable when used with a specialized profile for Zed.
 #apparmor
 seccomp
 # For hardening: `seccomp.block-secondary`

--- a/etc/profile-m-z/zed-editor.profile
+++ b/etc/profile-m-z/zed-editor.profile
@@ -24,6 +24,7 @@ noinput
 nodvd
 notv
 nou2f
+noroot
 nogroups
 
 disable-mnt

--- a/etc/profile-m-z/zed-editor.profile
+++ b/etc/profile-m-z/zed-editor.profile
@@ -11,7 +11,7 @@ noblacklist ${HOME}
 
 # NOTE: add common development-related modifications, such as blacklisting,
 # whitelisting, noexec, and other grants and permissions,
-# to `$XDG_RUNTIME_DIR/firejail/allow-common-devel.local`.
+# to `~/.config/firejail/allow-common-devel.local`.
 include allow-common-devel.inc
 
 include disable-common.inc

--- a/etc/profile-m-z/zed-editor.profile
+++ b/etc/profile-m-z/zed-editor.profile
@@ -9,10 +9,11 @@ ignore noexec ${HOME}
 
 noblacklist ${HOME}
 
+# NOTE: add common development-related modifications, such as blacklisting,
+# whitelisting, noexec, and other grants and permissions,
+# to `$XDG_RUNTIME_DIR/firejail/allow-common-devel.local`.
 include allow-common-devel.inc
 
-# NOTE: add `noblacklist` entries here or in `allow-common-devel.local` to allow
-# for more programming languages and tools , such as `noblacklist ${HOME}/.cargo`.
 include disable-common.inc
 include disable-exec.inc
 include disable-proc.inc
@@ -59,4 +60,8 @@ dbus-system none
 deterministic-exit-code
 deterministic-shutdown
 noexec /tmp
+# Given use of extensions and subprocesses in Zed-editor, although I have not
+# found clear indication that it critically relies on user-namespaces right now,
+# it is very likely that granulary sandboxing will happen in the future as it
+# hosts a variety of external, programming-language-specific tools.
 #restrict-namespaces

--- a/etc/profile-m-z/zed-editor.profile
+++ b/etc/profile-m-z/zed-editor.profile
@@ -59,4 +59,4 @@ dbus-system none
 deterministic-exit-code
 deterministic-shutdown
 noexec /tmp
-restrict-namespaces
+#restrict-namespaces

--- a/etc/profile-m-z/zed-editor.profile
+++ b/etc/profile-m-z/zed-editor.profile
@@ -47,4 +47,3 @@ nonewprivs
 caps.drop all
 deterministic-exit-code
 deterministic-shutdown
-

--- a/etc/profile-m-z/zed-editor.profile
+++ b/etc/profile-m-z/zed-editor.profile
@@ -44,7 +44,8 @@ nosound
 notv
 nou2f
 novideo
-protocol unix,inet,inet6,netlink
+protocol unix,inet,inet6
+#restrict-namespaces
 seccomp
 # For hardening: `seccomp.block-secondary`
 
@@ -55,16 +56,11 @@ private-tmp
 # TODO: likely not complete.
 dbus-user filter
 dbus-user.talk org.freedesktop.portal.Desktop
+dbus-user.talk org.a11y.Bus
 # Add below line to `~/.config/firejail/zed-editor.local` to enable keyring-access.
 #dbus-user.talk org.freedesktop.secrets
-dbus-user.talk org.a11y.Bus
 dbus-system none
 
 deterministic-exit-code
 deterministic-shutdown
 noexec /tmp
-# Given use of extensions and subprocesses in Zed-editor, although I have not
-# found clear indication that it critically relies on user-namespaces right now,
-# it is very likely that granulary sandboxing will happen in the future as it
-# hosts a variety of external, programming-language-specific tools.
-#restrict-namespaces

--- a/etc/profile-m-z/zed-editor.profile
+++ b/etc/profile-m-z/zed-editor.profile
@@ -7,9 +7,7 @@ include globals.local
 
 ignore noexec ${HOME}
 
-noblacklist ${HOME}
-
-# NOTE: add common development-related modifications, such as blacklisting, whitelisting, noexec, and other grants and permissions, to `~/.config/firejail/allow-common-devel.local`.
+# Allows files commonly used by IDEs
 include allow-common-devel.inc
 
 include disable-common.inc
@@ -18,15 +16,6 @@ include disable-proc.inc
 include disable-programs.inc
 #include disable-write-mnt.inc
 include disable-xdg.inc
-
-# TODO: consider landlock options.
-# Landlock commands
-##landlock.fs.read PATH
-##landlock.fs.write PATH
-##landlock.fs.makeipc PATH
-##landlock.fs.makedev PATH
-##landlock.fs.execute PATH
-#include landlock-common.inc
 
 # AppArmor causes issues with spawning sub-processes for language-tooling.
 # This is probably only viable when used with a specialized profile for Zed.
@@ -45,8 +34,8 @@ novideo
 protocol unix,inet,inet6
 # restricting namespaces, because they aren't used (yet), and there are risks
 # attached to their availability. Use `ignore restrict-namespaces` in
-# `~/.config/firejail/zed-editor.local` to override this protective measure in
-# case programming-language tooling refuses to start.
+# `zed-editor.local` to override this protective measure in case
+# programming-language tooling refuses to start.
 restrict-namespaces
 seccomp
 # For hardening: `seccomp.block-secondary`

--- a/etc/profile-m-z/zed-editor.profile
+++ b/etc/profile-m-z/zed-editor.profile
@@ -9,9 +9,7 @@ ignore noexec ${HOME}
 
 noblacklist ${HOME}
 
-# NOTE: add common development-related modifications, such as blacklisting,
-# whitelisting, noexec, and other grants and permissions,
-# to `~/.config/firejail/allow-common-devel.local`.
+# NOTE: add common development-related modifications, such as blacklisting, whitelisting, noexec, and other grants and permissions, to `~/.config/firejail/allow-common-devel.local`.
 include allow-common-devel.inc
 
 include disable-common.inc
@@ -45,7 +43,11 @@ notv
 nou2f
 novideo
 protocol unix,inet,inet6
-#restrict-namespaces
+# restricting namespaces, because they aren't used (yet), and there are risks
+# attached to their availability. Use `ignore restrict-namespaces` in
+# `~/.config/firejail/zed-editor.local` to override this protective measure in
+# case programming-language tooling refuses to start.
+restrict-namespaces
 seccomp
 # For hardening: `seccomp.block-secondary`
 

--- a/etc/profile-m-z/zed.profile
+++ b/etc/profile-m-z/zed.profile
@@ -1,4 +1,6 @@
-# Profile for ./bin/zed
+# Firejail profile for Zed-editor (`bin/zed`)
+# Description: Zed-editor
+# This file is overwritten after every install/update
 ignore deterministic-shutdown
 ignore deterministic-exit-code
 

--- a/etc/profile-m-z/zed.profile
+++ b/etc/profile-m-z/zed.profile
@@ -1,0 +1,5 @@
+# Profile for ./bin/zed
+ignore deterministic-shutdown
+ignore deterministic-exit-code
+
+include zed-editor.profile

--- a/etc/profile-m-z/zed.profile
+++ b/etc/profile-m-z/zed.profile
@@ -1,7 +1,7 @@
 # Firejail profile for Zed-editor (`bin/zed`)
 # Description: Zed-editor
 # This file is overwritten after every install/update
-ignore deterministic-shutdown
-ignore deterministic-exit-code
+include zed.local
 
+# Redirect
 include zed-editor.profile


### PR DESCRIPTION
Profile for the [Zed editor](<https://zed.dev>).

- `zed.profile` for `zed-linux/bin/zed` shell-script
- `zed-editor.profile` for zed-linux/libexec/zed-editor` program binary

According to `lsns`, executed within the firejail-container, Zed-editor does not yet use namespaces. However, I don't think restricting makes sense, due to high likelihood it will get added in the future and the plethora of development tools that can be hosted within Zed-editor or its container.

Best squash this profile when merging.