### PR TITLE
bugfix: use `O_NOFOLLOW` in sbox helper exec

### DIFF
--- a/src/firejail/sbox.c
+++ b/src/firejail/sbox.c
@@ -241,7 +241,7 @@ static int __attribute__((noreturn)) sbox_do_exec_v(unsigned filtermask, char * 
 	else assert(0);
 
 	if (arg[0]) { // get rid of scan-build warning
-		int fd = open(arg[0], O_PATH | O_CLOEXEC);
+		int fd = open(arg[0], O_PATH | O_NOFOLLOW | O_CLOEXEC);
 		if (fd == -1) {
 			if (errno == ENOENT) {
 				fprintf(stderr, "Error: %s does not exist\n", arg[0]);


### PR DESCRIPTION
When executing helper programs with root privileges via `sbox_run()` or `sbox_run_root()`, the `sbox.c` helper opens the executable path with `open(arg[0], O_PATH | O_CLOEXEC)` without `O_NOFOLLOW`. While ownership (uid=0, gid=0) and writability are verified via `fstat()` on the opened fd, a TOCTOU window exists between `open()` and `fstat()`. If `arg[0]` is a symlink that an attacker can swap, the `open()` could follow the symlink to a different file before `fstat()` runs.

Impact: The check after `fstat()` mitigates most risk (only root-owned, non-world-writable files can execute), but an attacker with root-owned file creation capabilities could potentially use this to redirect execution. Adding `O_NOFOLLOW` closes the window and follows the principle of least privilege.

Fix: Added `O_NOFOLLOW` to the `open()` flags so symlinks are never followed when opening helper executables.