### PR TITLE
modif: add backtick in `reject_meta_chars()`

### DIFF
--- a/src/lib/common.c
+++ b/src/lib/common.c
@@ -489,9 +489,9 @@ void reject_meta_chars(const char *fname, int globbing) {
 
 	reject_cntrl_chars(fname);
 
-	const char *reject = "\\&!?\"<>%^{};,*[]";
+	const char *reject = "\\&!?\"<>%^{};,*[]`";
 	if (globbing)
-		reject = "\\&!\"<>%^{};,"; // file globbing ('*?[]') is allowed
+		reject = "\\&!\"<>%^{};,`"; // file globbing ('*?[]') is allowed
 
 	const char *c = strpbrk(fname, reject);
 	if (c) {


### PR DESCRIPTION
The `reject_meta_chars()` function validates filenames by rejecting shell metacharacters. The rejected character set is `\&!?\"<>%^{};,*[]` (regular) and `\&!\"<>%^{};,` (globbing). The backtick character `` ` `` is **not** rejected in either set. Since `reject_meta_chars()` validates paths that may later reach `system()`, `popen()`, or other shell expansion contexts, an unescaped backtick in a filename or path could allow command injection.

Impact: Potential shell command injection if a validated path containing backticks is later passed to a shell function. Severity depends on whether validated paths ever reach shell evaluation, but the omission is a clear gap in input validation.

Fix: Added `` ` `` to both reject strings (regular and globbing modes), ensuring backtick characters are rejected during filename validation.