### PR TITLE
ci: dependabot: split and group codeql actions to fix checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,29 @@
 version: 2
 updates:
+  # Note: Grouping is used to ensure that all CodeQL actions are updated
+  # together in the same PR, to avoid CodeQL checks failing due to version
+  # mismatches (see #7192).
+
+  # CodeQL
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 4
+    groups:
+      codeql-actions:
+        patterns:
+          - "github/codeql-action/*"
+
+  # Other
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 4
+    groups:
+      other-actions:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "github/codeql-action/*"


### PR DESCRIPTION
Dependabot used to update all CodeQL actions at once ("bump
github/codeql-action") in the same PR.  For example:

* PR #7178: build(deps): bump github/codeql-action from 4.35.2 to 4.36.0

Now it started updating each CodeQL action in a separate PR:

* PR #7189: build(deps): bump github/codeql-action/init from 4.36.0 to 4.36.2
* PR #7191: build(deps): bump github/codeql-action/analyze from 4.36.0 to 4.36.2

This breaks CI due to version mismatches, as the CI job runs with one
action using the new version and the other one using the old version.

Use grouping to ensure that all CodeQL actions are always updated
together in the same PR.

From #7189[1]:

    ##[group]Run github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
    [...]
    ##[endgroup]
    ##[group]Validating workflow
    ##[warning]1 issue was detected with this workflow: Not all workflow steps that use `github/codeql-action` actions use the same version. Please ensure that all such steps use the same version to avoid compatibility issues.
    ##[endgroup]
    [...]
    ##[group]Run github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa
    [...]
    ##[endgroup]
    ##[error]Loaded a configuration file for version '4.36.2', but running version '4.36.0'
    Post job cleanup.
    ##[error]analyze post-action step failed: Loaded a configuration file for version '4.36.2', but running version '4.36.0'
    Post job cleanup.

From #7191[2]:

    ##[group]Run github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa
    [...]
    ##[endgroup]
    ##[group]Validating workflow
    ##[warning]1 issue was detected with this workflow: Not all workflow steps that use `github/codeql-action` actions use the same version. Please ensure that all such steps use the same version to avoid compatibility issues.
    ##[endgroup]
    [...]
    ##[group]Run github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
    [...]
    ##[endgroup]
    ##[error]Loaded a configuration file for version '4.36.0', but running version '4.36.2'
    Post job cleanup.
    ##[error]analyze post-action step failed: Loaded a configuration file for version '4.36.0', but running version '4.36.2'
    Post job cleanup.

[1] https://github.com/netblue30/firejail/actions/runs/28497938236/job/84468173598?pr=7189
[2] https://github.com/netblue30/firejail/actions/runs/28497950609/job/84468212940?pr=7191