### PR TITLE
bugfix: fbuilder: skip filenames with metacharacters

### DIFF
--- a/src/fbuilder/filedb.c
+++ b/src/fbuilder/filedb.c
@@ -54,6 +54,12 @@ FileDB *filedb_find(FileDB *head, const char *fname) {
 FileDB *filedb_add(FileDB *head, const char *fname) {
 	assert(fname);
 
+	// don't add paths with characters firejail rejects in filenames (#4592):
+	// they would produce whitelist entries firejail refuses to load. Globbing
+	// is allowed in whitelist entries, so only METACHARS are rejected here.
+	if (strpbrk(fname, METACHARS))
+		return head;
+
 	// don't add it if it is already there or if the parent directory is already in the list
 	if (filedb_find(head, fname))
 		return head;

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -157,6 +157,16 @@ char *replace_cntrl_chars(const char *str, char c);
 char *escape_cntrl_chars(const char *str);
 int has_cntrl_chars(const char *str);
 void reject_cntrl_chars(const char *fname);
+// Characters rejected by reject_meta_chars() in filenames.
+//
+// Note: Characters intentionally ignored:
+//
+// * `'`: Used in some dirnames (see #4614).
+// * `()`: Used in some dirnames (see #3001 #3156).
+// * `~`: Might be useful for expansion and seems unlikely to cause problems by
+//        itself.
+#define METACHARS "!\"#$%&',;<>\\^`{|}"
+#define GLOBCHARS "*?[]"
 void reject_meta_chars(const char *fname, int globbing);
 void warn_dumpable(void);
 const char *gnu_basename(const char *path);

--- a/src/lib/common.c
+++ b/src/lib/common.c
@@ -484,20 +484,7 @@ void reject_cntrl_chars(const char *fname) {
 	}
 }
 
-// Note: Characters intentionally ignored:
-//
-// * `'`: Used in some dirnames (see #4614).
-// * `()`: Used in some dirnames (see #3001 #3156).
-// * `~`: Might be useful for expansion and seems unlikely to cause problems by
-//        itself.
-#ifndef METACHARS
-// All metachars except for ignored chars and chars in other groups.
-#define METACHARS "!\"#$%&',;<>\\^`{|}"
-#endif
-#ifndef GLOBCHARS
-#define GLOBCHARS "*?[]"
-#endif
-
+// METACHARS and GLOBCHARS are defined in common.h.
 void reject_meta_chars(const char *fname, int globbing) {
 	assert(fname);
 

--- a/test/utils/build.exp
+++ b/test/utils/build.exp
@@ -76,6 +76,21 @@ after 100
 send -- "rm -f ~/_firejail-test-file\r"
 after 100
 
+# #4592: a home file whose name contains a character firejail rejects in
+# filenames (here a comma) must not be emitted as a whitelist entry, otherwise
+# the generated profile fails to load.
+send -- "echo testing > ~/_firejail-test-file,x\r"
+after 100
+send -- "firejail --build cat ~/_firejail-test-file,x\r"
+expect {
+	timeout {puts "TESTING ERROR 9.1\n";exit}
+	-re {whitelist \$\{HOME\}/[^\r\n]*,} {puts "TESTING ERROR 9.2: invalid path with comma was whitelisted\n";exit}
+	"caps.drop all"
+}
+after 100
+send -- "rm -f ~/_firejail-test-file,x\r"
+after 100
+
 send -- "firejail --build cat /etc/passwd\r"
 expect {
 	timeout {puts "TESTING ERROR 10\n";exit}


### PR DESCRIPTION
## Summary

`firejail --build` records the files a traced program accesses and emits them
as `whitelist` entries. When an accessed path contains a character that
firejail rejects in filenames (e.g. a comma — as produced by nvim's
comma-joined `runtimepath`), the generated profile contains a line firejail
itself refuses to load, so the profile is unusable:

```
Error: ".../after,/..." is an invalid filename: rejected character: ","
```

Fix: skip such paths in `filedb_add()` — the single point all `build_*`
categories funnel through — so `--build` never generates profile lines
firejail cannot parse. Globbing is allowed in whitelist entries, so only
`METACHARS` are rejected (not `GLOBCHARS`). `METACHARS`/`GLOBCHARS` are moved
to `common.h` so fbuilder and the sandbox share one definition instead of
duplicating the reject list.

Fixes #4592.

## Reproduces with

On unmodified `master`, tracing a program that opens a home file whose name
contains a comma:

```
$ printf hi > ~/'data,file'
$ firejail --build cat ~/'data,file'
...
whitelist ${HOME}/data,file          <-- invalid: firejail rejects ','
...
$ firejail --profile=<that profile> /bin/true
Error: "/data,file" is an invalid filename: rejected character: ","
```

## Test verification (RED -> GREEN)

A regression case was added to `test/utils/build.exp` (create a comma-named
home file, run `--build`, assert no `whitelist ${HOME}/...,` line is emitted).

RED — committed test run against unmodified `master`:

```
TESTING ERROR 9.2: invalid path with comma was whitelisted
```

GREEN — same test on this branch (full `test/utils/build.exp`):

```
...
all done
```

Also verified end to end (build with `-Wall -Wextra -Werror`, then
`firejail --build` tracing both a normal and a comma-named home file):

```
normal file whitelisted:      yes   (still whitelisted -- no over-skipping)
comma file leaked to profile: no
profile load rejected char:   no
VERDICT: GREEN
```

Build is clean with `-Wall -Wextra -Werror`; `codespell` clean on the changed
files.
