### PR TITLE
profiles: disable-exec: add mount points

### DIFF
--- a/etc/inc/disable-exec.inc
+++ b/etc/inc/disable-exec.inc
@@ -6,6 +6,10 @@ noexec ${HOME}
 noexec ${RUNUSER}
 noexec /dev/mqueue
 noexec /dev/shm
+noexec /media
+noexec /mnt
+noexec /run/media
+noexec /run/mount
 noexec /run/shm
 noexec /tmp
 # /var is noexec by default for unprivileged users


### PR DESCRIPTION
Example case: you want to access the photos and have scripts or binaries on the same USB flash drive.
Let's set mount points not executable in disable-exec.inc.

Relates to:

* #7111