### PR TITLE
ci: make all main make steps parallel and sync output

### DIFF
--- a/.github/workflows/build-extra.yml
+++ b/.github/workflows/build-extra.yml
@@ -68,7 +68,7 @@ jobs:
         --enable-apparmor --enable-selinux
         || (cat config.log; exit 1)
     - name: make
-      run: make
+      run: make -j "$(nproc)" -Orecurse
     - name: make install
       run: sudo make install
     - name: make installcheck
@@ -103,7 +103,7 @@ jobs:
         --enable-apparmor --enable-selinux
         || (cat config.log; exit 1)
     - name: make
-      run: make
+      run: make -j "$(nproc)" -Orecurse
     - name: make install
       run: sudo make install
     - name: make installcheck

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
         --disable-apparmor --disable-selinux
         || (cat config.log; exit 1)
     - name: make
-      run: make -j "$(nproc)"
+      run: make -j "$(nproc)" -Orecurse
     - name: make install
       run: sudo make install
     - name: make installcheck

--- a/.github/workflows/check-c.yml
+++ b/.github/workflows/check-c.yml
@@ -67,12 +67,12 @@ jobs:
       run: ./ci/printenv.sh
     - name: configure
       run: >
-        ./configure CC=clang-14 SCAN_BUILD=scan-build-14
+        ./configure CC=clang-14
         --prefix=/usr --enable-fatal-warnings
         --enable-apparmor --enable-selinux
         || (cat config.log; exit 1)
     - name: scan-build
-      run: make -j "$(nproc)" scan-build
+      run: scan-build-14 make -j "$(nproc)" -Orecurse
 
   cppcheck:
     runs-on: ubuntu-24.04
@@ -139,7 +139,7 @@ jobs:
       run: ./configure || (cat config.log; exit 1)
 
     - name: make
-      run: make -j "$(nproc)"
+      run: make -j "$(nproc)" -Orecurse
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
         --enable-apparmor --enable-selinux
         || (cat config.log; exit 1)
     - name: make
-      run: make -j "$(nproc)"
+      run: make -j "$(nproc)" -Orecurse
     - name: make install
       run: sudo make install
     - name: make installcheck
@@ -127,7 +127,7 @@ jobs:
         --enable-apparmor --enable-selinux
         || (cat config.log; exit 1)
     - name: make
-      run: make -j "$(nproc)"
+      run: make -j "$(nproc)" -Orecurse
     - name: make install
       run: sudo make install
     - name: make installcheck
@@ -168,7 +168,7 @@ jobs:
         --enable-apparmor --enable-selinux
         || (cat config.log; exit 1)
     - name: make
-      run: make -j "$(nproc)"
+      run: make -j "$(nproc)" -Orecurse
     - name: make install
       run: sudo make install
     - name: make installcheck
@@ -211,7 +211,7 @@ jobs:
         --enable-apparmor --enable-selinux
         || (cat config.log; exit 1)
     - name: make
-      run: make -j "$(nproc)"
+      run: make -j "$(nproc)" -Orecurse
     - name: make install
       run: sudo make install
     - name: make installcheck
@@ -258,7 +258,7 @@ jobs:
         --enable-apparmor --enable-selinux
         || (cat config.log; exit 1)
     - name: make
-      run: make -j "$(nproc)"
+      run: make -j "$(nproc)" -Orecurse
     - name: make install
       run: sudo make install
     - name: make installcheck

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,9 @@ build_ubuntu_package:
         - ./ci/printenv.sh
         - ./configure || (cat config.log; exit 1)
         - make dist
-        - ./mkdeb.sh --enable-fatal-warnings
+        - >
+            MAKEFLAGS="$MAKEFLAGS -Orecurse" ./mkdeb.sh
+            --enable-fatal-warnings
         - dpkg -i ./*.deb
         - make installcheck
 
@@ -41,7 +43,9 @@ build_debian_package:
         - ./ci/printenv.sh
         - ./configure || (cat config.log; exit 1)
         - make dist
-        - ./mkdeb.sh --enable-fatal-warnings
+        - >
+            MAKEFLAGS="$MAKEFLAGS -Orecurse" ./mkdeb.sh
+            --enable-fatal-warnings
         - dpkg -i ./*.deb
         - make installcheck
 
@@ -60,8 +64,8 @@ build_no_apparmor:
         - ./configure || (cat config.log; exit 1)
         - make dist
         - >
-            ./mkdeb.sh --enable-fatal-warnings
-            --disable-apparmor
+            MAKEFLAGS="$MAKEFLAGS -Orecurse" ./mkdeb.sh
+            --enable-fatal-warnings --disable-apparmor
         - dpkg -i ./*.deb
         - make installcheck
         - make installcheck | grep -F 'AppArmor support is disabled'
@@ -75,7 +79,9 @@ build_redhat_package:
         - ./ci/printenv.sh
         - ./configure || (cat config.log; exit 1)
         - make dist
-        - ./platform/rpm/mkrpm.sh --enable-fatal-warnings
+        - >
+            MAKEFLAGS="$MAKEFLAGS -Orecurse" ./platform/rpm/mkrpm.sh
+            --enable-fatal-warnings
         - rpm -i ./*.rpm
         - make installcheck
 
@@ -88,7 +94,9 @@ build_fedora_package:
         - ./ci/printenv.sh
         - ./configure || (cat config.log; exit 1)
         - make dist
-        - ./platform/rpm/mkrpm.sh --enable-fatal-warnings
+        - >
+            MAKEFLAGS="$MAKEFLAGS -Orecurse" ./platform/rpm/mkrpm.sh
+            --enable-fatal-warnings
         - rpm -i ./*.rpm
         - make installcheck
 
@@ -106,7 +114,7 @@ build_fedora_package:
 #        - >
 #            ./configure --prefix=/usr
 #            || (cat config.log; exit 1)
-#        - make
+#        - make -j "$(nproc)" -Orecurse
 #        - make install-strip
 #        - make installcheck
 


### PR DESCRIPTION
Changes:

* Use `scan-build make` instead of running `scan-build` inside of `make`
  (this appears to be necessary for the output synchronization to work)
* Use `-j "$(nproc)"` and `-Orecurse` for the main `make` step in all
  jobs (including where this step is currently not parallel)

The main drawback of using parallel make (`-j`) is that the output of
different jobs may be printed interspersed, which makes the output
harder to read and less stable across multiple executions.

Example:

    job1: line1
    job1: line2
    job2: line1
    job3: line1
    job1: line3

Using `-Orecurse` should fix this by ensuring that the output of all
jobs is still printed sequentially in the order that the jobs were
executed (that is, as if `-j` was not used), even if the jobs themselves
are executed in parallel.

This should ensure that the main `make` step in each job runs its
targets in parallel and has a stable output at the same time, making it
easier to compare the logs of the same job across different CI runs.

Note: The `-O` flag is specific to GNU make and was added in version 4.0
(2013-10-09).

Related commits:

* 500d8f2d6 ("ci: run make in parallel where applicable", 2023-08-14) /
  PR #5960
* 1f6400bd8 ("build: sync scan-build target with CI", 2024-02-24) /
  PR #6222