### PR TITLE
modif: allow `userns` in firejail-default apparmor profile

### DIFF
--- a/etc/apparmor/firejail-default
+++ b/etc/apparmor/firejail-default
@@ -15,6 +15,7 @@
 @{PID}={[1-9],[1-9][0-9],[1-9][0-9][0-9],[1-9][0-9][0-9][0-9],[1-9][0-9][0-9][0-9][0-9],[1-9][0-9][0-9][0-9][0-9][0-9],[1-4][0-9][0-9][0-9][0-9][0-9][0-9]}
 
 profile firejail-default flags=(attach_disconnected,mediate_deleted) {
+userns,
 
 ##########
 # Allow D-Bus access. It may negatively affect security. Comment those lines or

--- a/etc/apparmor/firejail-default
+++ b/etc/apparmor/firejail-default
@@ -15,6 +15,12 @@
 @{PID}={[1-9],[1-9][0-9],[1-9][0-9][0-9],[1-9][0-9][0-9][0-9],[1-9][0-9][0-9][0-9][0-9],[1-9][0-9][0-9][0-9][0-9][0-9],[1-4][0-9][0-9][0-9][0-9][0-9][0-9]}
 
 profile firejail-default flags=(attach_disconnected,mediate_deleted) {
+
+##########
+# Allow unprivileged user-namespaces. It may negatively affect security.
+# These privileges are granted to firejail in case they are needed and are
+# expected to be dropped by firejail as required.
+##########
 userns,
 
 ##########


### PR DESCRIPTION
Add `userns` to the AppArmor profile for firejail, such that with AppArmor enforcing restrictions, firejail is granted sufficient permissions to exert full control over the capabilities and permissions it is managing.

Fixes: #7078 

- question: Is the child-process of firejail already properly handled w.r.t. the AppArmor profile? Already before this patch, the spawned `firejail` child-process would likely be subjected to some influence from apparmor, or not?

The open question should not matter more/less specifically for this patch.