### PR TITLE
profiles: keepassxc: add ~/.local/state/keepassxc

### DIFF
--- a/etc/inc/disable-programs.inc
+++ b/etc/inc/disable-programs.inc
@@ -1136,6 +1136,7 @@ blacklist ${HOME}/.local/share/xreader
 blacklist ${HOME}/.local/share/zathura
 blacklist ${HOME}/.local/state/ani-cli
 blacklist ${HOME}/.local/state/audacity
+blacklist ${HOME}/.local/state/keepassxc
 blacklist ${HOME}/.local/state/mpv
 blacklist ${HOME}/.local/state/opencode
 blacklist ${HOME}/.local/state/pipewire

--- a/etc/profile-a-l/keepassxc.profile
+++ b/etc/profile-a-l/keepassxc.profile
@@ -13,6 +13,7 @@ noblacklist ${HOME}/.cache/keepassxc
 noblacklist ${HOME}/.config/KeePassXCrc
 noblacklist ${HOME}/.config/keepassxc
 noblacklist ${HOME}/.keepassxc
+noblacklist ${HOME}/.local/state/keepassxc
 noblacklist ${RUNUSER}/app
 noblacklist ${RUNUSER}/openssh_agent
 noblacklist /tmp/ssh-*
@@ -64,9 +65,11 @@ include disable-xdg.inc
 #whitelist ${HOME}/.mozilla/native-messaging-hosts/org.keepassxc.keepassxc_browser.json
 #mkdir ${HOME}/.cache/keepassxc
 #mkdir ${HOME}/.config/keepassxc
+#mkdir ${HOME}/.local/state/keepassxc
 #whitelist ${HOME}/.cache/keepassxc
 #whitelist ${HOME}/.config/keepassxc
 #whitelist ${HOME}/.config/KeePassXCrc
+#whitelist ${HOME}/.local/state/keepassxc
 #include whitelist-common.inc
 
 mkdir ${RUNUSER}/app/org.keepassxc.KeePassXC


### PR DESCRIPTION
Keepassxc now uses XDG_STATE_HOME instead of XDG_CACHE_HOME for its application state.
See https://github.com/keepassxreboot/keepassxc/commit/509e218676cebc30c72f15234d900528bc5e06fe
