### PR TITLE
ci: build: replace ubuntu-22.04 with ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
     - name: Harden Runner


### PR DESCRIPTION
The main build job already installs no dependencies and uses the default
system compiler, so use the default runner image as well to avoid having
to update it.

This build should keep working fine regardless of the software versions
used since the codebase is basically C89/C99 and
`--enable-fatal-warnings` is not used here.

Relevant software changes:

* ubuntu-22.04 -> ubuntu-24.04
* gcc 11.4.0 -> 13.2.0

Related commits:

* dbf4b9a22 ("ci: drop apt dependencies from main build", 2025-01-18) /
  PR #6864
* 692322b63 ("ci: update clang-14 to clang-18 (#7203)", 2026-07-19)

See also:

* https://github.com/actions/runner-images/blob/releases/ubuntu22/20260705/images/ubuntu/Ubuntu2204-Readme.md
* https://github.com/actions/runner-images/blob/releases/ubuntu24/20260705/images/ubuntu/Ubuntu2404-Readme.md