### PR TITLE
build: deb: add conflict with firejail-profiles

### DIFF
--- a/platform/debian/control.amd64
+++ b/platform/debian/control.amd64
@@ -5,6 +5,7 @@ Maintainer: netblue30 <netblue30@protonmail.com>
 Installed-Size: 2024
 Depends: libc6
 Suggests: python, python3
+Conflicts: firejail-profiles
 Section: admin
 Priority: optional
 Homepage: https://github.com/netblue30/firejail

--- a/platform/debian/control.i386
+++ b/platform/debian/control.i386
@@ -5,6 +5,7 @@ Maintainer: netblue30 <netblue30@protonmail.com>
 Installed-Size: 2024
 Depends: libc6
 Suggests: python, python3
+Conflicts: firejail-profiles
 Section: admin
 Priority: optional
 Homepage: https://github.com/netblue30/firejail


### PR DESCRIPTION
Debian has a separate "firejail-profiles" package for the profiles
(besides the main "firejail" package), which conflicts with our package
when trying to install it[1]:

    $ sudo dpkg -i firejail_0.9.80_1_amd64.deb

    FAIL: (Reading database ... 238526 files and directories currently installed.)
    Preparing to unpack ./firejail_0.9.80_1_amd64.deb ...
    Unpacking firejail (0.9.80-1) over (0.9.74-1~0ubuntu22.04.0) ...
    dpkg: error processing archive ./firejail_0.9.80_1_amd64.deb (--install):
     trying to overwrite '/etc/firejail/0ad.profile', which is also in package firejail-
     	profiles 0.9.74-1~0ubuntu22.04.0
    dpkg-deb: error: paste subprocess was killed by signal (Broken pipe)
    Errors were encountered while processing:
     ./firejail_0.9.80_1_amd64.deb

So add a `Conflicts:` line for "firejail-profiles".

Relates to #7110.

[1] https://github.com/netblue30/firejail/issues/7072#issuecomment-4273240052

Reported-by: @ginto37