### PR TITLE
profiles: firefox-common: allow auto light/dark theme switching

### DIFF
--- a/etc/profile-a-l/firefox-common.profile
+++ b/etc/profile-a-l/firefox-common.profile
@@ -113,7 +113,7 @@ dbus-user.talk org.freedesktop.portal.Documents
 #dbus-user.talk org.kde.kdeconnect
 #dbus-user.talk org.kde.kuiserver
 # Add the next lines to firefox-common.local to allow firefox to get notified
-# when system is switching light/dark style.
+# when the system switches to light/dark style.
 # dbus-user.broadcast ca.desrt.dconf=ca.desrt.dconf.*@/*
 # Add the next line to firefox-common.local to allow screensharing under
 # Wayland.

--- a/etc/profile-a-l/firefox-common.profile
+++ b/etc/profile-a-l/firefox-common.profile
@@ -112,6 +112,9 @@ dbus-user.talk org.freedesktop.portal.Documents
 #dbus-user.talk org.kde.JobViewServer
 #dbus-user.talk org.kde.kdeconnect
 #dbus-user.talk org.kde.kuiserver
+# Add the next lines to firefox-common.local to allow firefox to get notified
+# when system is switching light/dark style.
+# dbus-user.broadcast ca.desrt.dconf=ca.desrt.dconf.*@/*
 # Add the next line to firefox-common.local to allow screensharing under
 # Wayland.
 #dbus-user.talk org.freedesktop.portal.Desktop


### PR DESCRIPTION
This allows Firefox to know that the system has changed to light/dark mode and switch to it too.