### PR TITLE
modif: disable FUSE symlink following in `disable_file()`

### DIFF
--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -68,7 +68,7 @@ static int disable_file(OPERATION op, const char *filename) {
 		// realpath and stat functions will fail on FUSE filesystems
 		// they don't seem to like a uid of 0
 		// force mounting
-		int fd = open(filename, O_PATH|O_CLOEXEC);
+		int fd = open(filename, O_PATH|O_NOFOLLOW|O_CLOEXEC);
 		if (fd < 0)
 			return 1;
 


### PR DESCRIPTION
When `realpath()` fails with `EACCES` on a FUSE filesystem, `disable_file()` falls back to opening the path with `open(filename, O_PATH|O_CLOEXEC)` **without** `O_NOFOLLOW`. The resulting fd is then passed to `bind_mount_path_to_fd()` which performs a root-privileged bind mount. An attacker who can place a symlink on a FUSE filesystem pointing to a system file (e.g., `/etc/shadow`) would have that file's bind mount handled at the attacker's direction.

Impact: Local denial of service against arbitrary system files; potential contribution to sandbox escape by disrupting security mechanism files.

Fix: Add `O_NOFOLLOW` to the `open()` flags so that symlinks are not followed in the FUSE fallback path. If the path is a symlink, `open()` returns `-ELOOP` and the function safely returns with error code 1.