### PR TITLE
Warn when an unknown syscall is passed to seccomp

### DIFF
--- a/src/lib/syscall.c
+++ b/src/lib/syscall.c
@@ -2618,6 +2618,12 @@ static void syscall_process_name(const char *name, int *syscall_nr, int *error_n
 		}
 	}
 
+	if (*syscall_nr == SYSCALL_ERROR) {
+		if (!arg_quiet && strcmp(syscall_name, "__dummy_syscall__") != 0) {
+			fprintf(stderr, "Warning: unknown syscall '%s'\n", syscall_name);
+		}
+	}
+
 	free(str);
 	return;
 


### PR DESCRIPTION
Fixes #7063

When an invalid or non-existent syscall name (such as newuname instead of uname) is passed to --seccomp=, the parser silently ignores it instead of warning the user. This creates a false sense of security where the user believes a syscall is allowed/blocked, but the rule is entirely dropped.

This commit adds a warning to syscall_process_name when syscall_find_name returns SYSCALL_ERROR, informing the user that the syscall is unknown. The warning respects arg_quiet and ignores the internally used __dummy_syscall__.
