### PR TITLE
build: test: sync `DISTFILES_TEST` with `TESTS`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,21 +327,6 @@ DISTFILES = \
 	src \
 	testcompile.sh
 
-DISTFILES_TEST = \
-	test/Makefile \
-	test/apps \
-	test/capabilities \
-	test/environment \
-	test/fcopy \
-	test/filters \
-	test/fnetfilter \
-	test/fnettrace \
-	test/fs \
-	test/network \
-	test/private-lib \
-	test/profiles \
-	test/utils
-
 .PHONY: dist
 dist: clean config.mk
 	mkdir -p $(TARNAME)-$(VERSION)/test
@@ -429,6 +414,10 @@ TESTS = \
 	profiles \
 	seccomp-extra \
 	utils
+
+DISTFILES_TEST = \
+	test/Makefile \
+	$(patsubst %,test/%,$(TESTS))
 
 TEST_TARGETS = $(patsubst %,test-%,$(TESTS))
 


### PR DESCRIPTION
Standardize and deduplicate the test items by using the same test paths
in `make dist` as the test targets in `$(TESTS)`.

This should fix the errors caused by missing test files when running
`make test` from the tarball.

Added tests:

* apparmor
* appimage
* chroot
* firecfg
* private-etc
* seccompextra

Removed tests:

* private-lib

This is a follow-up to #7223.