### PR TITLE
docs: recommend .deb or building from source on debian/ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,34 @@ For the supported versions, see [SECURITY.md](SECURITY.md).
 
 ### Debian
 
+Note: The versions from Debian stable and backports are likely to be outdated,
+so currently we recommend either downloading and installing the .deb package
+from the latest release:
+
+* <https://github.com/netblue30/firejail/releases/latest>
+
+Or [building from source](#building).
+
+<details>
+<summary>Old instructions</summary>
+
 Debian stable (bullseye): We recommend to use the
 [backports](https://packages.debian.org/bullseye-backports/firejail) package.
 
+</details>
+
 ### Ubuntu
+
+Note: The versions from the distribution and PPA are likely to be outdated, so
+currently we recommend either downloading and installing the .deb package from
+the latest release:
+
+* <https://github.com/netblue30/firejail/releases/latest>
+
+Or [building from source](#building).
+
+<details>
+<summary>Old instructions</summary>
 
 Note: The PPA recommendation is mainly for firejail itself; it should be fine
 to install firetools and firejail-related tools directly from the distribution
@@ -137,6 +161,8 @@ See the following discussions for details:
   repos?](https://github.com/netblue30/firejail/discussions/4666)
 * [How to install the latest version on Ubuntu and
   derivatives](https://github.com/netblue30/firejail/discussions/4663)
+
+</details>
 
 ### Other
 


### PR DESCRIPTION
Most recent releases:

* firejail 0.9.72: 2023-01-16
* firejail 0.9.74: 2025-03-24
* firejail 0.9.76: 2025-07-30
* firejail 0.9.78: 2026-01-03
* firejail 0.9.80: 2026-03-14

firejail 0.9.76 was released over 6 months ago, but the packages from
both Debian stable (13 / Trixie) and the Ubuntu PPA appear to still be
on firejail 0.9.74, which is over 1 year old[1] [2].

As for installing firejail through Debian backports, it is unclear to me
if that is currently working and if so, which firejail version would be
installed on each Debian version.

Lastly, the packages on Ubuntu seem to still be on firejail 0.9.72,
which is over 3 years old, even on the latest Ubuntu 25.10 and on the
upcoming Ubuntu 26.04[3].

So to avoid bugs and bug reports caused by old firejail versions,
recommend either installing the release .deb file from GitHub or
building from source on Debian/Ubuntu.

Relates to #6842 #7060.

[1] https://tracker.debian.org/pkg/firejail
[2] https://launchpad.net/~deki/+archive/ubuntu/firejail
[3] https://launchpad.net/ubuntu/+source/firejail