### PR TITLE
profiles: mpv: allow dbus mpris

### DIFF
--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -92,12 +92,8 @@ private-bin env,mpv,python*,waf,youtube-dl,yt-dlp
 #private-cache
 private-dev
 
-# If you use mpv-mpris you should add this to your mpv.local file
-#ignore dbus-user none
-#dbus-user filter
-#dbus-user.own org.mpris.MediaPlayer2.mpv
-
-dbus-user none
+dbus-user filter
+dbus-user.own org.mpris.MediaPlayer2.mpv
 dbus-system none
 
 restrict-namespaces

--- a/etc/profile-m-z/mpv.profile
+++ b/etc/profile-m-z/mpv.profile
@@ -92,6 +92,11 @@ private-bin env,mpv,python*,waf,youtube-dl,yt-dlp
 #private-cache
 private-dev
 
+# If you use mpv-mpris you should add this to your mpv.local file
+#ignore dbus-user none
+#dbus-user filter
+#dbus-user.own org.mpris.MediaPlayer2.mpv
+
 dbus-user none
 dbus-system none
 


### PR DESCRIPTION
When using mpv-mpris without this fix, mpv will fail to open (unless --no-config is specified).

Fixes #7134.