### PR TITLE
bugfix: mountinfo: handle lines longer than 4096 bytes

### DIFF
--- a/src/firejail/mountinfo.c
+++ b/src/firejail/mountinfo.c
@@ -239,8 +239,8 @@ char **build_mount_array(const int mountid, const char *path) {
 	int found = 0;
 	MountData mntp;
 	char *line = NULL;
-	size_t line_size = 0;
-	while (getline(&line, &line_size, fp) != -1) {
+	size_t line_sz = 0;
+	while (getline(&line, &line_sz, fp) != -1) {
 		parse_line(line, &mntp);
 		if (mntp.mountid == mountid) {
 			found = 1;
@@ -268,7 +268,7 @@ char **build_mount_array(const int mountid, const char *path) {
 
 	// and add all following mountpoints contained in this directory
 	size_t pathlen = strlen(path);
-	while (getline(&line, &line_size, fp) != -1) {
+	while (getline(&line, &line_sz, fp) != -1) {
 		parse_line(line, &mntp);
 		if (strncmp(mntp.dir, path, pathlen) == 0 && mntp.dir[pathlen] == '/') {
 			if (++cnt == size) {

--- a/src/firejail/mountinfo.c
+++ b/src/firejail/mountinfo.c
@@ -143,11 +143,12 @@ MountData *get_last_mount(void) {
 	// go to the last line
 	while (getline(&mbuf, &mbuf_sz, fp) != -1);
 
-	fclose(fp);
-	if (mbuf == NULL) {
+	if (ferror(fp)) {
 		fprintf(stderr, "Error: cannot read /proc/self/mountinfo\n");
-		exit(1);
+		errExit("getline");
 	}
+	fclose(fp);
+
 	if (arg_debug)
 		printf("%s", mbuf);
 
@@ -248,6 +249,11 @@ char **build_mount_array(const int mountid, const char *path) {
 		}
 	}
 
+	if (ferror(fp)) {
+		fprintf(stderr, "Error: cannot read /proc/self/mountinfo\n");
+		errExit("getline");
+	}
+
 	if (!found) {
 		free(line);
 		fclose(fp);
@@ -282,6 +288,12 @@ char **build_mount_array(const int mountid, const char *path) {
 				errExit("strdup");
 		}
 	}
+
+	if (ferror(fp)) {
+		fprintf(stderr, "Error: cannot read /proc/self/mountinfo\n");
+		errExit("getline");
+	}
+
 	free(line);
 	fclose(fp);
 

--- a/src/firejail/mountinfo.c
+++ b/src/firejail/mountinfo.c
@@ -28,8 +28,13 @@
 
 #define MAX_BUF 4096
 
-static MountData mdata;
+// Note: mountinfo lines can be over 4096 bytes long (e.g. an overlayfs mount
+// with many lowerdirs or Docker overlays; see #6450), so grow the buffer as
+// needed (e.g. with getline).
+static char *mbuf = NULL;
+static size_t mbuf_sz = 0;
 
+static MountData mdata;
 
 // Convert octal escape sequence to decimal value
 static unsigned read_oct(char *s) {
@@ -135,22 +140,18 @@ MountData *get_last_mount(void) {
 		errExit("fopen");
 	}
 
-	// go to the last line; mountinfo lines can be arbitrarily long (e.g. an
-	// overlayfs mount with many lowerdirs), so grow the buffer as needed.
-	// The buffer is static because the returned MountData points into it.
-	static char *line = NULL;
-	static size_t line_size = 0;
-	while (getline(&line, &line_size, fp) != -1)
-		;
+	// go to the last line
+	while (getline(&mbuf, &mbuf_sz, fp) != -1);
+
 	fclose(fp);
-	if (line == NULL) {
+	if (mbuf == NULL) {
 		fprintf(stderr, "Error: cannot read /proc/self/mountinfo\n");
 		exit(1);
 	}
 	if (arg_debug)
-		printf("%s", line);
+		printf("%s", mbuf);
 
-	parse_line(line, &mdata);
+	parse_line(mbuf, &mdata);
 
 	if (arg_debug)
 		printf("mountid=%d fsname=%s dir=%s fstype=%s\n", mdata.mountid, mdata.fsname, mdata.dir, mdata.fstype);

--- a/src/firejail/mountinfo.c
+++ b/src/firejail/mountinfo.c
@@ -28,7 +28,6 @@
 
 #define MAX_BUF 4096
 
-static char mbuf[MAX_BUF];
 static MountData mdata;
 
 
@@ -78,13 +77,6 @@ static void parse_line(char *line, MountData *output) {
 	//		output.fsname: /
 	//		output.dir: /home/netblue/.cache
 	//		output.fstype: tmpfs
-
-	size_t linelen = strlen(line);
-	if (linelen >= MAX_BUF - 1) {
-		fprintf(stderr, "Error: /proc/self/mountinfo line is too long and may be truncated (%zu >= %d): %s\n",
-		        linelen, MAX_BUF - 1, line);
-		exit(1);
-	}
 
 	char *orig_line = strdup(line);
 	char *ptr = strtok(line, " ");
@@ -143,14 +135,22 @@ MountData *get_last_mount(void) {
 		errExit("fopen");
 	}
 
-	mbuf[0] = '\0';
-	// go to the last line
-	while (fgets(mbuf, MAX_BUF, fp));
+	// go to the last line; mountinfo lines can be arbitrarily long (e.g. an
+	// overlayfs mount with many lowerdirs), so grow the buffer as needed.
+	// The buffer is static because the returned MountData points into it.
+	static char *line = NULL;
+	static size_t line_size = 0;
+	while (getline(&line, &line_size, fp) != -1)
+		;
 	fclose(fp);
+	if (line == NULL) {
+		fprintf(stderr, "Error: cannot read /proc/self/mountinfo\n");
+		exit(1);
+	}
 	if (arg_debug)
-		printf("%s", mbuf);
+		printf("%s", line);
 
-	parse_line(mbuf, &mdata);
+	parse_line(line, &mdata);
 
 	if (arg_debug)
 		printf("mountid=%d fsname=%s dir=%s fstype=%s\n", mdata.mountid, mdata.fsname, mdata.dir, mdata.fstype);
@@ -237,8 +237,9 @@ char **build_mount_array(const int mountid, const char *path) {
 	// try to find line with mount id
 	int found = 0;
 	MountData mntp;
-	char line[MAX_BUF];
-	while (fgets(line, MAX_BUF, fp)) {
+	char *line = NULL;
+	size_t line_size = 0;
+	while (getline(&line, &line_size, fp) != -1) {
 		parse_line(line, &mntp);
 		if (mntp.mountid == mountid) {
 			found = 1;
@@ -247,6 +248,7 @@ char **build_mount_array(const int mountid, const char *path) {
 	}
 
 	if (!found) {
+		free(line);
 		fclose(fp);
 		return NULL;
 	}
@@ -265,7 +267,7 @@ char **build_mount_array(const int mountid, const char *path) {
 
 	// and add all following mountpoints contained in this directory
 	size_t pathlen = strlen(path);
-	while (fgets(line, MAX_BUF, fp)) {
+	while (getline(&line, &line_size, fp) != -1) {
 		parse_line(line, &mntp);
 		if (strncmp(mntp.dir, path, pathlen) == 0 && mntp.dir[pathlen] == '/') {
 			if (++cnt == size) {
@@ -279,6 +281,7 @@ char **build_mount_array(const int mountid, const char *path) {
 				errExit("strdup");
 		}
 	}
+	free(line);
 	fclose(fp);
 
 	// end of array


### PR DESCRIPTION
## Summary

`get_last_mount()` and `build_mount_array()` in `src/firejail/mountinfo.c` read
`/proc/self/mountinfo` into a fixed 4096-byte buffer with `fgets()`.

An overlayfs mount created with the kernel `lowerdir+=` syntax (kernel ≥ 6.7)
can produce a single mountinfo line far longer than 4096 bytes. `fgets()` then
keeps only the trailing chunk of the last line, so `parse_line()` receives a
truncated fragment and firejail aborts — either with `cannot parse line from
/proc/self/mountinfo` or the length guard added in #6711.

The fix reads lines with `getline()` (dynamically grown buffer), so mountinfo
entries of any length are handled, and drops the now-obsolete truncation guard.
The `MountData` returned by `get_last_mount()` still points into a `static`
buffer, as before. Both exit paths of `build_mount_array()` free the buffer.

## Reproduce (end-to-end, needs root + kernel ≥ 6.7)

```sh
mkdir -p lower upper work mnt
for x in $(seq 0 120); do d=$(printf 'd%.0s' $(seq 30)); mkdir -p "lower/$d$x"; done
dirs=$(find lower -mindepth 1 -maxdepth 1 -type d | paste -sd, -)
sudo mount -t overlay overlay -o "lowerdir+=$dirs,upperdir=upper,workdir=work" mnt
firejail --noprofile bash        # aborts on the over-long mountinfo line
```

## Test verification (RED → GREEN)

A privileged overlayfs mount is required for the end-to-end trigger, so no unit
test is added (consistent with the rest of the sandbox test suite). The exact
read path was exercised with a standalone program against a crafted
`/proc/self/mountinfo` whose last (overlayfs) line is 6955 bytes.

RED — current code (`fgets` into `mbuf[4096]` + `parse_line`):
```
read 2861 bytes into mbuf (buffer cap 4095)   # only the trailing chunk
RESULT: parse FAILED (firejail would exit(1)) -- BUG
exit=1
```

GREEN — with this patch (`getline`):
```
read 6956 bytes (full line, no truncation)
RESULT: mountid=587 dir=/mnt fstype=overlay
OK
exit=0
```

## Full local suite

- `./configure && make -j` — builds clean, no new warnings (this is the CI build job).
- `make codespell` — clean on the changed file.
- The `make installcheck` `test/**/*.exp` sandbox suites require root + user
  namespaces (SUID sandbox) and were not run locally; they exercise no mountinfo
  line-length behavior. CI runs them under `sudo`.

Fixes #6450
