### PR TITLE
profiles: blobby: allow lua

### DIFF
--- a/etc/profile-a-l/blobby.profile
+++ b/etc/profile-a-l/blobby.profile
@@ -6,6 +6,9 @@ include globals.local
 
 noblacklist ${HOME}/.blobby
 
+# Allow lua (blacklisted by disable-interpreters.inc)
+include allow-lua.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc


### PR DESCRIPTION
`firejail version 0.9.79`

Fixes error:

```
$ firejail blobby
Reading profile /etc/firejail/blobby.profile
blobby: error while loading shared libraries: liblua5.2.so.5.2: cannot open shared object file: Permission denied
```