### PR TITLE
bugfix: fbwrap: wait for target and propagate exit code

### DIFF
--- a/src/fbwrap/main.c
+++ b/src/fbwrap/main.c
@@ -154,9 +154,8 @@ int main(int argc, char **argv) {
 		_exit(127); // 127: standard "command not found/not executable" status
 	}
 
-	// wait for the target and propagate its exit status: callers (and the real
-	// bwrap that fbwrap stands in for) expect fbwrap to block until the child
-	// exits and to return the child's return code, not a fixed delay
+	// Note: Callers expect bwrap to block until the child exits and to
+	// return the child's exit status (see #7081).
 	int status;
 	while (waitpid(child, &status, 0) == -1) {
 		if (errno == EINTR)

--- a/src/fbwrap/main.c
+++ b/src/fbwrap/main.c
@@ -148,8 +148,9 @@ int main(int argc, char **argv) {
 		// kill the target if the parent dies
 		prctl(PR_SET_PDEATHSIG, SIGKILL, 0, 0, 0);
 		execvp(arglist[0], arglist);
+
 		// execvp only returns on failure
-		fprintf(stderr, "Error: fbwrap cannot execute %s\n", arglist[0]);
+		fprintf(stderr, "Error: fbwrap cannot execute %s: %s\n", arglist[0], strerror(errno));
 		_exit(127); // 127: standard "command not found/not executable" status
 	}
 
@@ -157,12 +158,11 @@ int main(int argc, char **argv) {
 	// bwrap that fbwrap stands in for) expect fbwrap to block until the child
 	// exits and to return the child's return code, not a fixed delay
 	int status;
-	pid_t rv;
-	do {
-		rv = waitpid(child, &status, 0);
-	} while (rv == -1 && errno == EINTR);
-	if (rv == -1) {
-		fprintf(stderr, "Error: fbwrap cannot wait for the target program\n");
+	while (waitpid(child, &status, 0) == -1) {
+		if (errno == EINTR)
+			continue;
+
+		fprintf(stderr, "Error: fbwrap cannot wait for %s: %s\n", arglist[0], strerror(errno));
 		exit(1);
 	}
 	if (WIFEXITED(status))

--- a/src/fbwrap/main.c
+++ b/src/fbwrap/main.c
@@ -18,6 +18,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #define _GNU_SOURCE
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -156,7 +157,11 @@ int main(int argc, char **argv) {
 	// bwrap that fbwrap stands in for) expect fbwrap to block until the child
 	// exits and to return the child's return code, not a fixed delay
 	int status;
-	if (waitpid(child, &status, 0) == -1) {
+	pid_t rv;
+	do {
+		rv = waitpid(child, &status, 0);
+	} while (rv == -1 && errno == EINTR);
+	if (rv == -1) {
 		fprintf(stderr, "Error: fbwrap cannot wait for the target program\n");
 		exit(1);
 	}

--- a/src/fbwrap/main.c
+++ b/src/fbwrap/main.c
@@ -25,6 +25,7 @@
 #include <sys/stat.h>
 //#include <linux/prctl.h>
 #include <sys/prctl.h>
+#include <sys/wait.h>
 #include <signal.h>
 
 // enable debug messages
@@ -146,15 +147,23 @@ int main(int argc, char **argv) {
 		// kill the target if the parent dies
 		prctl(PR_SET_PDEATHSIG, SIGKILL, 0, 0, 0);
 		execvp(arglist[0], arglist);
-		return 0;
+		// execvp only returns on failure
+		fprintf(stderr, "Error: fbwrap cannot execute %s\n", arglist[0]);
+		_exit(127); // 127: standard "command not found/not executable" status
 	}
 
-	// wait child to finish
-	//int status;
-	//waitpid(child, &status, 0);
+	// wait for the target and propagate its exit status: callers (and the real
+	// bwrap that fbwrap stands in for) expect fbwrap to block until the child
+	// exits and to return the child's return code, not a fixed delay
+	int status;
+	if (waitpid(child, &status, 0) == -1) {
+		fprintf(stderr, "Error: fbwrap cannot wait for the target program\n");
+		exit(1);
+	}
+	if (WIFEXITED(status))
+		return WEXITSTATUS(status);
+	if (WIFSIGNALED(status))
+		return 128 + WTERMSIG(status); // 128+signo: shell convention for signal death
 
-	// don't bother waiting
-	sleep(2);
-
-	return 0;
+	return 1;
 }

--- a/test/utils/fbwrap.exp
+++ b/test/utils/fbwrap.exp
@@ -9,17 +9,17 @@ match_max 100000
 
 # Check the target's exit status (see #7081).
 after 100
-send -- "fbwrap /usr/bin/false; echo ret $?\r"
-expect {
-	timeout {puts "TESTING ERROR 1\n";exit}
-	"ret 1"
-}
-
-after 100
 send -- "fbwrap /usr/bin/true; echo ret $?\r"
 expect {
 	timeout {puts "TESTING ERROR 2\n";exit}
 	"ret 0"
+}
+
+after 100
+send -- "fbwrap /usr/bin/false; echo ret $?\r"
+expect {
+	timeout {puts "TESTING ERROR 1\n";exit}
+	"ret 1"
 }
 
 # A target killed by a signal should return 128+signo (SIGTERM -> 143).

--- a/test/utils/fbwrap.exp
+++ b/test/utils/fbwrap.exp
@@ -16,10 +16,10 @@ expect {
 }
 
 after 100
-send -- "fbwrap /usr/bin/false; echo ret $?\r"
+send -- "fbwrap /bin/sh -c 'exit 10'; echo ret $?\r"
 expect {
 	timeout {puts "TESTING ERROR 1\n";exit}
-	"ret 1"
+	"ret 10"
 }
 
 # A target killed by a signal should return 128+signo (SIGTERM -> 143).

--- a/test/utils/fbwrap.exp
+++ b/test/utils/fbwrap.exp
@@ -7,29 +7,28 @@ set timeout 10
 spawn $env(SHELL)
 match_max 100000
 
-# fbwrap must wait for the target and propagate its exit status (#7081)
+# Check the target's exit status (see #7081).
 after 100
-send -- "fbwrap /usr/bin/false ; echo fbwrap-rc-$?\r"
+send -- "fbwrap /usr/bin/false; echo ret $?\r"
 expect {
 	timeout {puts "TESTING ERROR 1\n";exit}
-	"fbwrap-rc-1"
+	"ret 1"
 }
 
 after 100
-send -- "fbwrap /usr/bin/true ; echo fbwrap-rc-$?\r"
+send -- "fbwrap /usr/bin/true; echo ret $?\r"
 expect {
 	timeout {puts "TESTING ERROR 2\n";exit}
-	"fbwrap-rc-0"
+	"ret 0"
 }
 
-# a target killed by a signal is reported as 128+signo (SIGTERM -> 143)
+# A target killed by a signal should return 128+signo (SIGTERM -> 143).
 after 100
-send -- "fbwrap /bin/sh -c 'kill -TERM \$\$' ; echo fbwrap-rc-$?\r"
+send -- "fbwrap /bin/sh -c 'kill -TERM \$\$'; echo ret $?\r"
 expect {
 	timeout {puts "TESTING ERROR 3\n";exit}
-	"fbwrap-rc-143"
+	"ret 143"
 }
-
 
 after 100
 puts "\nall done\n"

--- a/test/utils/fbwrap.exp
+++ b/test/utils/fbwrap.exp
@@ -1,0 +1,35 @@
+#!/usr/bin/expect -f
+# This file is part of Firejail project
+# Copyright (C) 2014-2026 Firejail Authors
+# License GPL v2
+
+set timeout 10
+spawn $env(SHELL)
+match_max 100000
+
+# fbwrap must wait for the target and propagate its exit status (#7081)
+after 100
+send -- "fbwrap /usr/bin/false ; echo fbwrap-rc-$?\r"
+expect {
+	timeout {puts "TESTING ERROR 1\n";exit}
+	"fbwrap-rc-1"
+}
+
+after 100
+send -- "fbwrap /usr/bin/true ; echo fbwrap-rc-$?\r"
+expect {
+	timeout {puts "TESTING ERROR 2\n";exit}
+	"fbwrap-rc-0"
+}
+
+# a target killed by a signal is reported as 128+signo (SIGTERM -> 143)
+after 100
+send -- "fbwrap /bin/sh -c 'kill -TERM \$\$' ; echo fbwrap-rc-$?\r"
+expect {
+	timeout {puts "TESTING ERROR 3\n";exit}
+	"fbwrap-rc-143"
+}
+
+
+after 100
+puts "\nall done\n"

--- a/test/utils/utils.sh
+++ b/test/utils/utils.sh
@@ -136,5 +136,8 @@ echo "TESTING: firemon version (test/utils/firemon-version.exp)"
 echo "TESTING: firemon name (test/utils/firemon-name.exp)"
 ./firemon-name.exp
 
+echo "TESTING: fbwrap (test/utils/fbwrap.exp)"
+./fbwrap.exp
+
 cd ../../
 ./mkgcov.sh


### PR DESCRIPTION
## Problem

`fbwrap` (the bwrap replacement used inside the sandbox with `--allow-bwrap`)
forked the target program and then, instead of waiting for it:

```c
// don't bother waiting
sleep(2);
return 0;
```

Consequences:
- a fixed **2-second delay** on every invocation (the extra delay reported for
  xfce4 apps and geeqie);
- the child's **exit status is discarded** — `fbwrap` always returned `0`;
- any program still running after 2s is **killed** via `PR_SET_PDEATHSIG` when
  `fbwrap` returns.

## Fix

Wait for the child with `waitpid()` and return its exit status (`128+signo`
when it is killed by a signal), matching the real `bwrap` it stands in for.
Also `_exit(127)` when `execvp()` fails instead of returning `0`.

## Test verification (RED → GREEN)

New test `test/utils/fbwrap.exp` (wired into `test/utils/utils.sh`) asserts the
exit code is propagated, for a clean exit, a non-zero exit, and signal death.

RED (unmodified `master`, which does `sleep(2); return 0`):

```
$ fbwrap /usr/bin/false ; echo fbwrap-rc-$?
fbwrap-rc-0            # wrong: should be 1
# timing: ~2.003s      # fixed sleep
# fbwrap.exp -> "TESTING ERROR 1"
```

GREEN (with this patch):

```
$ fbwrap /usr/bin/false ; echo fbwrap-rc-$?
fbwrap-rc-1                              # correct, no fixed delay (~0.003s)
$ fbwrap /usr/bin/true ; echo fbwrap-rc-$?
fbwrap-rc-0
$ fbwrap /bin/sh -c 'kill -TERM $$' ; echo fbwrap-rc-$?
fbwrap-rc-143                            # 128 + SIGTERM(15)
# fbwrap.exp -> "all done"
```

Full build is clean (`-Wall -Wextra`, no new warnings).

Fixes #7081
