### PR TITLE
test/fs: support and use XDG user dir env vars

### DIFF
--- a/test/fs/fs.sh
+++ b/test/fs/fs.sh
@@ -7,16 +7,31 @@ export MALLOC_CHECK_=3
 export MALLOC_PERTURB_=$(($RANDOM % 255 + 1))
 export LC_ALL=C
 
+export XDG_CONFIG_DIR="${XDG_CONFIG_DIR:=$HOME/.config}"
+
+test -f "${XDG_CONFIG_DIR}/user-dirs.dirs" &&
+. "${XDG_CONFIG_DIR}/user-dirs.dirs"
+
+export XDG_DESKTOP_DIR="${XDG_DESKTOP_DIR:=$HOME/Desktop}"
+export XDG_DOCUMENTS_DIR="${XDG_DOCUMENTS_DIR:=$HOME/Documents}"
+export XDG_DOWNLOAD_DIR="${XDG_DOWNLOAD_DIR:=$HOME/Downloads}"
+export XDG_MUSIC_DIR="${XDG_MUSIC_DIR:=$HOME/Music}"
+export XDG_PICTURES_DIR="${XDG_PICTURES_DIR:=$HOME/Pictures}"
+export XDG_PROJECTS_DIR="${XDG_PROJECTS_DIR:=$HOME/Projects}"
+export XDG_PUBLICSHARE_DIR="${XDG_PUBLICSHARE_DIR:=$HOME/Public}"
+export XDG_TEMPLATES_DIR="${XDG_TEMPLATES_DIR:=$HOME/Templates}"
+export XDG_VIDEOS_DIR="${XDG_VIDEOS_DIR:=$HOME/Videos}"
+
 macro_paths=(
-	"$HOME/Desktop"
-	"$HOME/Documents"
-	"$HOME/Downloads"
-	"$HOME/Music"
-	"$HOME/Pictures"
-	"$HOME/Projects"
-	"$HOME/Public"
-	"$HOME/Templates"
-	"$HOME/Videos"
+	"${XDG_DESKTOP_DIR}"
+	"${XDG_DOCUMENTS_DIR}"
+	"${XDG_DOWNLOAD_DIR}"
+	"${XDG_MUSIC_DIR}"
+	"${XDG_PICTURES_DIR}"
+	"${XDG_PROJECTS_DIR}"
+	"${XDG_PUBLICSHARE_DIR}"
+	"${XDG_TEMPLATES_DIR}"
+	"${XDG_VIDEOS_DIR}"
 )
 
 # These directories are required by some tests:

--- a/test/fs/macro-subpath.exp
+++ b/test/fs/macro-subpath.exp
@@ -8,15 +8,15 @@ spawn $env(SHELL)
 match_max 100000
 
 set macros [ dict create \
-	"DESKTOP"     "$::env(HOME)/Desktop" \
-	"DOCUMENTS"   "$::env(HOME)/Documents" \
-	"DOWNLOADS"   "$::env(HOME)/Downloads" \
-	"MUSIC"       "$::env(HOME)/Music" \
-	"PICTURES"    "$::env(HOME)/Pictures" \
-	"PROJECTS"    "$::env(HOME)/Projects" \
-	"PUBLICSHARE" "$::env(HOME)/Public" \
-	"TEMPLATES"   "$::env(HOME)/Templates" \
-	"VIDEOS"      "$::env(HOME)/Videos" \
+	"DESKTOP"     "$::env(XDG_DESKTOP_DIR)" \
+	"DOCUMENTS"   "$::env(XDG_DOCUMENTS_DIR)" \
+	"DOWNLOADS"   "$::env(XDG_DOWNLOAD_DIR)" \
+	"MUSIC"       "$::env(XDG_MUSIC_DIR)" \
+	"PICTURES"    "$::env(XDG_PICTURES_DIR)" \
+	"PROJECTS"    "$::env(XDG_PROJECTS_DIR)" \
+	"PUBLICSHARE" "$::env(XDG_PUBLICSHARE_DIR)" \
+	"TEMPLATES"   "$::env(XDG_TEMPLATES_DIR)" \
+	"VIDEOS"      "$::env(XDG_VIDEOS_DIR)" \
 ]
 
 # Test that macros work with subpaths (see #2359).

--- a/test/fs/macro.exp
+++ b/test/fs/macro.exp
@@ -8,15 +8,15 @@ spawn $env(SHELL)
 match_max 100000
 
 set macros [ dict create \
-	"DESKTOP"     "$::env(HOME)/Desktop" \
-	"DOCUMENTS"   "$::env(HOME)/Documents" \
-	"DOWNLOADS"   "$::env(HOME)/Downloads" \
-	"MUSIC"       "$::env(HOME)/Music" \
-	"PICTURES"    "$::env(HOME)/Pictures" \
-	"PROJECTS"    "$::env(HOME)/Projects" \
-	"PUBLICSHARE" "$::env(HOME)/Public" \
-	"TEMPLATES"   "$::env(HOME)/Templates" \
-	"VIDEOS"      "$::env(HOME)/Videos" \
+	"DESKTOP"     "$::env(XDG_DESKTOP_DIR)" \
+	"DOCUMENTS"   "$::env(XDG_DOCUMENTS_DIR)" \
+	"DOWNLOADS"   "$::env(XDG_DOWNLOAD_DIR)" \
+	"MUSIC"       "$::env(XDG_MUSIC_DIR)" \
+	"PICTURES"    "$::env(XDG_PICTURES_DIR)" \
+	"PROJECTS"    "$::env(XDG_PROJECTS_DIR)" \
+	"PUBLICSHARE" "$::env(XDG_PUBLICSHARE_DIR)" \
+	"TEMPLATES"   "$::env(XDG_TEMPLATES_DIR)" \
+	"VIDEOS"      "$::env(XDG_VIDEOS_DIR)" \
 ]
 
 # Test that macros work.


### PR DESCRIPTION
This should ensure that the tests work even if custom XDG user
directories are used (such as when set in `~/.config/user-dirs.dirs`).

The tests should work even if the relevant environment variables are
empty (or set to `$HOME`), though note that the setup commands in
test/fs/fs.sh likely still have to be executed before the .exp files are
executed.

Relates to #7147 #7163.