### PR TITLE
feature: firecfg: add and use firejail-symlink wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,9 @@ endif
 	$(INSTALL) -m 0755 -t $(DESTDIR)$(libdir)/firejail src/profstats/profstats
 	$(INSTALL) -m 0755 -t $(DESTDIR)$(libdir)/firejail src/etc-cleanup/etc-cleanup
 	$(INSTALL) -m 0755 -t $(DESTDIR)$(libdir)/firejail src/fbwrap/fbwrap
+	# other scripts and executables
+	$(INSTALL) -m 0755 -d $(DESTDIR)$(libexecdir)/firejail
+	$(INSTALL) -m 0755 src/firecfg/firejail-symlink.sh $(DESTDIR)$(libexecdir)/firejail/firejail-symlink
 	# plugins w/o read permission (non-dumpable)
 	$(INSTALL) -m 0711 -t $(DESTDIR)$(libdir)/firejail $(SBOX_APPS_NON_DUMPABLE)
 	$(INSTALL) -m 0711 -t $(DESTDIR)$(libdir)/firejail src/fshaper/fshaper.sh

--- a/config.mk.in
+++ b/config.mk.in
@@ -17,6 +17,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 bindir=@bindir@
 libdir=@libdir@
+libexecdir=@libexecdir@
 datarootdir=@datarootdir@
 docdir=@docdir@
 mandir=@mandir@
@@ -92,6 +93,7 @@ COMMON_CFLAGS = \
 	-DPREFIX='"$(prefix)"' \
 	-DBINDIR='"$(bindir)"' \
 	-DLIBDIR='"$(libdir)"' \
+	-DLIBEXECDIR='"$(libexecdir)"' \
 	-DVARDIR='"$(localstatedir)/lib/$(TARNAME)"' \
 	-DSYSCONFDIR='"$(sysconfdir)/$(TARNAME)"'
 

--- a/config.mk.in
+++ b/config.mk.in
@@ -89,8 +89,10 @@ COMMON_CFLAGS = \
 	-Wall -Wextra $(HAVE_FATAL_WARNINGS) \
 	-Wformat -Wformat-security \
 	-fstack-protector-all \
-	-DPREFIX='"$(prefix)"' -DSYSCONFDIR='"$(sysconfdir)/$(TARNAME)"' \
-	-DLIBDIR='"$(libdir)"' -DBINDIR='"$(bindir)"' \
+	-DPREFIX='"$(prefix)"' \
+	-DSYSCONFDIR='"$(sysconfdir)/$(TARNAME)"' \
+	-DLIBDIR='"$(libdir)"' \
+	-DBINDIR='"$(bindir)"' \
 	-DVARDIR='"$(localstatedir)/lib/$(TARNAME)"'
 
 PROG_CFLAGS = \

--- a/config.mk.in
+++ b/config.mk.in
@@ -90,10 +90,10 @@ COMMON_CFLAGS = \
 	-Wformat -Wformat-security \
 	-fstack-protector-all \
 	-DPREFIX='"$(prefix)"' \
-	-DSYSCONFDIR='"$(sysconfdir)/$(TARNAME)"' \
-	-DLIBDIR='"$(libdir)"' \
 	-DBINDIR='"$(bindir)"' \
-	-DVARDIR='"$(localstatedir)/lib/$(TARNAME)"'
+	-DLIBDIR='"$(libdir)"' \
+	-DVARDIR='"$(localstatedir)/lib/$(TARNAME)"' \
+	-DSYSCONFDIR='"$(sysconfdir)/$(TARNAME)"'
 
 PROG_CFLAGS = \
 	$(COMMON_CFLAGS) \

--- a/src/firecfg/firecfg.h
+++ b/src/firecfg/firecfg.h
@@ -43,6 +43,7 @@
 
 // programs
 #define FIREJAIL_EXEC PREFIX "/bin/firejail"
+#define FIREJAIL_SYMLINK_EXEC LIBEXECDIR "/firejail/firejail-symlink"
 #define FIREJAIL_WELCOME_SH LIBDIR "/firejail/firejail-welcome.sh"
 #define FZENITY_EXEC        LIBDIR "/firejail/fzenity"
 #define ZENITY_EXEC "/usr/bin/zenity"

--- a/src/firecfg/firejail-symlink.sh
+++ b/src/firecfg/firejail-symlink.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# This file is part of Firejail project
+# Copyright (C) 2014-2026 Firejail Authors
+# License MIT
+
+FIREJAIL_SYMLINK=1
+export FIREJAIL_SYMLINK
+
+bindir="/usr/bin"
+basename="$(basename "$0")"
+
+exec firejail "$bindir/$basename" "$@"

