### PR TITLE
tests: fix strace color probing in allow-debuggers & seccomp-ptrace

### DIFF
--- a/test/environment/allow-debuggers.exp
+++ b/test/environment/allow-debuggers.exp
@@ -5,6 +5,10 @@
 
 set timeout 10
 cd /home
+
+# disable strace's terminal background color probing
+set env(NO_COLOR) 1
+
 spawn $env(SHELL)
 match_max 100000
 

--- a/test/filters/seccomp-ptrace.exp
+++ b/test/filters/seccomp-ptrace.exp
@@ -4,6 +4,10 @@
 # License GPL v2
 
 set timeout 10
+
+# disable strace's terminal background color probing
+set env(NO_COLOR) 1
+
 spawn $env(SHELL)
 match_max 100000
 


### PR DESCRIPTION
if strace runs in a terminal, it probes the background color to select its color palette. this probing expects a reply, but due to expect intercepting the io, the answer isn't sent back to strace, so it never starts printing the expected output.

this happens in the ubuntu automatic testing: https://bugs.launchpad.net/ubuntu/+source/firejail/+bug/2143830
