### PR TITLE
profile: blink-common-hardened: drop netlink & add mdwe comment

### DIFF
--- a/etc/profile-a-l/blink-common-hardened.inc.profile
+++ b/etc/profile-a-l/blink-common-hardened.inc.profile
@@ -5,7 +5,7 @@ include blink-common-hardened.inc.local
 caps.drop all
 nonewprivs
 #noroot breaks saving files
-protocol unix,inet,inet6,netlink
+protocol unix,inet,inet6
 seccomp !chroot
 
 #restrict-namespaces

--- a/etc/profile-a-l/chromium-common-hardened.inc.profile
+++ b/etc/profile-a-l/chromium-common-hardened.inc.profile
@@ -6,5 +6,8 @@ include chromium-common-hardened.inc.local
 # added by caller profile
 #include globals.local
 
+# Running with `--js-flags=--jitless` satisfies W^X
+#memory-deny-write-execute
+
 # Redirect
 include blink-common-hardened.inc.profile


### PR DESCRIPTION
I would propose the following change, considering that this is the _hardened_-profile.

1.  Remove `netlink` being an unnecessary protocol which, in my understanding, provides access into kernel mechanisms.
2.  Provide a comment hinting at a possibility of `memory-deny-write-execute` if Chromium is run with certain command-line argument.