### PR TITLE
bugfix: add localhost lines to /etc/hosts

### DIFF
--- a/src/firejail/fs_hostname.c
+++ b/src/firejail/fs_hostname.c
@@ -109,10 +109,12 @@ void fs_hostname(void) {
 			if (strstr(buf, "127.0.0.1") && done_ipv4 == 0) {
 				done_ipv4 = 1;
 				fprintf(fp2, "127.0.0.1 %s\n", cfg.hostname);
+				fprintf(fp2, "127.0.0.1 localhost\n");
 			}
 			else if (strstr(buf, "::1") && done_ipv6 == 0) {
 				done_ipv6 = 1;
 				fprintf(fp2, "::1 %s\n", cfg.hostname);
+				fprintf(fp2, "::1 localhost\n");
 			}
 			else
 				fprintf(fp2, "%s\n", buf);


### PR DESCRIPTION
Currently only the sandbox hostname is mapped to the default IP
addresses in /etc/hosts.

Default hosts file:

    $ cat /etc/hosts
    # Static table lookup for hostnames.
    # See hosts(5) for details.
    127.0.0.1        localhost
    ::1              localhost

Before:

    $ firejail --quiet --noprofile --hostname=foo cat /etc/hosts
    # Static table lookup for hostnames.
    # See hosts(5) for details.
    127.0.0.1 foo
    ::1 foo

After:

    $ firejail --quiet --noprofile --hostname=foo cat /etc/hosts
    # Static table lookup for hostnames.
    # See hosts(5) for details.
    127.0.0.1 foo
    127.0.0.1 localhost
    ::1 foo
    ::1 localhost

This is a follow-up to #7077.

Fixes #7048.

Reported-by: @liloman