--- a/src/firecfg/main.c
+++ b/src/firecfg/main.c
@@ -91,7 +91,8 @@ static void list(void) {
 		if (is_link(fullname)) {
 			char* fname = realpath(fullname, NULL);
 			if (fname) {
-				if (strcmp(fname, FIREJAIL_EXEC) == 0)
+				if ((strcmp(fname, FIREJAIL_EXEC) == 0) ||
+				    (strcmp(fname, FIREJAIL_SYMLINK_EXEC) == 0))
 					printf("%s\n", fullname);
 				free(fname);
 			}
@@ -124,7 +125,8 @@ static void clean(void) {
 		if (is_link(fullname)) {
 			char* fname = realpath(fullname, NULL);
 			if (fname) {
-				if (strcmp(fname, FIREJAIL_EXEC) == 0) {
+				if ((strcmp(fname, FIREJAIL_EXEC) == 0) ||
+				    (strcmp(fname, FIREJAIL_SYMLINK_EXEC) == 0)) {
 					char *ptr = strrchr(fullname, '/');
 					assert(ptr);
 					ptr++;
@@ -281,7 +283,7 @@ static void parse_config_file(const char *cfgfile, int do_symlink) {
 
 		// set link
 		if (do_symlink)
-			set_file(start, FIREJAIL_EXEC);
+			set_file(start, FIREJAIL_SYMLINK_EXEC);
 	}
 
 	fclose(fp);
@@ -369,7 +371,7 @@ static void set_links_homedir(const char *homedir) {
 			goto next;
 		}
 
-		set_file(exec, FIREJAIL_EXEC);
+		set_file(exec, FIREJAIL_SYMLINK_EXEC);
 next:
 		free(exec);
 	}
@@ -504,6 +506,8 @@ int main(int argc, char **argv) {
 	}
 
 	print_version();
+
+	printf("Symlink target: %s\n\n", FIREJAIL_SYMLINK_EXEC);
 	if (arg_debug)
 		printf("%s %d %d %d %d\n", user, getuid(), getgid(), geteuid(), getegid());
 

--- a/src/firejail/fs_lib.c
+++ b/src/firejail/fs_lib.c
@@ -45,7 +45,8 @@ int is_firejail_link(const char *fname) {
 
 	int rv = 0;
 	const char *base = gnu_basename(rp);
-	if (strcmp(base, "firejail") == 0)
+	if ((strcmp(base, "firejail") == 0) ||
+	    (strcmp(base, "firejail-symlink") == 0))
 		rv = 1;
 
 	free(rp);

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -63,6 +63,7 @@ gid_t firejail_gid = 0;
 static char child_stack[STACK_SIZE] __attribute__((aligned(STACK_ALIGNMENT)));		// space for child's stack
 
 Config cfg;					// configuration
+const char *env_symlink = NULL;
 int lockfd_directory = -1;
 int lockfd_network = -1;
 int arg_private = 0;				// mount private /home and /tmp directoryu
@@ -970,6 +971,10 @@ static void run_cmd_and_exit(int i, int argc, char **argv) {
 static int check_arg(int argc, char **argv, const char *argument, int strict) {
 	int i;
 	int found = 0;
+
+	if (env_symlink)
+		return found;
+
 	for (i = 1; i < argc; i++) {
 		if (strict) {
 			if (strcmp(argv[i], argument) == 0) {
@@ -1072,6 +1077,12 @@ int main(int argc, char **argv, char **envp) {
 		fprintf(stderr, "Error: argv is invalid\n");
 		exit(1);
 	}
+
+	// Check if firejail was executed from a symlink (such as one created
+	// by firecfg), which means that argv[0] is the program to be sandboxed
+	// and so any `--foo` flags after it belong to the program and should
+	// not be parsed by firejail (see #7140).
+	env_symlink = env_get("FIREJAIL_SYMLINK");
 
 	// process --quiet
 	const char *env_quiet = env_get("FIREJAIL_QUIET");

--- a/test/firecfg/firecfg.exp
+++ b/test/firecfg/firecfg.exp
@@ -10,14 +10,14 @@ match_max 100000
 send --  "file /usr/local/bin/ping\r"
 expect {
 	timeout {puts "TESTING ERROR 0\n";exit}
-	"ping: symbolic link to /usr/bin/firejail"
+	-re "ping: symbolic link to .*/firejail-symlink"
 }
 after 100
 
 send --  "file /tmp/ttt/ping\r"
 expect {
 	timeout {puts "TESTING ERROR 0\n";exit}
-	"ping: symbolic link to /usr/bin/firejail"
+	-re "ping: symbolic link to .*/firejail-symlink"
 }
 after 100
 

--- a/test/firecfg/firecfg.sh
+++ b/test/firecfg/firecfg.sh
@@ -16,5 +16,13 @@ echo "TESTING: firecfg (test/firecfg/firecfg.exp)"
 
 sudo rm -fr /tmp/ttt
 
+sudo cp -f firejail-program-args.sh /usr/bin/firejail-program-args
+sudo printf 'firejail-program-args\n' >/etc/firejail/firecfg.d/firejail-program-args.conf
+sudo firecfg
+echo "TESTING: firejail-program-args (test/firecfg/firejail-program-args.exp)"
+./firejail-program-args.exp
+sudo rm -f /etc/firejail/firecfg.d/firejail-program-args.conf
+sudo rm -f /usr/bin/firejail-program-args
+
 cd ../../
 ./mkgcov.sh

--- a/test/firecfg/firejail-program-args.exp
+++ b/test/firecfg/firejail-program-args.exp
@@ -1,0 +1,57 @@
+#!/usr/bin/expect -f
+# This file is part of Firejail project
+# Copyright (C) 2014-2026 Firejail Authors
+# License GPL v2
+
+set timeout 3
+spawn $env(SHELL)
+match_max 100000
+
+send -- "firecfg --list\r"
+expect {
+	timeout {puts "TESTING ERROR 0\n";exit}
+	"/usr/local/bin/firejail-program-args"
+}
+after 100
+
+send --  "file /usr/local/bin/firejail-program-args\r"
+expect {
+	timeout {puts "TESTING ERROR 1\n";exit}
+	-re "firejail-program-args: symbolic link to .*/firejail-symlink" {}
+	"cannot open" {puts "TESTING ERROR 2";exit}
+}
+after 100
+
+send --  "command -V firejail-program-args\r"
+expect {
+	timeout {puts "TESTING ERROR 3\n";exit}
+	"/usr/local/bin/firejail-program-args" {}
+	"not found" {puts "TESTING ERROR 4";exit}
+}
+after 100
+
+send --  "firejail --version\r"
+expect {
+	timeout {puts "TESTING ERROR 5\n";exit}
+	"firejail version "
+}
+after 100
+
+# Test that firejail does not intercept `--version` (see #7140).
+send --  "./firejail-program-args.sh --version\r"
+expect {
+	timeout {puts "TESTING ERROR 6\n";exit}
+	"firejail-program-args version " {}
+	"firejail version " {puts "TESTING ERROR 7";exit}
+}
+after 100
+
+send --  "firejail-program-args --version\r"
+expect {
+	timeout {puts "TESTING ERROR 8\n";exit}
+	"firejail-program-args version " {}
+	"firejail version " {puts "TESTING ERROR 9";exit}
+}
+after 100
+
+puts "\nall done\n"

--- a/test/firecfg/firejail-program-args.sh
+++ b/test/firecfg/firejail-program-args.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# This file is part of Firejail project
+# Copyright (C) 2014-2026 Firejail Authors
+# License GPL v2
+
+basename="$(basename "$0")"
+
+if test "$#" -lt 1; then
+	printf '%s: error: missing option\n' "$basename" >&2
+	exit 1
+fi
+
+case "$1" in
+--version)
+	printf '%s: version 1\n' "$basename"
+	break
+	;;
+*)
+	printf '%s: error: unknown option: %s\n' "$basename" "$1" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
Add a new `firejail-symlink` wrapper script that sets
`FIREJAIL_SYMLINK=1` before calling firejail and use that script as the
symlink in /usr/local/bin instead of `firejail`.

Check both paths in firecfg for backwards compatibility (especially for
`firecfg --clean`).

Place the script in `$(libexecdir)` (which is not currently used), as
that is a more appropriate location than `$(libdir)` and having a stable
target path for the symlinks makes maintenance and support easier (as
opposed to potentially moving the script path later).

Background: The early firejail init code is brittle due to certain
interdependencies between different parts (such as when checking
environment variables, flags and firejail.config options).

This should make the code more robust by not having to guess when
firejail is called as a symlink (which affects argument parsing).

This fixes a bug added on commit 907916d04 ("modif: check for --version
during early init", 2025-11-23) / PR #6972, in which running
`foo --version` (and with `foo` being a symlink to firejail) results in
firejail parsing `--version`, printing its version and exiting instead
of just forwarding the argument to the program:

    $ qpdf --version
    firejail version 0.9.80
    [...]

Misc: PR #6972 was still marked as a draft when it was merged.

Fixes #7140.

Relates to #6969 #6972.

Reported-by: @gcb
Bisected-by: @rusty-snake