### PR TITLE
fix(whitelist): restore shellrc symlinks over skel placeholders (#7213)

### DIFF
--- a/src/firejail/fs_whitelist.c
+++ b/src/firejail/fs_whitelist.c
@@ -270,14 +270,20 @@ static void whitelist_symlink(const TopDir * const top, const char *link, const 
 	const char *file = gnu_basename(relpath);
 
 	// create the link
-	if (symlinkat(target, fd, file) == -1) {
-		if (arg_debug || arg_debug_whitelists) {
-			perror("symlink");
-			printf("Debug %d: cannot create symbolic link %s\n", __LINE__, link);
-		}
+	// skel() may have already touched an empty regular file at this path
+	// (e.g. ~/.zshrc); remove it so whitelist can restore the real symlink
+	if (symlinkat(target, fd, file) == -1 && errno == EEXIST) {
+		if (unlinkat(fd, file, 0) == 0)
+			symlinkat(target, fd, file);
 	}
-	else if (arg_debug || arg_debug_whitelists)
-		printf("Created symbolic link %s -> %s\n", link, target);
+	if (is_link(link)) {
+		if (arg_debug || arg_debug_whitelists)
+			printf("Created symbolic link %s -> %s\n", link, target);
+	}
+	else if (arg_debug || arg_debug_whitelists) {
+		perror("symlink");
+		printf("Debug %d: cannot create symbolic link %s\n", __LINE__, link);
+	}
 
 	close(fd);
 	EUID_USER();

--- a/src/firejail/fs_whitelist.c
+++ b/src/firejail/fs_whitelist.c
@@ -272,15 +272,15 @@ static void whitelist_symlink(const TopDir * const top, const char *link, const 
 	// create the link
 	// skel() may have already touched an empty regular file at this path
 	// (e.g. ~/.zshrc); remove it so whitelist can restore the real symlink
-	if (symlinkat(target, fd, file) == -1 && errno == EEXIST) {
+	int symlink_rv = symlinkat(target, fd, file);
+	if (symlink_rv == -1 && errno == EEXIST) {
 		if (unlinkat(fd, file, 0) == 0)
-			symlinkat(target, fd, file);
+			symlink_rv = symlinkat(target, fd, file);
 	}
-	if (is_link(link)) {
+	if (symlink_rv == 0) {
 		if (arg_debug || arg_debug_whitelists)
 			printf("Created symbolic link %s -> %s\n", link, target);
-	}
-	else if (arg_debug || arg_debug_whitelists) {
+	} else if (arg_debug || arg_debug_whitelists) {
 		perror("symlink");
 		printf("Debug %d: cannot create symbolic link %s\n", __LINE__, link);
 	}


### PR DESCRIPTION
## Summary
- When whitelist builds a private home, `skel()` may touch an empty regular `~/.zshrc` before `whitelist_symlink` runs.
- `symlinkat` then failed with `EEXIST`, leaving the empty file (reporter had to use `--keep-shell-rc`).
- On `EEXIST`, unlink the placeholder and retry so whitelisted symlink shellrcs are restored.

Fixes #7213

## Test plan
- [ ] Host `~/.zshrc` is a symlink; profile whitelists it (and triggers home tmpfs)
- [ ] Inside sandbox, `~/.zshrc` is the symlink again (not an empty regular file)
- [ ] `--keep-shell-rc` behavior unchanged
- [ ] Non-symlink whitelisted files still mount correctly