### PR TITLE
test: fix unescaped newlines in error messages

### DIFF
--- a/test/fs/macro.exp
+++ b/test/fs/macro.exp
@@ -52,7 +52,7 @@ sleep 1
 
 send -- "firejail --profile=./macro-blacklist.profile ls ~/Documents\r"
 expect {
-	timeout {puts "TESTING ERROR 9n";exit}
+	timeout {puts "TESTING ERROR 9\n";exit}
 	-re "Child process initialized in \[0-9\]+.\[0-9\]+ ms"
 }
 expect {
@@ -63,11 +63,11 @@ sleep 1
 
 send -- "firejail --profile=./macro-blacklist.profile ls ~/Downloads\r"
 expect {
-	timeout {puts "TESTING ERROR 11n";exit}
+	timeout {puts "TESTING ERROR 11\n";exit}
 	-re "Child process initialized in \[0-9\]+.\[0-9\]+ ms"
 }
 expect {
-	timeout {puts "TESTING ERROR 12n";exit}
+	timeout {puts "TESTING ERROR 12\n";exit}
 	"Permission denied"
 }
 sleep 1

--- a/test/utils/ls.exp
+++ b/test/utils/ls.exp
@@ -34,7 +34,7 @@ send -- "firejail --get=test ~/lstesting\r"
 sleep 1
 send -- "cat lstesting\r"
 expect {
-	timeout {puts "TESTING ERROR 2n";exit}
+	timeout {puts "TESTING ERROR 2\n";exit}
 	"my_testing"
 }
 after 100


### PR DESCRIPTION
Commands used to search and replace:

    $ git grep -IElz 'ERROR [0-9]+n"' -- test |
      xargs -0 perl -pi -e 's/(ERROR [0-9]+)n"/$1\\n"/'

Related commits:

* 63e16bfcd ("major cleanup and testing", 2016-11-13)
* 2155203b3 ("xdg macro testing", 2018-08-07)
