### PR TITLE
security: create `~/.config/firejail` to prevent sandbox escape

### DIFF
--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -905,6 +905,7 @@ void disable_config(void) {
 	char *fname;
 	if (asprintf(&fname, "%s/.config/firejail", cfg.homedir) == -1)
 		errExit("asprintf");
+	fs_mkdir(fname);
 	disable_file(BLACKLIST_FILE, fname);
 	free(fname);
 #endif


### PR DESCRIPTION
A quick-and-dirty fix for https://github.com/netblue30/firejail/issues/7132#issuecomment-4239282977