### PR TITLE
bugfix: sandbox: search the default PATH when the environment has none

### DIFF
--- a/src/firejail/env.c
+++ b/src/firejail/env.c
@@ -313,7 +313,7 @@ void env_apply_whitelist(void) {
 	env_apply_list(env_whitelist, ARRAY_SIZE(env_whitelist));
 
 	// hardcoding PATH
-	if (setenv("PATH", "/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin", 1) < 0)
+	if (setenv("PATH", DEFAULT_PATH, 1) < 0)
 		errExit("setenv");
 }
 

--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -31,6 +31,9 @@
 
 
 
+// PATH used when the calling environment doesn't set one
+#define DEFAULT_PATH "/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
+
 // profiles
 #define DEFAULT_USER_PROFILE	"default"
 #define DEFAULT_ROOT_PROFILE	"server"

--- a/src/firejail/paths.c
+++ b/src/firejail/paths.c
@@ -29,7 +29,7 @@ static void init_paths(void) {
 	const char *env_path = env_get("PATH");
 	char *p;
 	if (!env_path) {
-		env_path = "/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin";
+		env_path = DEFAULT_PATH;
 		env_store_name_val("PATH", env_path, SETENV);
 	}
 	char *path = strdup(env_path);

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -428,44 +428,49 @@ static int ok_to_run(const char *program) {
 			return 1;
 	}
 	else { // search $PATH
+		// the program runs with DEFAULT_PATH when the calling environment has
+		// none (env_apply_whitelist()), so search that list here as well;
+		// otherwise the lookup depends on whether something else in this run
+		// called init_paths() first, e.g. a ${PATH} macro in the profile
 		const char *path1 = env_get("PATH");
-		if (path1) {
+		if (!path1)
+			path1 = DEFAULT_PATH;
+
+		if (arg_debug)
+			printf("Searching $PATH for %s\n", program);
+		char *path2 = strdup(path1);
+		if (!path2)
+			errExit("strdup");
+
+		// use path2 to count the entries
+		char *ptr = strtok(path2, ":");
+		while (ptr) {
+			char *fname;
+
+			if (asprintf(&fname, "%s/%s", ptr, program) == -1)
+				errExit("asprintf");
 			if (arg_debug)
-				printf("Searching $PATH for %s\n", program);
-			char *path2 = strdup(path1);
-			if (!path2)
-				errExit("strdup");
+				printf("trying #%s#\n", fname);
 
-			// use path2 to count the entries
-			char *ptr = strtok(path2, ":");
-			while (ptr) {
-				char *fname;
-
-				if (asprintf(&fname, "%s/%s", ptr, program) == -1)
-					errExit("asprintf");
-				if (arg_debug)
-					printf("trying #%s#\n", fname);
-
-				struct stat s;
-				int rv = stat(fname, &s);
-				if (rv == 0) {
-					if (access(fname, X_OK) == 0) {
-						free(path2);
-						free(fname);
-						return 1;
-					}
-					else
-						fprintf(stderr, "Error: execute permission denied for %s\n", fname);
-
+			struct stat s;
+			int rv = stat(fname, &s);
+			if (rv == 0) {
+				if (access(fname, X_OK) == 0) {
+					free(path2);
 					free(fname);
-					break;
+					return 1;
 				}
+				else
+					fprintf(stderr, "Error: execute permission denied for %s\n", fname);
 
 				free(fname);
-				ptr = strtok(NULL, ":");
+				break;
 			}
-			free(path2);
+
+			free(fname);
+			ptr = strtok(NULL, ":");
 		}
+		free(path2);
 	}
 	return 0;
 }

--- a/test/environment/environment.sh
+++ b/test/environment/environment.sh
@@ -35,6 +35,9 @@ echo "TESTING: extract command (extract_command.exp)"
 echo "TESTING: environment variables (test/environment/env.exp)"
 ./env.exp
 
+echo "TESTING: no PATH in the environment (test/environment/path-unset.exp)"
+./path-unset.exp
+
 echo "TESTING: firejail in firejail - single sandbox (test/environment/firejail-in-firejail.exp)"
 ./firejail-in-firejail.exp
 

--- a/test/environment/path-unset.exp
+++ b/test/environment/path-unset.exp
@@ -1,0 +1,27 @@
+#!/usr/bin/expect -f
+# This file is part of Firejail project
+# Copyright (C) 2014-2026 Firejail Authors
+# License GPL v2
+
+set timeout 10
+spawn $env(SHELL)
+match_max 100000
+
+send -- "stty -echo\r"
+after 100
+
+# Looking up the program must not depend on the profile expanding a ${PATH}
+# macro, so run without a profile and with no PATH in the environment.
+# printf assembles the marker at run time, so a shell that still echoes the
+# command line cannot be mistaken for the sandboxed program's output.
+send -- "FIREJAIL=\$(command -v firejail)\r"
+after 100
+send -- "env -u PATH \$FIREJAIL --quiet --noprofile printf 'path%s\\n' unset\r"
+expect {
+	timeout {puts "TESTING ERROR 1\n";exit}
+	"no suitable" {puts "TESTING ERROR 2\n";exit}
+	"pathunset"
+}
+after 100
+
+puts "\nall done\n"


### PR DESCRIPTION
`ok_to_run()` looks the program up in `env_get("PATH")`, which is firejail's
copy of the caller's environment. When the caller has no PATH that lookup finds
nothing and firejail gives up, even though it goes on to execute the program
with the default PATH it sets for itself in `env_apply_whitelist()`.

The lookup works anyway whenever something else in the run reaches
`init_paths()` first, because that stores the default PATH in the environment
list as a side effect. Expanding a `${PATH}` macro is the usual trigger and
`disable-common.inc` has 145 of them, so the stock profile hides the problem
while `--noprofile` (or any profile that never mentions `${PATH}`) shows it:

```console
$ env -u PATH firejail --quiet --noprofile ls
Error: no suitable ls executable found
$ env -u PATH firejail --quiet ls
<lists the directory>
```

That is the "depends on the content of the profile" behaviour reported in the
issue.

This searches the same default list in `ok_to_run()`, so the lookup matches
what the program is actually executed with. The default was already spelled out
twice (`env_apply_whitelist()` and `init_paths()`), so the first commit hoists
it into a single `DEFAULT_PATH` macro before the fix adds a third use.

Two things worth flagging:

* The `if (path1)` guard in `ok_to_run()` is always true now, so the block is
  de-indented. `git diff -w` reduces the change to +7/-2.
* With `--rmenv=PATH` a bare program name now runs instead of erroring out,
  because `execvp()` falls back to `confstr(_CS_PATH)`. A program that only
  lives in `/usr/local/bin` or an sbin directory still fails, with
  `Cannot start application` instead of `no suitable ... executable found`.

### Testing

`test/environment/path-unset.exp` run on unmodified `master` with only that
file added (RED):

```console
$ cd test/environment && ./path-unset.exp
spawn /bin/bash
stty -echo
[expect echoes the spawned shell prompt]
Warning: /usr/bin/bwrap was not disabled
Error: no suitable printf executable found
TESTING ERROR 2
```

Same test on this branch (GREEN):

```console
$ cd test/environment && ./path-unset.exp
spawn /bin/bash
stty -echo
[expect echoes the spawned shell prompt]
Warning: /usr/bin/bwrap was not disabled
pathunset

all done
```

Full local suite, run on `master` and on this branch with identical results:
the default build and the `gcc-12 --enable-analyzer` build, the clang build,
`make install` + `make installcheck`, `make test-environment`,
`scan-build-18 make`, `make cppcheck`, `make codespell`, and the profile
checks. `make test-environment` reports no `TESTING ERROR` on either side.

Fixes #5939
