### PR TITLE
profiles: torbrowser-launcher: add no3d

### DIFF
--- a/etc/profile-m-z/torbrowser-launcher.profile
+++ b/etc/profile-m-z/torbrowser-launcher.profile
@@ -45,6 +45,7 @@ include whitelist-var-common.inc
 #apparmor
 caps.drop all
 netfilter
+no3d
 nodvd
 nogroups
 noinput


### PR DESCRIPTION
`no3d` added to `torbrowser-launcher`-profile.

Without GPU acceleration, even video rendering is still possible. However, with GPU acceleration and 3D rendering capabilities, and especially with whole libraries hosted in a Javascript-engine, it is easy to gain and take advantage of direct access. Considering the nature and intentions of tor-browser, it is probably best to default to disabling 3D-acceleration, unless explicitly granted.