### PR TITLE
build: test: fix cleaning of some temporary files

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -18,10 +18,10 @@ clean:
 	$(RM) environment/index.html*
 	$(RM) environment/logfile*
 	$(RM) environment/wget-log*
-	$(RM) test/chroot/unchroot
-	$(RM) test/fcopy/src/dircopy.exp
-	$(RM) test/fnetfilter/outfile
-	$(RM) test/fnettrace/index.html
+	$(RM) chroot/unchroot
+	$(RM) fcopy/src/dircopy.exp
+	$(RM) fnetfilter/outfile
+	$(RM) fnettrace/index.html
 	$(RM) utils/firejail-test-file*
 	$(RM) utils/index.html*
 	$(RM) utils/lstesting

--- a/test/Makefile
+++ b/test/Makefile
@@ -15,10 +15,10 @@ $(TESTS):
 clean:
 	for test in $(TESTS); do $(RM) "$$test/$$test.log"; done
 	$(RM) -r environment/-testdir
+	$(RM) chroot/unchroot
 	$(RM) environment/index.html*
 	$(RM) environment/logfile*
 	$(RM) environment/wget-log*
-	$(RM) chroot/unchroot
 	$(RM) fcopy/src/dircopy.exp
 	$(RM) fnetfilter/outfile
 	$(RM) fnettrace/index.html


### PR DESCRIPTION
Remove the extraneous "test/" prefix on some paths.

This amends commit f9cc7b24e ("build: move cleaning of test files to
test/Makefile", 2026-01-17).