### PR TITLE
bugfix: fix some TOCTOU race conditions

### DIFF
--- a/src/firejail/fs.c
+++ b/src/firejail/fs.c
@@ -354,9 +354,11 @@ void fs_blacklist(void) {
 			// EUID_ROOT(); - option not accessible to non-root users
 			if (mount(dname1, dname2, NULL, MS_BIND|MS_REC, NULL) < 0)
 				errExit("mount bind");
-			/* coverity[toctou] */
-			if (set_perms(dname2,  s.st_uid, s.st_gid,s.st_mode))
-				errExit("set_perms");
+			int perms_fd = open(dname2, O_RDONLY|O_NOFOLLOW|O_CLOEXEC);
+			if (perms_fd < 0)
+				errExit("open");
+			SET_PERMS_FD(perms_fd, s.st_uid, s.st_gid, s.st_mode);
+			close(perms_fd);
 			// EUID_USER();
 
 			entry = entry->next;

--- a/src/firejail/fs_var.c
+++ b/src/firejail/fs_var.c
@@ -125,11 +125,15 @@ void fs_var_log(void) {
 		release_all();
 
 		// create an empty /var/log/wtmp file
-		/* coverity[toctou] */
-		FILE *fp = fopen("/var/log/wtmp", "wxe");
-		if (fp) {
-			SET_PERMS_STREAM(fp, 0, wtmp_group, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
-			fclose(fp);
+		int wtmp_fd = open("/var/log/wtmp", O_WRONLY|O_CREAT|O_EXCL|O_TRUNC|O_CLOEXEC|O_NOFOLLOW, 0644);
+		if (wtmp_fd >= 0) {
+			FILE *fp = fdopen(wtmp_fd, "we");
+			if (fp) {
+				SET_PERMS_STREAM(fp, 0, wtmp_group, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
+				fclose(fp);
+			}
+			else
+				close(wtmp_fd);
 		}
 		fs_logger("touch /var/log/wtmp");
 
@@ -272,10 +276,12 @@ void fs_var_utmp(void) {
 	if (arg_debug)
 		printf("Create the new utmp file\n");
 
-	/* coverity[toctou] */
-	FILE *fp = fopen(RUN_UTMP_FILE, "we");
+	int utmp_fd = open(RUN_UTMP_FILE, O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC|O_NOFOLLOW, 0644);
+	if (utmp_fd < 0)
+		errExit("open");
+	FILE *fp = fdopen(utmp_fd, "we");
 	if (!fp)
-		errExit("fopen");
+		errExit("fdopen");
 
 	// read current utmp
 	struct utmp *u;

--- a/src/firejail/restrict_users.c
+++ b/src/firejail/restrict_users.c
@@ -173,10 +173,14 @@ static void sanitize_passwd(void) {
 	FILE *fpout = NULL;
 
 	// open files
-	/* coverity[toctou] */
-	fpin = fopen("/etc/passwd", "re");
-	if (!fpin)
+	int pfd = open("/etc/passwd", O_RDONLY|O_NOFOLLOW|O_CLOEXEC);
+	if (pfd < 0)
 		goto errout;
+	fpin = fdopen(pfd, "re");
+	if (!fpin) {
+		close(pfd);
+		goto errout;
+	}
 	fpout = fopen(RUN_PASSWD_FILE, "we");
 	if (!fpout)
 		goto errout;
@@ -313,10 +317,14 @@ static void sanitize_group(void) {
 	FILE *fpout = NULL;
 
 	// open files
-	/* coverity[toctou] */
-	fpin = fopen("/etc/group", "re");
-	if (!fpin)
+	int gfd = open("/etc/group", O_RDONLY|O_NOFOLLOW|O_CLOEXEC);
+	if (gfd < 0)
 		goto errout;
+	fpin = fdopen(gfd, "re");
+	if (!fpin) {
+		close(gfd);
+		goto errout;
+	}
 	fpout = fopen(RUN_GROUP_FILE, "we");
 	if (!fpout)
 		goto errout;


### PR DESCRIPTION
The codebase contains 11 documented TOCTOU race conditions marked with `/* coverity[toctou] */` annotations. These have been acknowledged by Coverity and developers but remain unpatched. 5 of the most impactful instances are fixed here.

## Instance 1: `/etc/passwd` opening (`restrict_users.c:176`)
After an `is_link("/etc/passwd")` check at line 167, the file is opened with `fopen("/etc/passwd", "re")`. Between the check and the open, an attacker with write access could replace `/etc/passwd` with a symlink.

Fix: Use `open("/etc/passwd", O_RDONLY|O_NOFOLLOW|O_CLOEXEC)` followed by `fdopen()` to atomically verify the path is not a symlink at open time. The same pattern applies to instance 2.

## Instance 2: `/etc/group` opening (`restrict_users.c:316`)
Same pattern as Instance 1 for `/etc/group`.

Fix: Same `open(O_NOFOLLOW) + fdopen()` pattern.

## Instance 3: `/var/log/wtmp` creation (`fs_var.c:128`)
Between the mount of a tmpfs on `/var/log` and the `fopen("/var/log/wtmp", "wxe")` call, the `/var/log/wtmp` path could theoretically be replaced (low risk since on fresh tmpfs, but still a documented TOCTOU).

Fix: Use `open(O_WRONLY|O_CREAT|O_EXCL|O_TRUNC|O_CLOEXEC|O_NOFOLLOW)` followed by `fdopen()`.

## Instance 4: `RUN_UTMP_FILE` opening (`fs_var.c:275`)
Inside `fs_var_utmp()`, a utmp file is opened with `fopen(RUN_UTMP_FILE, "we")`. If the path under `/run/firejail/mnt/` has been replaced with a symlink, follower could redirect the write.

Fix: Use `open(O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC|O_NOFOLLOW)` followed by `fdopen()`.

## Instance 5: `set_perms` after bind mount (`fs.c:357`)
After `mount()` performs a bind mount, `set_perms(dname2, ...)` uses path-based `chmod()`/`chown()` on `dname2`. The target of the mount could be swapped between the mount and the `set_perms()` call.

Fix: Open `dname2` with `O_RDONLY|O_NOFOLLOW|O_CLOEXEC` to get an fd, then use `SET_PERMS_FD()` which calls `fchmod()`/`fchown()` on the fd. This eliminates the race window.

## Unfixed Instances
6 remaining TOCTOU instances exist in `fs_hostname.c:91`, `fs_mkdir.c:56`, `join.c:496`, `sandbox.c:1140`, `util.c:1040`, `util.c:1061`. These involve race conditions in home directory chdir, mkdir, and file creation operations. The `util.c` instances have partial mitigation via EEXIST handling but still lack full symlink protection.