### PR TITLE
profiles: steam: allow ~/.cache/nvidia to improve game performance

### DIFF
--- a/etc/profile-m-z/steam.profile
+++ b/etc/profile-m-z/steam.profile
@@ -103,6 +103,7 @@ mkdir ${HOME}/.steam
 mkdir ${HOME}/Zomboid
 mkfile ${HOME}/.steampath
 mkfile ${HOME}/.steampid
+whitelist ${HOME}/.cache/nvidia
 whitelist ${HOME}/.config/Epic
 whitelist ${HOME}/.config/Loop_Hero
 whitelist ${HOME}/.config/MangoHud


### PR DESCRIPTION
Improves launch performance for Team Fortress 2 on legacy OpenGL launch option and possibly other games.
Went from 100 seconds to launch the game and ~8% cpu usage during launch (~1 core on my machine?)
To 60 second and ~16% cpu usage (~2 cores)

It might be worth putting that whitelist into other profiles that in any way use OpenGL (e.g. allow-opengl-game.inc and lutris.profile)