### PR TITLE
modif: add more metachars in `reject_meta_chars()`

### DIFF
--- a/src/lib/common.c
+++ b/src/lib/common.c
@@ -484,8 +484,15 @@ void reject_cntrl_chars(const char *fname) {
 	}
 }
 
+// Note: Characters intentionally ignored:
+//
+// * `'`: Used in some dirnames (see #4614).
+// * `()`: Used in some dirnames (see #3001 #3156).
+// * `~`: Might be useful for expansion and seems unlikely to cause problems by
+//        itself.
 #ifndef METACHARS
-#define METACHARS "!\"%&,;<>\\^`{}"
+// All metachars except for ignored chars and chars in other groups.
+#define METACHARS "!\"#$%&',;<>\\^`{|}"
 #endif
 #ifndef GLOBCHARS
 #define GLOBCHARS "*?[]"

--- a/src/lib/common.c
+++ b/src/lib/common.c
@@ -484,14 +484,23 @@ void reject_cntrl_chars(const char *fname) {
 	}
 }
 
+#ifndef METACHARS
+#define METACHARS "!\"%&,;<>\\^`{}"
+#endif
+#ifndef GLOBCHARS
+#define GLOBCHARS "*?[]"
+#endif
+
 void reject_meta_chars(const char *fname, int globbing) {
 	assert(fname);
 
 	reject_cntrl_chars(fname);
 
-	const char *reject = "!\"%&*,;<>?[\\]^`{}";
-	if (globbing)
-		reject = "!\"%&,;<>\\^`{}"; // file globbing ('*?[]') is allowed
+	const char *reject = METACHARS GLOBCHARS;
+	if (globbing) {
+		// file globbing is allowed
+		reject = METACHARS;
+	}
 
 	const char *c = strpbrk(fname, reject);
 	if (c) {

--- a/src/lib/common.c
+++ b/src/lib/common.c
@@ -489,9 +489,9 @@ void reject_meta_chars(const char *fname, int globbing) {
 
 	reject_cntrl_chars(fname);
 
-	const char *reject = "\\&!?\"<>%^{};,*[]`";
+	const char *reject = "!\"%&*,;<>?[\\]^`{}";
 	if (globbing)
-		reject = "\\&!\"<>%^{};,`"; // file globbing ('*?[]') is allowed
+		reject = "!\"%&,;<>\\^`{}"; // file globbing ('*?[]') is allowed
 
 	const char *c = strpbrk(fname, reject);
 	if (c) {


### PR DESCRIPTION

Add:

* `#$|`

Ignore:

* `'()~`

Note: `,` does not appear to be a metacharacter, but it (and `%`) are
checked in test/fcopy/cmdline.exp.  I'm not sure if they matter for
fcopy, so they are left as is.

Misc: `$` was suggested by @rusty-snake[1].

This is a follow-up to #7183.

Relates to #3001 #3156 #4614.

[1] https://github.com/netblue30/firejail/pull/7183#issuecomment-4709569497