### PR TITLE
profiles: add llm-agent-common.inc

### DIFF
--- a/README
+++ b/README
@@ -167,6 +167,7 @@ Amin Vakil (https://github.com/aminvakil)
 	- new profile: gemini (#6936)
 	- new profile: opencode (#7135)
 	- new profile: pi (#7136)
+	- profiles: add common LLM agent include (#7158)
 Ammon Smith (https://github.com/ammongit)
 	- Add DBus filter rules specific to firefox-developer-edition
 Andreas Hunkeler (https://github.com/Karneades)

--- a/README
+++ b/README
@@ -167,7 +167,7 @@ Amin Vakil (https://github.com/aminvakil)
 	- new profile: gemini (#6936)
 	- new profile: opencode (#7135)
 	- new profile: pi (#7136)
-	- profiles: add common LLM agent include (#7158)
+	- profiles: add llm-agent-common.inc (#7158)
 Ammon Smith (https://github.com/ammongit)
 	- Add DBus filter rules specific to firefox-developer-edition
 Andreas Hunkeler (https://github.com/Karneades)

--- a/RELNOTES
+++ b/RELNOTES
@@ -24,7 +24,7 @@ firejail (0.9.81) baseline; urgency=low
   * profiles: firefox-common: allow auto light/dark theme switching (#7103)
   * profiles: steam: allow more 3d cache paths (#7149)
   * profiles: torbrowser-launcher: add no3d (#7143)
-  * profiles: add common LLM agent include (#7158)
+  * profiles: add llm-agent-common.inc (#7158)
   * new profile: gemini (#6936)
   * new profile: opencode (#7135)
   * new profile: pi (#7136)

--- a/RELNOTES
+++ b/RELNOTES
@@ -24,6 +24,7 @@ firejail (0.9.81) baseline; urgency=low
   * profiles: firefox-common: allow auto light/dark theme switching (#7103)
   * profiles: steam: allow more 3d cache paths (#7149)
   * profiles: torbrowser-launcher: add no3d (#7143)
+  * profiles: add common LLM agent include (#7158)
   * new profile: gemini (#6936)
   * new profile: opencode (#7135)
   * new profile: pi (#7136)

--- a/etc/inc/llm-agent-common.inc
+++ b/etc/inc/llm-agent-common.inc
@@ -58,4 +58,6 @@ private-tmp
 dbus-user none
 dbus-system none
 
+env NO_BROWSER=true
+
 restrict-namespaces

--- a/etc/inc/llm-agent-common.inc
+++ b/etc/inc/llm-agent-common.inc
@@ -1,5 +1,11 @@
-# Firejail common profile for LLM agents
+# Firejail profile for llm-agent-common
+# Description: Common profile for LLM agents
 # This file is overwritten after every install/update
+# Persistent local customizations
+include llm-agent-common.local
+# Persistent global definitions
+# added by caller profile
+#include globals.local
 
 # Allow /bin/sh (blacklisted by disable-shell.inc)
 include allow-bin-sh.inc

--- a/etc/inc/llm-agent-common.inc
+++ b/etc/inc/llm-agent-common.inc
@@ -1,0 +1,55 @@
+# Firejail common profile for LLM agents
+# This file is overwritten after every install/update
+
+# Allow /bin/sh (blacklisted by disable-shell.inc)
+include allow-bin-sh.inc
+
+# Allows files commonly used by IDEs
+include allow-common-devel.inc
+
+# Allow ssh (blacklisted by disable-common.inc)
+include allow-ssh.inc
+
+blacklist ${RUNUSER}
+
+include disable-common.inc
+include disable-proc.inc
+include disable-programs.inc
+include disable-x11.inc
+include disable-xdg.inc
+
+whitelist ${RUNUSER}/openssh_agent
+include whitelist-run-common.inc
+#include whitelist-usr-share-common.inc
+include whitelist-var-common.inc
+
+caps.drop all
+ipc-namespace
+machine-id
+netfilter
+no3d
+nodvd
+nogroups
+noinput
+nonewprivs
+noprinters
+noroot
+nosound
+notv
+nou2f
+novideo
+protocol unix,inet,inet6,netlink
+seccomp
+seccomp.block-secondary
+tracelog
+
+disable-mnt
+private-cache
+private-dev
+private-etc @network,@tls-ca
+private-tmp
+
+dbus-user none
+dbus-system none
+
+restrict-namespaces

--- a/etc/inc/llm-agent-common.inc
+++ b/etc/inc/llm-agent-common.inc
@@ -59,5 +59,4 @@ dbus-user none
 dbus-system none
 
 env NO_BROWSER=true
-
 restrict-namespaces

--- a/etc/profile-a-l/gemini.profile
+++ b/etc/profile-a-l/gemini.profile
@@ -17,7 +17,5 @@ noblacklist ${HOME}/.gemini
 #whitelist ${HOME}/.gitconfig
 #include whitelist-common.inc
 
-env NO_BROWSER=true
-
 # Redirect
 include llm-agent-common.inc

--- a/etc/profile-a-l/gemini.profile
+++ b/etc/profile-a-l/gemini.profile
@@ -19,4 +19,5 @@ noblacklist ${HOME}/.gemini
 
 env NO_BROWSER=true
 
+# Redirect
 include llm-agent-common.inc

--- a/etc/profile-a-l/gemini.profile
+++ b/etc/profile-a-l/gemini.profile
@@ -9,23 +9,6 @@ include globals.local
 
 noblacklist ${HOME}/.gemini
 
-# Allow /bin/sh (blacklisted by disable-shell.inc)
-include allow-bin-sh.inc
-
-# Allows files commonly used by IDEs
-include allow-common-devel.inc
-
-# Allow ssh (blacklisted by disable-common.inc)
-include allow-ssh.inc
-
-blacklist ${RUNUSER}
-
-include disable-common.inc
-include disable-proc.inc
-include disable-programs.inc
-include disable-x11.inc
-include disable-xdg.inc
-
 # Add the following lines to gemini.local to enable whitelisting in `${HOME}`.
 #whitelist ${HOME}/.config/git
 #whitelist ${HOME}/.gemini
@@ -34,39 +17,6 @@ include disable-xdg.inc
 #whitelist ${HOME}/.gitconfig
 #include whitelist-common.inc
 
-whitelist ${RUNUSER}/openssh_agent
-include whitelist-run-common.inc
-#include whitelist-usr-share-common.inc
-include whitelist-var-common.inc
-
-caps.drop all
-ipc-namespace
-machine-id
-netfilter
-no3d
-nodvd
-nogroups
-noinput
-nonewprivs
-noprinters
-noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix,inet,inet6,netlink
-seccomp
-seccomp.block-secondary
-tracelog
-
-disable-mnt
-private-cache
-private-dev
-private-etc @network,@tls-ca
-private-tmp
-
-dbus-user none
-dbus-system none
-
 env NO_BROWSER=true
-restrict-namespaces
+
+include llm-agent-common.inc

--- a/etc/profile-m-z/opencode.profile
+++ b/etc/profile-m-z/opencode.profile
@@ -12,23 +12,6 @@ noblacklist ${HOME}/.config/opencode
 noblacklist ${HOME}/.local/share/opencode
 noblacklist ${HOME}/.local/state/opencode
 
-# Allow /bin/sh (blacklisted by disable-shell.inc)
-include allow-bin-sh.inc
-
-# Allows files commonly used by IDEs
-include allow-common-devel.inc
-
-# Allow ssh (blacklisted by disable-common.inc)
-include allow-ssh.inc
-
-blacklist ${RUNUSER}
-
-include disable-common.inc
-include disable-proc.inc
-include disable-programs.inc
-include disable-x11.inc
-include disable-xdg.inc
-
 # Add the following lines to opencode.local to enable whitelisting in `${HOME}`.
 #mkdir ${HOME}/.cache/opencode
 #mkdir ${HOME}/.config/opencode
@@ -42,40 +25,7 @@ include disable-xdg.inc
 #whitelist ${HOME}/.local/state/opencode
 #include whitelist-common.inc
 
-whitelist ${RUNUSER}/openssh_agent
-include whitelist-run-common.inc
-#include whitelist-usr-share-common.inc
-include whitelist-var-common.inc
-
 apparmor
-caps.drop all
-ipc-namespace
-machine-id
-netfilter
-no3d
-nodvd
-nogroups
-noinput
-nonewprivs
-noprinters
-noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix,inet,inet6,netlink
-seccomp
-seccomp.block-secondary
-tracelog
-
-disable-mnt
-private-cache
-private-dev
-private-etc @network,@tls-ca
-private-tmp
-
-dbus-user none
-dbus-system none
-
 env NO_BROWSER=true
-restrict-namespaces
+
+include llm-agent-common.inc

--- a/etc/profile-m-z/opencode.profile
+++ b/etc/profile-m-z/opencode.profile
@@ -28,4 +28,5 @@ noblacklist ${HOME}/.local/state/opencode
 apparmor
 env NO_BROWSER=true
 
+# Redirect
 include llm-agent-common.inc

--- a/etc/profile-m-z/opencode.profile
+++ b/etc/profile-m-z/opencode.profile
@@ -26,7 +26,6 @@ noblacklist ${HOME}/.local/state/opencode
 #include whitelist-common.inc
 
 apparmor
-env NO_BROWSER=true
 
 # Redirect
 include llm-agent-common.inc

--- a/etc/profile-m-z/pi.profile
+++ b/etc/profile-m-z/pi.profile
@@ -10,23 +10,6 @@ include globals.local
 noblacklist ${HOME}/.agents
 noblacklist ${HOME}/.pi
 
-# Allow /bin/sh (blacklisted by disable-shell.inc)
-include allow-bin-sh.inc
-
-# Allows files commonly used by IDEs
-include allow-common-devel.inc
-
-# Allow ssh (blacklisted by disable-common.inc)
-include allow-ssh.inc
-
-blacklist ${RUNUSER}
-
-include disable-common.inc
-include disable-proc.inc
-include disable-programs.inc
-include disable-x11.inc
-include disable-xdg.inc
-
 # Add the following lines to pi.local to enable whitelisting in `${HOME}`.
 #mkdir ${HOME}/.agents
 #mkdir ${HOME}/.pi
@@ -36,38 +19,4 @@ include disable-xdg.inc
 #whitelist ${HOME}/.pi
 #include whitelist-common.inc
 
-whitelist ${RUNUSER}/openssh_agent
-include whitelist-run-common.inc
-#include whitelist-usr-share-common.inc
-include whitelist-var-common.inc
-
-caps.drop all
-ipc-namespace
-machine-id
-netfilter
-no3d
-nodvd
-nogroups
-noinput
-nonewprivs
-noprinters
-noroot
-nosound
-notv
-nou2f
-novideo
-protocol unix,inet,inet6,netlink
-seccomp
-seccomp.block-secondary
-tracelog
-
-disable-mnt
-private-cache
-private-dev
-private-etc @network,@tls-ca
-private-tmp
-
-dbus-user none
-dbus-system none
-
-restrict-namespaces
+include llm-agent-common.inc

--- a/etc/profile-m-z/pi.profile
+++ b/etc/profile-m-z/pi.profile
@@ -19,4 +19,5 @@ noblacklist ${HOME}/.pi
 #whitelist ${HOME}/.pi
 #include whitelist-common.inc
 
+# Redirect
 include llm-agent-common.inc


### PR DESCRIPTION
Regarding @cameronj86 comment in https://github.com/netblue30/firejail/issues/1139#issuecomment-3721450281 and @kmk3 comment in https://github.com/netblue30/firejail/pull/6936#issuecomment-4359189937.

Also I cannot remember why I hadn't added `env NO_BROWSER=true` in `pi.profile`.

Most probably because I have misremembered :) Please tell me if I should add it to `llm-agent-common.inc` as well, or it should be in another PR.