### PR TITLE
profiles: llm-agent-common: disable private-cache

### DIFF
--- a/etc/profile-a-l/llm-agent-common.profile
+++ b/etc/profile-a-l/llm-agent-common.profile
@@ -49,7 +49,6 @@ seccomp
 seccomp.block-secondary
 
 disable-mnt
-private-cache
 private-dev
 private-etc @network,@tls-ca
 private-tmp


### PR DESCRIPTION
This is a follow-up on my previous multiple PRs for adding profiles of coding agents.

Working with them in the past couple of months, I have allowed some `.cache` access in my `.local` file like this:
```
whitelist ${HOME}/.cache/go-build
whitelist ${HOME}/.cache/huggingface
```

I think it's better for coding agents to access `.cache` by default, therefore this PR.

Also note to myself in future, keep in mind that `disable-programs.inc` already disables accessing many sensitive `.cache` directories like browsers' caches, so with removing `private-cache`, firejail still protects browsers' caches.

Relates to #7158.