### PR TITLE
new profile: tldr

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -239,6 +239,7 @@ blacklist ${HOME}/.cache/systemsettings
 blacklist ${HOME}/.cache/telepathy
 blacklist ${HOME}/.cache/thunderbird
 blacklist ${HOME}/.cache/tiny-rdm
+blacklist ${HOME}/.cache/tldr
 blacklist ${HOME}/.cache/torbrowser
 blacklist ${HOME}/.cache/transmission
 blacklist ${HOME}/.cache/trivalent

--- a/etc/profile-m-z/tldr.profile
+++ b/etc/profile-m-z/tldr.profile
@@ -50,8 +50,7 @@ seccomp
 
 disable-mnt
 private-bin python*,tldr
-private-dev
-private-etc alternatives,ld.so.cache,ca-certificates,crypto-policies,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,mime.types,protocols,resolv.conf,ssl,xdg
+private-dev alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,mime.types,protocols,resolv.conf,ssl,xdg
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/tldr.profile
+++ b/etc/profile-m-z/tldr.profile
@@ -9,6 +9,7 @@ include globals.local
 
 noblacklist ${HOME}/.cache/tldr
 
+# Allow python (blacklisted by disable-interpreters.inc)
 include allow-python3.inc
 
 blacklist ${RUNUSER}/wayland-*
@@ -29,7 +30,6 @@ include disable-write-mnt.inc
 include disable-x11.inc
 include disable-xdg.inc
 
-# Commands that reduce access to resources.
 apparmor
 caps.drop all
 ipc-namespace
@@ -50,7 +50,7 @@ seccomp
 
 disable-mnt
 private-bin python*,tldr
-private-etc alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,mime.types,protocols,resolv.conf,ssl,xdg
+private-etc @alternatives,@network,@tls-ca
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/tldr.profile
+++ b/etc/profile-m-z/tldr.profile
@@ -50,7 +50,7 @@ seccomp
 
 disable-mnt
 private-bin python*,tldr
-private-dev alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,mime.types,protocols,resolv.conf,ssl,xdg
+private-etc alternatives,ca-certificates,crypto-policies,ld.so.cache,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,mime.types,protocols,resolv.conf,ssl,xdg
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/tldr.profile
+++ b/etc/profile-m-z/tldr.profile
@@ -12,7 +12,6 @@ noblacklist ${HOME}/.cache/tldr
 # Allow python (blacklisted by disable-interpreters.inc)
 include allow-python3.inc
 
-blacklist ${RUNUSER}/wayland-*
 blacklist ${RUNUSER}
 blacklist /usr/libexec
 

--- a/etc/profile-m-z/tldr.profile
+++ b/etc/profile-m-z/tldr.profile
@@ -49,7 +49,7 @@ seccomp
 
 disable-mnt
 private-bin python*,tldr
-private-etc @alternatives,@network,@tls-ca
+private-etc @network,@tls-ca
 private-tmp
 
 dbus-user none

--- a/etc/profile-m-z/tldr.profile
+++ b/etc/profile-m-z/tldr.profile
@@ -1,0 +1,60 @@
+# Firejail profile for tldr
+# Description: Python CLI for tldr pages
+# This file is overwritten after every install/update
+quiet
+# Persistent local customizations
+include tldr.local
+# Persistent global definitions
+include globals.local
+
+noblacklist ${HOME}/.cache/tldr
+
+include allow-python3.inc
+
+blacklist ${RUNUSER}/wayland-*
+blacklist ${RUNUSER}
+blacklist /usr/libexec
+
+mkdir ${HOME}/.cache/tldr
+whitelist ${HOME}/.cache/tldr
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-proc.inc
+include disable-programs.inc
+include disable-shell.inc
+include disable-write-mnt.inc
+include disable-x11.inc
+include disable-xdg.inc
+
+# Commands that reduce access to resources.
+apparmor
+caps.drop all
+ipc-namespace
+machine-id
+netfilter
+no3d
+nodvd
+nogroups
+noinput
+nonewprivs
+noprinters
+noroot
+nosound
+notv
+nou2f
+novideo
+seccomp
+
+disable-mnt
+private-bin python*,tldr
+private-dev
+private-etc alternatives,ld.so.cache,ca-certificates,crypto-policies,ld.so.conf,ld.so.conf.d,ld.so.preload,locale,locale.alias,locale.conf,localtime,mime.types,protocols,resolv.conf,ssl,xdg
+private-tmp
+
+dbus-user none
+dbus-system none
+
+restrict-namespaces


### PR DESCRIPTION
This is a profile for tldr official Python CLI:

* https://github.com/tldr-pages/tldr
* https://github.com/tldr-pages/tldr-python-client

It's working on my machine (Arch Linux) with stable Firejail (0.9.80). I tried to make it as restrictive as possible, as it's only downloading files and putting them in `~/.cache/tldr`.