### PR TITLE
profiles: use xdg macros with subpaths

### DIFF
--- a/etc/profile-a-l/jami.profile
+++ b/etc/profile-a-l/jami.profile
@@ -10,9 +10,9 @@ include jami.local
 noblacklist ${HOME}/.config/jami.net
 
 mkdir ${HOME}/.config/jami.net
-mkdir ${HOME}/Videos/Jami
+mkdir ${VIDEOS}/Jami
 whitelist ${HOME}/.config/jami.net
-whitelist ${HOME}/Videos/Jami
+whitelist ${VIDEOS}/Jami
 
 # Redirect
 include jami-gnome.profile

--- a/etc/profile-a-l/keepassxc.profile
+++ b/etc/profile-a-l/keepassxc.profile
@@ -37,9 +37,9 @@ include disable-shell.inc
 include disable-xdg.inc
 
 # You can enable whitelisting for keepassxc by adding the below to your keepassxc.local.
-# If you do, you MUST store your database under ${HOME}/Documents/KeePassXC/foo.kdbx.
-#mkdir ${HOME}/Documents/KeePassXC
-#whitelist ${HOME}/Documents/KeePassXC
+# If you do, you MUST store your database under ${DOCUMENTS}/KeePassXC/foo.kdbx.
+#mkdir ${DOCUMENTS}/KeePassXC
+#whitelist ${DOCUMENTS}/KeePassXC
 # Needed for KeePassXC-Browser.
 #mkdir ${HOME}/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts
 #mkfile ${HOME}/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts/org.keepassxc.keepassxc_browser.json

--- a/etc/profile-m-z/Mathematica.profile
+++ b/etc/profile-m-z/Mathematica.profile
@@ -13,12 +13,12 @@ include disable-devel.inc
 include disable-interpreters.inc
 include disable-programs.inc
 
+mkdir ${DOCUMENTS}/Wolfram Mathematica
 mkdir ${HOME}/.Mathematica
 mkdir ${HOME}/.Wolfram Research
-mkdir ${HOME}/Documents/Wolfram Mathematica
+whitelist ${DOCUMENTS}/Wolfram Mathematica
 whitelist ${HOME}/.Mathematica
 whitelist ${HOME}/.Wolfram Research
-whitelist ${HOME}/Documents/Wolfram Mathematica
 include whitelist-common.inc
 
 caps.drop all

--- a/etc/profile-m-z/prismlauncher.profile
+++ b/etc/profile-m-z/prismlauncher.profile
@@ -14,8 +14,8 @@ include disable-interpreters.inc
 include disable-proc.inc
 include disable-shell.inc
 
+whitelist ${DOWNLOADS}
 whitelist ${HOME}/.local/share/PrismLauncher
-whitelist ${HOME}/Downloads
 include whitelist-common.inc
 
 apparmor

--- a/etc/profile-m-z/zoom.profile
+++ b/etc/profile-m-z/zoom.profile
@@ -23,16 +23,16 @@ noblacklist ${HOME}/.zoom
 
 nowhitelist ${DOWNLOADS}
 
+mkdir ${DOCUMENTS}/Zoom
 mkdir ${HOME}/.cache/zoom
 mkdir ${HOME}/.zoom
-mkdir ${HOME}/Documents/Zoom
 mkfile ${HOME}/.config/zoom.conf
 mkfile ${HOME}/.config/zoomus.conf
+whitelist ${DOCUMENTS}/Zoom
 whitelist ${HOME}/.cache/zoom
 whitelist ${HOME}/.config/zoom.conf
 whitelist ${HOME}/.config/zoomus.conf
 whitelist ${HOME}/.zoom
-whitelist ${HOME}/Documents/Zoom
 
 # Disable for now, see https://github.com/netblue30/firejail/issues/3726
 #private-etc alternatives,ca-certificates,crypto-policies,fonts,group,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,machine-id,nsswitch.conf,pki,resolv.conf,ssl


### PR DESCRIPTION
Commands used to search and replace:

    $ git grep -IElz '\$\{HOME\}/(Desktop|Documents|Downloads|Music|Pictures|Projects|Videos)' -- etc |
      xargs -0 perl -pi -e '
        s/\$\{HOME\}\/Desktop/\${DESKTOP}/;
        s/\$\{HOME\}\/Documents/\${DOCUMENTS}/;
        s/\$\{HOME\}\/Downloads/\${DOWNLOADS}/;
        s/\$\{HOME\}\/Music/\${MUSIC}/;
        s/\$\{HOME\}\/Pictures/\${PICTURES}/;
        s/\$\{HOME\}\/Projects/\${PROJECTS}/;
        s/\$\{HOME\}\/Videos/\${VIDEOS}/;
      '

Note: The entries in the following profiles were sorted manually:

* etc/profile-m-z/Mathematica.profile
* etc/profile-m-z/prismlauncher.profile
* etc/profile-m-z/zoom.profile

This is a follow-up to #7151.