### PR TITLE
bugfix: map sandbox hostname to ipv6 in /etc/hosts

### DIFF
--- a/src/firejail/fs_hostname.c
+++ b/src/firejail/fs_hostname.c
@@ -97,7 +97,8 @@ void fs_hostname(void) {
 		}
 
 		char buf[4096];
-		int done = 0;
+		int done_ipv4 = 0;
+		int done_ipv6 = 0;
 		while (fgets(buf, sizeof(buf), fp1)) {
 			// remove '\n'
 			char *ptr = strchr(buf, '\n');
@@ -105,9 +106,13 @@ void fs_hostname(void) {
 				*ptr = '\0';
 
 			// copy line
-			if (strstr(buf, "127.0.0.1") && done == 0) {
-				done = 1;
+			if (strstr(buf, "127.0.0.1") && done_ipv4 == 0) {
+				done_ipv4 = 1;
 				fprintf(fp2, "127.0.0.1 %s\n", cfg.hostname);
+			}
+			else if (strstr(buf, "::1") && done_ipv6 == 0) {
+				done_ipv6 = 1;
+				fprintf(fp2, "::1 %s\n", cfg.hostname);
 			}
 			else
 				fprintf(fp2, "%s\n", buf);


### PR DESCRIPTION
Currently it is only mapped to ipv4, so add an ipv6 line.

Default hosts file:

    $ cat /etc/hosts
    # Static table lookup for hostnames.
    # See hosts(5) for details.
    127.0.0.1        localhost
    ::1              localhost

Before:

    $ firejail --quiet --noprofile --hostname=foo cat /etc/hosts
    # Static table lookup for hostnames.
    # See hosts(5) for details.
    127.0.0.1 foo
    ::1              localhost

After:

    $ firejail --quiet --noprofile --hostname=foo cat /etc/hosts
    # Static table lookup for hostnames.
    # See hosts(5) for details.
    127.0.0.1 foo
    ::1 foo

Related commits:

* 6f164f415 ("--keep-hostname part 2 (#7048)", 2026-02-03)

Relates to #7048.

Reported-by: @liloman