### PR TITLE
bugfix: disable /run/systemd/resolve with net=none

### DIFF
--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -2247,6 +2247,7 @@ int main(int argc, char **argv, char **envp) {
 			cfg.interface1.configured = 0;
 			cfg.interface2.configured = 0;
 			cfg.interface3.configured = 0;
+			profile_add("blacklist /run/systemd/resolve");
 			continue;
 		}
 #ifdef HAVE_NETWORK

--- a/src/firejail/profile.c
+++ b/src/firejail/profile.c
@@ -684,6 +684,7 @@ int profile_check_line(char *ptr, int lineno, const char *fname) {
 		cfg.interface1.configured = 0;
 		cfg.interface2.configured = 0;
 		cfg.interface3.configured = 0;
+		profile_add("blacklist /run/systemd/resolve");
 		return 0;
 	}
 	else if (strncmp(ptr, "net ", 4) == 0) {


### PR DESCRIPTION
From @michelesr[1]:

> I've noticed that some programs (like Wine for example) tend to use
> `/var/run/systemd/resolve/io.systemd.Resolve` (a varlink socket AFAIK)
> to talk to systemd-resolved and resolve domain names and this works when
> `net none` is used.

Just blacklist the directory for now as a quick fix.

Closes #7209.

[1] https://github.com/netblue30/firejail/issues/7209#issue-4924009444

Reported-by: @michelesr