### PR TITLE
profiles: torbrowser-launcher: add getconf to private-bin,dri-access, glxtest

### DIFF
--- a/etc/profile-m-z/torbrowser-launcher.profile
+++ b/etc/profile-m-z/torbrowser-launcher.profile
@@ -59,7 +59,7 @@ seccomp.block-secondary
 #tracelog # may cause issues, see #1930
 
 disable-mnt
-private-bin bash,cat,cp,cut,dirname,env,execdesktop,expr,file,gpg,grep,gxmessage,id,kdialog,ln,mkdir,mv,python*,rm,sed,sh,tail,tar,tclsh,test,tor-browser,tor-browser-en,torbrowser-launcher,update-desktop-database,xmessage,xz,zenity
+private-bin bash,cat,cp,cut,dirname,env,execdesktop,expr,file,getconf,gpg,grep,gxmessage,id,kdialog,ln,mkdir,mv,python*,rm,sed,sh,tail,tar,tclsh,test,tor-browser,tor-browser-en,torbrowser-launcher,update-desktop-database,xmessage,xz,zenity
 private-dev
 private-etc @tls-ca
 private-tmp


### PR DESCRIPTION
Several fixes, work-in-progress…

- 🗸 Add `getconf` to `private-bin` listing for allowed commands. (Used in conditional in start-up script.)
- 🗸 Investigate possible mention of `vaapitest` (unless not happening in resulting situation)
  - Issue with Debian's AppArmor profile for torbrowser-launcher. Adding `vaapitest` in same form as entry for `glxtest` is sufficient to make it execute successfully. Not an issue in firejail.
- ? Investigate matter of denied `/dev/dri/card*` access.
- ? Investigate crashes concerning `glxtest` (likely related to `/dev/dri/card*` access)

Firejail: 0.9.80 (github-package)
Distro: Debian Trixie (13)

---
Some reports

Current firejail-profile is interfering with proper detection of GPU hardware. I get these reports, though I'm not completely sure that I am not causing this with local changes. It doesn't seem to be.

```
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: ManageChildProcess failed
 (t=0.639868) [GFX1-]: glxtest: ManageChildProcess failed

Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: ManageChildProcess failed
 (t=0.639868) |[1][GFX1-]: No GPUs detected via PCI
 (t=0.639868) [GFX1-]: No GPUs detected via PCI
```

It might be connected to these dmesg reports:

```
[10309.722074] audit: type=1400 audit(1777313836.069:355): apparmor="DENIED" operation="file_receive" class="file" info="Failed name lookup - disconnected path" error=-13 profile="torbrowser_firefox" name="dev/dri/card0" pid=10894 comm="glxtest" requested_mask="wr" denied_mask="wr" fsuid=1001 ouid=0
[10309.724432] audit: type=1400 audit(1777313836.073:356): apparmor="DENIED" operation="file_receive" class="file" info="Failed name lookup - disconnected path" error=-13 profile="torbrowser_firefox" name="dev/dri/card0" pid=10894 comm="glxtest" requested_mask="wr" denied_mask="wr" fsuid=1001 ouid=0
```

Without `firejail`, seems related to AppArmor profile of torbrowser.

```
 (t=0.639465) [GFX1-]: FireTestProcess failed: Failed to spawn child process “/home/user/.local/share/torbrowser/tbb/x86_64/tor-browser/Browser/vaapitest” (Permission denied)
```

dmesg:
```
[ 2457.252435] audit: type=1400 audit(1777394876.112:226): apparmor="DENIED" operation="exec" class="file" profile="torbrowser_firefox" name="/home/user/.local/share/torbrowser/tbb/x86_64/tor-browser/Browser/vaapitest" pid=10116 comm="firefox.real" requested_mask="x" denied_mask="x" fsuid=1001 ouid=1001
```